### PR TITLE
[DocumentRepository] Use Cursor::toArray() instead of iterator_to_array()

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentRepository.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentRepository.php
@@ -170,7 +170,7 @@ class DocumentRepository implements ObjectRepository, Selectable
      */
     public function findBy(array $criteria, array $sort = null, $limit = null, $skip = null)
     {
-        return iterator_to_array($this->getDocumentPersister()->loadAll($criteria, $sort, $limit, $skip), false);
+        return $this->getDocumentPersister()->loadAll($criteria, $sort, $limit, $skip)->toArray(false);
     }
 
     /**


### PR DESCRIPTION
As per https://github.com/doctrine/mongodb-odm/pull/752#issuecomment-32599172 by @tgabi333 and following. This replaces a direct call to `iterator_to_array()` by a call to `Cursor::toArray()` (DRY principal and better respect of encapsulation).
