### PR TITLE
Convert ID to PHP value to register the document

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -464,7 +464,7 @@ class DocumentPersister
 
         if ($document !== null) {
             $hints[Query::HINT_REFRESH] = true;
-            $id = $result['_id'];
+            $id = $this->class->getPHPIdentifierValue($result['_id']);
             $this->uow->registerManaged($document, $id, $result);
         }
 


### PR DESCRIPTION
We need no MongoID in the `UnitOfWork.documentIdentifiers`.
