### PR TITLE
Checking if array indexes exist before using them.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -541,16 +541,16 @@ class DocumentPersister
             $mongoCollection = $this->dm->getDocumentCollection($className);
             $criteria = array_merge(
                 array('_id' => array($cmd . 'in' => $ids)),
-                $mapping['criteria']
+                isset($mapping['criteria']) ? $mapping['criteria'] : array()
             );
             $cursor = $mongoCollection->find($criteria);
-            if ($mapping['sort']) {
+            if (isset($mapping['sort'])) {
                 $cursor->sort($mapping['sort']);
             }
-            if ($mapping['limit']) {
+            if (isset($mapping['limit'])) {
                 $cursor->limit($mapping['limit']);
             }
-            if ($mapping['skip']) {
+            if (isset($mapping['skip'])) {
                 $cursor->skip($mapping['skip']);
             }
             foreach ($cursor as $documentData) {


### PR DESCRIPTION
This will help to avoid getting 'Undefined index' notices.
