### PR TITLE
Bug in PersistenceBuilder while udpating ReferenceMany in an "embedded many"

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
@@ -386,6 +386,13 @@ class PersistenceBuilder
                 /** @ReferenceOne */
                 } elseif (isset($mapping['association']) && $mapping['association'] == ClassMetadata::REFERENCE_ONE) {
                     $value = $this->prepareReferencedDocumentValue($mapping, $rawValue);
+
+                /** @ReferenceMany */
+                } elseif (isset($mapping['association']) && $mapping['association'] === ClassMetadata::REFERENCE_MANY) {
+                    $value = array();
+                    foreach ($rawValue as $reference) {
+                        $value[] = $this->prepareReferencedDocumentValue($mapping, $reference);
+                    }
                 }
             }
 


### PR DESCRIPTION
I have a case where 

Object Message
- Embed Many Object Response
  -- Reference Many Object Files (that are actually referencing "files")

while updating the order of the responses, Object Files were lost
