### PR TITLE
mappedby field of embedded document throws notice

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -705,7 +705,7 @@ class DocumentPersister
         $owner = $collection->getOwner();
         $ownerClass = $this->dm->getClassMetadata(get_class($owner));
         $targetClass = $this->dm->getClassMetadata($mapping['targetDocument']);
-        $mappedByMapping = $targetClass->fieldMappings[$mapping['mappedBy']];
+        $mappedByMapping = isset($targetClass->fieldMappings[$mapping['mappedBy']])?$targetClass->fieldMappings[$mapping['mappedBy']]:array();
         $mappedByFieldName = isset($mappedByMapping['simple']) && $mappedByMapping['simple'] ? $mapping['mappedBy'] : $mapping['mappedBy'].'.$id';
         $criteria = array_merge(
             array($mappedByFieldName => $ownerClass->getIdentifierObject($owner)),


### PR DESCRIPTION
Currently working on a versioned tree structure where the parent of the Category is referenced from the embedded CategoryVersion.

This works perfectly, but the only problem is that it throws a notice in de DocumentPersister at line 708.

Example of the structure:

```
Class Category
{
    /** @ODM\Id(strategy="AUTO") */
    private $id;

    /** @ODM\EmbedOne(targetDocument="CategoryVersion") */
    private $version;

    /** @ODM\EmbedMany(targetDocument="CategoryVersion") */
    private $versions;

    /**
     * @ODM\ReferenceMany(
     *      targetDocument="Category",
     *      cascade={"all"},
     *      mappedBy="version.parent",
     *      sort={"version.sequence"="asc"}
     * )
     */
    private $children;
}

/** @ODM\EmbeddedDocument */
class CategoryVersion
{
    /** @ODM\Field(type="int") */
    private $sequence = 0;

    /** @ODM\ReferenceOne(targetDocument="Category", cascade={"all"}, inversedBy="children") */
    private $parent;
}
```
