### PR TITLE
collection, custom_id, object_id and raw_type types added to basic-mapping list

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -188,7 +188,7 @@ This list explains some of the less obvious mapping types:
 -  ``bin_data_md5``: string to MongoBinData instance with a "md5" type
 -  ``bin_data``: string to MongoBinData instance with a "byte array" type
 -  ``bin_data_uuid``: string to MongoBinData instance with a "uuid" type
--  ``collection``: indexed array to MongoDB array
+-  ``collection``: numerically indexed array to MongoDB array
 -  ``date``: DateTime to MongoDate
 -  ``hash``: associative array to MongoDB object
 -  ``id``: string to MongoId by default, but other formats are possible


### PR DESCRIPTION
The basic mapping type in basic-mapping.rst did not seem to be up
to date with the MongoDB Types defined in Doctrine/ODM/MongoDB
(https://github.com/mapado/mongodb-odm/tree/master/lib/Doctrine/ODM/MongoDB/Types).

The following types were added:
- `collection`
- `custom_id`
- `object_id`
- `raw_type`

Also, a quick note was added on which MongoDB type the `collection`
type is mapped to.

Signed-off-by: Balthazar Rouberol balthazar.rouberol@mapado.com
