### PR TITLE
Load proxy with proper identifier type.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -539,7 +539,7 @@ class DocumentPersister
                             $className = $this->dm->getClassNameFromDiscriminatorValue($fieldMapping, $reference);
                             $mongoId = $reference[$cmd . 'id'];
                         }
-                        $id = (string) $mongoId;
+                        $id = ($mongoId instanceof \MongoId) ? (string) $mongoId : $mongoId;
                         $document = $this->uow->tryGetById($id, $className);
                         if (!$document || $document instanceof Proxy && ! $document->__isInitialized__) {
                             if ( ! isset($groupedIds[$className])) {
@@ -640,7 +640,7 @@ class DocumentPersister
                 $className = $this->dm->getClassNameFromDiscriminatorValue($mapping, $reference);
                 $mongoId = $reference[$cmd . 'id'];
             }
-            $id = (string) $mongoId;
+            $id = ($mongoId instanceof \MongoId) ? (string) $mongoId : $mongoId;
             $reference = $this->dm->getReference($className, $id);
             if ($mapping['strategy'] === 'set') {
                 $collection->set($key, $reference);


### PR DESCRIPTION
Document proxy **identifier** was always string type. It causes problem when the proxy document, that should have integer identifier, was saved into reference relation of other object. The relation couldn't be resolved again, because there was no object with string id in MongoDB.
