### PR TITLE
Fix odm schema create fatal error

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -247,6 +247,9 @@ class SchemaManager
         if ($indexes = $this->getDocumentIndexes($documentName)) {
             $collection = $this->dm->getDocumentCollection($class->name);
             foreach ($indexes as $index) {
+                if (!is_array($index['options'])) { 
+                    $index['options'] = array(); 
+                }
                 if (!isset($index['options']['safe'])) {
                     $index['options']['safe'] = true;
                 }


### PR DESCRIPTION
In CLI mode, on command odm:schema:create. May produce some error, it path fix aftermath, but not reason. I am think that error hapens becouse code:

if (!isset($index['options']['safe'])) {
$index['options']['safe'] = true;
}

look normal, but if $index['options'] == bool suddenly provide error.

prevent error: "Cannot use a scalar value as an array", if $index['options'] == 1(bool)

It may provide fatal error: "Catchable fatal error: Argument 2 passed to Doctrine\MongoDB\Collection::ensureIndex() must be an array, boolean given"
