### PR TITLE
Acquire exclusive lock to file write when generating hydrators

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorException.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorException.php
@@ -39,8 +39,8 @@ class HydratorException extends MongoDBException
         return new self("You must configure a hydrator namespace. See docs for details");
     }
 
-    public static function hydratorDirectoryMustExist()
+    public static function hydratorDirectoryNotWritable()
     {
-        return new self("You must create a hydrator directory specified");
+        return new self("Your hydrator directory must be writable.");
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -384,7 +384,19 @@ EOF
             $code
         );
 
-        file_put_contents($fileName, $code);
+        $parentDirectory = dirname($fileName);
+
+        if ( ! is_dir($parentDirectory) && (false === @mkdir($parentDirectory, 0775, true))) {
+            throw HydratorException::hydratorDirectoryNotWritable();
+        }
+
+        if ( ! is_writable($parentDirectory)) {
+            throw HydratorException::hydratorDirectoryNotWritable();
+        }
+
+        $tmpFileName = $fileName . '.' . uniqid('', true);
+        file_put_contents($tmpFileName, $code);
+        rename($tmpFileName, $fileName);
     }
 
     /**


### PR DESCRIPTION
I found several php crash just like in this detailed description: http://zecrazytux.net/troubleshooting/php-sigbus-crash-prestashop

HydratorFactory needs to write out files with exclusive lock in case of avoid chrashes at high concurrency. 

Also i brought some code from ProxyFactory and deleted an unused exception.
