### PR TITLE
Fix wrong $set behavior with embed many collections

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -125,7 +125,9 @@ class CollectionPersister
         if ($deleteDiff) {
             list($propertyPath, $parent) = $this->getPathAndParent($coll);
             $query = array($this->cmd.'unset' => array());
+            $isAssocArray = false;
             foreach ($deleteDiff as $key => $document) {
+                $isAssocArray = !$isAssocArray && !is_int($key);
                 $query[$this->cmd.'unset'][$propertyPath.'.'.$key] = true;
             }
             $this->executeQuery($parent, $query, $options);
@@ -139,7 +141,7 @@ class CollectionPersister
              * http://www.mongodb.org/display/DOCS/Updating#Updating-%24unset
              */
             $mapping = $coll->getMapping();
-            if ($mapping['strategy'] !== 'set') {
+            if ($mapping['strategy'] !== 'set' || !$isAssocArray) {
                 $this->executeQuery($parent, array($this->cmd.'pull' => array($propertyPath => null)), $options);
             }
         }
@@ -166,8 +168,12 @@ class CollectionPersister
                         $documentUpdates = $this->pb->prepareEmbeddedDocumentValue($mapping, $document);
                     }
 
-                    foreach ($documentUpdates as $currFieldName => $currFieldValue) {
-                        $setData[$propertyPath. '.' .$key . '.' . $currFieldName] = $currFieldValue;
+                    if (is_int($key)) {
+                        $setData[$propertyPath][] = $documentUpdates;
+                    } else {
+                        foreach ($documentUpdates as $currFieldName => $currFieldValue) {
+                            $setData[$propertyPath. '.' .$key . '.' . $currFieldName] = $currFieldValue;
+                        }
                     }
                 }
 


### PR DESCRIPTION
EmbedMany with set strategy behavior seem wrong.
Maybe the problem is CollectionPersister is always persist as associative array.

For example, I define two document classes below.

``` php
/** @ODM\Document */
class Parent
{
    /** @ODM\Id */
    private $id;

    /** @ODM\EmbedMany(targetDocument="Child", strategy="set") */
    private $childs;

    ...
}

/** @ODM\EmbeddedDocument */
class Child
{
    /** @ODM\String */
    private $value

   ...
}
```

Then,  when these classes are persist by CollectionPersister.
I expect that query is like this.

```
{ $set : { childs: [{'value': 'foo'}, {'value': 'bar'}] } }
```

However, the query I got is as below.

```
{ $set : { 'childs.0.value' :  'foo', 'childs.1.value': 'bar' } }
```

It might be wrong.
So I fixed this.

See also: #341
