### PR TITLE
[BC break!] Fix DocumentRepository to fit ObjectRepository interface

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentRepository.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentRepository.php
@@ -127,21 +127,21 @@ class DocumentRepository implements ObjectRepository, Selectable
         }
 
         if ($lockMode == LockMode::NONE) {
-            return $this->uow->getDocumentPersister($this->documentName)->load($id);
+            return $this->getDocumentPersister()->load($id);
         }
 
         if ($lockMode == LockMode::OPTIMISTIC) {
             if (!$this->class->isVersioned) {
                 throw LockException::notVersioned($this->documentName);
             }
-            $document = $this->uow->getDocumentPersister($this->documentName)->load($id);
+            $document = $this->getDocumentPersister()->load($id);
 
             $this->uow->lock($document, $lockMode, $lockVersion);
 
             return $document;
         }
 
-        return $this->uow->getDocumentPersister($this->documentName)->load($id, null, array(), $lockMode);
+        return $this->getDocumentPersister()->load($id, null, array(), $lockMode);
     }
 
     /**
@@ -161,11 +161,12 @@ class DocumentRepository implements ObjectRepository, Selectable
      * @param array        $sort     Sort array for Cursor::sort()
      * @param integer|null $limit    Limit for Cursor::limit()
      * @param integer|null $skip     Skip for Cursor::skip()
-     * @return Cursor
+     *
+     * @return array The entities.
      */
     public function findBy(array $criteria, array $sort = null, $limit = null, $skip = null)
     {
-        return $this->uow->getDocumentPersister($this->documentName)->loadAll($criteria, $sort, $limit, $skip);
+        return iterator_to_array($this->getDocumentPersister()->loadAll($criteria, $sort, $limit, $skip), false);
     }
 
     /**
@@ -176,7 +177,7 @@ class DocumentRepository implements ObjectRepository, Selectable
      */
     public function findOneBy(array $criteria)
     {
-        return $this->uow->getDocumentPersister($this->documentName)->load($criteria);
+        return $this->getDocumentPersister()->load($criteria);
     }
 
     /**
@@ -278,5 +279,10 @@ class DocumentRepository implements ObjectRepository, Selectable
 
         // @TODO: wrap around a specialized Collection for efficient count on large collections
         return new ArrayCollection($queryBuilder->getQuery()->execute()->toArray());
+    }
+
+    protected function getDocumentPersister()
+    {
+        return $this->uow->getDocumentPersister($this->documentName);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CursorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CursorTest.php
@@ -14,7 +14,7 @@ class CursorTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->persist($user);
         $this->dm->flush();
 
-        $cursor = $this->dm->getRepository('Documents\User')->findAll();
+        $cursor = $this->uow->getDocumentPersister('Documents\User')->loadAll();
 
         $cursor->next();
         $this->assertSame($user, $cursor->current());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomIdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomIdTest.php
@@ -77,7 +77,7 @@ class CustomIdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $users = $this->dm->getRepository("Documents\User")->findAll();
 
-        $this->assertEquals(2, $users->count());
+        $this->assertCount(2, $users);
 
         $results = array();
         foreach ($users as $user) {
@@ -90,7 +90,7 @@ class CustomIdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $users = $this->dm->getRepository("Documents\CustomUser")->findAll();
 
-        $this->assertEquals(1, $users->count());
+        $this->assertCount(1, $users);
 
         foreach ($users as $user) {
             if ($user->getId() === 'userId') {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RepositoriesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RepositoriesTest.php
@@ -33,8 +33,8 @@ class RepositoriesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $users = $this->repository->findAll();
 
-        $this->assertInstanceOf('Doctrine\ODM\MongoDB\Cursor', $users);
-        $this->assertEquals(1, count($users));
+        $this->assertInternalType('array', $users);
+        $this->assertCount(1, $users);
     }
 
     public function testFind()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
@@ -15,7 +15,7 @@ class GH580Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $repository = $this->dm->getRepository($class);
 
-        $this->assertEquals(0, $repository->findAll()->count());
+        $this->assertCount(0, $repository->findAll());
 
         // Create, persist and flush initial object
         $doc1 = new GH580Document();
@@ -54,7 +54,7 @@ class GH580Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         /* Repository should contain one object, but may contain two if the
          * DocumentPersister was not cleaned up.
          */
-        $this->assertEquals(1, $repository->findAll()->count());
+        $this->assertCount(1, $repository->findAll());
     }
 }
 

--- a/tests/Documents/CommentRepository.php
+++ b/tests/Documents/CommentRepository.php
@@ -9,7 +9,7 @@ class CommentRepository extends DocumentRepository
 {
     public function findOneComment()
     {
-        return $this->findBy(array())
+        return $this->getDocumentPersister()->loadAll()
             ->sort(array('date' => 'desc'))
             ->limit(1)
             ->getSingleResult();
@@ -17,6 +17,6 @@ class CommentRepository extends DocumentRepository
 
     public function findManyComments()
     {
-        return $this->findBy(array());
+        return $this->getDocumentPersister()->loadAll();
     }
 }


### PR DESCRIPTION
Hello,

https://github.com/doctrine/common/blob/master/lib/Doctrine/Common/Persistence/ObjectRepository.php#L60 explicitly document the `findBy()` method as returning an array of objects.

This interface spec is broken in spec and behaviour by https://github.com/doctrine/mongodb-odm/blob/master/lib/Doctrine/ODM/MongoDB/DocumentRepository.php#L164

This PR aims to fix this. It is quite a major BC break for the MongoDB ODM (as the various updated tests show), but I believe the interface shouldn't have been broken in the first place. We were able to break the interface only because PHP doesn't provide a way to check the type of the return value of a method and because Doctrine Common does not provide implementation tests for its interfaces (I don't intend this remark as a critic, but to describe a fact here :wink:). It prevents code base engineered to interact with the Doctrine\Common\Persistence interfaces to crash miserably without clean workarounds.

In order to minimize BC break. I provided the protected method `getDocumentPersister()` in the DocumentRepository so custom repositories could easily return a Cursor (For example, to load associations through custom repository methods).

If you have any ideas that could fix this without BC Break, I would be happy to ear about it and try as hard as possible to reduce BC breaks and update my PR accordingly.
