### PR TITLE
Remove the call to proxies __load private method in UnitOfWork

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2548,9 +2548,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function initializeObject($obj)
     {
-        if ($obj instanceof Proxy) {
-            $obj->__load();
-        } else if ($obj instanceof PersistentCollection) {
+        if ($obj instanceof PersistentCollection) {
             $obj->initialize();
         }
     }


### PR DESCRIPTION
Remove the call to proxies __load private method in UnitOfWork::initializeObject.

It is unneeded and (of course) it causes this error:

( ! ) Fatal error: Call to private method Proxies\WinitiAdServerBundleDocumentCampaignProxy::__load() from context 'Doctrine\ODM\MongoDB\UnitOfWork' in /Users/dunglas/Documents/workspace/mongodb-odm/lib/Doctrine/ODM/MongoDB/UnitOfWork.php on line 2552
