### PR TITLE
Fix cascade persist for associations.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -175,6 +175,10 @@ class PersistentCollection implements BaseCollection
                 // Has NEW objects added through add(). Remember them.
                 $newObjects = $this->coll->toArray();
             }
+            else if (! empty($this->snapshot)) {
+                // a snapshot has been taken during a cascade persist. Remember it.
+                $newObjects = $this->snapshot;
+            }
             $this->coll->clear();
             $this->uow->loadCollection($this);
             $this->takeSnapshot();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AssocationCascadePersistTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AssocationCascadePersistTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Documents\Phonenumber;
+use Documents\Group;
+use Documents\User;
+
+class AssociationCascadePersistTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testManyReferenceAddAndPersist()
+    {
+        $user = new \Documents\User();
+
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $qb = $this->dm->createQueryBuilder('Documents\User')
+            ->field('id')
+            ->equals($user->getId());
+        $query = $qb->getQuery();
+        $user2 = $query->getSingleResult();
+        $groups = $user2->getGroups();
+
+        $user2->addGroup(new Group('Group'));
+        $this->assertEquals(1, count($groups));
+        $this->dm->persist($user2);
+        $this->dm->flush();
+        $groups->initialize();
+        $this->assertEquals(1, count($groups));
+    }
+
+    public function testManyEmbeddedAddAndPersist()
+    {
+        $user = new \Documents\User();
+
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $qb = $this->dm->createQueryBuilder('Documents\User')
+            ->field('id')
+            ->equals($user->getId());
+        $query = $qb->getQuery();
+        $user2 = $query->getSingleResult();
+        $phoneNumbers = $user2->getPhoneNumbers();
+
+        $user2->addPhoneNumber(new Phonenumber('555 555 555'));
+        $this->assertEquals(1, count($phoneNumbers));
+        $this->dm->persist($user2);
+        $this->dm->flush();
+        $phoneNumbers->initialize();
+        $this->assertEquals(1, count($phoneNumbers));
+    }
+}


### PR DESCRIPTION
This PR is somewhat related to https://github.com/doctrine/mongodb-odm/issues/715 I think (the last comment at least).

During a cascade persist operation on a *Many* association, a snapshot of the associated collection is [taken](https://github.com/doctrine/mongodb-odm/blob/master/lib/Doctrine/ODM/MongoDB/UnitOfWork.php#L473), marking the collection as "not dirty".  So if items were added to the collection before persisting, and the collection was never initialized, the items are lost (persisted in DB but not present in the instanciated collection anymore).

By using the previously taken snapshot during the collection initialization, we can re-add the lost items after loading the collection.

That's the first time I take a look at Doctrine's internals, so I very well might be completely off with the solution, but I think the use case really is bugged. Or did I miss something ?