### PR TITLE
Make it possible to re-persist removed embeded documents

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1794,16 +1794,14 @@ class UnitOfWork implements PropertyChangedListener
                     "Behavior of persist() for a detached document is not yet defined.");
                 break;
             case self::STATE_REMOVED:
-                if ( ! $class->isEmbeddedDocument) {
-                    // Document becomes managed again
-                    if ($this->isScheduledForDelete($document)) {
-                        unset($this->documentDeletions[$oid]);
-                    } else {
-                        //FIXME: There's more to think of here...
-                        $this->scheduleForInsert($class, $document);
-                    }
-                    break;
+                // Document becomes managed again
+                if ($this->isScheduledForDelete($document)) {
+                    unset($this->documentDeletions[$oid]);
+                } else {
+                    //FIXME: There's more to think of here...
+                    $this->scheduleForInsert($class, $document);
                 }
+                break;
             default:
                 throw MongoDBException::invalidDocumentState($documentState);
         }


### PR DESCRIPTION
Not sure why the restriction was there in the first place, but it seems like it isn't needed. If it is kept, I can't find any way to re-persist an embedded document marked for deletion.
