### PR TITLE
Fix DocumentPersister::prepareTypeValue when the value is the $exists command

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -594,6 +594,8 @@ class DocumentPersister
         if (is_array($value)) {
             if (isset($value[$this->cmd.'type'])) {
                 // do nothing
+            } elseif (isset($value[$this->cmd.'exists'])) {
+                $value[$this->cmd.'exists'] = (bool) $value[$this->cmd.'exists'];
             } elseif (isset($value[$this->cmd.'not'])) {
                 $value[$this->cmd.'not'] = $this->prepareTypeValue($type, $value[$this->cmd.'not']);
             } elseif (isset($value[$this->cmd.'in'])) {


### PR DESCRIPTION
```
$queryBuilder->field('date')->exists(true)
```

Actually this fails because DocumentPersister tries to transform `true` to a DateTime object.
After this commit, $exists values are properly casted to (bool).
