### PR TITLE
DocumentPersister::delete use fixed field name "locked"

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -300,8 +300,8 @@ class DocumentPersister
         $id = $this->uow->getDocumentIdentifier($document);
         $query = array('_id' => $this->class->getDatabaseIdentifierValue($id));
 
-        if ($this->class->isVersioned) {
-            $query['locked'] = array($this->cmd . 'exists' => false);
+        if ($this->class->isLockable) {
+            $query[$this->class->lockField] = array($this->cmd . 'exists' => false);
             $options['safe'] = true;
         }
 


### PR DESCRIPTION
In the delete method of DocumentPersister, a query criteria $exists on the locked field is added when the class is versionable. I think it shoud be only added when the class is lockable and with the field name comming from mapping metadata.
