### PR TITLE
Add object upsert functionality.

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -34,6 +34,69 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
+    public function provideUpsertObjects()
+    {
+        return array(
+            array('Documents\\UserUpsert', new \MongoId('4f18f593acee41d724000005')),
+            array('Documents\\UserUpsertIdStrategyNone', 'jwage')
+        );
+    }
+
+    /**
+     * @dataProvider provideUpsertObjects
+     */
+    public function testUpsertObject($className, $id)
+    {
+        $user = new $className();
+        $user->id = (string) $id;
+        $user->username = 'test';
+        $user->count = 1;
+        $group = new \Documents\Group('Group');
+        $user->groups = array($group);
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $check = $this->dm->getDocumentCollection($className)->findOne(array('_id' => $id));
+        $this->assertNotNull($check);
+        $this->assertEquals((string) $id, (string) $check['_id']);
+        $this->assertEquals($group->getId(), (string) $check['groups'][0]['$id']);
+
+        $group2 = new \Documents\Group('Group');
+
+        $user = new $className();
+        $user->id = $id;
+        $user->hits = 5;
+        $user->count = 2;
+        $user->groups = array($group2);
+        $this->dm->persist($user);
+        $this->dm->flush();
+
+        $check = $this->dm->getDocumentCollection($className)->findOne(array('_id' => $id));
+        $this->assertEquals(3, $check['count']);
+        $this->assertEquals(5, $check['hits']);
+        $this->assertEquals(2, count($check['groups']));
+        $this->assertEquals($group->getId(), (string) $check['groups'][0]['$id']);
+        $this->assertEquals($group2->getId(), (string) $check['groups'][1]['$id']);
+        $this->assertTrue(isset($check['username']));
+        $this->assertEquals('test', $check['username']);
+
+        $user = new $className();
+        $user->id = $id;
+        $user->hits = 100;
+        $this->dm->persist($user);
+        $this->dm->flush(array('safe' => true));
+
+        $check = $this->dm->getDocumentCollection($className)->findOne(array('_id' => $id));
+        $this->assertEquals(3, $check['count']);
+        $this->assertEquals(100, $check['hits']);
+        $this->assertEquals(2, count($check['groups']));
+        $this->assertEquals($group->getId(), (string) $check['groups'][0]['$id']);
+        $this->assertEquals($group2->getId(), (string) $check['groups'][1]['$id']);
+        $this->assertTrue(isset($check['username']));
+        $this->assertEquals('test', $check['username']);
+    }
+
     public function testNestedCategories()
     {
         $root = new \Documents\Category('Root');

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -30,6 +30,27 @@ class UnitOfWorkTest extends \PHPUnit_Framework_TestCase
         unset($this->dm, $this->uow);
     }
 
+    public function testScheduleForInsert()
+    {
+        $class = $this->dm->getClassMetadata('Documents\ForumUser');
+        $user = new ForumUser();
+        $this->assertFalse($this->uow->isScheduledForInsert($user));
+        $this->uow->scheduleForInsert($class, $user);
+        $this->assertTrue($this->uow->isScheduledForInsert($user));
+    }
+
+    public function testScheduleForInsertUpsert()
+    {
+        $class = $this->dm->getClassMetadata('Documents\ForumUser');
+        $user = new ForumUser();
+        $user->id = 1;
+        $this->assertFalse($this->uow->isScheduledForInsert($user));
+        $this->assertFalse($this->uow->isScheduledForUpsert($user));
+        $this->uow->scheduleForInsert($class, $user);
+        $this->assertTrue($this->uow->isScheduledForInsert($user));
+        $this->assertTrue($this->uow->isScheduledForUpsert($user));
+    }
+
     public function testRegisterRemovedOnNewEntityIsIgnored()
     {
         $user = new ForumUser();

--- a/tests/Documents/UserUpsert.php
+++ b/tests/Documents/UserUpsert.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Documents;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document(collection="users_upsert")
+ */
+class UserUpsert
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\String */
+    public $username;
+
+    /** @ODM\Int */
+    public $hits;
+
+    /** @ODM\Increment */
+    public $count;
+
+    /** @ODM\ReferenceMany(targetDocument="Group", cascade={"all"}) */
+    public $groups;
+}

--- a/tests/Documents/UserUpsertIdStrategyNone.php
+++ b/tests/Documents/UserUpsertIdStrategyNone.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Documents;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document(collection="users_upsert_id_strategy_none")
+ */
+class UserUpsertIdStrategyNone
+{
+    /** @ODM\Id(strategy="none") */
+    public $id;
+
+    /** @ODM\String */
+    public $username;
+
+    /** @ODM\Int */
+    public $hits;
+
+    /** @ODM\Increment */
+    public $count;
+
+    /** @ODM\ReferenceMany(targetDocument="Group", cascade={"all"}) */
+    public $groups;
+}


### PR DESCRIPTION
For #218

With this the following will work:

```
$user = new User();
$user->setId('4f163fbaf05a2f6019000072');
$user->setUsername('jwage');
$dm->persist($user);
$dm->flush();
```

The above would result in the following query:

```
$userCollection->update(
    array('_id' => new MongoId('4f163fbaf05a2f6019000072')),
    array(
        '$set' => array('username' => 'jwage')
    ),
    array('upsert' => true)
);
```
