### PR TITLE
Fix call to Yaml::parse - using the stable Symfony component

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
@@ -201,6 +201,6 @@ class YamlDriver extends AbstractFileDriver
 
     protected function loadMappingFile($file)
     {
-        return \Symfony\Component\Yaml\Yaml::load($file);
+        return \Symfony\Component\Yaml\Yaml::parse($file);
     }
 }

--- a/lib/vendor/Symfony/Component/Yaml/Yaml.php
+++ b/lib/vendor/Symfony/Component/Yaml/Yaml.php
@@ -54,7 +54,7 @@ class Yaml
    *
    *  Usage:
    *  <code>
-   *   $array = Yaml::load('config.yml');
+   *   $array = Yaml::parse('config.yml');
    *   print_r($array);
    *  </code>
    *


### PR DESCRIPTION
Same as https://github.com/doctrine/mongodb-odm/pull/114 but in one commit
