### PR TITLE
Use non-strict comparison for existing indexes

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -399,7 +399,7 @@ class SchemaManager
     {
         $documentIndexOptions = $documentIndex['options'];
 
-        if ($mongoIndex['key'] !== $documentIndex['keys']) {
+        if ($mongoIndex['key'] != $documentIndex['keys']) {
             return false;
         }
 


### PR DESCRIPTION
When using doctrine to regenerate indexes on our MongoDB, we found that indexes would often be deleted and regenerated. We were able to isolate the problem to only indexes that had been initially created via the Mongo shell. They do not look wrong inside the shell, but at some point between Mongo and PHP, the value of the index becomes typed.

e.g. In Mongo shell:

```
db.users.ensureIndex({"phoneNumber":1}, {"sparse":true, "background":true});
db.users.getIndexes();
[
        {
                "v" : 1,
                "key" : {
                        "phoneNumber" : 1
                },
                "ns" : "devmike.users",
                "name" : "phoneNumber_1",
                "sparse" : true,
                "background" : true
        }
]
```

In php:

```
 array(6) {
    ["v"]=>
    int(1)
    ["key"]=>
    array(1) {
      ["phoneNumber"]=>
      float(1)
    }
    ["ns"]=>
    string(24) "devmike.users"
    ["name"]=>
    string(14) "phoneNumber_1"
    ["sparse"]=>
    bool(true)
    ["background"]=>
    bool(true)
  }
```

As you can see, the in the key field, 'phoneNumber' is set with a directionality of float(1), not int(1).

This seems like it may be a bug in the Mongo shell, probably due to the shell using javascript, which wouldn't distinguish between and integer and float in this case. While the bug may lie in the shell, Mongo itself does not care what type of value is passed in, and does not distinguish between 1 and 1.0.

It seems like the doctrine introspection should behave similarly and not be strict about matching the type of the direction value.
