### PR TITLE
Unset parentAssociation while detaching document

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2088,7 +2088,8 @@ class UnitOfWork implements PropertyChangedListener
                 $this->removeFromIdentityMap($document);
                 unset($this->documentInsertions[$oid], $this->documentUpdates[$oid],
                         $this->documentDeletions[$oid], $this->documentIdentifiers[$oid],
-                        $this->documentStates[$oid], $this->originalDocumentData[$oid]);
+                        $this->documentStates[$oid], $this->originalDocumentData[$oid],
+                        $this->parentAssociations[$oid]);
                 break;
             case self::STATE_NEW:
             case self::STATE_DETACHED:


### PR DESCRIPTION
Current code is not allowing detached objects cleared by garbage collector. (UoW eating all memory when doing numerous document inserts and full uow->clear() is not usable)
