### PR TITLE
Queries containing embedded document clauses are incorrectly prepared

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -343,6 +343,7 @@ class DocumentPersister
         $criteria = $this->prepareQuery($criteria);
         $cursor = $this->collection->find($criteria)->limit(1);
         if ($sort) {
+        	$sort = $this->prepareQuery($sort);
             $cursor->sort($sort);
         }
         $result = $cursor->getSingleResult();
@@ -369,6 +370,7 @@ class DocumentPersister
         $cursor = $this->collection->find($criteria);
 
         if (null !== $orderBy) {
+        	$orderBy = $this->prepareQuery($orderBy);
             $cursor->sort($orderBy);
         }
 


### PR DESCRIPTION
This is rather an issue report than a pull request. Please treat my commit as "inspirational hack" rather than a real pull request.

Currently DocumentPersister.prepareQueryValue does not handle queries targeting embedded documents correctly. For queries containing a dot (e.g. adress.label) prepare correctly recognizes address as a field, but then fails to recognize label as a field of the embedded document.

This causes problem when the class field names are mapped to (shortened) db field names.

The fix corrects this situation by introducing a scope in which the prepare takes place. For embedded documents prepare is called recursively, omitting the already processed part of fieldName before invocation and concatenating the resulting fieldname afterwards to form the correct query fieldname to use.
