### PR TITLE
Renamed backup filename to prevent duplicate class exception

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
@@ -177,7 +177,7 @@ public function <methodName>()
         }
 
         if ($this->backupExisting && file_exists($path)) {
-            $backupPath = dirname($path) . DIRECTORY_SEPARATOR .  "~" . basename($path);
+            $backupPath = dirname($path) . DIRECTORY_SEPARATOR . basename($path) . '~' ;
             if (!copy($path, $backupPath)) {
                 throw new \RuntimeException("Attempt to backup overwritten document file but copy operation failed.");
             }


### PR DESCRIPTION
Backup files should contain the "~" at the end of the filename to hide it from AutoClassloader.

It prevents the "Fatal error: Cannot redeclare class Namespace\XxxxClass in /path/to/class/~XxxxClass.php on line xx"
