### PR TITLE
Use DateType in UoW to skip equivalent date values

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -744,9 +744,15 @@ class UnitOfWork implements PropertyChangedListener
                     continue;
                 }
 
-                // skip equivalent DateTime values
-                if (($orgValue instanceof \DateTime || $actualValue instanceof \DateTime) && $orgValue == $actualValue) {
-                    continue;
+                // skip equivalent date values
+                if ($class->fieldMappings[$propName]['type'] === 'date') {
+                    $dateType = Type::getType('date');
+                    $dbOrgValue = $dateType->convertToDatabaseValue($orgValue);
+                    $dbActualValue = $dateType->convertToDatabaseValue($actualValue);
+
+                    if ($dbOrgValue instanceof \MongoDate && $dbActualValue instanceof \MongoDate && $dbOrgValue == $dbActualValue) {
+                        continue;
+                    }
                 }
 
                 // regular field

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
@@ -32,19 +32,31 @@ class DateTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals('09/01/1985', $user->getCreatedAt()->format('m/d/Y'));
     }
 
-    public function testDateInstanceChangeDoesNotCauseUpdateIfValueIsTheSame()
+    /**
+     * @dataProvider provideEquivalentDates
+     */
+    public function testDateInstanceChangeDoesNotCauseUpdateIfValueIsTheSame($oldValue, $newValue)
     {
         $user = new User();
-        $user->setCreatedAt(new \DateTime('1985-09-01 00:00:00'));
+        $user->setCreatedAt($oldValue);
         $this->dm->persist($user);
         $this->dm->flush();
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->findOneBy(array());
-        $user->setCreatedAt(new \DateTime('1985-09-01 00:00:00'));
+        $user->setCreatedAt($newValue);
         $this->dm->getUnitOfWork()->computeChangeSets();
         $changeset = $this->dm->getUnitOfWork()->getDocumentChangeset($user);
         $this->assertEmpty($changeset);
+    }
+
+    public function provideEquivalentDates()
+    {
+        return array(
+            array(new \DateTime('1985-09-01 00:00:00'), new \DateTime('1985-09-01 00:00:00')),
+            array(new \DateTime('2012-07-11T14:55:14-04:00'), new \DateTime('2012-07-11T19:55:14+01:00')),
+            array(new \DateTime('@1342033881'), new \MongoDate(1342033881)),
+        );
     }
 
     public function testDateInstanceValueChangeDoesCauseUpdateIfValueIsTheSame()


### PR DESCRIPTION
I think this is a better replacement for #349 as it utilizes logic we already have in DateType. For whatever reason, the Type class was already imported in UoW but never used. I decided to use it's getter to avoid constructing a DateType instance myself.

Note that I left a comment in b702787869dcccfc1ab203a1616527662c3d661d regarding some possible cleanup in the DateType class.
