### PR TITLE
Hydrator not acception DateTime objects on @ODM\Date fields

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/DateType.php
@@ -76,6 +76,6 @@ class DateType extends Type
 
     public function closureToPHP()
     {
-        return 'if ($value instanceof \MongoDate) { $return = new \DateTime(); $return->setTimestamp($value->sec); } elseif (is_numeric($value)) { $return = new \DateTime(); $return->setTimestamp($value); } else { $return = new \DateTime($value); }';
+        return 'if ($value instanceof \MongoDate) { $return = new \DateTime(); $return->setTimestamp($value->sec); } elseif (is_numeric($value)) { $return = new \DateTime(); $return->setTimestamp($value); } elseif ($value instanceof \DateTime) { $return = $value; } else { $return = new \DateTime($value); }';
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
@@ -14,6 +14,7 @@ class HydratorTest extends BaseTest
         $this->dm->getHydratorFactory()->hydrate($user, array(
             '_id' => 1,
             'name' => 'jon',
+            'birthdate' => new \DateTime('1961-01-01'),
             'referenceOne' => array('$id' => '1'),
             'referenceMany' => array(
                 array(
@@ -31,6 +32,7 @@ class HydratorTest extends BaseTest
 
         $this->assertEquals(1, $user->id);
         $this->assertEquals('jon', $user->name);
+        $this->assertInstanceOf('DateTime', $user->birthdate);
         $this->assertInstanceOf(__NAMESPACE__.'\HydrationClosureReferenceOne', $user->referenceOne);
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\PersistentCollection', $user->referenceMany);
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $user->referenceMany[0]);
@@ -49,6 +51,9 @@ class HydrationClosureUser
 
     /** @ODM\String */
     public $name;
+    
+    /** @ODM\Date */
+    public $birthdate;
 
     /** @ODM\ReferenceOne(targetDocument="HydrationClosureReferenceOne") */
     public $referenceOne;


### PR DESCRIPTION
```
Exception: DateTime::__construct() expects parameter 1 to be string, object given
tests\Hydrators\DoctrineODMMongoDBTestsHydrationClosureUserHydrator.php:49
lib\Doctrine\ODM\MongoDB\Hydrator\HydratorFactory.php:428
tests\Doctrine\ODM\MongoDB\Tests\HydratorTest.php:31
```
