### PR TITLE
Also store mapping indexes in the cache

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -114,7 +114,8 @@ class ClassMetadata extends ClassMetadataInfo
             'rootDocumentName',
             'generatorType',
             'generatorOptions',
-            'idGenerator'
+            'idGenerator',
+            'indexes'
         );
 
         // The rest of the metadata is only serialized if necessary.


### PR DESCRIPTION
If not, then mappings fetched from cache do not contain index informations, and index creation command does nothing.
