### PR TITLE
Enable hydration for Cursor::getNext(), as is already done for current()

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Cursor.php
+++ b/lib/Doctrine/ODM/MongoDB/Cursor.php
@@ -89,6 +89,16 @@ class Cursor extends \Doctrine\MongoDB\Cursor
         return $current ? $current : null;
     }
 
+    /** @override */
+    public function getNext()
+    {
+        $next = parent::getNext();
+        if ($next && $this->hydrate) {
+            return $this->unitOfWork->getOrCreateDocument($this->class->name, $next, $this->hints);
+        }
+        return $next ? $next : null;
+    }
+
     /**
      * Set whether to hydrate the documents to objects or not.
      *

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CursorHydrationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CursorHydrationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Documents\User;
+
+class CursorHydrationTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->user = new User();
+        $this->user->setUsername('foo');
+
+        $this->dm->persist($this->user);
+        $this->dm->flush();
+
+        $this->repository = $this->dm->getRepository('Documents\User');
+    }
+
+    public function testCursorShouldHydrateCurrent()
+    {
+        $cursor = $this->repository->findAll();
+        $cursor->next();
+
+        $this->assertSame($this->user, $cursor->current());
+    }
+
+    public function testCursorShouldHydrateGetNext()
+    {
+        $cursor = $this->repository->findAll();
+
+        $this->assertSame($this->user, $cursor->getNext());
+    }
+}


### PR DESCRIPTION
In addition to `current()`, `getNext()` is another way to fetch results from a MongoCursor. Before this PR, `current()` would return a hydrated object while `getNext()` would return a non-hydrated array.

Per the PECL docs, the call sequence `next(); current()` should be equivalent to `getNext()`.
