### PR TITLE
Fix post persist loop

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -736,13 +736,11 @@ class UnitOfWork implements PropertyChangedListener
                 $this->addToIdentityMap($document);
 
                 if ($hasLifecycleCallbacks || $hasListeners) {
-                    foreach ($documents as $document) {
-                        if ($hasLifecycleCallbacks) {
-                            $class->invokeLifecycleCallbacks(ODMEvents::postPersist, $document);
-                        }
-                        if ($hasListeners) {
-                            $this->evm->dispatchEvent(ODMEvents::postPersist, new LifecycleEventArgs($document, $this->dm));
-                        }
+                    if ($hasLifecycleCallbacks) {
+                        $class->invokeLifecycleCallbacks(ODMEvents::postPersist, $document);
+                    }
+                    if ($hasListeners) {
+                        $this->evm->dispatchEvent(ODMEvents::postPersist, new LifecycleEventArgs($document, $this->dm));
                     }
                 }
                 $this->invokeEmbeddedLifecycleCallbacks(ODMEvents::postPersist, $document);


### PR DESCRIPTION
I noticed a huge CPU usage when batch inserting 500 documents.
Using xdebug and kcachegrind, I noticed that my PostPersist events were
called 250.000 times. Which is the number of documents, squarred.
This change fixes that bug. It may break things, as I don't understand
why it was done this way. But it doesn't add any failure when I
run the test suite.
