### PR TITLE
change UnitOfWork so that changeset calculation related to DateTime document properties is done based on the comparison of the represented values.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -578,11 +578,11 @@ class UnitOfWork implements PropertyChangedListener
                 } else if (isset($class->fieldMappings[$propName]['file'])) {
                     if ($orgValue !== $actualValue || $actualValue->isDirty()) {
                         $changeSet[$propName] = array($orgValue, $actualValue);
-                    } //*
+                    }
                 } else if ($orgValue instanceof \DateTime) {
-                	if ($orgValue != $actualValue) {
-                		$changeSet[$propName] = array($orgValue, $actualValue);
-                	} //*/
+                    if ($orgValue != $actualValue) {
+                        $changeSet[$propName] = array($orgValue, $actualValue);
+                    }
                 } else if (is_object($orgValue) && $orgValue !== $actualValue) {
                     $changeSet[$propName] = array($orgValue, $actualValue);
                 } else if ($orgValue != $actualValue || ($orgValue === null ^ $actualValue === null)) {


### PR DESCRIPTION
This change causes document properties that contain \DateTime objects to be have the values of the original and actual data
rather than the objects themselves compared when trying to determine if said property should be part of the document's changeset

possibly it is not really the responsibility of UnitOfWork to make the differentiation between object-comparison and the
value-stored-by-object-comparison but rather the consumer of the ODM library, but then again it would seem wise to build-in
robustness at the lowest possible level.

In my case it was Symfony2's Form Request data binding functionality that caused new DateTime objects to be set on
documents where the existing DateTime objects actually represented the same value _but_ given that:

```
1. the Symfony2 Form data binding code is rather inpenitrable.
2. I believe the lower-level libraries should be helpful and lenient, where possible, when it comes to
handling incorrect usage (in this case UnitOfWork is capable of determining that the underlying datetime data hasn't changed
even though 2 references are not the same object)
3. I don't use a framework and lots of abstraction so that my ODM managed objects have to check in each relevant setter whether
a given \DateTime object represents a different datetime to the currently held \DateTime instance - that would get old fast,
and is guaranteed to get forgotten sometime/somewhere.
```

as a result I hacked this change! I question whether the comparable tests shouldn't be performed on all document pproperties that
contain objects, when determining a document's changeset ODM should only be interested in the values not whether 2 relevant object variables
acutally reference the same instance (although a === check is a nice short cut to determine that nothing has changed!) ... I imagine
that there are alot of problems in trying to make such a change if we consider that objects can generally be complex and nested (which is not
the case with \DateTime - instances are immutable and act as a wrapper for what is essentially a single value)
