### PR TITLE
updated references() and includesReferenceTo() queries to use as few keys as possible

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Expr.php
@@ -61,15 +61,23 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
      */
     public function references($document)
     {
+        $dbRef = $this->dm->createDBRef($document);
+
         if ($this->currentField) {
-            $reference = $this->class
-                ? $this->dm->createDBRef($document, $this->class->getFieldMapping($this->currentField))
-                : $this->dm->createDBRef($document);
-            foreach ($reference as $key => $value) {
-                $this->query[$this->currentField . '.' . $key] = $value;
+            $keys = array('ref' => true, 'id' => true, 'db' => true);
+
+            if ($this->class) {
+                $mapping = $this->class->getFieldMapping($this->currentField);
+                if (isset($mapping['targetDocument'])) {
+                    unset($keys['ref'], $keys['db']);
+                }
+            }
+
+            foreach ($keys as $key => $value) {
+                $this->query[$this->currentField . '.' . $this->cmd . $key] = $dbRef[$this->cmd . $key];
             }
         } else {
-            $this->query = $this->dm->createDBRef($document);
+            $this->query = $dbRef;
         }
 
         return $this;
@@ -80,12 +88,23 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
      */
     public function includesReferenceTo($document)
     {
+        $dbRef = $this->dm->createDBRef($document);
+
         if ($this->currentField) {
-            $this->query[$this->currentField][$this->cmd . 'elemMatch'] = $this->class
-                ? $this->dm->createDBRef($document, $this->class->getFieldMapping($this->currentField))
-                : $this->dm->createDBRef($document);
+            $keys = array('ref' => true, 'id' => true, 'db' => true);
+
+            if ($this->class) {
+                $mapping = $this->class->getFieldMapping($this->currentField);
+                if (isset($mapping['targetDocument'])) {
+                    unset($keys['ref'], $keys['db']);
+                }
+            }
+
+            foreach ($keys as $key => $value) {
+                $this->query[$this->currentField][$this->cmd . 'elemMatch'][$this->cmd . $key] = $dbRef[$this->cmd . $key];
+            }
         } else {
-            $this->query[$this->cmd . 'elemMatch'] = $this->dm->createDBRef($document);
+            $this->query[$this->cmd . 'elemMatch'] = $dbRef;
         }
 
         return $this;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Query;
+
+use Doctrine\ODM\MongoDB\Query\Expr;
+
+class ExprTest extends \PHPUnit_Framework_TestCase
+{
+    public function testReferencesUsesMinimalKeys()
+    {
+        $dm = $this->getMockBuilder('Doctrine\\ODM\\MongoDB\\DocumentManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $class = $this->getMockBuilder('Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dm->expects($this->once())
+            ->method('createDBRef')
+            ->will($this->returnValue(array('$ref' => 'coll', '$id' => '1234', '$db' => 'db')));
+        $class->expects($this->once())
+            ->method('getFieldMapping')
+            ->will($this->returnValue(array('targetDocument' => 'Foo')));
+
+        $expr = new Expr($dm, '$');
+        $expr->setClassMetadata($class);
+        $expr->field('foo')->references(new \stdClass());
+
+        $this->assertEquals(array('foo.$id' => '1234'), $expr->getQuery(), '->references() uses just $id if a targetDocument is set');
+    }
+
+    public function testReferencesUsesAllKeys()
+    {
+        $dm = $this->getMockBuilder('Doctrine\\ODM\\MongoDB\\DocumentManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $class = $this->getMockBuilder('Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dm->expects($this->once())
+            ->method('createDBRef')
+            ->will($this->returnValue(array('$ref' => 'coll', '$id' => '1234', '$db' => 'db')));
+        $class->expects($this->once())
+            ->method('getFieldMapping')
+            ->will($this->returnValue(array()));
+
+        $expr = new Expr($dm, '$');
+        $expr->setClassMetadata($class);
+        $expr->field('foo')->references(new \stdClass());
+
+        $this->assertEquals(array('foo.$ref' => 'coll', 'foo.$id' => '1234', 'foo.$db' => 'db'), $expr->getQuery(), '->references() uses all keys if no targetDocument is set');
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -55,7 +55,6 @@ class QueryTest extends BaseTest
             'bestFriend.$ref' => 'people',
             'bestFriend.$id' => new \MongoId($jon->id),
             'bestFriend.$db' => 'doctrine_odm_tests',
-            'bestFriend._doctrine_class_name' => 'Doctrine\ODM\MongoDB\Tests\Person',
         ), $queryArray);
 
         $query = $qb->getQuery();
@@ -86,7 +85,6 @@ class QueryTest extends BaseTest
                     '$ref' => 'people',
                     '$id' => new \MongoId($kris->id),
                     '$db' => 'doctrine_odm_tests',
-                    '_doctrine_class_name' => 'Doctrine\ODM\MongoDB\Tests\Person',
                 ),
             ),
         ), $queryArray);


### PR DESCRIPTION
I've updated the `Expr::references()` and `Expr::includesReferenceTo()` methods to add fewer keys to the query. If a `targetDocument` is mapped, only `$id` will be used; otherwise `$ref`, `$id` and `$db` will all be used.
Discriminator values are never used.
