### PR TITLE
[WIP] Strict Mode for QueryBuilder

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/MongoDBException.php
+++ b/lib/Doctrine/ODM/MongoDB/MongoDBException.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ODM\MongoDB;
 
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+
 /**
  * Class for all exceptions related to the Doctrine MongoDB ODM
  *
@@ -57,10 +59,22 @@ class MongoDBException extends \Exception
         return new self("You need to pass a parameter to '".$methodName."'");
     }
 
-    public static function unknownDocumentField($field, $class)
+    public static function unknownDocumentField($field, ClassMetadata $class)
     {
-        // @todo: Have you meant: f1, f2? - that's why $class is passed
-        return new self(sprintf("Unknown field %s in %s", $field, $class->name));
+        $suggestions = array();
+        foreach ($class->getFieldNames() as $existing) {
+            if (levenshtein($field, $existing)<=2) {
+                $suggestions[] = $existing;
+            }
+        }
+        switch (count($suggestions)) {
+            case 0:
+                return new self(sprintf("Unknown field %s in %s", $field, $class->name));
+            case 1:
+                return new self(sprintf("Unknown field %s in %s. Have you meant %s?", $field, $class->name, $suggestions[0]));
+            default:
+                return new self(sprintf("Unknown field %s in %s. Have you meant one of %s?", $field, $class->name, join(', ', $suggestions)));
+        }
     }
     
     public static function unknownDocumentNamespace($documentNamespaceAlias)

--- a/lib/Doctrine/ODM/MongoDB/MongoDBException.php
+++ b/lib/Doctrine/ODM/MongoDB/MongoDBException.php
@@ -57,6 +57,12 @@ class MongoDBException extends \Exception
         return new self("You need to pass a parameter to '".$methodName."'");
     }
 
+    public static function unknownDocumentField($field, $class)
+    {
+        // @todo: Have you meant: f1, f2? - that's why $class is passed
+        return new self(sprintf("Unknown field %s in %s", $field, $class->name));
+    }
+    
     public static function unknownDocumentNamespace($documentNamespaceAlias)
     {
         return new self("Unknown Document namespace alias '$documentNamespaceAlias'.");

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryBuilderStrictModeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryBuilderStrictModeTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\Query\Builder;
+use Doctrine\ODM\MongoDB\Query\Query;
+
+class QueryBuilderStrictModeTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testSimpleFieldsPassing()
+    {
+        $qb = $this->qb('Documents\User')
+                ->field('count')->notEqual(3)
+                ->sort('createdAt', 'asc');
+        $this->assertTrue($qb->getQuery() instanceof Query);
+    }
+    
+    /**
+     * @expectedException Doctrine\ODM\MongoDB\MongoDBException
+     * @expectedExceptionMessage Unknown field cont in Documents\User
+     */
+    public function testSimpleFieldsNotPassing()
+    {
+        $qb = $this->qb('Documents\User')
+                ->field('cont')->notEqual(3)
+                ->getQuery();
+    }
+    
+    public function testSimpleEmbedOnePassing()
+    {
+        $qb = $this->qb('Documents\User')
+                ->field('address.city')->equals('Cracow');
+        $this->assertTrue($qb->getQuery() instanceof Query);
+    }
+    
+    /**
+     * @expectedException Doctrine\ODM\MongoDB\MongoDBException
+     * @expectedExceptionMessage Unknown field adress in Documents\User
+     */
+    public function testSimpleEmbedOneNotPassing()
+    {
+        $qb = $this->qb('Documents\User')
+                ->field('adress.city')->equals('Cracow')
+                ->getQuery();
+    }
+    
+    /**
+     * @expectedException Doctrine\ODM\MongoDB\MongoDBException
+     * @expectedExceptionMessage Unknown field ciity in Documents\Address
+     */
+    public function testSimpleEmbedOnePropertyNotPassing()
+    {
+        $qb = $this->qb('Documents\User')
+                ->field('address.ciity')->equals('Cracow')
+                ->getQuery();
+    }
+    
+    public function testDeepEmbedPassing()
+    {
+        $qb = $this->qb('Documents\User')
+                ->field('address.subAddress.city')->equals('Cracow');
+        $this->assertTrue($qb->getQuery() instanceof Query);
+    }
+    
+    /**
+     * @expectedException Doctrine\ODM\MongoDB\MongoDBException
+     * @expectedExceptionMessage Unknown field ciity in Documents\Address
+     */
+    public function testDeepEmbedNotPassing()
+    {
+        $qb = $this->qb('Documents\User')
+                ->field('address.subAddress.ciity')->equals('Cracow')
+                ->getQuery();
+    }
+    
+    public function testReferenceOnePassing()
+    {
+        $qb = $this->qb('Documents\User')
+                ->field('account.name')->equals('Maciej');
+        $this->assertTrue($qb->getQuery() instanceof Query);
+    }
+    
+    /**
+     * @expectedException Doctrine\ODM\MongoDB\MongoDBException
+     * @expectedExceptionMessage Unknown field namme in Documents\Account
+     */
+    public function testReferenceOneNotPassing()
+    {
+        $qb = $this->qb('Documents\User')
+                ->field('account.namme')->equals('Maciej')
+                ->getQuery();
+    }
+    
+    /**
+     * @param string $class
+     * @return Builder
+     */
+    private function qb($class)
+    {
+        return $this->dm->createQueryBuilder($class)
+                ->strictMode();
+    }
+}


### PR DESCRIPTION
Implementation for feature proposed in https://github.com/doctrine/mongodb-odm/issues/866 Any suggestions of what else should be tested are more than welcome

Checklist:
- [x] simple fields and simple fields in EmbedOne/ReferenceOne documents
- [ ] tests with EmbedMany, ReferenceOne, $elemMatch
- [ ] tests with discriminators
- [x] test with different field and fieldName
- [x] "Have you meant" in Exception
- [ ] Docs
