### PR TITLE
ensureIndex: remove "safe" option.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -247,9 +247,6 @@ class SchemaManager
         if ($indexes = $this->getDocumentIndexes($documentName)) {
             $collection = $this->dm->getDocumentCollection($class->name);
             foreach ($indexes as $index) {
-                if (!isset($index['options']['safe'])) {
-                    $index['options']['safe'] = true;
-                }
                 $collection->ensureIndex($index['keys'], $index['options']);
             }
         }


### PR DESCRIPTION
This haven't been working for us for quite some time now and I finally decided to look into it.

According to http://www.mongodb.org/display/DOCS/Indexes there is no "safe" option for ensureIndex and having safe set makes MongoCursor throw an exception with "norepl" message.

It could also be useful to have a check in there and throw an exception that's more meaningful than "norepl".

``` php
if (isset($index['options']['safe']))
    throw new \RuntimeException('safe ensureIndex option is not supported.');
}
```
