### PR TITLE
Update query-builder-api.rst "Selecting Fields" section.

### DIFF
--- a/docs/en/reference/query-builder-api.rst
+++ b/docs/en/reference/query-builder-api.rst
@@ -157,12 +157,13 @@ the ``select()`` method:
     <?php
 
     $qb = $dm->createQueryBuilder('User')
+        ->hydrate(false)
         ->select('username', 'password');
     $query = $qb->getQuery();
     $users = $query->execute();
 
 In the results only the data from the username and password will be
-returned.
+returned (disabling hydration is mandatory, otherwise your select() will be ignored).
 
 Selecting Distinct Values
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
disabling hydration is required in order to use the select() function.
