### PR TITLE
Removed $cmd args/properties (Mongo command character)

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -121,13 +121,6 @@ class DocumentManager implements ObjectManager
     private $closed = false;
 
     /**
-     * Mongo command character
-     *
-     * @var string
-     */
-    private $cmd;
-
-    /**
      * Collection of query filters.
      *
      * @var \Doctrine\ODM\MongoDB\Query\FilterCollection
@@ -145,7 +138,6 @@ class DocumentManager implements ObjectManager
     protected function __construct(Connection $conn = null, Configuration $config = null, EventManager $eventManager = null) {
         $this->config = $config ?: new Configuration();
         $this->eventManager = $eventManager ?: new EventManager();
-        $this->cmd = $this->config->getMongoCmd();
         $this->connection = $conn ?: new Connection(null, array(), $this->config, $this->eventManager);
 
         $metadataFactoryClassName = $this->config->getClassMetadataFactoryName();
@@ -163,11 +155,10 @@ class DocumentManager implements ObjectManager
             $this->eventManager,
             $hydratorDir,
             $hydratorNs,
-            $this->config->getAutoGenerateHydratorClasses(),
-            $this->config->getMongoCmd()
+            $this->config->getAutoGenerateHydratorClasses()
         );
 
-        $this->unitOfWork = new UnitOfWork($this, $this->eventManager, $this->hydratorFactory, $this->cmd);
+        $this->unitOfWork = new UnitOfWork($this, $this->eventManager, $this->hydratorFactory);
         $this->hydratorFactory->setUnitOfWork($this->unitOfWork);
         $this->schemaManager = new SchemaManager($this, $this->metadataFactory);
         $this->proxyFactory = new ProxyFactory($this,
@@ -369,7 +360,7 @@ class DocumentManager implements ObjectManager
      */
     public function createQueryBuilder($documentName = null)
     {
-        return new Query\Builder($this, $this->cmd, $documentName);
+        return new Query\Builder($this, $documentName);
     }
 
     /**
@@ -710,9 +701,9 @@ class DocumentManager implements ObjectManager
         }
 
         $dbRef = array(
-            $this->cmd . 'ref' => $class->getCollection(),
-            $this->cmd . 'id'  => $class->getDatabaseIdentifierValue($id),
-            $this->cmd . 'db'  => $this->getDocumentDatabase($className)->getName()
+            '$ref' => $class->getCollection(),
+            '$id'  => $class->getDatabaseIdentifierValue($id),
+            '$db'  => $this->getDocumentDatabase($className)->getName()
         );
 
         if ($class->discriminatorField) {

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -88,22 +88,14 @@ class HydratorFactory
     private $hydrators = array();
 
     /**
-     * Mongo command prefix
-     *
-     * @var string
-     */
-    private $cmd;
-
-    /**
      * @param DocumentManager $dm
      * @param EventManager $evm
      * @param string $hydratorDir
      * @param string $hydratorNs
      * @param boolean $autoGenerate
-     * @param string $cmd
      * @throws HydratorException
      */
