### PR TITLE
LoadClassMetadataEventArgs::getDocumentManager method

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/LoadClassMetadataEventArgs.php
@@ -20,7 +20,8 @@
 namespace Doctrine\ODM\MongoDB\Event;
 
 use Doctrine\Common\EventArgs,
-    Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+    Doctrine\ODM\MongoDB\Mapping\ClassMetadata,
+    Doctrine\ODM\MongoDB\DocumentManager;
 
 /**
  * Class that holds event arguments for a loadMetadata event.
@@ -35,13 +36,21 @@ class LoadClassMetadataEventArgs extends EventArgs
 {
     private $classMetadata;
 
-    public function __construct(ClassMetadata $classMetadata)
+    private $dm;
+
+    public function __construct(ClassMetadata $classMetadata, DocumentManager $dm)
     {
         $this->classMetadata = $classMetadata;
+        $this->dm = $dm;
     }
 
     public function getClassMetadata()
     {
         return $this->classMetadata;
+    }
+
+    public function getDocumentManager()
+    {
+        return $this->dm;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -239,7 +239,7 @@ class ClassMetadataFactory
             $class->setParentClasses($visited);
 
             if ($this->evm->hasListeners(ODMEvents::loadClassMetadata)) {
-                $eventArgs = new \Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs($class);
+                $eventArgs = new \Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs($class, $this->dm);
                 $this->evm->dispatchEvent(ODMEvents::loadClassMetadata, $eventArgs);
             }
 


### PR DESCRIPTION
added a way to get the DocumentManager from a LoadClassMetadataEventArgs instance.
