### PR TITLE
DateType: support dates past 2038 on 32-bit systems

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Types/DateType.php
@@ -40,7 +40,7 @@ class DateType extends Type
         }
         $timestamp = false;
         if ($value instanceof \DateTime) {
-            $timestamp = $value->getTimestamp();
+            $timestamp = $value->format('U');
         } elseif (is_numeric($value)) {
             $timestamp = $value;
         } elseif (is_string($value)) {


### PR DESCRIPTION
This change should be backwards compatible.

I didn't bother to write a unit test, sorry. Here's some plain old PHP
code to demonstrate the issue. The assertion in this code will fail on
32-bit systems, and pass on 64-bit systems:

  $dt = new DateTime('2039/1/1');
  assert($dt->getTimestamp() !== false);

The fix is to use format() instead. The assertion in this code will pass
on both 32- an 64-bit systems:

  $dt = new DateTime('2039/1/1');
  assert($dt->format('U') === '2177481600');

This is documented at
http://php.net/datetime.gettimestamp#99598

See also:
https://bugs.php.net/bug.php?id=52062

Two other calls will probably need to be addressed to completely fix
issues that show up on 32-bit systems:
- call to getTimestamp() in closureToMongo()
- call to setTimestamp() in closureToPHP()
