### PR TITLE
Serialize ClassMetadata::$associationMappings correctly

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -104,6 +104,7 @@ class ClassMetadata extends ClassMetadataInfo
         // This metadata is always serialized/cached.
         $serialized = array(
             'fieldMappings',
+            'associationMappings',
             'identifier',
             'name',
             'namespace', // TODO: REMOVE
@@ -113,7 +114,7 @@ class ClassMetadata extends ClassMetadataInfo
             'generatorType',
             'generatorOptions',
             'idGenerator',
-            'indexes'
+            'indexes',
         );
 
         // The rest of the metadata is only serialized if necessary.

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -33,6 +33,7 @@ class ClassMetadataTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $cm->setSlaveOkay(true);
         $this->assertTrue(is_array($cm->getFieldMapping('phonenumbers')));
         $this->assertEquals(1, count($cm->fieldMappings));
+        $this->assertEquals(1, count($cm->associationMappings));
 
         $serialized = serialize($cm);
         $cm = unserialize($serialized);
@@ -49,6 +50,7 @@ class ClassMetadataTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals('disc', $cm->discriminatorField);
         $this->assertTrue(is_array($cm->getFieldMapping('phonenumbers')));
         $this->assertEquals(1, count($cm->fieldMappings));
+        $this->assertEquals(1, count($cm->associationMappings));
         $this->assertEquals('customFileProperty', $cm->file);
         $this->assertEquals('customDistanceProperty', $cm->distance);
         $this->assertTrue($cm->slaveOkay);


### PR DESCRIPTION
Prior to this commit, APC cached ClassMetadata was completely broken. ClassMetadata::__sleep()
does not return associationMappings, which menas that when it is written to cache, that field
is not added.

When it is read from the cache it is simply an empty array. In certain cases this can cause
problems (data loss).
