### PR TITLE
Bring initial Criteria support

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Criteria/QueryBuilderExpressionVisitor.php
+++ b/lib/Doctrine/ODM/MongoDB/Criteria/QueryBuilderExpressionVisitor.php
@@ -1,0 +1,117 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ODM\MongoDB\Criteria;
+
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\CompositeExpression;
+use Doctrine\Common\Collections\Expr\ExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Value;
+use Doctrine\MongoDB\Query\Builder;
+
+/**
+ * @since       1.0
+ * @author      Antoine Hedgecock <antoine@pmg.se>
+ * @author      Michaël Gallego <mic.gallego@gmail.com>
+ */
+class QueryBuilderExpressionVisitor extends ExpressionVisitor
+{
+    /**
+     * Map Criteria API expressions to MongoDB ones
+     *
+     * @var array
+     */
+    private $comparisonTable = array(
+        '='   => 'equals',
+        '<>'  => 'notEqual',
+        '<'   => 'lt',
+        '<='  => 'lte',
+        '>'   => 'gt',
+        '>='  => 'gte',
+        'IN'  => 'in',
+        'NIN' => 'notIn'
+    );
+
+    /**
+     * @var Builder
+     */
+    protected $queryBuilder;
+
+    /**
+     * @param Builder $queryBuilder
+     */
+    public function __construct(Builder $queryBuilder)
+    {
+        $this->queryBuilder = $queryBuilder;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function walkComparison(Comparison $comparison)
+    {
+        $operator = $comparison->getOperator();
+        $field    = $comparison->getField();
+        $value    = $this->dispatch($comparison->getValue());
+
+        if (!isset($this->comparisonTable[$operator])) {
+            throw RuntimeException::unknownComparisonOperator($operator);
+        }
+
+        $method = $this->comparisonTable[$operator];
+
+        $expr = $this->queryBuilder->expr();
+        $expr->field($field)
+             ->{$method}($value);
+
+        return $expr;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function walkValue(Value $value)
+    {
+        return $value->getValue();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function walkCompositeExpression(CompositeExpression $compositeExpr)
+    {
+        $expr = $this->queryBuilder->expr();
+
+        foreach ($compositeExpr->getExpressionList() as $child) {
+            $child = $this->dispatch($child);
+
+            switch ($compositeExpr->getType()) {
+                case CompositeExpression::TYPE_AND:
+                    $expr->addAnd($child);
+                    break;
+
+                case CompositeExpression::TYPE_OR:
+                    $expr->addOr($child);
+                    break;
+            }
+        }
+
+        return $expr;
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Criteria/RuntimeException.php
+++ b/lib/Doctrine/ODM/MongoDB/Criteria/RuntimeException.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ODM\MongoDB\Criteria;
+
+use RuntimeException as BaseRuntimeException;
+
+/**
+ * @since       1.0
+ * @author      Michaël Gallego <mic.gallego@gmail.com>
+ */
+class RuntimeException extends BaseRuntimeException
+{
+    public static function unknownComparisonOperator($operator)
+    {
+        return new self(sprintf(
+            'An unknown operator (%s) was used in Comparison object',
+            $operator
+        ));
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Criteria/QueryBuilderExpressionVisitorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Criteria/QueryBuilderExpressionVisitorTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Criteria;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\Value;
+use Doctrine\ODM\MongoDB\Criteria\QueryBuilderExpressionVisitor;
+use Doctrine\ODM\MongoDB\Query\Builder as QueryBuilder;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class QueryBuilderExpressionVisitorTest extends BaseTest
+{
+    /**
+     * @var QueryBuilder
+     */
+    protected $queryBuilder;
+
+    /**
+     * @var QueryBuilderExpressionVisitor
+     */
+    protected $visitor;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->queryBuilder = $this->dm->createQueryBuilder('Documents\Bars\Bar');
+        $this->visitor      = new QueryBuilderExpressionVisitor($this->queryBuilder);
+    }
+
+    /**
+     * @covers QueryBuilderExpressionVisitor::walkValue
+     */
+    public function testWalkValueReturnValueDirectly()
+    {
+        $valueExpr = new Value('bar');
+        $result    = $this->visitor->dispatch($valueExpr);
+
+        $this->assertEquals('bar', $result);
+    }
+
+    /**
+     * @covers QueryBuilderExpressionVisitor::walkComparison
+     */
+    public function testThrowExceptionWithInvalidOperator()
+    {
+        $this->setExpectedException('Doctrine\ODM\MongoDB\Criteria\RuntimeException');
+
+        $comparison = new Comparison('name', 'lolzExpr', 'baz');
+        $this->visitor->dispatch($comparison);
+    }
+
+    /**
+     * @covers QueryBuilderExpressionVisitor::walkComparison
+     */
+    public function testDispatchWithSimpleEqualsComparison()
+    {
+        $comparison = new Comparison('name', '=', 'baz');
+        $result     = $this->visitor->dispatch($comparison);
+
+        $this->assertEquals(array('name' => 'baz'), $result->getQuery());
+    }
+
+    /**
+     * @return array
+     */
+    public function comparisonProvider()
+    {
+        return array(
+            array('operator' => '<>', 'command' => '$ne'),
+            array('operator' => '<', 'command' => '$lt'),
+            array('operator' => '<=', 'command' => '$lte'),
+            array('operator' => '>', 'command' => '$gt'),
+            array('operator' => '>=', 'command' => '$gte'),
+            array('operator' => 'IN', 'command' => '$in'),
+            array('operator' => 'NIN', 'command' => '$nin')
+        );
+    }
+
+    /**
+     * @covers QueryBuilderExpressionVisitor::walkComparison
+     * @dataProvider comparisonProvider
+     *
+     * @param string $operator
+     * @param string $command
+     * @param bool $isValueArray
+     */
+    public function testDispatchWithSimpleComparison($operator, $command, $isValueArray = false)
+    {
+        $comparison = new Comparison('name', $operator, 'baz');
+        $result     = $this->visitor->dispatch($comparison);
+
+        if ($isValueArray) {
+            $expected   = array(
+                'name' => array(
+                    $command => array('baz')
+                )
+            );
+        } else {
+            $expected   = array(
+                'name' => array(
+                    $command => 'baz'
+                )
+            );
+        }
+
+        $this->assertEquals($expected, $result->getQuery());
+    }
+
+    /**
+     * @covers QueryBuilderExpressionVisitor::walkCompositeExpression
+     */
+    public function testDispatchWithOrCompositeExpression()
+    {
+        $expr1 = new Comparison('name', '=', 'baz');
+        $expr2 = new Comparison('other', '<>', 'barBaz');
+
+        $criteria = new Criteria($expr1);
+        $criteria->andWhere($expr2);
+
+        $result   = $this->visitor->dispatch($criteria->getWhereExpression());
+        $expected = array(
+            '$and' => array(
+                array('name' => 'baz'),
+                array('other' => array(
+                    '$ne' => 'barBaz'
+                ))
+            )
+        );
+
+        $this->assertEquals($expected, $result->getQuery());
+    }
+
+    /**
+     * @covers QueryBuilderExpressionVisitor::walkCompositeExpression
+     */
+    public function testDispatchWithAndCompositeExpression()
+    {
+        $expr1 = new Comparison('name', '=', 'baz');
+        $expr2 = new Comparison('other', '<>', 'barBaz');
+
+        $criteria = new Criteria($expr1);
+        $criteria->orWhere($expr2);
+
+        $result   = $this->visitor->dispatch($criteria->getWhereExpression());
+        $expected = array(
+            '$or' => array(
+                array('name' => 'baz'),
+                array('other' => array(
+                    '$ne' => 'barBaz'
+                ))
+            )
+        );
+
+        $this->assertEquals($expected, $result->getQuery());
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RepositoriesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RepositoriesTest.php
@@ -2,12 +2,10 @@
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\Common\Collections\Criteria;
 use Documents\Account;
 use Documents\Address;
-use Documents\Group;
 use Documents\Phonenumber;
-use Documents\Profile;
-use Documents\File;
 use Documents\User;
 
 class RepositoriesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
@@ -46,5 +44,19 @@ class RepositoriesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $user3 = $this->repository->findOneBy(array('username' => 'w00ting'));
         $this->assertTrue($user2 === $user3);
+    }
+
+    public function testCriteria()
+    {
+        $exprBuilder = Criteria::expr();
+        $expr        = $exprBuilder->eq('username', 'lolcat');
+
+        $users = $this->repository->matching(new Criteria($expr));
+        $this->assertCount(0, $users);
+
+        $expr = $exprBuilder->eq('username', 'w00ting');
+
+        $users = $this->repository->matching(new Criteria($expr));
+        $this->assertCount(1, $users);
     }
 }


### PR DESCRIPTION
Hi,

This PR brings initial support for the Criteria API introduced in Doctrine 2.3. Currently, only the repository is made. If this seems good I'll write tests.

To be complete and in par with ORM, PersistentCollection needs to implement the Selectable API, but this is much harder to do (I've been thinking about using some kind of visitor for cursor but that's not that easy). If anyone has an idea, I'd be glad to hear about it.

There is also a TODO for the Repository. The problem by returning an ArrayCollection is for things like this (https://github.com/doctrine/DoctrineModule/blob/master/src/DoctrineModule/Paginator/Adapter/Selectable.php#L75). Ideally the data should be wrapped and initialized on demand, so that we can perform an efficient count.

Thanks
