### PR TITLE
ClassMetadata.allowCustomID should be serialized

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -1222,6 +1222,7 @@ class ClassMetadata
             'db',
             'collection',
             'rootDocumentName',
+            'allowCustomID'
         );
 
         // The rest of the metadata is only serialized if necessary.


### PR DESCRIPTION
As for now it's not, so when using apc metadata cache, this property is lost.
I also removed some trailing whitespace in ClassMetadata.php
