### PR TITLE
Change repository method used in QueryCommand from findAll to findBy

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
@@ -83,7 +83,7 @@ EOT
     {
         $dm = $this->getHelper('dm')->getDocumentManager();
         $query = json_decode($input->getArgument('query'));
-        $cursor = $dm->getRepository($input->getArgument('class'))->findAll((array) $query);
+        $cursor = $dm->getRepository($input->getArgument('class'))->findBy((array) $query);
         $cursor->hydrate((bool) $input->getOption('hydrate'));
 
         $depth = $input->getOption('depth');


### PR DESCRIPTION
... since DocumentRepository::findAll doesn't accept any arguments

The command then works with a query string like '{"field": "value"}' - "{'field': 'value'}" is not decoded correctly.
