### PR TITLE
Flag proxy as __initialized__ just after hydrating it

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -29,6 +29,7 @@ use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Event\PreLoadEventArgs;
 use Doctrine\ODM\MongoDB\PersistentCollection;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Proxy\Proxy;
 
 /**
  * The HydratorFactory class is responsible for instantiating a correct hydrator
@@ -372,6 +373,9 @@ EOF
         }
 
         $data = $this->getHydratorFor($metadata->name)->hydrate($document, $data);
+        if ($document instanceof Proxy) {
+            $document->__isInitialized__ = true;
+        }
 
         // Invoke the postLoad lifecycle callbacks and listeners
         if (isset($metadata->lifecycleCallbacks[Events::postLoad])) {


### PR DESCRIPTION
If we don't, and if the document has a postLoad listener that
accesses a document getter, then the document will get hydrated
twice.
