### PR TITLE
Fix Annotation Driver always overriding inherited fields informations

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -128,7 +128,11 @@ class AnnotationDriver extends AbstractAnnotationDriver
         }
 
         foreach ($reflClass->getProperties() as $property) {
-            if ($class->isMappedSuperclass && ! $property->isPrivate()) {
+            if (($class->isMappedSuperclass
+                 && ! $property->isPrivate())
+                ||
+                ($class->isInheritedField($property->name)
+                 && $property->getDeclaringClass()->name != $class->name)) {
                 continue;
             }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
@@ -8,6 +8,19 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 class AnnotationDriverTest extends AbstractMappingDriverTest
 {
+    public function testAnnotationDriverRespectsInheritedFieldsInformations()
+    {
+        $className = __NAMESPACE__.'\ColumnWithoutType';
+        $this->_ensureIsLoaded($className);
+
+        $className = __NAMESPACE__.'\ColumnWithoutTypeChild';
+        $this->_ensureIsLoaded($className);
+
+        $class = $this->dm->getClassMetadata($className);
+
+        $this->assertTrue($class->isInheritedField('id'));
+    }
+
     /**
      * @group DDC-268
      */
@@ -116,4 +129,11 @@ class ColumnWithoutType
 {
     /** @ODM\Id */
     public $id;
+}
+
+/**
+ * @ODM\Document
+ */
+class ColumnWithoutTypeChild extends ColumnWithoutType
+{
 }


### PR DESCRIPTION
Given two document classes:

``` php
/**
* @ODM\Document
*/
class Parent
{
    /**
    * @ODM\String
    */
    protected $parent;
}

/**
* @ODM\Document
*/
class Child extends Parent
{
    /**
    * @ODM\String
    */
    protected $child;
}
```

Then, if we fetch the ClassMetadata for Child:
`$class = $dm->getClassMetadata(‘Child’);`

The child class rightly has two fields (`parent` and `child`), both `strings` and so on. However, two markers are missing from the field mapping on the parent field: `declared` and `inherited`. This implies that `$class->isInheritedField(‘parent’)` will return false and the Metadata is unreliable.

Although this is not much of a big deal in the most common use cases, as soon as you need to hook in the ClassMetadata Loading to customize fields handling, you need to declare your fields private so they are not part of the child classes and are not returned by the annotation reader. This also have a negative performance impact since we end up parsing non-private inherited fields repeatedly for no good reasons.

Here is the fix for this behaviour, along with an additional PHPUnit TestCase for it.
I took special care to keep the desired behaviour related to https://github.com/doctrine/mongodb-odm/issues/435
