### PR TITLE
Fix dot-notation when using the querybuilder with hash field types

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -937,6 +937,8 @@ class DocumentPersister
                         }
                     }
                 }
+            } elseif ($mapping['type'] === 'hash') {
+                $fieldName = implode('.', $e);
             }
 
         // Process all non identifier fields


### PR DESCRIPTION
This fixes a bug where the field name (property name on the document) is used in the actual query instead of the mapped mongodb field name.

With the following mapping:
`<field fieldName="pages" name="p" type="hash" />`

This bit of an upsert query:
`$qb->field('pages.1.i')->inc(1)`

Results in this:
`{ "$inc": {"pages.1.i": 1 } })`

Instead of the expected:
`{ "$inc": {"p.1.i": 1 } })`
