### PR TITLE
Don't strip new lines from generated files

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
@@ -235,7 +235,7 @@ public function <methodName>()
         $body = str_replace('<spaces>', $this->spaces, $body);
         $last = strrpos($currentCode, '}');
 
-        return substr($currentCode, 0, $last) . $body . (strlen($body) > 0 ? "\n" : ''). "}";
+        return substr($currentCode, 0, $last) . $body . (strlen($body) > 0 ? "\n" : ''). "}\n";
     }
 
     /**


### PR DESCRIPTION
It is more common to require a new line at the end of files, than it is to not. Unless a new setting is added (overkill) it would therefore be more 'friendly' to add a new line to the end of generated files.

Prevents seeing diffs like this when running the code generators and it does "nothing":

```
-}
+}
\ No newline at end of file
```
