### PR TITLE
Fix ReferencesTest failure with Doctrine Common 2.4.2

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
@@ -299,6 +299,10 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $test->referenceOne->__load();
     }
 
+    /**
+     * @expectedException \Doctrine\ODM\MongoDB\DocumentNotFoundException
+     * @expectedExceptionMessage The "Proxies\__CG__\Documents\Profile" document with identifier "abcdefabcdefabcdefabcdef" could not be found.
+     */
     public function testDocumentNotFoundExceptionWithMongoId()
     {
         $profile = new Profile();
@@ -312,7 +316,7 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $collection = $this->dm->getDocumentCollection(get_class($user));
 
-        $invalidId = new \MongoId();
+        $invalidId = new \MongoId('abcdefabcdefabcdefabcdef');
 
         $collection->update(
             array('_id' => new \MongoId($user->getId())),
@@ -320,8 +324,6 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                 'profile.$id' => $invalidId,
             ))
         );
-
-        $this->setExpectedException('Doctrine\ODM\MongoDB\DocumentNotFoundException', sprintf('The "Proxies\__CG__\Documents\Profile" document with identifier "%s" could not be found.', (string) $invalidId));
 
         $user = $this->dm->find(get_class($user), $user->getId());
         $profile = $user->getProfile();


### PR DESCRIPTION
As of [build 1236](https://travis-ci.org/doctrine/mongodb-odm/builds/26415417), the test suite was failing due to doctrine/common#298, which was included in Doctrine Common [v2.4.2](https://github.com/doctrine/common/releases/tag/v2.4.2).
