### PR TITLE
Added optional argument to ODM console commands to allow specification of a document manager

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -44,7 +44,12 @@ class MetadataCommand extends Command
         $this
         ->setName('odm:clear-cache:metadata')
         ->setDescription('Clear all metadata cache of the various cache drivers.')
-        ->setDefinition(array())
+        ->setDefinition(array(
+            new InputOption(
+                'documentmanager', null, InputOption::VALUE_OPTIONAL,
+                'The name of the documentmanager to use. If none is provided, it will use odm_default.'
+            ),
+        ))
         ->setHelp(<<<EOT
 Clear all metadata cache of the various cache drivers.
 EOT

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateDocumentsCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateDocumentsCommand.php
@@ -76,7 +76,11 @@ class GenerateDocumentsCommand extends Console\Command\Command
             new InputOption(
                 'num-spaces', null, InputOption::VALUE_OPTIONAL,
                 'Defines the number of indentation spaces', 4
-            )
+            ),
+            new InputOption(
+                'documentmanager', null, InputOption::VALUE_OPTIONAL,
+                'The name of the documentmanager to use. If none is provided, it will use odm_default.'
+            ),
         ))
         ->setHelp(<<<EOT
 Generate document classes and method stubs from your mapping information.

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php
@@ -52,6 +52,10 @@ class GenerateHydratorsCommand extends Console\Command\Command
                 'dest-path', InputArgument::OPTIONAL,
                 'The path to generate your hydrator classes. If none is provided, it will attempt to grab from configuration.'
             ),
+            new InputOption(
+                'documentmanager', null, InputOption::VALUE_OPTIONAL,
+                'The name of the documentmanager to use. If none is provided, it will use odm_default.'
+            ),
         ))
         ->setHelp(<<<EOT
 Generates hydrator classes for document classes.

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
@@ -52,6 +52,10 @@ class GenerateProxiesCommand extends Console\Command\Command
                 'dest-path', InputArgument::OPTIONAL,
                 'The path to generate your proxy classes. If none is provided, it will attempt to grab from configuration.'
             ),
+            new InputOption(
+                'documentmanager', null, InputOption::VALUE_OPTIONAL,
+                'The name of the documentmanager to use. If none is provided, it will use odm_default.'
+            ),
         ))
         ->setHelp(<<<EOT
 Generates proxy classes for document classes.

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateRepositoriesCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateRepositoriesCommand.php
@@ -51,7 +51,11 @@ class GenerateRepositoriesCommand extends Console\Command\Command
             ),
             new InputArgument(
                 'dest-path', InputArgument::REQUIRED, 'The path to generate your repository classes.'
-            )
+            ),
+            new InputOption(
+                'documentmanager', null, InputOption::VALUE_OPTIONAL,
+                'The name of the documentmanager to use. If none is provided, it will use odm_default.'
+            ),
         ))
         ->setHelp(<<<EOT
 Generate repository classes from your mapping information.

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
@@ -63,7 +63,11 @@ class QueryCommand extends Console\Command\Command
             new InputOption(
                 'depth', null, InputOption::VALUE_REQUIRED,
                 'Dumping depth of Document graph.', 7
-            )
+            ),
+            new InputOption(
+                'documentmanager', null, InputOption::VALUE_OPTIONAL,
+                'The name of the documentmanager to use. If none is provided, it will use odm_default.'
+            ),
         ))
         ->setHelp(<<<EOT
 Execute a query and output the results.

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
@@ -43,6 +43,12 @@ class CreateCommand extends AbstractCommand
             ->addOption(self::COLLECTION, null, InputOption::VALUE_NONE, 'Create collections')
             ->addOption(self::INDEX, null, InputOption::VALUE_NONE, 'Create indexes')
             ->setDescription('Create databases, collections and indexes for your documents')
+            ->setDefinition(array(
+                new InputOption(
+                    'documentmanager', null, InputOption::VALUE_OPTIONAL,
+                    'The name of the documentmanager to use. If none is provided, it will use odm_default.'
+                ),
+            ));
         ;
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
@@ -40,7 +40,12 @@ class DropCommand extends AbstractCommand
             ->addOption(self::COLLECTION, null, InputOption::VALUE_NONE, 'Drop collections')
             ->addOption(self::INDEX, null, InputOption::VALUE_NONE, 'Drop indexes')
             ->setDescription('Drop databases, collections and indexes for your documents')
-        ;
+            ->setDefinition(array(
+                new InputOption(
+                    'documentmanager', null, InputOption::VALUE_OPTIONAL,
+                    'The name of the documentmanager to use. If none is provided, it will use odm_default.'
+                ),
+            ));
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
@@ -41,6 +41,12 @@ class UpdateCommand extends AbstractCommand
             ->addOption('class', 'c', InputOption::VALUE_OPTIONAL, 'Document class to process (default: all classes)')
             ->addOption('timeout', 't', InputOption::VALUE_OPTIONAL, 'Timeout (ms) for acknowledged index creation')
             ->setDescription('Update indexes for your documents')
+            ->setDefinition(array(
+                new InputOption(
+                    'documentmanager', null, InputOption::VALUE_OPTIONAL,
+                    'The name of the documentmanager to use. If none is provided, it will use odm_default.'
+                ),
+            ));
         ;
     }
 


### PR DESCRIPTION
I have a case where I need to use different MongoDB servers for different portions of the same ZF2 application. The application itself works with the setup, but the command-line tool defaults to `doctrine.documentmanager.odm_default`, which prevents me from generating hydrators, schema, etc...

This PR creates a new, optional parameter on all ODM-related commands called `documentmanager`, which allows the person executing the script to give a name to use instead of `odm_default`.

I've sent another PR to the [doctrine/DoctrineMongoODMModule repository](https://github.com/doctrine/DoctrineMongoODMModule/pull/92) with the rest of this. They are both individually backwards-compatible, so they can be merged in any order.
