### PR TITLE
Add two tests for Query, the second one demonstrating the bug described below

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
@@ -273,4 +273,32 @@ class QueryTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user2 = $query->getSingleResult();
         $this->assertSame($user, $user2);
     }
+
+    public function testQueryWhereIn()
+    {
+        $qb = $this->dm->createQueryBuilder('Documents\User');
+        $choices = array('a', 'b');
+        $qb->field('username')->in($choices);
+        $expected = array(
+            'username' => array(
+                '$in' => $choices
+            )
+        );
+        $this->assertSame($expected, $qb->getQueryArray());
+    }
+
+    public function testQueryWhereInReferenceId()
+    {
+        $qb = $this->dm->createQueryBuilder('Documents\User');
+        $choices = array(new \MongoId(), new \MongoId());
+        $qb->field('account.$id')->in($choices);
+        $expected = array(
+            'account.$id' => array(
+                '$in' => $choices
+            )
+        );
+        $this->assertSame($expected, $qb->getQueryArray());
+
+        $this->assertSame($expected, $qb->getQuery()->debug());
+    }
 }


### PR DESCRIPTION
Add two tests for Query, the second one demonstrating the bug described below

Issue with $in and referenced document.
Be 2 documents, User and Account. User references one Account.

```
UserQueryBuilder->field('account.$id')->in(array of account ids)
```

will not work as expected.
The problem lies in DocumentPersister::prepareWhereValue.
$in queries are ignored when the field name contains a dot.
But in the case of "account.$id", the $in query is possible and should
