### PR TITLE
Adds support for discriminatorField/discriminatorMap for ReferenceOne.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -670,7 +670,7 @@ class DocumentManager implements ObjectManager
 
     public function getClassNameFromDiscriminatorValue(array $mapping, $value)
     {
-        $discriminatorField = isset($mapping['discriminatorField']) ? $mapping['discriminatorField'] : '_doctrine_class_name';
+        $discriminatorField = $this->getDiscriminatorField($mapping);
         if (is_array($value) && isset($value[$discriminatorField])) {
             $discriminatorValue = $value[$discriminatorField];
             return isset($mapping['discriminatorMap'][$discriminatorValue]) ? $mapping['discriminatorMap'][$discriminatorValue] : $discriminatorValue;
@@ -685,6 +685,11 @@ class DocumentManager implements ObjectManager
             }
         }
         return $mapping['targetDocument'];
+    }
+
+    public function getDiscriminatorField(array $mapping)
+    {
+        return isset($mapping['discriminatorField']) ? $mapping['discriminatorField'] : '_doctrine_class_name';
     }
 
     /**


### PR DESCRIPTION
So ReferenceOne with discriminator map/type doesn't seem to be working. It's not saving the type. This is what my mapping file looks like:

```
referenceOne:
    model:
        discriminatorField: model_type
        discriminatorMap:
            user: Blah\Bundle\UserBundle\Model\User
            reservation: Blah\Bundle\WebBundle\Model\Reservation
```

And all I have in the DB is:

``` js
{ ... "model" : DBRef("reservations", ObjectId("51cf0b65d0c3f5661000001a")) ... }
```

model_type is not set.

This pull request fixes this issue by saving the type.

Before I spend any more time on this could someone take a quick look and tell me if I'm going in the right direction.
