### PR TITLE
Revert "PersistentCollection::count() with ReferenceMany InverseSide map...

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -483,16 +483,10 @@ class PersistentCollection implements BaseCollection
      */
     public function count()
     {
-        if ($this->mapping['isInverseSide'] && ! $this->initialized) {
-            $documentPersister = $this->uow->getDocumentPersister(get_class($this->owner));
-            $count = empty($this->mapping['repositoryMethod'])
-                ? $documentPersister->createReferenceManyInverseSideQuery($this)->count()
-                : $documentPersister->createReferenceManyWithRepositoryMethodCursor($this)->count();
-        } else {
-            $count = $this->coll->count();
+        if ($this->mapping['isInverseSide']) {
+            $this->initialize();
         }
-
-        return count($this->mongoData) + $count;
+        return count($this->mongoData) + $this->coll->count();
     }
 
     /**


### PR DESCRIPTION
...ping queries DB without collection initialization"

This reverts commit bd7d99e290159e310469b0a14aee1aafc7df2381.

Conflicts:
    lib/Doctrine/ODM/MongoDB/PersistentCollection.php

Reverting, because not initializing counted incorrectly when:

    - the collection has the isInverseSide flag set
    - the collection is uninitialized
    - has had an item added using add(), making it dirty

Here's the previous (and broken before this commit) flow:

    - the collection is inverse-side and not initially initialized
    - we add an item via add()
        - has the side-effect of marking the collection as dirty
        - but still keeps the collection uninitialized
    - if count() is called now for this uninitialized inverse-side collection:
        - a query gets sent to the database to count the objects
        - the result of counting is 0, because:
            - there's nothing in the DB yet
            (assuming there really was nothing old there for starters)
            - nobody cared that $this->coll had some items added to it
            and the collection was dirty

The easiest fix I can think of is to restore the old behavior, which
causes initialize() to happen just in case.