### PR TITLE
Removing unnecessary remnant from QueryTest

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -156,9 +156,6 @@ class Person
     /** @ODM\ReferenceOne */
     public $bestFriend;
 
-    /** @ODM\ReferenceOne(name="s") */
-    public $son;
-
     /** @ODM\ReferenceMany */
     public $friends = array();
 


### PR DESCRIPTION
This is an addition to https://github.com/doctrine/mongodb-odm/pull/207 as my commit came a little too late and  did not made it into the merge.

Removing an accidentally committed property from the test class.
