### PR TITLE
Missing check of dropDups flag causes unique index drop/regeneration

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -432,7 +432,7 @@ class SchemaManager
         }
 
         if (!empty($mongoIndex['unique']) && empty($mongoIndex['dropDups']) &&
-            !empty($documentIndexOptions['unique']) && !empty($documentIndexOptions)) {
+            !empty($documentIndexOptions['unique']) && !empty($documentIndexOptions['dropDups'])) {
 
             return false;
         }


### PR DESCRIPTION
The dropDups flag on documentIndexOptions does not appear to be being checked as the comment on the code suggests it should be.

As a result, all unique indexes without the dropDups flag set in mongo are incorrectly dropped and then recreated when we run SchemaManager::updateIndexes()

This looks like a typo, so I've included the patch to fix.
