### PR TITLE
Fix findOne() call in DocumentPersister::exists()

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -523,7 +523,7 @@ class DocumentPersister
     public function exists($document)
     {
         $id = $this->class->getIdentifierObject($document);
-        return (boolean) $this->collection->findOne(array(array('_id' => $id)), array('_id'));
+        return (boolean) $this->collection->findOne(array('_id' => $id), array('_id'));
     }
 
     /**


### PR DESCRIPTION
The first paramter needs to be a map of fields and not a list of mappings.

Until now exists() always returned false.
