### PR TITLE
Added object filters for MongoDB ODM like ORM does.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -350,7 +350,8 @@ class Configuration extends \Doctrine\MongoDB\Configuration
      */
     public function addFilter($name, $filter)
     {
-        $this->attributes['filters'][$name] = $filter;
+
+        $this->attributes['filters'][$name] = $filter;   
         if (is_object($filter) && ! $filter instanceof Query\Filter\BsonFilter) {
             throw new \InvalidArgumentException(
                 "A filter can be either a class name or an object extending \Doctrine\ODM\MongoDB\Query\Filter\BsonFilter," .
@@ -358,7 +359,7 @@ class Configuration extends \Doctrine\MongoDB\Configuration
             );
         }
 
-        $this->_attributes['filters'][$name] = $filter;
+        $this->attributes['filters'][$name] = $filter;
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Query/FilterCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/FilterCollection.php
@@ -92,6 +92,8 @@ class FilterCollection
                 ? $filter
                 : new $filter($this->dm);
         }
+        
+        ksort($this->enabledFilters);
 
         return $this->enabledFilters[$name];
     }


### PR DESCRIPTION
It is very useful to have object as a filter.

I have made the changes but I need some review on the code or maybe more things need to be done (probably some test)

**BTW**, I realize that in the Configuration.php there are

```
// Doctrine\ODM\MongoDB\Configuration
$this->attributes
// and
$this->_attributes
```

It confuse me when I edit the config file, so I wonder it is some mistake on this, in ORM it uses `$this->_attributes`

_Filter object In ORM_ : https://github.com/doctrine/doctrine2/pull/434/files
