### PR TITLE
Fix issue with MongoId objects in UnitOfWork

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -730,6 +730,9 @@ class UnitOfWork implements PropertyChangedListener
                 if ($actualValue instanceof PersistentCollection) {
                     $owner = $actualValue->getOwner();
                     if ($owner === null) { // cloned
+                        if (!isset ($class->fieldMappings[$propName])) {
+                            $class->fieldMappings[$propName] = array();
+                        }
                         $actualValue->setOwner($document, $class->fieldMappings[$propName]);
                     } elseif ($owner !== $document) { // no clone, we have to fix
                         if ( ! $actualValue->isInitialized()) {


### PR DESCRIPTION
When using references and embedded objects with references, you get this exception when trying to get the referenced object.

```
[Symfony\Component\Debug\Exception\ContextErrorException]                                                                                                                      
  Warning: Illegal offset type in isset or empty in 
./vendor/doctrine/mongodb-odm/lib/Doctrine/ODM/MongoDB/UnitOfWork.php line 1693
```
