### PR TITLE
Ability to specify field name for one/many references.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -224,7 +224,6 @@ class XmlDriver extends AbstractFileDriver
             'reference'        => true,
             'simple'           => isset($attributes['simple']) ? (boolean) $attributes['simple'] : false,
             'targetDocument'   => isset($attributes['target-document']) ? (string) $attributes['target-document'] : null,
-            'name'             => (string) $attributes['field'],
             'strategy'         => isset($attributes['strategy']) ? (string) $attributes['strategy'] : 'pushAll',
             'inversedBy'       => isset($attributes['inversed-by']) ? (string) $attributes['inversed-by'] : null,
             'mappedBy'         => isset($attributes['mapped-by']) ? (string) $attributes['mapped-by'] : null,
@@ -233,8 +232,11 @@ class XmlDriver extends AbstractFileDriver
             'skip'             => isset($attributes['skip']) ? (integer) $attributes['skip'] : null,
         );
 
-        if (isset($attributes['fieldName'])) {
-            $mapping['fieldName'] = (string) $attributes['fieldName'];
+        if (isset($attributes['field'])) {
+            $mapping['fieldName'] = (string) $attributes['field'];
+        }
+        if (isset($attributes['name'])) {
+            $mapping['name'] = (string) $attributes['name'];
         }
         if (isset($reference->{'discriminator-field'})) {
             $attr = $reference->{'discriminator-field'};

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -224,6 +224,7 @@ class XmlDriver extends AbstractFileDriver
             'reference'        => true,
             'simple'           => isset($attributes['simple']) ? (boolean) $attributes['simple'] : false,
             'targetDocument'   => isset($attributes['target-document']) ? (string) $attributes['target-document'] : null,
+            'name'             => (string) $attributes['field'],
             'strategy'         => isset($attributes['strategy']) ? (string) $attributes['strategy'] : 'pushAll',
             'inversedBy'       => isset($attributes['inversed-by']) ? (string) $attributes['inversed-by'] : null,
             'mappedBy'         => isset($attributes['mapped-by']) ? (string) $attributes['mapped-by'] : null,
@@ -232,11 +233,8 @@ class XmlDriver extends AbstractFileDriver
             'skip'             => isset($attributes['skip']) ? (integer) $attributes['skip'] : null,
         );
 
-        if (isset($attributes['field'])) {
-            $mapping['fieldName'] = (string) $attributes['field'];
-        }
-        if (isset($attributes['name'])) {
-            $mapping['name'] = (string) $attributes['name'];
+        if (isset($attributes['fieldName'])) {
+            $mapping['fieldName'] = (string) $attributes['fieldName'];
         }
         if (isset($reference->{'discriminator-field'})) {
             $attr = $reference->{'discriminator-field'};

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
@@ -201,6 +201,9 @@ class YamlDriver extends AbstractFileDriver
             'limit'            => isset($reference['limit']) ? (integer) $reference['limit'] : null,
             'skip'             => isset($reference['skip']) ? (integer) $reference['skip'] : null,
         );
+        if (isset($reference['name'])) {
+            $mapping['name'] = $reference['name'];
+        }
         if (isset($reference['discriminatorField'])) {
             $mapping['discriminatorField'] = $reference['discriminatorField'];
         }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -40,7 +40,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
      */
     public function testFieldMappings($class)
     {
-        $this->assertEquals(8, count($class->fieldMappings));
+        $this->assertEquals(9, count($class->fieldMappings));
         $this->assertTrue(isset($class->fieldMappings['id']));
         $this->assertTrue(isset($class->fieldMappings['name']));
         $this->assertTrue(isset($class->fieldMappings['email']));
@@ -76,7 +76,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
      */
     public function testAssocations($class)
     {
-        $this->assertEquals(8, count($class->fieldMappings));
+        $this->assertEquals(9, count($class->fieldMappings));
 
         return $class;
     }
@@ -134,6 +134,16 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
         $this->assertEquals('username', $class->fieldMappings['name']['name']);
 
         return $class;
+    }
+
+    /**
+     * @depends testCustomFieldName
+     * @param ClassMetadata $class
+     */
+    public function testCustomReferenceFieldName($class)
+    {
+        $this->assertEquals('morePhoneNumbers', $class->fieldMappings['morePhoneNumbers']['fieldName']);
+        $this->assertEquals('more_phone_numbers', $class->fieldMappings['morePhoneNumbers']['name']);
     }
 
     /**
@@ -265,6 +275,11 @@ class User
     public $groups;
 
     /**
+     * @ODM\ReferenceMany(targetDocument="Phonenumber", name="more_phone_numbers")
+     */
+    public $morePhoneNumbers;
+
+    /**
      * @ODM\EmbedMany(targetDocument="Phonenumber", discriminatorField="discr", discriminatorMap={"home"="HomePhonenumber", "work"="WorkPhonenumber"})
      */
     public $otherPhonenumbers;
@@ -323,7 +338,7 @@ class User
         $metadata->mapOneReference(array(
            'fieldName' => 'address',
            'targetDocument' => 'Doctrine\\ODM\\MongoDB\\Tests\\Mapping\\Address',
-           'cascade' => 
+           'cascade' =>
            array(
            0 => 'remove',
            )
@@ -331,7 +346,7 @@ class User
         $metadata->mapManyReference(array(
            'fieldName' => 'phonenumbers',
            'targetDocument' => 'Doctrine\\ODM\\MongoDB\\Tests\\Mapping\\Phonenumber',
-           'cascade' => 
+           'cascade' =>
            array(
            1 => 'persist',
            ),
@@ -342,9 +357,14 @@ class User
            )
           ));
         $metadata->mapManyReference(array(
+           'fieldName' => 'morePhoneNumbers',
+           'name' => 'more_phone_numbers',
+           'targetDocument' => 'Doctrine\\ODM\\MongoDB\\Tests\\Mapping\\Phonenumber'
+        ));
+        $metadata->mapManyReference(array(
            'fieldName' => 'groups',
            'targetDocument' => 'Doctrine\\ODM\\MongoDB\\Tests\\Mapping\\Group',
-           'cascade' => 
+           'cascade' =>
            array(
            0 => 'remove',
            1 => 'persist',

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.User.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.User.dcm.xml
@@ -40,7 +40,7 @@
                 <all />
             </cascade>
         </reference-many>
-        <reference-many target-document="Phonenumber" field="morePhoneNumbers" name="more_phone_numbers">
+        <reference-many target-document="Phonenumber" fieldName="morePhoneNumbers" field="more_phone_numbers">
         </reference-many>
         <embed-many target-document="Phonenumber" field="otherPhonenumbers">
             <discriminator-field name="discr" />

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.User.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.User.dcm.xml
@@ -40,6 +40,8 @@
                 <all />
             </cascade>
         </reference-many>
+        <reference-many target-document="Phonenumber" field="morePhoneNumbers" name="more_phone_numbers">
+        </reference-many>
         <embed-many target-document="Phonenumber" field="otherPhonenumbers">
             <discriminator-field name="discr" />
             <discriminator-map>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.User.dcm.yml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.User.dcm.yml
@@ -46,6 +46,9 @@ Doctrine\ODM\MongoDB\Tests\Mapping\User:
     groups:
       targetDocument: Group
       cascade: [ all ]
+    morePhoneNumbers:
+      targetDocument: Phonenumber
+      name: more_phone_numbers
   embedMany:
     otherPhonenumbers:
       targetDocument: Phonenumber
@@ -53,7 +56,7 @@ Doctrine\ODM\MongoDB\Tests\Mapping\User:
       discriminatorMap:
         home: HomePhonenumber
         work: WorkPhonenumber
-        
+
   lifecycleCallbacks:
-    prePersist: [ doStuffOnPrePersist, doOtherStuffOnPrePersistToo ] 
+    prePersist: [ doStuffOnPrePersist, doOtherStuffOnPrePersistToo ]
     postPersist: [ doStuffOnPostPersist ]


### PR DESCRIPTION
This patch should allow specifying custom field name for references.

``` yaml
Post\
    referenceMany:
        relatedPosts:
            name: related_posts
            targetDocument: Post
```

My text editor automatically removed couple trailing white spaces. I can put those back if that's important.
