### PR TITLE
Remove leading backslashes from $documentName in DocumentManager::getRepository() to prevent MappingException on getting repository by absolute class name

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -498,6 +498,8 @@ class DocumentManager implements ObjectManager
      */
     public function getRepository($documentName)
     {
+        $documentName = ltrim($documentName, '\\');
+
         if (isset($this->repositories[$documentName])) {
             return $this->repositories[$documentName];
         }


### PR DESCRIPTION
DocumentManager::getRepository() does not strip leading backslash from the given document's class name like ORM's EntityManager::getRepository() does, so getting repository by class name only works if given class name has no leading backslash, otherwise MappingException is thrown.
