### PR TITLE
Update the composer to use the latest version of doctrine/mongodb

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "doctrine/common": "2.4.*",
         "doctrine/cache": "~1.0",
         "doctrine/inflector": "~1.0",
-        "doctrine/mongodb": "1.1.*"
+        "doctrine/mongodb": "~1.0"
     },
     "require-dev": {
         "symfony/yaml": "~2.0"


### PR DESCRIPTION
The `doctrine/mongodb` 1.0 uses an old version of mongo that is not available in several hosts anymore. This PR updates the composer to use the version >=1.0 and <2.0 of `doctrine/mongodb` that will be compatible with mongo until 1.6 for now.
