### PR TITLE
Xml driver should return options for custom id generator

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -53,6 +53,9 @@
   </xs:complexType>
 
   <xs:complexType name="field">
+    <xs:sequence>
+      <xs:element name="id-generator-option" type="odm:id-generator-option" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>  
     <xs:attribute name="id" type="xs:boolean" default="false" />
     <xs:attribute name="name" type="xs:NMTOKEN" />
     <xs:attribute name="type" type="xs:NMTOKEN" default="string" />
@@ -66,6 +69,11 @@
     <xs:attribute name="file" type="xs:boolean" />
     <xs:attribute name="distance" type="xs:boolean" />
     <xs:attribute name="reference" type="xs:boolean" />
+  </xs:complexType>
+  
+  <xs:complexType name="id-generator-option">
+    <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="value" type="xs:string" use="required"/>
   </xs:complexType>
 
   <xs:complexType name="embed-one">

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -112,6 +112,18 @@ class XmlDriver extends FileDriver
                         $mapping[$key] = ('true' === $mapping[$key]) ? true : false;
                     }
                 }
+                if (isset($mapping['id']) && $mapping['id'] === true && isset($mapping['strategy'])) {
+                    $mapping['options'] = array();
+                    if (isset($field->{'id-generator-option'})) {
+                        foreach ($field->{'id-generator-option'} as $generatorOptions) {
+                            $attributesGenerator = iterator_to_array($generatorOptions->attributes());
+                            if (isset($attributesGenerator['name']) && isset($attributesGenerator['value'])) {
+                                $mapping['options'][(string) $attributesGenerator['name']] = (string) $attributesGenerator['value'];
+                            }
+                        }
+                    }
+                } 
+                
                 if (isset($attributes['not-saved'])) {
                     $mapping['notSaved'] = ('true' === $attributes['not-saved']) ? true : false;
                 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\ODM\MongoDB\Tests\Mapping\Driver;
 
 use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 
 /**
  * @author Bulat Shakirzyanov <bulat@theopenskyproject.com>
@@ -13,4 +14,42 @@ class XmlDriverTest extends AbstractDriverTest
     {
         $this->driver = new XmlDriver(__DIR__ . '/fixtures/xml');
     }
+    
+    public function testDriverShouldReturnOptionsForCustomIdGenerator()
+    {
+        $classMetadata = new ClassMetadata('TestDocuments\UserCustomIdGenerator');
+        $this->driver->loadMetadataForClass('TestDocuments\UserCustomIdGenerator', $classMetadata);
+        $this->assertEquals(array(
+            'fieldName' => 'id',
+            'strategy' => 'custom',
+            'options' => array(
+                'class' => 'TestDocuments\CustomIdGenerator',
+                'someOption' => 'some-option'
+            ),
+            'id' => true,
+            'name' => '_id',
+            'type' => 'custom_id',
+            'isCascadeCallbacks' => false,
+            'isCascadeDetach' => false,
+            'isCascadeMerge' => false,
+            'isCascadePersist' => false,
+            'isCascadeRefresh' => false,
+            'isCascadeRemove' => false,
+            'isInverseSide' => false,
+            'isOwningSide' => true,
+            'nullable' => false
+        ), $classMetadata->fieldMappings['id']);
+    }
 }
+
+namespace TestDocuments;
+
+class UserCustomIdGenerator
+{
+    protected $id;
+
+    public function __construct()
+    {
+    }
+}
+

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.UserCustomIdGenerator.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.UserCustomIdGenerator.dcm.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="TestDocuments\UserCustomIdGenerator" db="documents" collection="users">
+        <field name="id" id="true" strategy="custom">
+            <id-generator-option name="class" value="TestDocuments\CustomIdGenerator"/>
+            <id-generator-option name="someOption" value="some-option"/>
+        </field>
+    </document>
+</doctrine-mongo-mapping>


### PR DESCRIPTION
Adding a correction to allow custom id generator (#402) with the xml driver.
