### PR TITLE
fixed DateType when unixtimestamp is given (ie. time())

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Types/DateType.php
@@ -38,8 +38,9 @@ class DateType extends Type
         $timestamp = false;
         if ($value instanceof \DateTime) {
             $timestamp = $value->getTimestamp();
-        }
-        if (is_string($value)) {
+        } elseif (is_numeric($value)) {
+          $timestamp = $value;
+        } elseif (is_string($value)) {
             $timestamp = strtotime($value);
         }
         // Could not convert date to timestamp so store ISO 8601 formatted date instead


### PR DESCRIPTION
If value comes from using time() an error will occur:

exception (Exception) in /usr/local/sgcontrol2_dev/src/vendor/doctrine-mongodb/lib/Doctrine/ODM/MongoDB/Mapping/Types/DateType.php on line 47: DateTime::__construct(): Failed to parse time string (1286245836) at position 7 (8): Unexpected character

DateTime() does not seem to handle unix timestamps directly.

Checking if value is numeric should do the trick. Also doing elseif will prevent useless conditions if timestamp was already set.
