### PR TITLE
Fix findAndModify hydration after initialization and "new" option

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -156,6 +156,12 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
         return parent::findAndUpdate();
     }
 
+    public function returnNew($bool = true)
+    {
+        $this->refresh(true);
+        return parent::returnNew($bool);
+    }
+
     /**
      * @param string $documentName
      * @return Builder

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FindAndModifyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FindAndModifyTest.php
@@ -38,4 +38,25 @@ class FindAndModifyTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         // Test the object was removed
         $this->assertEquals(1, $this->dm->getDocumentCollection('Documents\User')->find()->count());
     }
+
+    public function testFindAndModifyAlt()
+    {
+        $doc = new User();
+        $doc->setUsername('jwage');
+
+        $this->dm->persist($doc);
+        $this->dm->flush();
+
+        // test update findAndModify
+        $q = $this->dm->createQueryBuilder()
+            ->findAndUpdate('Documents\User')
+            ->returnNew(true)
+            ->field('username')->equals('jwage')
+            ->field('username')->set('Romain Neutron')
+            ->getQuery();
+        $result = $q->execute();
+
+        // Test the username was set
+        $this->assertEquals('Romain Neutron', $result->getUsername());
+    }
 }


### PR DESCRIPTION
Hello,

this PR fix an issue which is visible when using `findAndModify` AND `returnNew` 
As you can see in the unit test embedded, the updated document is not used to hydrate if the document has already been initialized.
