### PR TITLE
QueryBuilder forces refresh() if select() was used

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -285,6 +285,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
 
         if (isset($query['select'])) {
             $query['select'] = $documentPersister->prepareSortOrProjection($query['select']);
+            $this->refresh();
         }
 
         if (isset($query['sort'])) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH895Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH895Test.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class GH895Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testQueryWithSelect()
+    {
+        $d = new GH895Document();
+        $d->a = "a";
+        $d->b = "b";
+        $d->c = "c";
+        $d->d = "d";
+        $this->dm->persist($d);
+        $this->dm->flush();
+        $this->dm->clear();
+        
+        $r = $this->dm->getRepository('Doctrine\ODM\MongoDB\Tests\GH895Document');
+        $qb = $r->createQueryBuilder()
+                ->select('a', 'b', 'c')
+                ->field('a')->equals('a');
+        $doc = $qb->getQuery()->getSingleResult();
+        $this->assertEquals($doc->a, $d->a);
+        $this->assertEquals($doc->b, $d->b);
+        $this->assertEquals($doc->c, $d->c);
+        $this->assertNull($doc->d);
+        
+        $qb = $r->createQueryBuilder()
+                ->select('b', 'c', 'd')
+                ->field('d')->equals('d');
+        $doc = $qb->getQuery()->getSingleResult();
+        $this->assertEquals($doc->b, $d->b);
+        $this->assertEquals($doc->c, $d->c);
+        $this->assertEquals($doc->d, $d->d);
+    }
+}
+
+/**
+ * @ODM\Document
+ */
+class GH895Document
+{
+    /** @ODM\Id(strategy="auto") */
+    private $id;
+    
+    /** @ODM\String */
+    public $a;
+    
+    /** @ODM\String */
+    public $b;
+    
+    /** @ODM\String */
+    public $c;
+    
+    /** @ODM\String */
+    public $d;
+}


### PR DESCRIPTION
Fixes #895

I have tried detecting that document managed by UoW contains less data than just fetched ``$data`` in ``UnitOfWork::getOrCreateDocument`` but it was ~0.4s slower (for whole test suite) so imo it's no way to go.