### PR TITLE
Fix DocumentPersister's loadReferenceManyCollectionInverseSide function and a ClassMetadata prototype bug

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -119,9 +119,11 @@ class SchemaManager
                     //There's no mapping for the discriminator field,
                     //but it's still a valid document field.
                     $newIndex['keys'][$discriminatorFieldName] = $value;
-                } else {
+                } elseif ($class->hasField($key)) {
                     $mapping = $class->getFieldMapping($key);
                     $newIndex['keys'][$mapping['name']] = $value;
+                } else {
+                    $newIndex['keys'][$key] = $value;
                 }
             }
 


### PR DESCRIPTION
The `@MongoDB\ReferenceMany(targetDocument="Document", mappedBy="field")` annotation was not working because the query generated by `DocumentPersister` does not prefix the `id` reference by `$` and it's needed by MongoDB.

This PR also fix a ClassMetadata prototype change.
