### PR TITLE
Document strategy attribute for Id annotation

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -570,8 +570,8 @@ Alias of @Field, with "type" attribute set to
 ---
 
 The annotated instance variable will be marked as document
-identifier. This annotation is a marker only and has no required or
-optional attributes.
+identifier. If you don’t want to use the default MongoId you may set 
+:ref:`strategy attribute <basic_mapping_identifiers>`. 
 
 Example:
 

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -212,6 +212,8 @@ fields that hold scalar values like strings, numbers, etc.
 References to other objects and embedded objects are covered in the
 chapter "Reference Mapping".
 
+.. _basic_mapping_identifiers:
+
 Identifiers
 ~~~~~~~~~~~
 


### PR DESCRIPTION
"This annotation is a marker only and has no required or optional attributes." is not true for @Id annotation as one can set `strategy` attribute
