### PR TITLE
fix issue #162 : incorrect creation of indexes for referenced documents

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -89,10 +89,10 @@ class SchemaManager
                 }
 
             } else if (isset($fieldMapping['reference']) && isset($fieldMapping['targetDocument'])) {
-                foreach($indexes as $idx => $index) {
-                    foreach($index['keys'] as $key => $v) {
+                foreach ($indexes as $idx => $index) {
+                    foreach ($index['keys'] as $key => $v) {
                         if ($key == $fieldMapping['name']) {
-                            $indexes[$idx]['keys'][$key . '.$id'] = $v ;
+                            $indexes[$idx]['keys'][$key . '.$id'] = $v;
                             unset($indexes[$idx]['keys'][$key]);
                         }
                     }


### PR DESCRIPTION
this should fix issue #162 about the incorrect creation of indexes for referenced documents.

just added a for loop to find indexes of type `reference` and add a `.$id` at the end of each of one's name.
