### PR TITLE
spl_object_hash collision when doing merge() twice

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2133,6 +2133,12 @@ class UnitOfWork implements PropertyChangedListener
             $prevClass = $this->dm->getClassMetadata(get_class($prevManagedCopy));
 
             if ($assoc['type'] === 'one') {
+                $oldManagedCopy = $prevClass->reflFields[$assocField]->getValue($prevManagedCopy);
+                if (is_object($oldManagedCopy)) {
+                    // remove the current managed copy as it gets replaced with the setValue() call
+                    $subVisited = array();
+                    $this->doDetach($oldManagedCopy, $subVisited);
+                }
                 $prevClass->reflFields[$assocField]->setValue($prevManagedCopy, $managedCopy);
             } else {
                 $prevClass->reflFields[$assocField]->getValue($prevManagedCopy)->add($managedCopy);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH878Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH878Test.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\UnitOfWork;
+
+class GH878Test extends BaseTest
+{
+    public function testSPLObjectHashCollisionOnDoubleMerge()
+    {
+        $document = $this->getPersistedButDetachedDocument();
+
+        // should be detached as coming from cache
+        $state = $this->uow->getDocumentState($document);
+        $this->assertEquals(UnitOfWork::STATE_DETACHED, $state);
+        // clear to have again clear state
+        $this->dm->clear();
+
+        // merge + flush twice the same detached document
+        $first = $this->dm->merge($document);
+        $this->dm->flush();
+
+        $state = $this->uow->getDocumentState($first);
+        $this->assertEquals(UnitOfWork::STATE_MANAGED, $state);
+
+        $second = $this->dm->merge($document);
+        $this->dm->flush();
+
+        $state = $this->uow->getDocumentState($second);
+        $this->assertEquals(UnitOfWork::STATE_MANAGED, $state);
+
+        $someOtherDocument = new GH878OtherDocument();
+
+        $state = $this->uow->getDocumentState($someOtherDocument);
+        $this->assertEquals(UnitOfWork::STATE_NEW, $state);
+    }
+
+    /**
+     * @return GH878Document
+     */
+    private function getPersistedButDetachedDocument() {
+        $document = new GH878Document();
+        $document->embeddedField = new GH878SubDocument();
+
+        $this->dm->persist($document);
+        $this->dm->flush();
+        // clear here to simulate a cache
+        $this->dm->clear();
+
+        return $document;
+    }
+}
+
+/** @ODM\Document */
+class GH878Document
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedOne(targetDocument="GH878SubDocument") */
+    public $embeddedField;
+}
+
+/** @ODM\EmbeddedDocument */
+class GH878SubDocument
+{
+    /** @ODM\String */
+    public $some = '2';
+}
+
+/** @ODM\Document */
+class GH878OtherDocument
+{
+    /** @ODM\Id */
+    public $id;
+}


### PR DESCRIPTION
After spending hours of trying to figure out why our system does not save certain documents, and afterwards hours of producing a reproducable testcase, I finally managed to track it down to the merge inside odm.

##### Background:
We have a **main-document** (1) that embedds on **embedded-document** (1).
We also have an **other-document** with just an identifier.
Initially in the test we get the **main-document** from somewhere other than doctrine (cache for example).

##### Problem:
Now when calling merge on the detached **main-document** (1), the logic inside the *UnitOfWork::doMerge* creates a new **embedded-document** (2), merges it with its detached one and sets it on the managed **main-document** (2).
When calling merge a second time on the same detached **main-document** (1), its "managed version" (2) is already found in the identity map. Still a new **embedded-document** (3) is created and merged with the one from the detached **embedded-document** (1). After the **embedded-document**(3) is merged it is set back on the **main-document**(2), replacing the previous managed **embedded-document**(2). This previous document in our scenario now does not have any references (because documents without identifiers are not in the identity map) and is probably gc by php.
The newly created **other-document** that the test tries to insert afterwards is then detected as managed, as the spl_object_hash for this document is the same as for the unreferenced **embedded-document** (2).

##### Fix:
I already have a fix for that in the second commit, but I'm not sure if it introduces any side effects that I might not be aware of. But I can not see anything bad currently and all the tests still work.

The fix simply detaches the (at least inside odm) not anymore referenced embedded document.

Relates to #642