### PR TITLE
Made the ODM compatible with Common 2.2 again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3.2",
         "symfony/yaml": ">=2.0",
         "symfony/console": ">=2.0",
-        "doctrine/common": ">=2.3.0,<2.5-dev",
+        "doctrine/common": ">=2.2.0,<2.5-dev",
         "doctrine/mongodb": "dev-master"
     },
     "minimum-stability": "dev",

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -127,7 +127,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     /**
      * {@inheritDoc}
      */
-    protected function doLoadMetadata($class, $parent, $rootEntityFound, array $nonSuperclassParents)
+    protected function doLoadMetadata($class, $parent, $rootEntityFound, array $nonSuperclassParents = array())
     {
         /** @var $class ClassMetadata */
         /** @var $parent ClassMetadata */


### PR DESCRIPTION
Common 2.3 added an argument that was not in 2.2. Making it optional in the ODM makes it compatible with both (I haven't tested on 2.2, there may be some bugs due to the missing argument). But this makes it installable with Symfony 2.0
