### PR TITLE
Fixed Proxy-autogenerate issue

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/ProxyFactory.php
@@ -168,7 +168,12 @@ class ProxyFactory
             }
 
             if ($method->isPublic() && ! $method->isFinal() && ! $method->isStatic()) {
-                $methods .= PHP_EOL . '    public function ' . $method->getName() . '(';
+                $methods .= PHP_EOL . '    public function ';
+                if ($method->returnsReference()) {
+                    $methods .= '&';
+                }
+                $methods .= $method->getName() . '(';
+
                 $firstParam = true;
                 $parameterString = $argumentString = '';
 


### PR DESCRIPTION
Fixed issue with generating methods that return reference.

Useful for example when one wants to use the magic getter in document:
    public function &__get() {
        ...
    }

Without a reference this would not work for arrays (PHP behavior).
