### PR TITLE
Fixed typo in referenceMany criteria example

### DIFF
--- a/docs/en/reference/complex-references.rst
+++ b/docs/en/reference/complex-references.rst
@@ -90,7 +90,7 @@ administrators:
      * @ReferenceMany(
      *      targetDocument="Comment",
      *      mappedBy="blogPost",
-     *      criteria={"isByAdmin" : true}
+     *      criteria={"isByAdmin"=true}
      * )
      */
     private $commentsByAdmin;


### PR DESCRIPTION
The criteria was using a JSON notation instead of the necessary "=" assignment.
