### PR TITLE
Restore ClassMetadataInfo::$lifecycleCallbacks array structure

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -576,9 +576,11 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
      */
     public function addLifecycleCallback($callback, $event)
     {
-        if ( ! isset($this->lifecycleCallbacks[$event][$callback])) {
-            $this->lifecycleCallbacks[$event][$callback] = $callback;
+        if (isset($this->lifecycleCallbacks[$event]) && in_array($callback, $this->lifecycleCallbacks[$event])) {
+            return;
         }
+
+        $this->lifecycleCallbacks[$event][] = $callback;
     }
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -144,27 +144,18 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
      */
     public function testLifecycleCallbacks($class)
     {
-        $this->assertEquals(count($class->lifecycleCallbacks), 2);
-        $this->assertEquals($class->lifecycleCallbacks['prePersist']['doStuffOnPrePersist'], 'doStuffOnPrePersist');
-        $this->assertEquals($class->lifecycleCallbacks['postPersist']['doStuffOnPostPersist'], 'doStuffOnPostPersist');
+        $expectedLifecycleCallbacks = array(
+            'prePersist' => array('doStuffOnPrePersist'),
+            'postPersist' => array('doStuffOnPrePersist', 'doOtherStuffOnPrePersistToo'),
+        );
+
+        $this->assertEquals($expectedLifecycleCallbacks, $class->lifecycleCallbacks);
 
         return $class;
     }
 
     /**
      * @depends testLifecycleCallbacks
-     * @param ClassMetadata $class
-     */
-    public function testLifecycleCallbacksSupportMultipleMethodNames($class)
-    {
-        $this->assertEquals(count($class->lifecycleCallbacks['prePersist']), 2);
-        $this->assertEquals($class->lifecycleCallbacks['prePersist']['doOtherStuffOnPrePersistToo'], 'doOtherStuffOnPrePersistToo');
-
-        return $class;
-    }
-
-    /**
-     * @depends testLifecycleCallbacksSupportMultipleMethodNames
      * @param ClassMetadata $class
      */
     public function testCustomFieldName($class)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -210,13 +210,8 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             array(
-                'postPersist' => array(
-                    'doStuffOnPostPersist' => 'doStuffOnPostPersist',
-                    'doOtherStuffOnPostPersist' => 'doOtherStuffOnPostPersist',
-                ),
-                'prePersist' => array(
-                    'doStuffOnPrePersist' => 'doStuffOnPrePersist',
-                )
+                'postPersist' => array('doStuffOnPostPersist', 'doOtherStuffOnPostPersist'),
+                'prePersist' => array('doStuffOnPrePersist'),
             ),
             $classMetadata->lifecycleCallbacks
         );


### PR DESCRIPTION
Fixes #803. This restores the structure before 59a67f3f29020f6dfc82b7446c6140b4010d8681 (#428) to be consistent with ORM while still ensuring that the same callback is not registered multiple times.
