### PR TITLE
Fix orphan removal on clear and embed relations with references

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -695,6 +695,16 @@ class UnitOfWork implements PropertyChangedListener
                     }
                 }
 
+                // if relationship is a embed-one, schedule orphan removal to trigger cascade remove operations
+                if (isset($class->fieldMappings[$propName]['embedded']) && $class->fieldMappings[$propName]['type'] === 'one') {
+                    if ($orgValue !== null) {
+                        $this->scheduleOrphanRemoval($orgValue);
+                    }
+
+                    $changeSet[$propName] = array($orgValue, $actualValue);
+                    continue;
+                }
+
                 // if owning side of reference-one relationship
                 if (isset($class->fieldMappings[$propName]['reference']) && $class->fieldMappings[$propName]['type'] === 'one' && $class->fieldMappings[$propName]['isOwningSide']) {
                     if ($orgValue !== null && $class->fieldMappings[$propName]['orphanRemoval']) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalEmbedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalEmbedTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * Test the orphan removal on embedded documents that contain references with cascade operations.
+ */
+class OrphanRemovalEmbedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    /**
+     * Test un-setting a embed one relationship
+     */
+    public function testUnSettingEmbedOne()
+    {
+        $profile = new OrphanRemovalCascadeProfile();
+        $address = new OrphanRemovalCascadeAddress();
+        $user = new OrphanRemovalCascadeUser();
+        $profile->address = $address;
+        $user->profile = $profile;
+
+        $this->dm->persist($user);
+        $this->dm->flush();
+
+        $user->profile = null;
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $this->assertNull($this->getAddressRepository()->find($address->id), 'Should have removed the address');
+    }
+
+    /**
+     * Test remove method on a embed many relationship
+     */
+    public function testRemoveEmbedMany()
+    {
+        $profile1 = new OrphanRemovalCascadeProfile();
+        $address1 = new OrphanRemovalCascadeAddress();
+        $profile1->address = $address1;
+
+        $profile2 = new OrphanRemovalCascadeProfile();
+        $address2 = new OrphanRemovalCascadeAddress();
+        $profile2->address = $address2;
+
+        $user = new OrphanRemovalCascadeUser();
+        $user->profileMany[] = $profile1;
+        $user->profileMany[] = $profile2;
+
+        $this->dm->persist($user);
+        $this->dm->flush();
+
+        $this->assertNotNull($this->getAddressRepository()->find($address1->id), 'Should have persist-cascaded address 1');
+        $this->assertNotNull($this->getAddressRepository()->find($address2->id), 'Should have persist-cascaded address 2');
+
+        $user->profileMany->removeElement($profile1);
+
+        $this->dm->flush();
+        $this->dm->clear($user);
+
+        $user = $this->getUserRepository()->find($user->id);
+        $this->assertNotNull($user, 'Should retrieve user');
+        $this->assertFalse($user->profileMany->contains($profile1), 'Should not contain profile 1');
+        $this->assertNull($this->getAddressRepository()->find($address1->id), 'Should have removed address 1');
+        $this->assertTrue($user->profileMany->contains($profile2), 'Should contain profile 2');
+        $this->assertNotNull($this->getAddressRepository()->find($address2->id), 'Should have kept address 2');
+    }
+
+    /**
+     * Test clear method on a embed many relationship
+     */
+    public function testClearEmbedMany()
+    {
+        $profile1 = new OrphanRemovalCascadeProfile();
+        $address1 = new OrphanRemovalCascadeAddress();
+        $profile1->address = $address1;
+
+        $profile2 = new OrphanRemovalCascadeProfile();
+        $address2 = new OrphanRemovalCascadeAddress();
+        $profile2->address = $address2;
+
+        $user = new OrphanRemovalCascadeUser();
+        $user->profileMany[] = $profile1;
+        $user->profileMany[] = $profile2;
+
+        $this->dm->persist($user);
+        $this->dm->flush();
+
+        $user->profileMany->clear();
+
+        $this->dm->flush();
+        $this->dm->clear($user);
+
+        $this->assertNull($this->getAddressRepository()->find($address1->id), 'Should have removed address 1');
+        $this->assertNull($this->getAddressRepository()->find($address2->id), 'Should have removed address 2');
+    }
+
+    /**
+     * Test clearing and adding on a embed many relationship
+     */
+    public function testClearAndAddEmbedMany()
+    {
+        $profile1 = new OrphanRemovalCascadeProfile();
+        $address1 = new OrphanRemovalCascadeAddress();
+        $profile1->address = $address1;
+
+        $profile2 = new OrphanRemovalCascadeProfile();
+        $address2 = new OrphanRemovalCascadeAddress();
+        $profile2->address = $address2;
+
+        $profile3 = new OrphanRemovalCascadeProfile();
+        $address3 = new OrphanRemovalCascadeAddress();
+        $profile3->address = $address3;
+
+        $user = new OrphanRemovalCascadeUser();
+        $user->profileMany[] = $profile1;
+        $user->profileMany[] = $profile2;
+
+        $this->dm->persist($user);
+        $this->dm->flush();
+
+        $user->profileMany->clear();
+        $user->profileMany->add($profile3);
+
+        $this->dm->flush();
+        $this->dm->clear($user);
+
+        $user = $this->getUserRepository()->find($user->id);
+        $this->assertNotNull($user, 'Should retrieve user');
+        $this->assertFalse($user->profileMany->contains($profile1), 'Should not contain profile 1');
+        $this->assertNull($this->getAddressRepository()->find($address1->id), 'Should have removed address 1');
+        $this->assertFalse($user->profileMany->contains($profile2), 'Should not contain profile 2');
+        $this->assertNull($this->getAddressRepository()->find($address2->id), 'Should have removed address 2');
+        $this->assertTrue($user->profileMany->contains($profile3), 'Should contain profile 3');
+        $this->assertNotNull($this->getAddressRepository()->find($address3->id), 'Should have added address 3');
+    }
+
+    /**
+     * @return \Doctrine\ODM\MongoDB\DocumentRepository
+     */
+    protected function getUserRepository()
+    {
+        return $this->dm->getRepository('Doctrine\ODM\MongoDB\Tests\Functional\OrphanRemovalCascadeUser');
+    }
+
+    /**
+     * @return \Doctrine\ODM\MongoDB\DocumentRepository
+     */
+    protected function getAddressRepository()
+    {
+        return $this->dm->getRepository('Doctrine\ODM\MongoDB\Tests\Functional\OrphanRemovalCascadeAddress');
+    }
+}
+
+/** @ODM\Document */
+class OrphanRemovalCascadeUser
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedOne(targetDocument="OrphanRemovalCascadeProfile") */
+    public $profile;
+
+    /** @ODM\EmbedMany(targetDocument="OrphanRemovalCascadeProfile") */
+    public $profileMany = array();
+}
+
+/** @ODM\EmbeddedDocument */
+class OrphanRemovalCascadeProfile
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\String */
+    public $name;
+
+    /** @ODM\ReferenceOne(targetDocument="OrphanRemovalCascadeAddress", orphanRemoval=true, cascade={"all"}) */
+    public $address;
+
+    /** @ODM\ReferenceMany(targetDocument="OrphanRemovalCascadeAddress", orphanRemoval=true, cascade={"all"}) */
+    public $addressMany;
+}
+
+/** @ODM\Document */
+class OrphanRemovalCascadeAddress
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\String */
+    public $name;
+}


### PR DESCRIPTION
I've added several tests that were failing on orphan removal.
- Using clear() on a persistent collection did not trigger the orphan removal process.
- Removing an embedded document from a collection did not trigger the orphan removal process. This is needed to trigger cascade operations when the embedded document references another document. (A embeds B, B references C, removing B from A did not trigger any cascade remove on C)
