### PR TITLE
Cursor::hint() signature changed

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Cursor.php
+++ b/lib/Doctrine/ODM/MongoDB/Cursor.php
@@ -300,7 +300,7 @@ class Cursor extends BaseCursor
      * @param array|string $keyPattern
      * @return self
      */
-    public function hint(array $keyPattern)
+    public function hint($keyPattern)
     {
         $this->baseCursor->hint($keyPattern);
         return $this;


### PR DESCRIPTION
I think this fixes #826 and #827.
The signature of Cursor::hint() changed in doctrine/mongodb but not in doctrine/mongodb-odm.
