### PR TITLE
Allow discriminator fields to be indexed.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -106,10 +106,7 @@ class SchemaManager
     {
         $indexes = $class->getIndexes();
         $newIndexes = array();
-        $discriminatorFieldName = null;
-        if ($class->discriminatorField !== null) {
-            $discriminatorFieldName = $class->discriminatorField['name'];
-        }
+        $discriminatorFieldName = ($class->discriminatorField !== null) ? $class->discriminatorField['name'] : null;
         foreach ($indexes as $index) {
             $newIndex = array(
                 'keys' => array(),


### PR DESCRIPTION
There is no mapping for discriminator fields, but that
doesn't mean it shouldn't be possible to create an index on them.
They're still valid document fields and often times
it makes perfect sense to query on them.
