### PR TITLE
Fixing #366 (Undefined index in AbstractFileDriver line 116)

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AbstractFileDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AbstractFileDriver.php
@@ -113,6 +113,11 @@ abstract class AbstractFileDriver implements Driver
     {
         if ($file = $this->findMappingFile($className)) {
             $result = $this->loadMappingFile($file);
+
+            if (!isset($result[$className])) {
+                throw MongoDBException::mappingClassNotFoundInFile($className, $file);
+            }
+
             return $result[$className];
         }
         return false;

--- a/lib/Doctrine/ODM/MongoDB/MongoDBException.php
+++ b/lib/Doctrine/ODM/MongoDB/MongoDBException.php
@@ -54,6 +54,11 @@ class MongoDBException extends \Exception
         return new self(sprintf('Could not find mapping file "%s" for class "%s".', $fileName, $className));
     }
 
+    public static function mappingClassNotFoundInFile($className, $fileName)
+    {
+        return new self(sprintf('Could not find mapping for class "%s" in file "%s".', $className, $fileName));
+    }
+
     public static function documentNotMappedToDB($className)
     {
         return new self(sprintf('The "%s" document is not mapped to a MongoDB database.', $className));


### PR DESCRIPTION
Checking if index is set, otherwise throwing dedicated exception.

```
  [ErrorException]                                                                                                                                                                       
  Notice: Undefined index: Acme\FooBundle\Document\Links in /projects/acme/vendor/doctrine/mongodb-odm/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AbstractFileDriver.php line 116    
```

turned into

```
  [Doctrine\ODM\MongoDB\MongoDBException]                                                                                                                                          
  Could not find mapping for class "Acme\FooBundle\Document\Links" in file "/projects/acme/src/Acme/FooBundle/Resources/config/doctrine/Link.mongodb.yml".
```
