### PR TITLE
Fixed potentially uninitialised driver field

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -428,6 +428,13 @@ class ClassMetadataFactory implements \Doctrine\Common\Persistence\Mapping\Class
         if (!$this->initialized) {
             $this->initialize();
         }
+
+        // Check for namespace alias
+        if (strpos($className, ':') !== false) {
+            list($namespaceAlias, $simpleClassName) = explode(':', $className);
+            $className = $this->dm->getConfiguration()->getDocumentNamespace($namespaceAlias) . '\\' . $simpleClassName;
+        }
+
         return $this->driver->isTransient($className);
     }
 }


### PR DESCRIPTION
`$this->driver` may not exist when `isTransient` is called
