### PR TITLE
Fixing DocumentPersister::prepareQueryValue() for embedded documents

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -135,11 +135,12 @@ class QueryTest extends BaseTest
     {
         $qb = $this->dm->createQueryBuilder(__NAMESPACE__.'\EmbedTest')
             ->find()
-            ->field('embeddedOne.embeddedOne.embeddedMany.embeddedOne.person.id')->equals('Foo');
+            ->field('embeddedOne.embeddedOne.embeddedMany.embeddedOne.pet.owner.id')->equals('Foo');
         $query = $qb->getQuery();
         $debug = $query->debug();
-        $this->assertTrue(array_key_exists('eO.eO.embeddedMany.eO.p.$id', $debug));
-        $this->assertInstanceOf('\MongoId', $debug['eO.eO.embeddedMany.eO.p.$id']);
+
+        $this->assertTrue(array_key_exists('eO.eO.embeddedMany.eO.eP.pO._id', $debug));
+        $this->assertInstanceOf('\MongoId', $debug['eO.eO.embeddedMany.eO.eP.pO._id']);
     }
 }
 
@@ -155,6 +156,9 @@ class Person
     /** @ODM\ReferenceOne */
     public $bestFriend;
 
+    /** @ODM\ReferenceOne(name="s") */
+    public $son;
+
     /** @ODM\ReferenceMany */
     public $friends = array();
 
@@ -162,6 +166,13 @@ class Person
     {
         $this->firstName = $firstName;
     }
+}
+
+/** @ODM\EmbeddedDocument */
+class Pet
+{
+    /** @ODM\ReferenceOne(name="pO", targetDocument="Doctrine\ODM\MongoDB\Tests\Person") */
+    public $owner;
 }
 
 /** @ODM\EmbeddedDocument */
@@ -178,4 +189,7 @@ class EmbedTest
 
     /** @ODM\ReferenceOne(name="p", targetDocument="Doctrine\ODM\MongoDB\Tests\Person") */
     public $person;
+
+    /** @ODM\EmbedOne(name="eP", targetDocument="Doctrine\ODM\MongoDB\Tests\Pet") */
+    public $pet;
 }


### PR DESCRIPTION
prepareQueryValue() does not load the metadata of embedded documents correctly. So when trying to access a field like this

``` php
->field('bidList.highest.bidder.id')->equals($bidder->getId())
```

it is not recognizing that `bidList.highest` is embedding another document and fails to load the mapping for it:

```
Doctrine\ODM\MongoDB\MongoDBException: No mapping found for field 'bidder' in class 'App\BaseBundle\Document\Item'.
```

I was very confused that this is not working currently, but after i have fixed prepareQueryValue() to handle these fields correctly, i discovered an older pull request which is adressing the same bug:

https://github.com/doctrine/mongodb-odm/pull/102

Seems it was not merged yet due to conflicts and coding standard issues, so i would like to take a new approach to fix this.
