### PR TITLE
Serialize ClassMetadata.generatorType

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -1372,7 +1372,8 @@ class ClassMetadata
             'db',
             'collection',
             'rootDocumentName',
-            'idGenerator'
+            'idGenerator',
+            'generatorType'
         );
 
         // The rest of the metadata is only serialized if necessary.


### PR DESCRIPTION
Actually when the Id strategy="none", and error occurs because there is no generator. It can be fixed by serializing the generatorType.
