### PR TITLE
fixed generating of classes

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -341,7 +341,7 @@ class ClassMetadataFactory implements \Doctrine\Common\Persistence\Mapping\Class
         return $parentClasses;
     }
 
-    private function completeIdGeneratorMapping(ClassMetadata $class)
+    private function completeIdGeneratorMapping(ClassMetadataInfo $class)
     {
         $idGenOptions = $class->generatorOptions;
         switch ($class->generatorType) {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -133,7 +133,7 @@ class XmlDriver extends AbstractFileDriver
         }
     }
 
-    private function addFieldMapping(ClassMetadata $class, $mapping)
+    private function addFieldMapping(ClassMetadataInfo $class, $mapping)
     {
         $keys = null;
         $name = isset($mapping['name']) ? $mapping['name'] : $mapping['fieldName'];
@@ -172,7 +172,7 @@ class XmlDriver extends AbstractFileDriver
         $class->mapField($mapping);
     }
 
-    private function addEmbedMapping(ClassMetadata $class, $embed, $type)
+    private function addEmbedMapping(ClassMetadataInfo $class, $embed, $type)
     {
         $cascade = array_keys((array) $embed->cascade);
         if (1 === count($cascade)) {
@@ -199,7 +199,7 @@ class XmlDriver extends AbstractFileDriver
         $this->addFieldMapping($class, $mapping);
     }
 
-    private function addReferenceMapping(ClassMetadata $class, $reference, $type)
+    private function addReferenceMapping(ClassMetadataInfo $class, $reference, $type)
     {
         $cascade = array_keys((array) $reference->cascade);
         if (1 === count($cascade)) {
@@ -229,7 +229,7 @@ class XmlDriver extends AbstractFileDriver
         $this->addFieldMapping($class, $mapping);
     }
 
-    private function addIndex(ClassMetadata $class, SimpleXmlElement $xmlIndex)
+    private function addIndex(ClassMetadataInfo $class, SimpleXmlElement $xmlIndex)
     {
         $attributes = $xmlIndex->attributes();
         $options = array();

--- a/lib/Doctrine/ODM/MongoDB/Tools/DisconnectedClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/DisconnectedClassMetadataFactory.php
@@ -20,7 +20,7 @@
 namespace Doctrine\ODM\MongoDB\Tools;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 
 /**
  * The DisconnectedClassMetadataFactory is used to create ClassMetadata objects
@@ -43,7 +43,7 @@ class DisconnectedClassMetadataFactory extends ClassMetadataFactory
      */
     protected function newClassMetadataInstance($className)
     {
-        $metadata = new ClassMetadata($className);
+        $metadata = new ClassMetadataInfo($className);
         if (strpos($className, "\\") !== false) {
             $metadata->namespace = strrev(substr( strrev($className), strpos(strrev($className), "\\")+1 ));
         } else {


### PR DESCRIPTION
fixed the generating of classes based on xml files, changed ClassMetadata to ClassMetadataInfo in these files (as in the ORM tool/mapping)

the following did not work, but works after these changes:
$cmf = new \Doctrine\ODM\MongoDB\Tools\DisconnectedClassMetadataFactory();  
$cmf->setDocumentManager($this->_dm);  
$cmf->setConfiguration($this->_dm->getConfiguration());  
$driver = $this->_dm->getConfiguration()->getMetadataDriverImpl();      

$metadatas = $cmf->getAllMetadata(); //this would break it

// $this->_dm is an instance of Doctrine\ODM\MongoDB\DocumentManager
