### PR TITLE
EagerCursor should inherit hydrate option and hints from BaseCursor

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -221,6 +221,7 @@ class Query extends \Doctrine\MongoDB\Query\Query
         if ($this->query['eagerCursor'] === true) {
             $results = new EagerCursor($results, $this->dm->getUnitOfWork(), $this->class);
             $results->hydrate($this->hydrate);
+            $results->setHints($hints);
         }
 
         // GeoLocationFindQuery just returns an instance of ArrayIterator so we have to

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EagerCursorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EagerCursorTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\ODM\MongoDB\Query\Query;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 class EagerCursorTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
@@ -23,6 +24,24 @@ class EagerCursorTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $qb = $this->dm->createQueryBuilder('Doctrine\ODM\MongoDB\Tests\Functional\EagerTestDocument');
         $qb->eagerCursor(true);
         $this->test = $qb->getQuery()->execute();
+    }
+
+    public function testEagerCursorInheritsHydrateOptionAndHints()
+    {
+        $qb = $this->dm->createQueryBuilder('Doctrine\ODM\MongoDB\Tests\Functional\EagerTestDocument')
+            ->refresh(true)
+            ->slaveOkay(true)
+            ->hydrate(false)
+            ->eagerCursor(true);
+
+        $eagerCursor = $qb->getquery()->execute();
+        $hints = $eagerCursor->getHints();
+
+        $this->assertArrayHasKey(Query::HINT_REFRESH, $hints);
+        $this->assertTrue(true, $hints[Query::HINT_REFRESH]);
+        $this->assertArrayHasKey(Query::HINT_SLAVE_OKAY, $hints);
+        $this->assertTrue(true, $hints[Query::HINT_SLAVE_OKAY]);
+        $this->assertTrue(is_array($eagerCursor->getSingleResult()));
     }
 
     public function testEagerCursor()


### PR DESCRIPTION
This includes commits from #424, rebased atop master. There is an additional fix per @jwage's suggestion to copy cursor hints.

Additionally, the second commit adds tests for this improvement.
