### PR TITLE
Modified UnitOfWorks dispatching of postUpdate events to use LifecycleEventArgs instead of Event\PreUpdateEventArgs

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1140,9 +1140,7 @@ class UnitOfWork implements PropertyChangedListener
                             $this->recomputeSingleDocumentChangeSet($entryClass, $entry);
                         }
                         if ($this->evm->hasListeners(Events::postUpdate)) {
-                            $this->evm->dispatchEvent(Events::postUpdate, new Event\PreUpdateEventArgs(
-                                $entry, $this->dm, $this->documentChangeSets[$entryOid])
-                            );
+                            $this->evm->dispatchEvent(Events::postUpdate, new LifecycleEventArgs($entry, $this->dm));
                         }
                     }
                     $this->cascadePostUpdateAndPostPersist($entryClass, $entry);


### PR DESCRIPTION
I noticed a bug when using ODM event subscribers with postUpdate events.

I had a collection `Path` with embedded document `Template`.  Upon editing a `Template`, postUpdate args for the Path collection would be an instanceof `LifecycleEventArgs` which (I believe) is correct.  The embedded document  `Template` would be an instance of `PreUpdateEventArgs` (which doesn't make sense here anyway).

I'm assuming this was a copy/paste mistake to begin with?

I tested this patch and it appears to be working.
