### PR TITLE
fixing serialization of ClassMetadata

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -156,7 +156,7 @@ class ClassMetadata extends ClassMetadataInfo
         if ($this->file) {
             $serialized[] = 'file';
         }
-        
+
         if ($this->slaveOkay) {
             $serialized[] = 'slaveOkay';
         }


### PR DESCRIPTION
This change makes slaveOkay works again, this value is lost in the middle of metadata serialization.
