### PR TITLE
[Query] Do not test $where criteria being set by reduce JavaScript

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
@@ -131,12 +131,6 @@ class QueryTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $query = $qb->getQuery();
         $user = $query->getSingleResult();
         $this->assertEquals('boo', $user->getUsername());
-
-        $qb = $this->dm->createQueryBuilder('Documents\User')
-            ->reduce("function() { return this.username == 'boo' }");
-        $query = $qb->getQuery();
-        $user = $query->getSingleResult();
-        $this->assertEquals('boo', $user->getUsername());
     }
 
     public function testUpdateQuery()


### PR DESCRIPTION
See: doctrine/mongodb@031e1920c92e2f63b2f4455895735ca7867f558f and doctrine/mongodb#64
