### PR TITLE
Fix MODM-151: Add missing annotation HasLifecycleCallbacks

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php
@@ -260,6 +260,8 @@ final class ChangeTrackingPolicy extends Annotation {}
 /* Annotations for lifecycle callbacks */
 
 /** @Annotation */
+final class HasLifecycleCallbacks extends Annotation {}
+/** @Annotation */
 final class PrePersist extends Annotation {}
 /** @Annotation */
 final class PostPersist extends Annotation {}


### PR DESCRIPTION
Hi, it seems like you forgot to add class HasLifecycleCallbacks to DoctrineAnnotations 
