### PR TITLE
Added the ObjectId / MongoId field type.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php
@@ -180,6 +180,11 @@ final class Increment extends AbstractField
     public $type = 'increment';
 }
 /** @Annotation */
+final class ObjectId extends AbstractField
+{
+    public $type = 'object_id';
+}
+/** @Annotation */
 final class Collection extends AbstractField
 {
     public $type = 'collection';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Types/ObjectIdType.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Types/ObjectIdType.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ODM\MongoDB\Mapping\Types;
+
+/**
+ * The ObjectId type.
+ *
+ * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
+ * @link        www.doctrine-project.org
+ * @since       1.0
+ * @author      Jonathan H. Wage <jonwage@gmail.com>
+ * @author      Roman Borschel <roman@code-factory.org>
+ */
+class ObjectIdType extends Type
+{
+    public function convertToDatabaseValue($value)
+    {
+        if ($value === null) {
+            return null;
+        }
+        if ( ! $value instanceof \MongoId) {
+            $value = new \MongoId($value);
+        }
+        return $value;
+    }
+
+    public function convertToPHPValue($value)
+    {
+        return $value !== null ? (string) $value : null;
+    }
+
+    public function closureToMongo()
+    {
+        return '$return = new MongoId($value);';
+    }
+
+    public function closureToPHP()
+    {
+        return '$return = (string) $value;';
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Types/Type.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Types/Type.php
@@ -53,7 +53,8 @@ abstract class Type
         'file' => 'Doctrine\ODM\MongoDB\Mapping\Types\FileType',
         'hash' => 'Doctrine\ODM\MongoDB\Mapping\Types\HashType',
         'collection' => 'Doctrine\ODM\MongoDB\Mapping\Types\CollectionType',
-        'increment' => 'Doctrine\ODM\MongoDB\Mapping\Types\IncrementType'
+        'increment' => 'Doctrine\ODM\MongoDB\Mapping\Types\IncrementType',
+        'object_id' => 'Doctrine\ODM\MongoDB\Mapping\Types\ObjectIdType'
     );
 
     /**


### PR DESCRIPTION
Added document field type 'object_id' which abstracts the MongoId / ObjectId data type. Can be annotated using @ObjectId or @Field(type="object_id")

This feature was proposed and discussed at #125. It was further discussed in the IRC channel with @jwage. 
