### PR TITLE
Make the __load function public so the line 2552 of "lib/Doctrine/ODM/Mo...

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/ProxyFactory.php
@@ -268,7 +268,7 @@ class <proxyClassName> extends \<className> implements \Doctrine\ODM\MongoDB\Pro
         $this->__documentPersister__ = $documentPersister;
         $this->__identifier__ = $identifier;
     }
-    private function __load()
+    public function __load()
     {
         if (!$this->__isInitialized__ && $this->__documentPersister__) {
             $this->__isInitialized__ = true;


### PR DESCRIPTION
...ngoDB/UnitOfWork.php" not throw error (fixes #219)

Please, look here too: https://github.com/doctrine/DoctrineMongoDBBundle/pull/70

Actually i cant take data from a different document_manager and put in a drop down using DoctrineMongoDBBundle.
With this fix and the one from the link above, everything works fine.

Thank you! 
