### PR TITLE
Manager persist and flush

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -366,6 +366,22 @@ class DocumentManager
     }
 
     /**
+     * Tells the DocumentManager to manage and persist a document directly to the storage.
+     *
+     * NOTE: this method is just a shortcut for the two operations but it's useful as 
+     * developers generally persist only one document at a time and it avoids to write two 
+     * lines of code everytime.
+     *
+     * @param object $document The document to make managed and persisted immediatly
+     * @param array $options Array of options to be used with batchInsert(), update() and remove()
+     */
+    public function persistAndFlush($document, array $options = array())
+    {
+        $this->persist($document);
+        $this->flush($options);
+    }
+
+    /**
      * Removes a document instance.
      *
      * A removed document will be removed from the database at or before transaction commit

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -70,6 +70,7 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         return array(
             array('persist'),
+            array('persistAndFlush'),
             array('remove'),
             array('merge'),
             array('refresh'),
@@ -91,6 +92,7 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         return array(
             array('flush'),
             array('persist'),
+            array('persistAndFlush'),
             array('remove'),
             array('merge'),
             array('refresh'),


### PR DESCRIPTION
Hello,

I have added a shortcut method to the DocumentManager class: persistAndFlush()

Generally, developers need to persist and flush one single document at a time. That means, we need to write two lines of code in controllers. The goal is to reduce a bit the number of lines of code by calling one single method, which is responsible to persist and flush the document to the storage immediatly.

I didn't manage to run the tests suite so I cannot guarantee tests pass. Please, run the tests suite before applying the patch if you are convinced of its added value for the API.

Hugo Hamon
Sensio Labs Trainings Manager.
