### PR TITLE
Invalid argument error in doctrine:mongodb:cache:clear-metadata

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -71,12 +71,10 @@ EOT
 
         $output->write('Clearing ALL Metadata cache entries' . PHP_EOL);
 
-        $cacheIds = $cacheDriver->deleteAll();
+        $success = $cacheDriver->deleteAll();
 
-        if ($cacheIds) {
-            foreach ($cacheIds as $cacheId) {
-                $output->write(' - ' . $cacheId . PHP_EOL);
-            }
+        if ($success) {
+            $output->write('The cache entries were successfully deleted.' . PHP_EOL);
         } else {
             $output->write('No entries to be deleted.' . PHP_EOL);
         }


### PR DESCRIPTION
There is bug when cache entries were successfully deleted in the command.

```
php app/console doctrine:mongodb:cache:clear-metadata
Clearing ALL Metadata cache entries

  [ErrorException]                                                                                                               
  Warning: Invalid argument supplied for foreach() in /vagrant/Development/Projects/.../vendor/doctr  
  ine-mongodb-odm/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php line 77  
```

The latest(2.2) doctrine's CacheProvider#deleteAll return a boolean value.
However, current implementation expect to return an array.

See also: https://github.com/doctrine/common/commit/486169851ea87b3e14ed45d5bfd7d07b1d41af65
