### PR TITLE
[DocumentManager] Slight PHPDoc correction

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -338,7 +338,7 @@ class DocumentManager implements ObjectManager
      * Create a new Query instance for a class.
      *
      * @param string $documentName The document class name.
-     * @return Document\ODM\MongoDB\Query
+     * @return Document\ODM\MongoDB\Query\Builder
      */
     public function createQueryBuilder($documentName = null)
     {


### PR DESCRIPTION
Hey guys-

Simple. Also - I'm sure everyone's aware of it, but just in case - the current documentation talks frequently about a `createQuery` method on the `$dm`, which appears to no longer exist (everything now appears to be the query builder).

Thanks!
