### PR TITLE
Add sorts to wrapCursor

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -427,7 +427,7 @@ class DocumentPersister
     private function wrapCursor(BaseCursor $cursor)
     {
         if ($cursor instanceof BaseLoggableCursor) {
-            return new LoggableCursor(
+            $newCursor = new LoggableCursor(
                 $this->dm->getConnection(),
                 $this->collection,
                 $this->dm->getUnitOfWork(),
@@ -438,18 +438,22 @@ class DocumentPersister
                 $this->dm->getConfiguration()->getRetryQuery(),
                 $cursor->getLoggerCallable()
             );
+        } else {
+            $newCursor = new Cursor(
+                $this->dm->getConnection(),
+                $this->collection,
+                $this->dm->getUnitOfWork(),
+                $this->class,
+                $cursor,
+                $cursor->getQuery(),
+                $cursor->getFields(),
+                $this->dm->getConfiguration()->getRetryQuery()
+            );
         }
 
-        return new Cursor(
-            $this->dm->getConnection(),
-            $this->collection,
-            $this->dm->getUnitOfWork(),
-            $this->class,
-            $cursor,
-            $cursor->getQuery(),
-            $cursor->getFields(),
-            $this->dm->getConfiguration()->getRetryQuery()
-        );
+        $newCursor->setSorts($cursor->getSorts());
+
+        return $newCursor;
     }
 
     /**


### PR DESCRIPTION
See https://github.com/doctrine/mongodb/pull/113

The DoctrineMongoODMModule\Paginator\Adapter\DoctrinePaginator calls $cursor->recreate(); in getItems() which recreates the cursor.  However, when the Mongo cursor is wrapped in it's ODM container the sorts are lost so the paginator does not sort in the order of the cursor sent to it.
