### PR TITLE
change the behavior of the "set" strategy to handle associative arrays

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -154,11 +154,11 @@ class CollectionPersister
         list($propertyPath, $parent) = $this->getPathAndParent($coll);
         if ($mapping['strategy'] === 'set') {
             $setData = array();
-            foreach ($coll as $document) {
+            foreach ($coll as $key => $document) {
                 if (isset($mapping['reference'])) {
-                    $setData[] = $this->pb->prepareReferencedDocumentValue($mapping, $document);
+                    $setData[$key] = $this->pb->prepareReferencedDocumentValue($mapping, $document);
                 } else {
-                    $setData[] = $this->pb->prepareEmbeddedDocumentValue($mapping, $document);
+                    $setData[$key] = $this->pb->prepareEmbeddedDocumentValue($mapping, $document);
                 }
             }
             $query = array($this->cmd.'set' => array($propertyPath => $setData));
@@ -168,7 +168,7 @@ class CollectionPersister
             $insertDiff = $coll->getInsertDiff();
             if ($insertDiff) {
                 $query = array($this->cmd.$strategy => array());
-                foreach ($insertDiff as $key => $document) {
+                foreach ($insertDiff as $document) {
                     if (isset($mapping['reference'])) {
                         $query[$this->cmd.$strategy][$propertyPath][] = $this->pb->prepareReferencedDocumentValue($mapping, $document);
                     } else {


### PR DESCRIPTION
Currently, there is no way to save the key from an associative array, it is always stored numerically. This change has the "set" strategy saving the key in `insertRows()`. I also removed the `$key =>` from the "pushAll" strategy, since it cannot be used with $push.

I have also checked the deleting of the "set" array in `deleteRows()` and it doesn't present any problems.
