### PR TITLE
Simplify DateType::closureToPhp

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Types/DateType.php
@@ -77,6 +77,6 @@ class DateType extends Type
 
     public function closureToPHP()
     {
-        return 'if ($value === null) { return null; } if ($value instanceof \MongoDate) { $date = new \DateTime(); $date->setTimestamp($value->sec); $return = $date; } else { $return = new \DateTime($value); }';
+        return 'if ($value instanceof \MongoDate) { $date = new \DateTime(); $date->setTimestamp($value->sec); $return = $date; } else { $return = new \DateTime($value); }';
     }
 }


### PR DESCRIPTION
The `$value === null` test is superfluous because this code only
execute if the value is set, i.e. not null.
Plus, the `return` statement is weird as we certainly do not want to
return the hydrator method, skipping next fields.
