### PR TITLE
Automatically handle querying by referenced document's id, if it is a DBRef

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -949,6 +949,10 @@ class DocumentPersister
                     $targetClass = $this->dm->getClassMetadata($mapping['targetDocument']);
                     $value = $targetClass->getDatabaseIdentifierValue($value);
                 }
+            } elseif ($prepareValue === true && isset($mapping['reference']) && isset($mapping['simple']) && false === $mapping['simple']) {
+                $fieldName .= '.$id';
+                $targetClass = $this->dm->getClassMetadata($mapping['targetDocument']);
+                $value = $targetClass->getDatabaseIdentifierValue($value);
             }
 
         // Process identifier


### PR DESCRIPTION
Currently, to find a document by a referenced document's id, you have to do this:

``` PHP

$postRepository->findBy(array('category.$id' => new \MongoId($id)));
```

This PR allows querying for a document by a referenced document's DBRef id, so code like the following can be written and will work with both the ORM and the Mongodb ODM:

``` PHP

$postRepository->findBy(array('category' => $id));
```
