### PR TITLE
[UOW] Only get change set from documentChangeSets if it exists.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -706,7 +706,7 @@ class UnitOfWork implements PropertyChangedListener
             // and we have a copy of the original data
             $originalData = $this->originalDocumentData[$oid];
             $isChangeTrackingNotify = $class->isChangeTrackingNotify();
-            if ($isChangeTrackingNotify && ! $recompute) {
+            if ($isChangeTrackingNotify && ! $recompute && isset($this->documentChangeSets[$oid])) {
                 $changeSet = $this->documentChangeSets[$oid];
             } else {
                 $changeSet = array();


### PR DESCRIPTION
This prevents notices of `Undefined index: 0000000062aacd13000000000d79d12e` in documents that use CHANGETRACKING_NOTIFY and for some reason do not have an entry in UnitOfWork::documentChangeSets.