### PR TITLE
Added support for the expireAfterSeconds option for an Index

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractIndex.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractIndex.php
@@ -28,6 +28,7 @@ abstract class AbstractIndex extends Annotation
     public $dropDups;
     public $background;
     public $safe;
+    public $expireAfterSeconds;
     public $order;
     public $unique = false;
     public $sparse = false;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -205,7 +205,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
     {
         $keys = array_merge($keys, $index->keys);
         $options = array();
-        $allowed = array('name', 'dropDups', 'background', 'safe', 'unique', 'sparse');
+        $allowed = array('name', 'dropDups', 'background', 'safe', 'unique', 'sparse', 'expireAfterSeconds');
         foreach ($allowed as $name) {
             if (isset($index->$name)) {
                 $options[$name] = $index->$name;


### PR DESCRIPTION
This option allows documents to expire after a given amount of seconds.

The `expireAfterSeconds` option may optionally be added onto an index
for a field containing a 'Date' BSON typed entry. For more information
regarding this option please see the following entry on the MongoDB
website: http://docs.mongodb.org/manual/tutorial/expire-data/

Documentation update will follow after this PR
