### PR TITLE
Fix DocumentPersister::loadReferenceManyCollection should call Uow::getById with the root document name

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -479,7 +479,7 @@ class DocumentPersister
             $mongoCollection = $this->dm->getDocumentCollection($className);
             $data = $mongoCollection->find(array('_id' => array($cmd . 'in' => $ids)));
             foreach ($data as $documentData) {
-                $document = $this->uow->getById((string) $documentData['_id'], $className);
+                $document = $this->uow->getById((string) $documentData['_id'], $class->rootDocumentName);
                 $data = $this->hydrator->hydrate($document, $documentData);
                 $this->uow->setOriginalDocumentData($document, $data);
             }


### PR DESCRIPTION
Simple fix to ensure Uow::getById is called with a root document name.
