### PR TITLE
Fix duplicated class names returned by DriverChain

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/DriverChain.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/DriverChain.php
@@ -89,7 +89,7 @@ class DriverChain implements Driver
         foreach ($this->drivers AS $driver) {
             $classNames = array_merge($classNames, $driver->getAllClassNames());
         }
-        return $classNames;
+        return array_values(array_unique($classNames));
     }
 
     /**


### PR DESCRIPTION
Before this change, `DriverChain::getAllClassNames` was returning 4500+ classes... while I have only 126.

Because drivers can return the same class names.
