### PR TITLE
Added support for custom ID generators

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -67,10 +67,20 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
     const GENERATOR_TYPE_ALNUM = 4;
 
     /**
+     * CUSTOM means Doctrine expect a class parameter. It will then try to initiate that class
+     * and pass other options to the generator. It will throw an Exception if the class 
+     * does not exist or if an option was passed for that there is not setter in the new
+     * generator class.
+     * 
+     * The class  will have to be a subtype of AbstractIdGenerator.
+     */
+    const GENERATOR_TYPE_CUSTOM = 5;
+
+    /**
      * NONE means Doctrine will not generate any id for us and you are responsible for manually
      * assigning an id.
      */
-    const GENERATOR_TYPE_NONE = 5;
+    const GENERATOR_TYPE_NONE = 6;
 
 
     const REFERENCE_ONE  = 1;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -98,4 +98,19 @@ class MappingException extends BaseMappingException
     {
         return new self("The identifier $fieldName is missing for a query of " . $className);
     }
+    
+    public static function missingIdGeneratorClass($className)
+    {
+        return new self("The class-option for the custom ID generator is missing in class $className.");
+    }
+    
+    public static function classIsNotAValidGenerator($className)
+    {
+        return new self("The class $className if not a valid ID generator of type AbstractIdGenerator.");
+    }
+    
+    public static function missingGeneratorSetter($className, $optionName)
+    {
+        return new self("The class $className is missing a setter for the option $optionName.");
+    }
 }


### PR DESCRIPTION
I think it is really important to be able to create custom IDs. For that reason a modified the ClassMetadataFactory to support this.

When using a custom generator the annotation for the ID would look like this:

``` PHP
/** @Id(strategy="custom",options={
 *     "class"="MyGeneratorClass",
 *     "someOption"="myValue"
 * }) */
protected $id;
```

The customer generator class would have to be of the type AbstractIdGenerator:

``` PHP
class MyGeneratorClass extends Doctrine\ODM\MongoDB\Id\AbstractIdGenerator
{
    public function generate(\Doctrine\ODM\MongoDB\DocumentManager $dm, $document)
    {
          $id = "..."; // Should be 24 hex chars
          return new \MongoId($id);
    }

    public function setSomeOption($value) 
    {
        // $value = "myValue"
    }
}
```

Could someone please check if this is compatible with XML, YAML, ...! Thanks!
