### PR TITLE
no need to query for discriminator mapped names when looking up an identifier

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -794,7 +794,7 @@ class DocumentPersister
      */
     public function prepareQuery($query = array())
     {
-        if (is_scalar($query) || $query instanceof \MongoId) {
+        if ($isScalar = (is_scalar($query) || $query instanceof \MongoId)) {
             $query = array('_id' => $query);
         }
         if ($query === null) {
@@ -802,7 +802,7 @@ class DocumentPersister
         }
         $query = array_merge($query, $this->dm->getFilterCollection()->getFilterCriteria($this->class));
 
-        if ($this->class->hasDiscriminator() && ! isset($query[$this->class->discriminatorField['name']])) {
+        if (! $isScalar & $this->class->hasDiscriminator() && ! isset($query[$this->class->discriminatorField['name']])) {
             $discriminatorValues = $this->getClassDiscriminatorValues($this->class);
             $query[$this->class->discriminatorField['name']] = array('$in' => $discriminatorValues);
         }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -675,6 +675,21 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals(1, count($test));
     }
 
+    public function testSameCollectionTestFindById()
+    {
+        $test1 = new SameCollection1();
+        $test1->name = 'test1';
+        $this->dm->persist($test1);
+
+        $test2 = new SameCollection2();
+        $test2->name = 'test2';
+        $this->dm->persist($test2);
+        $this->dm->flush();
+
+        $query = $this->dm->getUnitOfWork()->getDocumentPersister('Documents\Functional\SameCollection1')->prepareQuery($test1->id);
+        $this->assertEquals(array('_id' => new \MongoId($test1->id)), $query);
+    }
+
     /**
      * @expectedException InvalidArgumentException
      */


### PR DESCRIPTION
After running the profiler, I noticed every query had, `$in: [.. some large array ..]` when I'm simply doing a find.

id's are unique in itself... is this behavior correct?

I'm not really feeling like putting an index on _id and the discriminator field.  If someone really needs this behavior, perhaps they can then use the query builder
