### PR TITLE
Update composer.json for Symfony 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/console": ">=2.0-dev,<2.3-dev",
+        "symfony/console": "~2.0",
         "doctrine/common": ">=2.2.0,<2.5-dev",
         "doctrine/mongodb": "1.0.*"
     },
     "require-dev": {
-        "symfony/yaml": ">=2.0-dev,<2.3-dev"
+        "symfony/yaml": "~2.0"
     },
     "suggest": {
         "symfony/yaml": "Enables the YAML metadata mapping driver"


### PR DESCRIPTION
It's safe to use 2.0+, since Symfony 2.3 is going to be a LTS.
