### PR TITLE
Fix upsert on insert new document with defined id

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1432,15 +1432,15 @@ class UnitOfWork implements PropertyChangedListener
         
         // Allows to insert new documents with user-defined id
         $actualData = $this->getDocumentActualData($document);
-		$isNewDocument = ! isset($this->originalDocumentData[$oid]);
-		if ($isNewDocument) {
-			$this->originalDocumentData[$oid] = $actualData;
-			$changeSet = array();
-			foreach ($actualData as $propName => $actualValue) {
-				$changeSet[$propName] = array(null, $actualValue);
-			}
-			$this->documentChangeSets[$oid] = $changeSet;
-		}
+        $isNewDocument = ! isset($this->originalDocumentData[$oid]);
+        if ($isNewDocument) {
+            $this->originalDocumentData[$oid] = $actualData;
+            $changeSet = array();
+            foreach ($actualData as $propName => $actualValue) {
+                $changeSet[$propName] = array(null, $actualValue);
+            }
+            $this->documentChangeSets[$oid] = $changeSet;
+        }
     }
 
     /**


### PR DESCRIPTION
After this commit: https://github.com/doctrine/mongodb-odm/commit/8251bb9bf943e6abfdb7c347fa1ad6383c795c88
when I trying to insert document with defined id, I get an error: ContextErrorException: Notice: Undefined index: $set in /opt/local/www/realty/vendor/doctrine/mongodb-odm/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php line 290

I have wrote details about problem here: https://github.com/doctrine/mongodb-odm/commit/8251bb9bf943e6abfdb7c347fa1ad6383c795c88#commitcomment-5114932

Sorry, I don't know doctrine well, just try to fix this problem. Maybe should be another solution. Thanks.
