### PR TITLE
Test post remove event on embedded many document

### DIFF
--- a/tests/Documents/Functional/EmbeddedTestLevel0b.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel0b.php
@@ -11,4 +11,6 @@ class EmbeddedTestLevel0b
     public $name;
     /** @EmbedOne(targetDocument="EmbeddedTestLevel1") */
     public $oneLevel1;
+    /** @EmbedMany(targetDocument="EmbeddedTestLevel1") */
+    public $level1 = array();
 }

--- a/tests/Documents/Functional/EmbeddedTestLevel1.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel1.php
@@ -2,11 +2,29 @@
 
 namespace Documents\Functional;
 
-/** @EmbeddedDocument */
+/**
+ * @EmbeddedDocument
+ * @HasLifecycleCallbacks
+ */
 class EmbeddedTestLevel1
 {
     /** @String */
     public $name;
     /** @EmbedMany(targetDocument="EmbeddedTestLevel2") */
     public $level2 = array();
+
+    public $preRemove = false;
+    public $postRemove = false;
+
+    /** @PreRemove */
+    public function onPreRemove()
+    {
+        $this->preRemove = true;
+    }
+
+    /** @PostRemove */
+    public function onPostRemove()
+    {
+        $this->postRemove = true;
+    }
 }

--- a/tests/Documents/Functional/EmbeddedTestLevel2.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel2.php
@@ -2,9 +2,27 @@
 
 namespace Documents\Functional;
 
-/** @EmbeddedDocument */
+/**
+ * @EmbeddedDocument
+ * @HasLifecycleCallbacks
+ */
 class EmbeddedTestLevel2
 {
     /** @String */
     public $name;
+
+    public $preRemove = false;
+    public $postRemove = false;
+
+    /** @PreRemove */
+    public function onPreRemove()
+    {
+        $this->preRemove = true;
+    }
+
+    /** @PostRemove */
+    public function onPostRemove()
+    {
+        $this->postRemove = true;
+    }
 }


### PR DESCRIPTION
This commit only adds failing tests.

DocumentA embeds many DocumentB. When a DocumentB is removed, its lifecycle callbacks (and events) PreRemove and PostRemove are not called.
