### PR TITLE
Access reader from annotation driver.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -119,6 +119,16 @@ class AnnotationDriver implements Driver
     }
 
     /**
+     * Retrieve the current annotation reader
+     *
+     * @return AnnotationReader
+     */
+    public function getReader()
+    {
+        return $this->reader;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function loadMetadataForClass($className, ClassMetadataInfo $class)


### PR DESCRIPTION
Here's a minor fix to provide access to annotation reader from the driver. There's a similar method in orm driver implementation but for some reason there's none in the mongo-odm.
It may come quite handy for things like gedmo doctrine extensions, where you need your reader to set up listeners.

See:

Reader access in orm driver: 
https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php#L107
