### PR TITLE
Fix segfault in PHP with goto statement... switch to continue statement

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -131,7 +131,7 @@ class AnnotationDriver implements Driver
             foreach (self::$documentAnnotationClasses as $i => $annotClass) {
                 if ($annot instanceof $annotClass) {
                     $documentAnnots[$i] = $annot;
-                    goto next_annotation;
+                    continue 2;
                 }
             }
 
@@ -155,7 +155,6 @@ class AnnotationDriver implements Driver
                 $class->setChangeTrackingPolicy(constant('Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata::CHANGETRACKING_'.$annot->value));
             }
 
-            next_annotation:
         }
 
         if (!$documentAnnots) {


### PR DESCRIPTION
Fix segfault in PHP with goto statement... switch to continue statement instead.

Using PHP 5.3.5-1ubuntu7.2 with Suhosin-Patch (cli) (built: May  2 2011 23:18:30) on my Ubuntu 11.04 machine.

goto statment caused a segfault in PHP.  This PR fixes the goto statement by changing it into a continue 2;

Goto statements cause raptors to crash into you anyway... http://xkcd.com/292/

In short, this doesn't change functionality at all.  I'm not sure if anyone else has this issue.  If you decide to pull this, great!  If not, I'll have to maintain my own fork for now.  Not sure why goto is broken in this case.
