### PR TITLE
Added use Doctrine\ODM\MongoDB\LoggableCursor; in DocumentPersister

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -23,6 +23,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\MongoDB\Cursor as BaseCursor;
 use Doctrine\MongoDB\Iterator;
 use Doctrine\MongoDB\LoggableCursor as BaseLoggableCursor;
+use Doctrine\ODM\MongoDB\LoggableCursor;
 use Doctrine\ODM\MongoDB\Cursor;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Event\OnUpdatePreparedArgs;


### PR DESCRIPTION
Build passes, but it's missing a use statement.

FatalErrorException: Error: Class 'Doctrine\ODM\MongoDB\Persisters\LoggableCursor' not found in /vendor/doctrine/mongodb-odm/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php line 429

Added missing Doctrine\ODM\MongoDB\LoggableCursor
