### PR TITLE
getClassNameFromDiscriminatorValue assumes an array

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -639,7 +639,7 @@ class DocumentManager implements ObjectManager
     public function getClassNameFromDiscriminatorValue(array $mapping, $value)
     {
         $discriminatorField = isset($mapping['discriminatorField']) ? $mapping['discriminatorField'] : '_doctrine_class_name';
-        if (isset($value[$discriminatorField])) {
+        if (is_array($value) && isset($value[$discriminatorField])) {
             $discriminatorValue = $value[$discriminatorField];
             return isset($mapping['discriminatorMap'][$discriminatorValue]) ? $mapping['discriminatorMap'][$discriminatorValue] : $discriminatorValue;
         } else {


### PR DESCRIPTION
This is the first error I encountered playing around with the flat-references branch.

Fixing it did not result in usable code, it then lead to this error:

https://gist.github.com/f8cf67346abd57c8dec1

The relevant snippet from the twig template triggering that error was simply `{{  data.board.name }}` where data is a post, board is a ReferenceOne (simple=true) definition, and it worked before changing to simple=true.

Haven't tried to address that yet (perhaps it's simple, end of the day here).
