### PR TITLE
Fix cascade remove for associations.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2509,6 +2509,9 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function cascadeRemove($document, array &$visited)
     {
+        if ($document instanceof Proxy) {
+            $document->__load();
+        }
         $class = $this->dm->getClassMetadata(get_class($document));
         foreach ($class->fieldMappings as $mapping) {
             if ( ! $mapping['isCascadeRemove']) {


### PR DESCRIPTION
Option casade={"remove"}  does not working on second and deeper level of cascade.
Because in association we are have proxy object which not loaded. 
And call of \ReflectionProperty::getValue on this object returns defalt value, not real related documents.

``` php
$relatedDocuments = $class->reflFields[$mapping['fieldName']]->getValue($document); 
```

Cascade delete continues without affecting nested objects

This commit fixed this bug.

Mapping Example:

My user class:

``` php
 // User.php
use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;

/**
* @MongoDB\Document
*/
class User 
{
    /**
     * @var string
     *
     * @MongoDB\Id
     */
    protected $id;

    /**
     * @var string
     *
     * @MongoDB\String
     */
    protected $username;

    /**
     *  @MongoDB\ReferenceMany(targetDocument="House", mappedBy="user", cascade="remove")
     */
    protected $houses;
}
```

My house class:

``` php
 // House.php
use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;

/**
* @MongoDB\Document
*/
class House 
{
    /**
     * @var string
     *
     * @MongoDB\Id
     */
    protected $id;

    /**
     * @var User
     *
     * @MongoDB\ReferenceOne(targetDocument="User", inversedBy="houese")
     */
    protected $user;

    /**
     *  @var Photo[]
     *
     *  @MongoDB\ReferenceMany(targetDocument="House", cascade="remove")
     */
    protected $photos;
}
```

My photo class:

``` php
 // Photo.php
use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;

/**
* @MongoDB\Document
*/
class Photo 
{
    /**
     * @var string
     *
     * @MongoDB\Id
     */
    protected $id;

    /**
     * @var string
     *
     * @MongoDB\String
     */
    protected $filename;
}
```

With this mapping when i execute 

``` php
$documentManager->remove($someUserDocument);
```

All houses associated with `$someUserDocument` will be removed from mongo, but all photos associated with this houses will not be removed 
