### PR TITLE
Load AlsoLoad field only when primary field does not exists

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -176,7 +176,7 @@ class HydratorFactory
                     $code .= sprintf(<<<EOF
 
         /** @AlsoLoad("$name") */
-        if (isset(\$data['$name'])) {
+        if (!array_key_exists('$fieldName', \$data) && array_key_exists('$name', \$data)) {
             \$data['$fieldName'] = \$data['$name'];
         }
 
@@ -271,7 +271,7 @@ EOF
         \$mappedByFieldName = isset(\$mappedByMapping['simple']) && \$mappedByMapping['simple'] ? \$mapping['mappedBy'] : \$mapping['mappedBy'].'.\$id';
         \$criteria = array_merge(
             array(\$mappedByFieldName => \$data['_id']),
-            isset(\$this->class->fieldMappings['%2\$s']['criteria']) ? \$this->class->fieldMappings['%2\$s']['criteria'] : array() 
+            isset(\$this->class->fieldMappings['%2\$s']['criteria']) ? \$this->class->fieldMappings['%2\$s']['criteria'] : array()
         );
         \$sort = isset(\$this->class->fieldMappings['%2\$s']['sort']) ? \$this->class->fieldMappings['%2\$s']['sort'] : array();
         \$return = \$this->unitOfWork->getDocumentPersister(\$className)->load(\$criteria, null, array(), 0, \$sort);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -434,15 +434,41 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             'foo' => 'cool'
         );
         $collection->insert($doc);
-        $document = $this->dm->getRepository('Documents\Functional\AlsoLoad')->findOneBy(array('bar' => 'w00t'));
-        $this->assertNotNull($document->foo);
+        $document = $this->dm->getRepository('Documents\Functional\AlsoLoad')->findOneBy(array('foo' => 'cool'));
+        $this->assertEquals('cool', $document->foo);
 
         $doc = array(
-            'zip' => 'test'
+            'bar' => 'bar',
+            'zip' => 'zip'
         );
         $collection->insert($doc);
-        $document = $this->dm->getRepository('Documents\Functional\AlsoLoad')->findOneBy(array('bar' => 'w00t'));
-        $this->assertNotNull($document->foo);
+        $document = $this->dm->getRepository('Documents\Functional\AlsoLoad')->findOneBy(array('zip' => 'zip'));
+        $this->assertEquals('bar', $document->foo);
+        $this->assertEquals('zip', $document->baz);
+
+        $doc = array(
+            'foo' => null,
+            'bar' => 'nice'
+        );
+        $collection->insert($doc);
+        $document = $this->dm->getRepository('Documents\Functional\AlsoLoad')->findOneBy(array('bar' => 'nice'));
+        $this->assertNull($document->foo);
+
+        $doc = array(
+            'bar' => null,
+            'zip' => 'good'
+        );
+        $collection->insert($doc);
+        $document = $this->dm->getRepository('Documents\Functional\AlsoLoad')->findOneBy(array('zip' => 'good'));
+        $this->assertNull($document->foo);
+
+        $doc = array(
+            'foo' => 'foo',
+            'bar' => 'bar'
+        );
+        $collection->insert($doc);
+        $document = $this->dm->getRepository('Documents\Functional\AlsoLoad')->findOneBy(array('foo' => 'foo'));
+        $this->assertEquals('foo', $document->foo);
     }
 
     public function testAlsoLoadOnMethod()

--- a/tests/Documents/Functional/AlsoLoad.php
+++ b/tests/Documents/Functional/AlsoLoad.php
@@ -16,6 +16,12 @@ class AlsoLoad
      */
     public $foo;
 
+    /**
+     * @ODM\NotSaved
+     * @ODM\AlsoLoad({"zip", "bar"})
+     */
+    public $baz;
+
     /** @ODM\NotSaved */
     public $bar;
 


### PR DESCRIPTION
In [docs](http://docs.doctrine-project.org/projects/doctrine-mongodb-odm/en/latest/reference/annotations-reference.html#alsoload) described:
The above $fieldName will be loaded from fieldName if it exists and will fallback to oldFieldName if it does not exist.
But now AlsoLoad loads field even when primary fields exists.

Also add some test fixes.
