### PR TITLE
Fixes CLI using $helpers as a hash with cli-config defining it as an arr...

### DIFF
--- a/tools/sandbox/cli-config.php
+++ b/tools/sandbox/cli-config.php
@@ -4,4 +4,4 @@ use Doctrine\ODM\MongoDB\Tools\Console\Helper\DocumentManagerHelper;
 
 require_once 'config.php';
 
-$helpers = array(new DocumentManagerHelper($dm));
+$helpers = array('dm' => new DocumentManagerHelper($dm));


### PR DESCRIPTION
...ay.
- Define it as the expected array('dm' => helper) hash.
- This caused "[InvalidArgumentException] The helper "dm" is not defined."
