### PR TITLE
Fix orphan-removal in XML driver

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -113,6 +113,7 @@
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />
     <xs:attribute name="mapped-by" type="xs:NMTOKEN" />
     <xs:attribute name="repositoryMethod" type="xs:NMTOKEN" />
+    <xs:attribute name="orphan-removal" type="xs:boolean" />
   </xs:complexType>
 
   <xs:complexType name="reference-many">
@@ -133,6 +134,7 @@
     <xs:attribute name="repositoryMethod" type="xs:NMTOKEN" />
     <xs:attribute name="limit" type="xs:integer" />
     <xs:attribute name="skip" type="xs:integer" />
+    <xs:attribute name="orphan-removal" type="xs:boolean" />
   </xs:complexType>
 
   <xs:complexType name="sort-type">

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -257,7 +257,7 @@ class XmlDriver extends FileDriver
         $attributes = $reference->attributes();
         $mapping = array(
             'cascade'          => $cascade,
-            'orphanRemoval'    => isset($attributes['orphan-removal']) ? $reference['orphan-removal'] : false,
+            'orphanRemoval'    => isset($attributes['orphan-removal']) ? (boolean) $attributes['orphan-removal'] : false,
             'type'             => $type,
             'reference'        => true,
             'simple'           => isset($attributes['simple']) ? (boolean) $attributes['simple'] : false,

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -147,7 +147,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'repositoryMethod' => null,
             'limit' => null,
             'skip' => null,
-            'orphanRemoval' => false,
+            'orphanRemoval' => true,
         ), $classMetadata->fieldMappings['profile']);
 
         $this->assertEquals(array(

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.User.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.User.dcm.xml
@@ -12,7 +12,7 @@
         <field name="tags" type="collection" />
         <embed-one target-document="Documents\Address" field="address" />
         <!--<field name="profile" targetDocument="Documents\Profile" reference="true" type="one" cascade="all" />-->
-        <reference-one target-document="Documents\Profile" field="profile" simple="true">
+        <reference-one target-document="Documents\Profile" field="profile" simple="true" orphan-removal="true">
             <cascade>
                 <all />
             </cascade>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/yaml/TestDocuments.User.dcm.yml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/yaml/TestDocuments.User.dcm.yml
@@ -26,6 +26,7 @@ TestDocuments\User:
       simple: true
       targetDocument: Documents\Profile
       cascade: all
+      orphanRemoval: true
     account:
       targetDocument: Documents\Account
       cascade: all


### PR DESCRIPTION
Issue: When using XML mapping, the "orphan-removal" attribute is stored in the ClassMetadata as a SimpleXML object instead of a boolean. This leads Doctrine to consider orphan-removal as enabled as soon as you provide an "orphan-removal" attribute, even if you specify orphan-removal="false".

Solution: The XML driver was mapping the wrong value. I've added a test case since it was missing for orphan-removal, and i've also updated the XSD file with the orphan-removal attribute.
