### PR TITLE
Fix PreLoadEventArgsTest for PHP 5.3

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/PreLoadEventArgsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/PreLoadEventArgsTest.php
@@ -14,10 +14,11 @@ class PreLoadEventArgsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $data = array('id' => '1234', 'name' => 'test');
 
         $eventArgs = new PreLoadEventArgs($document, $dm, $data);
+        $eventArgsData =& $eventArgs->getData();
 
-        $this->assertEquals('test', $eventArgs->getData()['name']);
+        $this->assertEquals('test', $eventArgsData['name']);
 
-        $eventArgs->getData()['name'] = 'alt name';
+        $eventArgsData['name'] = 'alt name';
 
         $this->assertEquals('alt name', $data['name']);
     }


### PR DESCRIPTION
Originally introduced in commit 13338b2ad0257e9e783665c392cdf928f1396eeb for #792.
