### PR TITLE
Preserving results sort after recreate

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -306,6 +306,8 @@ class Query extends \Doctrine\MongoDB\Query\Query
                 $this->dm->getConfiguration()->getRetryQuery()
             );
         }
+        // Preserve the sort
+        $cursor->sort($this->query['sort']);
         $cursor->hydrate($this->hydrate);
         $cursor->setHints($hints);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -104,6 +104,79 @@ class QueryTest extends BaseTest
         $this->assertEquals(1, $query->count());
         $this->assertSame($jon, $query->getSingleResult());
     }
+    
+    public function testSorting()
+    {
+        $people = array('Alex', 'David', 'Jon', 'Kris', 'Xander');
+        $peopleDocs = array();
+        foreach ($people as $firstName){
+            $peopleDocs[$firstName] = new Person($firstName);
+        }
+        
+        // Persist in non-alphabetical order
+        $this->dm->persist($peopleDocs['David']);
+        $this->dm->persist($peopleDocs['Xander']);
+        $this->dm->persist($peopleDocs['Alex']);
+        $this->dm->persist($peopleDocs['Kris']);
+        $this->dm->persist($peopleDocs['Jon']);
+        
+        $this->dm->flush();
+
+        $qb = $this->dm->createQueryBuilder(__NAMESPACE__.'\Person');
+        $qb->sort('firstName', 'asc');
+
+        $query = $qb->getQuery();
+
+        // Check the number of results
+        $this->assertEquals(5, $query->count());
+        
+        // Get the cursor
+        $result = $query->execute();
+        
+        // Check the order of the results is correct
+        $count = 0;
+        foreach ($result as $person){
+            $this->assertEquals($people[$count], $person->firstName);
+            $count++;
+        }
+    }
+    
+    public function testSortingAfterRecreate()
+    {
+        $people = array('Alex', 'David', 'Jon', 'Kris', 'Xander');
+        $peopleDocs = array();
+        foreach ($people as $firstName){
+            $peopleDocs[$firstName] = new Person($firstName);
+        }
+        
+        // Persist in non-alphabetical order
+        $this->dm->persist($peopleDocs['David']);
+        $this->dm->persist($peopleDocs['Xander']);
+        $this->dm->persist($peopleDocs['Alex']);
+        $this->dm->persist($peopleDocs['Kris']);
+        $this->dm->persist($peopleDocs['Jon']);
+        
+        $this->dm->flush();
+
+        $qb = $this->dm->createQueryBuilder(__NAMESPACE__.'\Person');
+        $qb->sort('firstName', 'asc');
+
+        $query = $qb->getQuery();
+
+        // Check the number of results
+        $this->assertEquals(5, $query->count());
+        
+        // Get the cursor and recreate it
+        $result = $query->execute();
+        $result->recreate();
+        
+        // Check the order of the results is correct
+        $count = 0;
+        foreach ($result as $person){
+            $this->assertEquals($people[$count], $person->firstName);
+            $count++;
+        }
+    }
 
     public function testQueryIdIn()
     {


### PR DESCRIPTION
When an cursor is recreated and wrapped, the sort data is lost. I have
preserved the sort during the wrap so that it is preserved. I have added
a unit test for this issue, and a more general sorting unit test.
