### PR TITLE
fixes triggering fatal error on preupdate event in case changeset is clea

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -911,7 +911,7 @@ class UnitOfWork implements PropertyChangedListener
                         $this->recomputeSingleDocumentChangeSet($class, $document);
                     }
 
-                    if ($hasPreUpdateListeners) {
+                    if ($hasPreUpdateListeners && isset($this->documentChangeSets[$oid])) {
                         $this->evm->dispatchEvent(Events::preUpdate, new Event\PreUpdateEventArgs(
                             $document, $this->dm, $this->documentChangeSets[$oid])
                         );
@@ -919,7 +919,7 @@ class UnitOfWork implements PropertyChangedListener
                     $this->cascadePreUpdate($class, $document);
                 }
 
-                if ( ! $class->isEmbeddedDocument) {
+                if ( ! $class->isEmbeddedDocument && isset($this->documentChangeSets[$oid])) {
                     $persister->update($document, $options);
                 }
                 unset($this->documentUpdates[$oid]);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mocks/PreUpdateListenerMock.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mocks/PreUpdateListenerMock.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Mocks;
+
+use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
+use Doctrine\ODM\MongoDB\Event\PreUpdateEventArgs;
+use Doctrine\Common\EventSubscriber;
+
+class PreUpdateListenerMock implements EventSubscriber
+{
+    public function getSubscribedEvents()
+    {
+        return array(
+            'onFlush',
+            'preUpdate'
+        );
+    }
+
+    public function onFlush(OnFlushEventArgs $args)
+    {
+        $uow = $args->getDocumentManager()->getUnitOfWork();
+        foreach ($uow->getScheduledDocumentUpdates() as $document) {
+            $uow->clearDocumentChangeSet(spl_object_hash($document));
+        }
+    }
+
+    public function preUpdate(PreUpdateEventArgs $args)
+    {
+        return; // fatal error
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -218,6 +218,23 @@ class UnitOfWorkTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(array('name' => 'd'), $c, 'b.c.d'), $unitOfWork->getParentAssociation($d));
     }
 
+    public function testPreUpdateTriggeredWithEmptyChangeset()
+    {
+        $dm = DocumentManagerMock::create();
+        $evm = $dm->getEventManager()->addEventSubscriber(
+            new \Doctrine\ODM\MongoDB\Tests\Mocks\PreUpdateListenerMock()
+        );
+        $user = new \Documents\ForumUser();
+        $user->username = '12345';
+
+        $dm->persist($user);
+        $dm->flush();
+
+        $user->username = '1234';
+        $dm->persist($user);
+        $dm->flush();
+    }
+
     protected function getDocumentManager()
     {
         return new \Stubs\DocumentManager();


### PR DESCRIPTION
fixes triggering fatal error on preupdate event in case changeset is cleared during onFlush

similar issue is fixed in ORM it should be supported on ODM mongodb also
