### PR TITLE
Fixed typo in postFlush event dispatching

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -472,7 +472,7 @@ class UnitOfWork implements PropertyChangedListener
 
         // Raise postFlush
         if ($this->evm->hasListeners(Events::postFlush)) {
-            $this->evm->dispatchEvent(Events::postFlush, new Event\PostFlushEventArgs($this->em));
+            $this->evm->dispatchEvent(Events::postFlush, new Event\PostFlushEventArgs($this->dm));
         }
 
         // Clear up


### PR DESCRIPTION
Using document manager instead of entity manager in ODM UnitOfWork
