### PR TITLE
Fix the "Erroneous data format for unserializing" error message

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -196,7 +196,12 @@ class ClassMetadata extends ClassMetadataInfo
     public function newInstance()
     {
         if ($this->prototype === null) {
-            $this->prototype = unserialize(sprintf('O:%d:"%s":0:{}', strlen($this->name), $this->name));
+            if (version_compare(PHP_VERSION, '5.4') >= 0) {
+                $rc = new \ReflectionClass($this->name);
+                $this->prototype = $rc->newInstanceWithoutConstructor();
+            } else {
+                $this->prototype = unserialize(sprintf('O:%d:"%s":0:{}', strlen($this->name), $this->name));
+            }
         }
 
         return clone $this->prototype;


### PR DESCRIPTION
Fix the "Erroneous data format for unserializing" warning as in:
http://www.doctrine-project.org/jira/browse/DDC-3120
https://github.com/doctrine/doctrine2/pull/1045
but for mongodb-odm.
