### PR TITLE
Makes the UnitOfWork#getOrCreateDocument to use DocumentManager#getClassNameFromDiscriminatorValue in order to resolve the discriminator value

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2526,8 +2526,8 @@ class UnitOfWork implements PropertyChangedListener
         // @TODO figure out how to remove this
         if ($class->discriminatorField) {
             if (isset($data[$class->discriminatorField['name']])) {
-                $type = $data[$class->discriminatorField['name']];
-                $class = $this->dm->getClassMetadata($class->discriminatorMap[$data[$class->discriminatorField['name']]]);
+                $className = $this->dm->getClassNameFromDiscriminatorValue(array('targetDocument' => $className), $data);
+                $class = $this->dm->getClassMetadata($className);
                 unset($data[$class->discriminatorField['name']]);
             }
         }


### PR DESCRIPTION
This doesn't break any test and provide a uniform behaviour throughout the Framework with respect to the Discriminator Map interpretation.

I'd also suggest moving the method to the UnitOfWork class, I fail to see why this is required to be in the DocumentManager and looks more like internal behaviour than an external API'ed primitive.

My final goal is to make extending the DiscriminatorMap related behaviour easier.

I needed that for a project of mine which required a pretty extensive (and invasive) enhancement of the whole ODM and Connection (MongoDB layer) libraries.

I'm writing a post-mortem blog post on it detailing the process and enhancements I made, along with several suggestion to make such extensions easier in the future. I will keep you posted with respect to that if you are interested in it.
