### PR TITLE
Expr bug

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -174,7 +174,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
         return new Expr($this->dm, $this->cmd);
     }
 
-	private function setDocumentName($documentName)
+    private function setDocumentName($documentName)
     {
         if (is_array($documentName)) {
             $documentNames = $documentName;


### PR DESCRIPTION
References would not work in QueryBuilder->expr().  The problem is that expr() is called in the parent class, so the Doctrine\Mongo\Query\Expr was pass back instead of the Doctrine\ORM\Mongo\Query\Expr.  With the correct Expr being passed back, references now work.
