### PR TITLE
fix ReflectionClass::getMethods bug

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/ProxyFactory.php
@@ -160,11 +160,14 @@ class ProxyFactory
     private function generateMethods(ClassMetadata $class)
     {
         $methods = '';
+        $previousMethods = array();
 
         foreach ($class->reflClass->getMethods() as $method) {
             /* @var $method ReflectionMethod */
-            if ($method->isConstructor() || strtolower($method->getName()) == "__sleep") {
+            if ($method->isConstructor() || strtolower($method->getName()) == "__sleep" || in_array($method->getName(), $previousMethods)) {
                 continue;
+            } else {
+                $previousMethods[] = $method->getName();
             }
 
             if ($method->isPublic() && ! $method->isFinal() && ! $method->isStatic()) {


### PR DESCRIPTION
There is a bug in some PHP versions in the method ReflectionClass::getMethods()

See: http://stackoverflow.com/questions/7437132/php-reflectionclassgetmethods-does-not-returns-the-right-number-of-methods

Not sure if it would be fix and if the implementation is good enough...
