### PR TITLE
Bug fix in PersistentCollection handling during merge operation.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -104,6 +104,17 @@ class PersistentCollection implements BaseCollection
     }
 
     /**
+     * Sets the document manager and unit of work (used during merge operations).
+     *
+     * @param type $dm 
+     */
+    public function setDocumentManager(DocumentManager $dm)
+    {
+        $this->dm = $dm;
+        $this->uow = $dm->getUnitOfWork();
+    }
+
+    /**
      * Sets the array of raw mongo data that will be used to initialize this collection.
      *
      * @param array $mongoData

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1829,8 +1829,11 @@ class UnitOfWork implements PropertyChangedListener
                         if ( ! $mergeCol instanceof PersistentCollection) {
                             $mergeCol = new PersistentCollection($mergeCol, $this->dm, $this, $this->cmd);
                             $mergeCol->setInitialized(true);
+                        } else {
+                            $mergeCol->setDocumentManager($this->dm);
                         }
                         $mergeCol->setOwner($managedCopy, $assoc2);
+                        $mergeCol->setDirty(true); // mark for dirty checking
                         $prop->setValue($managedCopy, $mergeCol);
                     }
                 }


### PR DESCRIPTION
After serializing/deserializing a document with PersistentCollection(s), initialized collections lose their reference to the DocumentManager and UnitOfWork.
And as a result an error will be triggered when trying to clear the collection or do any other operation requiring access to one of these 2 objects.

Another issue is the fact that any collection in a merged document may have different contents than the coresponding document field from the database, so a dirty check is required in order to properly synchronize.