-    public function __construct(DocumentManager $dm, EventManager $evm, $hydratorDir, $hydratorNs, $autoGenerate, $cmd)
+    public function __construct(DocumentManager $dm, EventManager $evm, $hydratorDir, $hydratorNs, $autoGenerate)
     {
         if ( ! $hydratorDir) {
             throw HydratorException::hydratorDirectoryRequired();
@@ -116,7 +108,6 @@ class HydratorFactory
         $this->hydratorDir = $hydratorDir;
         $this->hydratorNamespace = $hydratorNs;
         $this->autoGenerate = $autoGenerate;
-        $this->cmd = $cmd;
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -88,13 +88,6 @@ class PersistentCollection implements BaseCollection
     private $uow;
 
     /**
-     * Mongo command prefix
-     *
-     * @var string
-     */
-    private $cmd;
-
-    /**
      * The raw mongo data that will be used to initialize this collection.
      *
      * @var array
@@ -112,14 +105,12 @@ class PersistentCollection implements BaseCollection
      * @param BaseCollection $coll
      * @param DocumentManager $dm
      * @param UnitOfWork $uow
-     * @param string $cmd
      */
-    public function __construct(BaseCollection $coll, DocumentManager $dm, UnitOfWork $uow, $cmd)
+    public function __construct(BaseCollection $coll, DocumentManager $dm, UnitOfWork $uow)
     {
         $this->coll = $coll;
         $this->dm = $dm;
         $this->uow = $uow;
-        $this->cmd = $cmd;
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -57,26 +57,17 @@ class CollectionPersister
     private $pb;
 
     /**
-     * Mongo command prefix
-     *
-     * @var string
-     */
-    private $cmd;
-
-    /**
      * Constructs a new CollectionPersister instance.
      *
      * @param DocumentManager $dm
      * @param PersistenceBuilder $pb
      * @param UnitOfWork $uow
-     * @param string $cmd
      */
-    public function __construct(DocumentManager $dm, PersistenceBuilder $pb, UnitOfWork $uow, $cmd)
+    public function __construct(DocumentManager $dm, PersistenceBuilder $pb, UnitOfWork $uow)
     {
         $this->dm = $dm;
         $this->pb = $pb;
         $this->uow = $uow;
-        $this->cmd = $cmd;
     }
 
     /**
@@ -92,7 +83,7 @@ class CollectionPersister
             return; // ignore inverse side
         }
         list($propertyPath, $parent) = $this->getPathAndParent($coll);
-        $query = array($this->cmd . 'unset' => array($propertyPath => true));
+        $query = array('$unset' => array($propertyPath => true));
         $this->executeQuery($parent, $query, $options);
     }
 
@@ -156,7 +147,7 @@ class CollectionPersister
             $setData = array_values($setData);
         }
 
-        $query = array($this->cmd.'set' => array($propertyPath => $setData));
+        $query = array('$set' => array($propertyPath => $setData));
 
         $this->executeQuery($parent, $query, $options);
     }
@@ -180,10 +171,10 @@ class CollectionPersister
 
         list($propertyPath, $parent) = $this->getPathAndParent($coll);
 
-        $query = array($this->cmd . 'unset' => array());
+        $query = array('$unset' => array());
 
         foreach ($deleteDiff as $key => $document) {
-            $query[$this->cmd . 'unset'][$propertyPath . '.' . $key] = true;
+            $query['$unset'][$propertyPath . '.' . $key] = true;
         }
 
         $this->executeQuery($parent, $query, $options);
@@ -194,7 +185,7 @@ class CollectionPersister
          * in the element being left in the array as null so we have to pull
          * null values.
          */
-        $this->executeQuery($parent, array($this->cmd . 'pull' => array($propertyPath => null)), $options);
+        $this->executeQuery($parent, array('$pull' => array($propertyPath => null)), $options);
     }
 
     /**
@@ -226,10 +217,10 @@ class CollectionPersister
         $value = array_values(array_map($callback, $insertDiff));
 
         if ($mapping['strategy'] !== 'pushAll') {
-            $value = array($this->cmd . 'each' => $value);
+            $value = array('$each' => $value);
         }
 
-        $query = array($this->cmd . $mapping['strategy'] => array($propertyPath => $value));
+        $query = array('$' . $mapping['strategy'] => array($propertyPath => $value));
 
         $this->executeQuery($parent, $query, $options);
     }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -105,13 +105,6 @@ class DocumentPersister
     private $queuedInserts = array();
 
     /**
-     * Mongo command prefix
-     *
-     * @var string
-     */
-    private $cmd;
-
-    /**
      * The CriteriaMerger instance.
      *
      * @var CriteriaMerger
@@ -127,14 +120,12 @@ class DocumentPersister
      * @param UnitOfWork $uow
      * @param HydratorFactory $hydratorFactory
      * @param ClassMetadata $class
-     * @param string $cmd
      */
-    public function __construct(PersistenceBuilder $pb, DocumentManager $dm, EventManager $evm, UnitOfWork $uow, HydratorFactory $hydratorFactory, ClassMetadata $class, $cmd, CriteriaMerger $cm = null)
+    public function __construct(PersistenceBuilder $pb, DocumentManager $dm, EventManager $evm, UnitOfWork $uow, HydratorFactory $hydratorFactory, ClassMetadata $class, CriteriaMerger $cm = null)
     {
         $this->pb = $pb;
         $this->dm = $dm;
         $this->evm = $evm;
-        $this->cmd = $cmd;
         $this->cm = $cm ?: new CriteriaMerger();
         $this->uow = $uow;
         $this->hydratorFactory = $hydratorFactory;
@@ -251,11 +242,11 @@ class DocumentPersister
             $upsertOptions = $options;
             $upsertOptions['upsert'] = true;
             foreach ($upserts as $oid => $data) {
-                $criteria = array('_id' => $data[$this->cmd . 'set']['_id']);
-                unset($data[$this->cmd . 'set']['_id']);
+                $criteria = array('_id' => $data['$set']['_id']);
+                unset($data['$set']['_id']);
                 // stupid php
-                if (empty($data[$this->cmd . 'set'])) {
-                    $data[$this->cmd . 'set'] = new \stdClass;
+                if (empty($data['$set'])) {
+                    $data['$set'] = new \stdClass;
                 }
                 $this->collection->update($criteria, $data, $upsertOptions);
             }
@@ -289,12 +280,12 @@ class DocumentPersister
                 $currentVersion = $this->class->reflFields[$this->class->versionField]->getValue($document);
                 if ($versionMapping['type'] === 'int') {
                     $nextVersion = $currentVersion + 1;
-                    $update[$this->cmd . 'inc'][$versionMapping['name']] = 1;
+                    $update['$inc'][$versionMapping['name']] = 1;
                     $query[$versionMapping['name']] = $currentVersion;
                     $this->class->reflFields[$this->class->versionField]->setValue($document, $nextVersion);
                 } elseif ($versionMapping['type'] === 'date') {
                     $nextVersion = new \DateTime();
-                    $update[$this->cmd . 'set'][$versionMapping['name']] = new \MongoDate($nextVersion->getTimestamp());
+                    $update['$set'][$versionMapping['name']] = new \MongoDate($nextVersion->getTimestamp());
                     $query[$versionMapping['name']] = new \MongoDate($currentVersion->getTimestamp());
                     $this->class->reflFields[$this->class->versionField]->setValue($document, $nextVersion);
                 }
@@ -307,13 +298,13 @@ class DocumentPersister
                 $isLocked = $this->class->reflFields[$this->class->lockField]->getValue($document);
                 $lockMapping = $this->class->fieldMappings[$this->class->lockField];
                 if ($isLocked) {
-                    $update[$this->cmd . 'unset'] = array($lockMapping['name'] => true);
+                    $update['$unset'] = array($lockMapping['name'] => true);
                 } else {
-                    $query[$lockMapping['name']] = array($this->cmd . 'exists' => false);
+                    $query[$lockMapping['name']] = array('$exists' => false);
                 }
             }
 
-            unset($update[$this->cmd . 'set']['_id']);
+            unset($update['$set']['_id']);
             $result = $this->collection->update($query, $update, $options);
 
             if (($this->class->isVersioned || $this->class->isLockable) && ! $result['n']) {
@@ -335,7 +326,7 @@ class DocumentPersister
         $query = array('_id' => $this->class->getDatabaseIdentifierValue($id));
 
         if ($this->class->isLockable) {
-            $query[$this->class->lockField] = array($this->cmd . 'exists' => false);
+            $query[$this->class->lockField] = array('$exists' => false);
             $options['safe'] = true;
         }
 
@@ -500,7 +491,7 @@ class DocumentPersister
         $id = $this->uow->getDocumentIdentifier($document);
         $criteria = array('_id' => $this->class->getDatabaseIdentifierValue($id));
         $lockMapping = $this->class->fieldMappings[$this->class->lockField];
-        $this->collection->update($criteria, array($this->cmd . 'set' => array($lockMapping['name'] => $lockMode)));
+        $this->collection->update($criteria, array('$set' => array($lockMapping['name'] => $lockMode)));
         $this->class->reflFields[$this->class->lockField]->setValue($document, $lockMode);
     }
 
@@ -514,7 +505,7 @@ class DocumentPersister
         $id = $this->uow->getDocumentIdentifier($document);
         $criteria = array('_id' => $this->class->getDatabaseIdentifierValue($id));
         $lockMapping = $this->class->fieldMappings[$this->class->lockField];
-        $this->collection->update($criteria, array($this->cmd . 'unset' => array($lockMapping['name'] => true)));
+        $this->collection->update($criteria, array('$unset' => array($lockMapping['name'] => true)));
         $this->class->reflFields[$this->class->lockField]->setValue($document, null);
     }
 
@@ -560,7 +551,6 @@ class DocumentPersister
 
         $fieldMapping = $collectionMetaData->fieldMappings[$fieldName];
 
-        $cmd = $this->cmd;
         $groupedIds = array();
 
         foreach ($collection as $element) {
@@ -573,7 +563,7 @@ class DocumentPersister
                             $mongoId = $reference;
                         } else {
                             $className = $this->dm->getClassNameFromDiscriminatorValue($fieldMapping, $reference);
-                            $mongoId = $reference[$cmd . 'id'];
+                            $mongoId = $reference['$id'];
                         }
                         $id = $this->dm->getClassMetadata($className)->getPHPIdentifierValue($mongoId);
                         $document = $this->uow->tryGetById($id, $className);
@@ -665,7 +655,6 @@ class DocumentPersister
     {
         $hints = $collection->getHints();
         $mapping = $collection->getMapping();
-        $cmd = $this->cmd;
         $groupedIds = array();
 
         $sorted = isset($mapping['sort']) && $mapping['sort'];
@@ -676,7 +665,7 @@ class DocumentPersister
                 $mongoId = $reference;
             } else {
                 $className = $this->dm->getClassNameFromDiscriminatorValue($mapping, $reference);
-                $mongoId = $reference[$cmd . 'id'];
+                $mongoId = $reference['$id'];
             }
             $id = $this->dm->getClassMetadata($className)->getPHPIdentifierValue($mongoId);
             if ( ! $id) {
@@ -704,7 +693,7 @@ class DocumentPersister
             $class = $this->dm->getClassMetadata($className);
             $mongoCollection = $this->dm->getDocumentCollection($className);
             $criteria = $this->cm->merge(
-                array('_id' => array($cmd . 'in' => $ids)),
+                array('_id' => array('$in' => $ids)),
                 $this->dm->getFilterCollection()->getFilterCriteria($class),
                 isset($mapping['criteria']) ? $mapping['criteria'] : array()
             );
@@ -918,14 +907,14 @@ class DocumentPersister
 
         foreach ($query as $key => $value) {
             // Recursively prepare logical query clauses
-            if (in_array($key, array($this->cmd . 'and', $this->cmd . 'or', $this->cmd . 'nor')) && is_array($value)) {
+            if (in_array($key, array('$and', '$or', '$nor')) && is_array($value)) {
                 foreach ($value as $k2 => $v2) {
                     $preparedQuery[$key][$k2] = $this->prepareQueryOrNewObj($v2);
                 }
                 continue;
             }
 
-            if (isset($key[0]) && $key[0] === $this->cmd && is_array($value)) {
+            if (isset($key[0]) && $key[0] === '$' && is_array($value)) {
                 $preparedQuery[$key] = $this->prepareQueryOrNewObj($value);
                 continue;
             }
@@ -987,12 +976,12 @@ class DocumentPersister
 
             foreach ($value as $k => $v) {
                 // Ignore query operators whose arguments need no type conversion
-                if (in_array($k, array($this->cmd . 'exists', $this->cmd . 'type', $this->cmd . 'mod', $this->cmd . 'size'))) {
+                if (in_array($k, array('$exists', '$type', '$mod', '$size'))) {
                     continue;
                 }
 
                 // Process query operators whose arguments need type conversion (e.g. "$in")
-                if (isset($k[0]) && $k[0] === $this->cmd && is_array($v)) {
+                if (isset($k[0]) && $k[0] === '$' && is_array($v)) {
                     foreach ($v as $k2 => $v2) {
                         $value[$k][$k2] = $targetClass->getDatabaseIdentifierValue($v2);
                     }
@@ -1019,12 +1008,12 @@ class DocumentPersister
 
             foreach ($value as $k => $v) {
                 // Ignore query operators whose arguments need no type conversion
-                if (in_array($k, array($this->cmd . 'exists', $this->cmd . 'type', $this->cmd . 'mod', $this->cmd . 'size'))) {
+                if (in_array($k, array('$exists', '$type', '$mod', '$size'))) {
                     continue;
                 }
 
                 // Process query operators whose arguments need type conversion (e.g. "$in")
-                if (isset($k[0]) && $k[0] === $this->cmd && is_array($v)) {
+                if (isset($k[0]) && $k[0] === '$' && is_array($v)) {
                     foreach ($v as $k2 => $v2) {
                         $value[$k][$k2] = $class->getDatabaseIdentifierValue($v2);
                     }
@@ -1125,7 +1114,7 @@ class DocumentPersister
 
             foreach ($value as $k => $v) {
                 // Process query operators (e.g. "$in")
-                if (isset($k[0]) && $k[0] === $this->cmd && is_array($v)) {
+                if (isset($k[0]) && $k[0] === '$' && is_array($v)) {
                     foreach ($v as $k2 => $v2) {
                         $value[$k][$k2] = $class->getDatabaseIdentifierValue($v2);
                     }

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -86,14 +86,13 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
      * Construct a Builder
      *
      * @param DocumentManager $dm
-     * @param string $cmd
      * @param string[]|string|null $documentName (optional) an array of document names, the document name, or none
      */
-    public function __construct(DocumentManager $dm, $cmd, $documentName = null)
+    public function __construct(DocumentManager $dm, $documentName = null)
     {
         $this->dm = $dm;
-        $this->expr = new Expr($dm, $cmd);
-        $this->cmd = $cmd;
+        $this->cmd  = '$';
+        $this->expr = new Expr($dm);
         if ($documentName !== null) {
             $this->setDocumentName($documentName);
         }
@@ -289,7 +288,6 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
             $this->collection,
             $query,
             $options,
-            $this->cmd,
             $this->hydrate,
             $this->refresh,
             $this->primers,
@@ -304,7 +302,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
      */
     public function expr()
     {
-        $expr = new Expr($this->dm, $this->cmd);
+        $expr = new Expr($this->dm);
         $expr->setClassMetadata($this->class);
 
         return $expr;

--- a/lib/Doctrine/ODM/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Expr.php
@@ -44,10 +44,10 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
      */
     private $class;
 
-    public function __construct(DocumentManager $dm, $cmd)
+    public function __construct(DocumentManager $dm)
     {
         $this->dm = $dm;
-        $this->cmd = $cmd;
+        $this->cmd = '$';
     }
 
     public function setClassMetadata(ClassMetadata $class)
@@ -74,7 +74,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
                 }
 
                 foreach ($keys as $key => $value) {
-                    $this->query[$this->currentField . '.' . $this->cmd . $key] = $dbRef[$this->cmd . $key];
+                    $this->query[$this->currentField . '.$' . $key] = $dbRef['$' . $key];
                 }
             }
         } else {
@@ -95,7 +95,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
             $dbRef = $this->dm->createDBRef($document, $mapping);
 
             if (isset($mapping['simple']) && $mapping['simple']) {
-                $this->query[$mapping['name']][$this->cmd . 'elemMatch'] = $dbRef;
+                $this->query[$mapping['name']]['$elemMatch'] = $dbRef;
             } else {
                 $keys = array('ref' => true, 'id' => true, 'db' => true);
 
@@ -104,12 +104,12 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
                 }
 
                 foreach ($keys as $key => $value) {
-                    $this->query[$this->currentField][$this->cmd . 'elemMatch'][$this->cmd . $key] = $dbRef[$this->cmd . $key];
+                    $this->query[$this->currentField]['$elemMatch']['$' . $key] = $dbRef['$' . $key];
                 }
             }
         } else {
             $dbRef = $this->dm->createDBRef($document);
-            $this->query[$this->cmd . 'elemMatch'] = $dbRef;
+            $this->query['$elemMatch'] = $dbRef;
         }
 
         return $this;

--- a/lib/Doctrine/ODM/MongoDB/Query/FieldExtractor.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/FieldExtractor.php
@@ -29,13 +29,11 @@ class FieldExtractor
 {
     private $query;
     private $sort;
-    private $cmd;
 
-    public function __construct(array $query, array $sort = array(), $cmd = '$')
+    public function __construct(array $query, array $sort = array())
     {
         $this->query = $query;
         $this->sort = $sort;
-        $this->cmd = $cmd;
     }
 
     public function getFields()
@@ -43,8 +41,8 @@ class FieldExtractor
         $fields = array();
 
         foreach ($this->query as $k => $v) {
-            if (is_array($v) && isset($v[$this->cmd.'elemMatch'])) {
-                $elemMatchFields = $this->getFieldsFromElemMatch($v[$this->cmd.'elemMatch']);
+            if (is_array($v) && isset($v['$elemMatch'])) {
+                $elemMatchFields = $this->getFieldsFromElemMatch($v['$elemMatch']);
                 foreach ($elemMatchFields as $field) {
                     $fields[] = $k.'.'.$field;
                 }
@@ -53,7 +51,7 @@ class FieldExtractor
                     $test = new self($q);
                     $fields = array_merge($fields, $test->getFields());
                 }
-            } elseif ($k[0] !== $this->cmd) {
+            } elseif ($k[0] !== '$') {
                 $fields[] = $k;
             }
         }
@@ -87,7 +85,7 @@ class FieldExtractor
             $operator = array($operator);
         }
         foreach ($operator as $op) {
-            if ($fieldName === $this->cmd.$op) {
+            if ($fieldName === '$'.$op) {
                 return true;
             }
         }

--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -92,15 +92,14 @@ class Query extends \Doctrine\MongoDB\Query\Query
      * @param Collection $collection
      * @param array $query
      * @param array $options
-     * @param string $cmd
      * @param bool $hydrate
      * @param bool $refresh
      * @param array $primers
      * @param null $requireIndexes
      */
-    public function __construct(DocumentManager $dm, ClassMetadata $class, Database $database, Collection $collection, array $query = array(), array $options = array(), $cmd = '$', $hydrate = true, $refresh = false, array $primers = array(), $requireIndexes = null)
+    public function __construct(DocumentManager $dm, ClassMetadata $class, Database $database, Collection $collection, array $query = array(), array $options = array(), $hydrate = true, $refresh = false, array $primers = array(), $requireIndexes = null)
     {
-        parent::__construct($database, $collection, $query, $options, $cmd);
+        parent::__construct($database, $collection, $query, $options, '$');
         $this->dm = $dm;
         $this->class = $class;
         $this->hydrate = $hydrate;
@@ -156,7 +155,7 @@ class Query extends \Doctrine\MongoDB\Query\Query
      */
     public function getFieldsInQuery()
     {
-        $extractor = new FieldExtractor($this->query['query'], $this->query['sort'], $this->cmd);
+        $extractor = new FieldExtractor($this->query['query'], $this->query['sort']);
         return $extractor->getFields();
     }
 

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -251,26 +251,17 @@ class UnitOfWork implements PropertyChangedListener
     private $parentAssociations = array();
 
     /**
-     * Mongo command character
-     *
-     * @var string
-     */
-    private $cmd;
-
-    /**
      * Initializes a new UnitOfWork instance, bound to the given DocumentManager.
      *
      * @param DocumentManager $dm
      * @param EventManager $evm
      * @param HydratorFactory $hydratorFactory
-     * @param string $cmd
      */
-    public function __construct(DocumentManager $dm, EventManager $evm, HydratorFactory $hydratorFactory, $cmd)
+    public function __construct(DocumentManager $dm, EventManager $evm, HydratorFactory $hydratorFactory)
     {
         $this->dm = $dm;
         $this->evm = $evm;
         $this->hydratorFactory = $hydratorFactory;
-        $this->cmd = $cmd;
     }
 
     /**
@@ -282,7 +273,7 @@ class UnitOfWork implements PropertyChangedListener
     public function getPersistenceBuilder()
     {
         if ( ! $this->persistenceBuilder) {
-            $this->persistenceBuilder = new PersistenceBuilder($this->dm, $this, $this->cmd);
+            $this->persistenceBuilder = new PersistenceBuilder($this->dm, $this);
         }
         return $this->persistenceBuilder;
     }
@@ -331,7 +322,7 @@ class UnitOfWork implements PropertyChangedListener
         if ( ! isset($this->persisters[$documentName])) {
             $class = $this->dm->getClassMetadata($documentName);
             $pb = $this->getPersistenceBuilder();
-            $this->persisters[$documentName] = new Persisters\DocumentPersister($pb, $this->dm, $this->evm, $this, $this->hydratorFactory, $class, $this->cmd);
+            $this->persisters[$documentName] = new Persisters\DocumentPersister($pb, $this->dm, $this->evm, $this, $this->hydratorFactory, $class);
         }
         return $this->persisters[$documentName];
     }
@@ -345,7 +336,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         if ( ! isset($this->collectionPersister)) {
             $pb = $this->getPersistenceBuilder();
-            $this->collectionPersister = new Persisters\CollectionPersister($this->dm, $pb, $this, $this->cmd);
+            $this->collectionPersister = new Persisters\CollectionPersister($this->dm, $pb, $this);
         }
         return $this->collectionPersister;
     }
@@ -597,7 +588,7 @@ class UnitOfWork implements PropertyChangedListener
                 }
 
                 // Inject PersistentCollection
-                $coll = new PersistentCollection($value, $this->dm, $this, $this->cmd);
+                $coll = new PersistentCollection($value, $this->dm, $this);
                 $coll->setOwner($document, $mapping);
                 $coll->setDirty( ! $value->isEmpty());
                 $class->reflFields[$name]->setValue($document, $coll);
@@ -2056,7 +2047,7 @@ class UnitOfWork implements PropertyChangedListener
                             if ( ! $mergeCol instanceof Collection) {
                                 $mergeCol = new ArrayCollection($mergeCol);
                             }
-                            $mergeCol = new PersistentCollection($mergeCol, $this->dm, $this, $this->cmd);
+                            $mergeCol = new PersistentCollection($mergeCol, $this->dm, $this);
                             $mergeCol->setInitialized(true);
                         } else {
                             $mergeCol->setDocumentManager($this->dm);

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -75,9 +75,4 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
             }
         }
     }
-
-    public function escape($command)
-    {
-        return $this->dm->getConfiguration()->getMongoCmd() . $command;
-    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -383,7 +383,7 @@ class UnitOfWorkTest extends \PHPUnit_Framework_TestCase
 
     protected function getUnitOfWork(DocumentManager $dm)
     {
-        return new UnitOfWork($dm, $this->getMockEventManager(), $this->getMockHydratorFactory(), '$');
+        return new UnitOfWork($dm, $this->getMockEventManager(), $this->getMockHydratorFactory());
     }
 
     /**
@@ -422,7 +422,7 @@ class UnitOfWorkTest extends \PHPUnit_Framework_TestCase
 
     private function getMockDocumentPersister(PersistenceBuilder $pb, ClassMetadata $class)
     {
-        return new DocumentPersisterMock($pb, $this->dm, $this->dm->getEventManager(), $this->uow, $this->dm->getHydratorFactory(), $class, '$');
+        return new DocumentPersisterMock($pb, $this->dm, $this->dm->getEventManager(), $this->uow, $this->dm->getHydratorFactory(), $class);
     }
 
     protected function getClassMetadata($class, $flag)


### PR DESCRIPTION
Submitting this pull request to avoid raising the `MongoDB command prefix option is no longer used` error when using the latest doctrine/mongodb (which deprecated `$cmd` in doctrine/mongodb pull request #131: https://github.com/doctrine/mongodb/pull/131). 

I did leave three literal `$` artifacts in `__construct()` methods of some extending objects (`\Doctrine\ODM\MongoDB\Query\Query`, `\Doctrine\ODM\MongoDB\Query\Expr` and – even though not strictly required to make code pass unit tests – `\Doctrine\ODM\MongoDB\Query\Builder`), for compatibility with versions 1.0.3 and earlier of doctrine/mongodb.

Resulting code passes all unit tests (aside from `Doctrine\ODM\MongoDB\Tests\Functional\DateTest::testOldDate`, which produced an error before the changes and still does afterwards).
