### PR TITLE
Check the document before creating the DBRef

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -647,8 +647,8 @@ class DocumentManager implements ObjectManager
      */
     public function createDBRef($document, array $referenceMapping = null)
     {
-        if (null === $document) {
-            throw new \InvalidArgumentException('Cannot create a DBRef, the document is null');
+        if (!is_object($document)) {
+            throw new \InvalidArgumentException('Cannot create a DBRef, the document is not an object');
         }
         $className = get_class($document);
         $class = $this->getClassMetadata($className);


### PR DESCRIPTION
If the $document argument is null then the next line

```
$className = get_class($document);
```

returns the class of the document manager.
Then, of course, things go very wrong.
As DocumentManager::createDBRef is public,
I think we should ensure it never happens.
