### PR TITLE
Bugfix Issue #190

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -539,6 +539,7 @@ class DocumentPersister
             if (!is_int($mongoId)) {
                 $mongoId = (string) $mongoId;
             }
+            $id = $mongoId;
             
             $reference = $this->dm->getReference($className, $id);
             if ($mapping['strategy'] === 'set') {


### PR DESCRIPTION
As described in #190 by cbou. The problem occurs in the function "loadReferenceManyCollectionOwningSide" in DocumentPersister. Each ReferenceID will cast to a String also Increment Id's.
