### PR TITLE
Fix preparation of trailing positional operator in query field

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1033,11 +1033,15 @@ class DocumentPersister
             $objectProperty = $e[1];
             $objectPropertyPrefix = '';
             $nextObjectProperty = implode('.', array_slice($e, 2));
-        } else {
+        } elseif (isset($e[2])) {
             $fieldName = $e[0] . '.' . $e[1] . '.' . $e[2];
             $objectProperty = $e[2];
             $objectPropertyPrefix = $e[1] . '.';
             $nextObjectProperty = implode('.', array_slice($e, 3));
+        } else {
+            $fieldName = $e[0] . '.' . $e[1];
+
+            return array($fieldName, $value);
         }
 
         // No further processing for fields without a targetDocument mapping

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -137,13 +137,15 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals(array('address.subAddress.subAddress.subAddress.testFieldName' => 'test'), $debug);
     }
 
-    public function testPrepareNestedCollectionDocuments()
+    public function testPreparePositionalOperator()
     {
         $qb = $this->dm->createQueryBuilder('Documents\User')
-            ->field('phonenumbers.$.phonenumber')->equals('test');
-        $query = $qb->getQuery();
-        $debug = $query->debug();
-        $this->assertEquals(array('phonenumbers.$.phonenumber' => 'test'), $debug);
+            ->update()
+            ->field('phonenumbers.$.phonenumber')->equals('foo')
+            ->field('phonenumbers.$')->set(array('phonenumber' => 'bar'));
+
+        $this->assertEquals(array('phonenumbers.$.phonenumber' => 'foo'), $qb->getQueryArray());
+        $this->assertEquals(array('$set' => array('phonenumbers.$' => array('phonenumber' => 'bar'))), $qb->getNewObj());
     }
 
     public function testSortIsPrepared()


### PR DESCRIPTION
See: http://stackoverflow.com/questions/17886359/update-embedded-subdocument-in-array-with-doctrine-and-mongodb

If `DocumentPersister::prepareQueryElement()` receives a field name ending in `$` (i.e. [positional operator](http://docs.mongodb.org/manual/reference/operator/positional/)), we should not assume that there is another field part after it. This addresses the case where an entire array element is being matched or updated.
