### PR TITLE
Fix document manager test

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -45,7 +45,7 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testGetEventManager()
     {
-        $this->assertInstanceOf('\Doctrine\ODM\MongoDB\EventManager', $this->dm->getEventManager());
+        $this->assertInstanceOf('\Doctrine\Common\EventManager', $this->dm->getEventManager());
     }
 
     public function testGetSchemaManager()


### PR DESCRIPTION
The event manager is now in `Doctrine\Common`
