### PR TITLE
There was an issue when using the @distance field for geospatial queries and metadata cache

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -112,8 +112,7 @@ class ClassMetadata extends ClassMetadataInfo
             'generatorType',
             'generatorOptions',
             'idGenerator',
-            'indexes',
-            'distance'
+            'indexes'
         );
 
         // The rest of the metadata is only serialized if necessary.
@@ -157,6 +156,10 @@ class ClassMetadata extends ClassMetadataInfo
 
         if ($this->slaveOkay) {
             $serialized[] = 'slaveOkay';
+        }
+
+        if ($this->distance) {
+            $serialized[] = 'distance';
         }
 
         return $serialized;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -29,6 +29,7 @@ class ClassMetadataTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $cm->setDiscriminatorField(array('name' => 'disc'));
         $cm->mapOneEmbedded(array('fieldName' => 'phonenumbers', 'targetDocument' => 'Bar'));
         $cm->setFile('customFileProperty');
+        $cm->setDistance('customDistanceProperty');
         $cm->setSlaveOkay(true);
         $this->assertTrue(is_array($cm->getFieldMapping('phonenumbers')));
         $this->assertEquals(1, count($cm->fieldMappings));
@@ -49,6 +50,7 @@ class ClassMetadataTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue(is_array($cm->getFieldMapping('phonenumbers')));
         $this->assertEquals(1, count($cm->fieldMappings));
         $this->assertEquals('customFileProperty', $cm->file);
+        $this->assertEquals('customDistanceProperty', $cm->distance);
         $this->assertTrue($cm->slaveOkay);
         $mapping = $cm->getFieldMapping('phonenumbers');
         $this->assertEquals('Documents\Bar', $mapping['targetDocument']);


### PR DESCRIPTION
The @distance field was not waked up when it is cached
