### PR TITLE
Fix `PHP Fatal error:  Using $this when not in object context`

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -92,7 +92,7 @@ class SchemaManager
 
             /**
              * Determine which Mongo indexes should be deleted. Exclude the ID
-             index and those that are equivalent to any in the class metadata.
+             * index and those that are equivalent to any in the class metadata.
              */
             $self = $this;
             $mongoIndexes = array_filter($mongoIndexes, function($mongoIndex) use ($documentIndexes, $self) {


### PR DESCRIPTION
[![Build Status](https://secure.travis-ci.org/leek/mongodb-odm.png?branch=patch-1)](http://travis-ci.org/leek/mongodb-odm)

Force `isMongoIndexEquivalentToDocumentIndex()` to public because that is less worse than requiring PHP 5.4.
