### PR TITLE
Preserve index keys ordering when dealing with referenced documents.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -90,12 +90,14 @@ class SchemaManager
 
             } else if (isset($fieldMapping['reference']) && isset($fieldMapping['targetDocument'])) {
                 foreach ($indexes as $idx => $index) {
+                    $newKeys = array();
                     foreach ($index['keys'] as $key => $v) {
                         if ($key == $fieldMapping['name']) {
-                            $indexes[$idx]['keys'][$key . '.$id'] = $v;
-                            unset($indexes[$idx]['keys'][$key]);
+                            $key = $key . '.$id';
                         }
+                        $newKeys[$key] = $v;
                     }
+                    $indexes[$idx]['keys'] = $newKeys;
                 }
             }
         }


### PR DESCRIPTION
By design, indexes for document reference fields get modified.
Example: {"referenceField": 1} gets changed to {"referenceField.$id": 1}.

This only worked okay when the index is on a single key.
An index for {"referenceField": 1, "other": 1}
used to incorrectly change to {"other": 1, "referenceField.$id": 1}.

The new code takes care to preserve the order of multi-key indexes.
