### PR TITLE
Fix query get cursor

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query.php
@@ -1069,7 +1069,7 @@ class Query
      */
     private function getCursor()
     {
-        if ($this->type !== self::TYPE_FIND) {
+        if (!in_array($this->type, array(self::TYPE_FIND, self::TYPE_GROUP))) {
             throw new \InvalidArgumentException(
                 'Cannot get cursor for an update or remove query. Use execute() method.'
             );


### PR DESCRIPTION
Make it possible to call ->getCursor() on a GROUP query.
