### PR TITLE
Fixed type hinting in method docblock

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
@@ -725,7 +725,7 @@ public function <methodName>()
           '<variableName>'      => Inflector::camelize($fieldName),
           '<methodName>'        => $methodName,
           '<fieldName>'         => $fieldName,
-          '<document>'          => '\\' . $this->getClassName($metadata),
+          '<document>'          => '\\' . $metadata->name,
         );
 
         $method = str_replace(


### PR DESCRIPTION
Fixed missing namespace form a method return value docblock.
