### PR TITLE
Create a GridFS file instead of a collection

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -307,12 +307,17 @@ class SchemaManager
         if ($class->isMappedSuperclass || $class->isEmbeddedDocument) {
             throw new \InvalidArgumentException('Cannot create document collection for mapped super classes or embedded documents.');
         }
-        $this->dm->getDocumentDatabase($documentName)->createCollection(
-            $class->getCollection(),
-            $class->getCollectionCapped(),
-            $class->getCollectionSize(),
-            $class->getCollectionMax()
-        );
+
+        if ($class->isFile()) {
+            $this->dm->getDocumentDatabase($documentName)->getGridFS($class->getCollection());
+        } else {
+            $this->dm->getDocumentDatabase($documentName)->createCollection(
+                $class->getCollection(),
+                $class->getCollectionCapped(),
+                $class->getCollectionSize(),
+                $class->getCollectionMax()
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
When using the "odm:schema:create" command it would create a GridFS file collection as a regular collection. This creates the proper GridFS files collection instead.
