### PR TITLE
preserve dirty state - refs #963

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -194,6 +194,10 @@ class PersistentCollection implements BaseCollection
             }
         }
 
+        if ($newObjects) {
+            $this->isDirty = true;
+        }
+
         $this->mongoData = array();
         $this->initialized = true;
     }


### PR DESCRIPTION
Since bd573cb7 the dirty state is reset to false when you call `PersistentCollection::initialize()` even if extra elements have been added to the collection before being called.

This addresses #963 but I'm not sure if it could have other implication (tests pass 100%)