### PR TITLE
Querying simple references for existence

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -829,7 +829,7 @@ class DocumentPersister
     private function prepareQueryElement(&$fieldName, $value = null, $metadata = null, $prepareValue = true)
     {
         $metadata = ($metadata === null) ? $this->class : $metadata;
-        
+
         // Process "association.fieldName"
         if (strpos($fieldName, '.') !== false) {
             $e = explode('.', $fieldName);
@@ -874,7 +874,7 @@ class DocumentPersister
                             } else {
                                 $value = $this->prepareQueryElement($key, $value, null, $prepareValue);
                             }
-                            
+
                             $fieldName .= '.' . $key;
                         }
                     }
@@ -887,7 +887,7 @@ class DocumentPersister
             $mapping = $metadata->fieldMappings[$fieldName];
             $fieldName = $mapping['name'];
 
-            if ($prepareValue === true && isset($mapping['reference']) && isset($mapping['simple']) && $mapping['simple']) {
+            if (is_string($value) && $prepareValue === true && isset($mapping['reference']) && isset($mapping['simple']) && $mapping['simple']) {
                 $targetClass = $this->dm->getClassMetadata($mapping['targetDocument']);
                 $value = $targetClass->getDatabaseIdentifierValue($value);
             }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SimpleReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SimpleReferencesTest.php
@@ -97,4 +97,19 @@ class SimpleReferencesTest extends BaseTest
         $test = $user->getSimpleReferenceOneInverse();
         $this->assertEquals('test', $test->getName());
     }
+
+    public function testQueryForNonIds() {
+        $qb = $this->dm->createQueryBuilder('Documents\SimpleReferenceUser');
+        $qb->field('user')->equals(null);
+        $this->assertEquals(array('userId' => null), $qb->getQueryArray());
+
+        $qb = $this->dm->createQueryBuilder('Documents\SimpleReferenceUser');
+        $qb->field('user')->notEqual(null);
+        $this->assertEquals(array('userId' => array('$ne' => null)), $qb->getQueryArray());
+
+        $qb = $this->dm->createQueryBuilder('Documents\SimpleReferenceUser');
+        $qb->field('user')->exists(true);
+        $this->assertEquals(array('userId' => array('$exists' => true)), $qb->getQueryArray());
+
+    }
 }


### PR DESCRIPTION
Hey,

I've already sent a mail about this but I figured this is the better way of doing it. 

So this is a tiny change about how "simple" references are handled when queried for with exists or notEqual.

Thanks again for the good work. We are using the ODM in our project with success so far.

Nikolas
