### PR TITLE
fixed DateType when unixtimestamp is given (ie. time())

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Types/DateType.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -30,25 +31,26 @@ namespace Doctrine\ODM\MongoDB\Mapping\Types;
  */
 class DateType extends Type
 {
+
     public function convertToDatabaseValue($value)
     {
         if ($value === null) {
-          return null;
+            return null;
         }
         $timestamp = false;
         if ($value instanceof \DateTime) {
             $timestamp = $value->getTimestamp();
         } elseif (is_numeric($value)) {
-          $timestamp = $value;
+            $timestamp = $value;
         } elseif (is_string($value)) {
             $timestamp = strtotime($value);
         }
         // Could not convert date to timestamp so store ISO 8601 formatted date instead
         if ($timestamp === false) {
-          $date = new \DateTime($value);
-          return $date->format('c');
+            $date = new \DateTime($value);
+            return $date->format('c');
         } else {
-          $value = $timestamp;
+            $value = $timestamp;
         }
         return new \MongoDate($value);
     }
@@ -66,4 +68,5 @@ class DateType extends Type
         }
         return $date;
     }
+
 }


### PR DESCRIPTION
If value comes from using time() an error will occur:

exception (Exception) in src/vendor/doctrine-mongodb/lib/Doctrine/ODM/MongoDB/Mapping/Types/DateType.php on line 47: DateTime::__construct(): Failed to parse time string (1286245836) at position 7 (8): Unexpected character

DateTime() does not seem to handle unix timestamps directly.

Checking if value is numeric should do the trick. Also doing elseif will prevent useless conditions if timestamp was already set.

Fixed coding standards.
