### PR TITLE
Fix db conversion of mongo timestamp values

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Types/TimestampType.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Types/TimestampType.php
@@ -32,6 +32,10 @@ class TimestampType  extends Type
 {
     public function convertToDatabaseValue($value)
     {
+        if ($value instanceof MongoTimestamp) {
+            return $value;
+        }
+
         return $value !== null ? new \MongoTimestamp($value) : null;
     }
 


### PR DESCRIPTION
Using embeded referance with MongoTimestamp fields, may produce warning: "Warning: MongoTimestamp::__construct() expects parameter 1 to be long, object given"

It hapans becouse $value is already MongoTimestamp.
