### PR TITLE
Partial reference support (without $db property)

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -701,8 +701,10 @@ class DocumentManager implements ObjectManager
         $dbRef = array(
             '$ref' => $class->getCollection(),
             '$id'  => $class->getDatabaseIdentifierValue($id),
-            '$db'  => $this->getDocumentDatabase($class->name)->getName(),
         );
+        if ( empty($referenceMapping['partial'])) {
+            $dbRef['$db'] = $this->getDocumentDatabase($class->name)->getName();
+        }
 
         if ($class->hasDiscriminator()) {
             $dbRef[$class->discriminatorField] = $class->discriminatorValue;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceMany.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceMany.php
@@ -25,6 +25,7 @@ final class ReferenceMany extends AbstractField
     public $type = 'many';
     public $reference = true;
     public $simple = false;
+    public $partial = false;
     public $targetDocument;
     public $discriminatorField;
     public $discriminatorMap;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceOne.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceOne.php
@@ -25,6 +25,7 @@ final class ReferenceOne extends AbstractField
     public $type = 'one';
     public $reference = true;
     public $simple = false;
+    public $partial = false;
     public $targetDocument;
     public $discriminatorField;
     public $discriminatorMap;


### PR DESCRIPTION
This PR introduces new annotation property ##partial## for ReferenceOne and ReferenceMany which, when set to true, will create a reference with no $db key.