### PR TITLE
Update custom ID generator to allow a custom mapping type

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -68,10 +68,10 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
 
     /**
      * CUSTOM means Doctrine expect a class parameter. It will then try to initiate that class
-     * and pass other options to the generator. It will throw an Exception if the class 
+     * and pass other options to the generator. It will throw an Exception if the class
      * does not exist or if an option was passed for that there is not setter in the new
      * generator class.
-     * 
+     *
      * The class  will have to be a subtype of AbstractIdGenerator.
      */
     const GENERATOR_TYPE_CUSTOM = 5;
@@ -1009,12 +1009,18 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
             $mapping['type'] = isset($mapping['type']) ? $mapping['type'] : 'id';
             $this->identifier = $mapping['fieldName'];
             if (isset($mapping['strategy'])) {
+                $this->generatorOptions = isset($mapping['options']) ? $mapping['options'] : array();
+
                 $generatorType = constant('Doctrine\ODM\MongoDB\Mapping\ClassMetadata::GENERATOR_TYPE_' . strtoupper($mapping['strategy']));
                 if ($generatorType !== self::GENERATOR_TYPE_AUTO) {
-                    $mapping['type'] = 'custom_id';
+                    $mapping['type'] = isset($this->generatorOptions['type'])
+                        ? $this->generatorOptions['type']
+                        : 'custom_id';
+
+                    unset($this->generatorOptions['type']);
                 }
+
                 $this->generatorType = $generatorType;
-                $this->generatorOptions = isset($mapping['options']) ? $mapping['options'] : array();
             }
         }
         if ( ! isset($mapping['nullable'])) {


### PR DESCRIPTION
Currently, the implementation of custom ID generators (#402) hardcoded the type to custom_id. When your generator returns a MongoId instance, the value isn't converted which means it can't be used in areas like `UnitOfWork#addToIdentityMap` ([source](https://github.com/doctrine/mongodb-odm/blob/4a5457eb713b12d6124db9817c634533d8018044/lib/Doctrine/ODM/MongoDB/UnitOfWork.php#L1512)) .

It would be nice if you could specify a type when using a custom strategy. This would allow a user to specify a type of "object_id" when using a custom generator that returned a MongoId.

An example:

```
/**
 * @ODM\Id(
 *     strategy="custom",
 *     options={
 *         "class"="CustomObjectIdGenerator",
 *         "type"="object_id"
 *     }
 * )
 */
protected $id;
```
