### PR TITLE
Fix infinite loop in unit of work 

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1307,6 +1307,11 @@ class UnitOfWork implements PropertyChangedListener
 
             $targetClass = $this->dm->getClassMetadata($mapping['targetDocument']);
 
+            // If the dependency already exists, it has already passed here.
+            if ($calc->hasDependency($targetClass, $class)) {
+                continue;
+            }
+
             if ( ! $calc->hasClass($targetClass->name)) {
                 $calc->addClass($targetClass);
             }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/BidirectionalInheritanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/BidirectionalInheritanceTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+use Documents\Tournament\ParticipantTeam;
+use Documents\Tournament\TournamentFootball;
+
+class BidirectionalInheritanceTest extends BaseTest
+{
+    /**
+     * Test bi-directional reference "one to many", both owning sides and with inheritance maps.
+     */
+    public function testOneToManyWithoutSides()
+    {
+        $tournament = new TournamentFootball('tournament_name');
+
+        $participant1 = new ParticipantTeam('name1');
+        $tournament->addParticipant($participant1);
+
+        $participant2 = new ParticipantTeam('name2');
+        $tournament->addParticipant($participant2);
+
+        $this->dm->persist($tournament);
+        $this->dm->flush();
+
+        $this->assertTrue(true, 'Should not provoke an infinite loop');
+    }
+}

--- a/tests/Documents/Tournament/Participant.php
+++ b/tests/Documents/Tournament/Participant.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Documents\Tournament;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document(db="doctrine_odm_tests", collection="participants")
+ * @ODM\InheritanceType("SINGLE_COLLECTION")
+ * @ODm\DiscriminatorMap({"solo"="ParticipantSolo", "team"="ParticipantTeam"})
+ */
+class Participant
+{
+    /** @ODM\Id */
+    private $id;
+
+    /** @ODM\Field */
+    private $name;
+
+    /** @ODM\ReferenceOne(targetDocument="Tournament", cascade={"all"}) */
+    protected $tournament;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setTournament(Tournament $tournament)
+    {
+        $this->tournament = $tournament;
+    }
+
+    public function getTournament()
+    {
+        return $this->tournament;
+    }
+}

--- a/tests/Documents/Tournament/ParticipantSolo.php
+++ b/tests/Documents/Tournament/ParticipantSolo.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Documents\Tournament;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document
+ */
+class ParticipantSolo extends Participant
+{
+}

--- a/tests/Documents/Tournament/ParticipantTeam.php
+++ b/tests/Documents/Tournament/ParticipantTeam.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Documents\Tournament;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document
+ */
+class ParticipantTeam extends Participant
+{
+}

--- a/tests/Documents/Tournament/Tournament.php
+++ b/tests/Documents/Tournament/Tournament.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Documents\Tournament;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document(db="doctrine_odm_tests", collection="tournaments")
+ * @ODM\InheritanceType("SINGLE_COLLECTION")
+ * @ODM\DiscriminatorMap({"football"="TournamentFootball","tennis": "TournamentTennis"})
+ */
+class Tournament
+{
+    /** @ODM\Id */
+    private $id;
+
+    /** @ODM\Field */
+    private $name;
+
+    /** @ODM\ReferenceMany(targetDocument="Participant", cascade={"all"}) */
+    protected $participants = array();
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function addParticipant(Participant $participant) {
+        $this->participants[] = $participant;
+        $participant->setTournament($this);
+    }
+}

--- a/tests/Documents/Tournament/TournamentFootball.php
+++ b/tests/Documents/Tournament/TournamentFootball.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Documents\Tournament;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document
+ */
+class TournamentFootball extends Tournament
+{
+}

--- a/tests/Documents/Tournament/TournamentTennis.php
+++ b/tests/Documents/Tournament/TournamentTennis.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Documents\Tournament;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document
+ */
+class TournamentTennis extends Tournament
+{
+}


### PR DESCRIPTION
The issue takes place when you have a bi-directional reference between 2 classes that have both a discriminator map and that are also both owning side (because no owning/inversed side has been specified). When building the dependencies in the unit of work, it'll loop between both classes and generate an out of memory crash.

I've simply added a check to avoid adding dependencies that already exist and thus avoid the loop. I've also added a functional test that provokes the loop issue.
