### PR TITLE
fix non hydrated EagerCursor.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -220,6 +220,7 @@ class Query extends \Doctrine\MongoDB\Query\Query
         // Wrap odm cursor with EagerCursor if true
         if ($this->query['eagerCursor'] === true) {
             $results = new EagerCursor($results, $this->dm->getUnitOfWork(), $this->class);
+	        $results->hydrate($this->hydrate);
         }
 
         // GeoLocationFindQuery just returns an instance of ArrayIterator so we have to


### PR DESCRIPTION
Map hydrate properties of EagerCursor to the same properties of its BaseCursor.
I was trying to speed some queries with this combination:
$qb = $this->doctrine->createQueryBuilder('collection_name')
->eagerCursor(true)
->hydrate(false);

It didn't work because the EagerCursor lost information about the hydration flag on its way.
This PR fixes this problem.
