### PR TITLE
Id operators fix

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -597,7 +597,12 @@ class DocumentPersister
         // Process identifier
         } elseif ($fieldName === $this->class->identifier || $fieldName === '_id') {
             $fieldName = '_id';
-            $value = $this->class->getDatabaseIdentifierValue($value);
+            if(is_array($value)) {
+                $key = key($value);
+                $value[$key] = $this->class->getDatabaseIdentifierValue($value);
+            } else {
+                $value = $this->class->getDatabaseIdentifierValue($value);
+            }
         }
         return $value;
     }


### PR DESCRIPTION
 <pre>$query->field('_id')->notEqual($myObject->getId());</pre>
would result in 

<pre>{"_id":ObjectId("1235456")}</pre>

instead of 

<pre>{"_id":{"$ne", ObjectId("123456")}}</pre>


the behavior has been corrected
