### PR TITLE
Allow hint by index name (BUG)

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Cursor.php
+++ b/lib/Doctrine/ODM/MongoDB/Cursor.php
@@ -300,7 +300,7 @@ class Cursor extends BaseCursor
      * @param array|string $keyPattern
      * @return self
      */
-    public function hint(array $keyPattern)
+    public function hint($keyPattern)
     {
         $this->baseCursor->hint($keyPattern);
         return $this;


### PR DESCRIPTION
Wait for a string or an array but force an array in the signature of the method.

http://php.net/manual/en/mongocursor.hint.php
