### PR TITLE
fix update of inherited documents on findAndUpdate [#971]

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -844,7 +844,11 @@ class DocumentPersister
          */
         if ($this->class->hasDiscriminator() && ! isset($preparedQuery[$this->class->discriminatorField])) {
             $discriminatorValues = $this->getClassDiscriminatorValues($this->class);
-            $preparedQuery[$this->class->discriminatorField] = array('$in' => $discriminatorValues);
+            if((count($discriminatorValues) == 1)) {
+                $preparedQuery[$this->class->discriminatorField] = $discriminatorValues[0];
+            } else {
+                $preparedQuery[$this->class->discriminatorField] = array('$in' => $discriminatorValues);
+            }
         }
 
         return $preparedQuery;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
@@ -9,10 +9,10 @@ class _Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest {
 
     public function testUpdateOfInheritedDocumentUsingFindAndUpdate() {
         $name = "Ferrari";
-        $features = [
+        $features = array(
             "Super Engine",
             "Huge Wheels"
-        ];
+        );
 
         //first query, create Car with name "Ferrari"
         $this->dm->createQueryBuilder(__NAMESPACE__ . '\Car')

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
@@ -5,9 +5,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-class _Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest {
+class GH971Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
 
-    public function testUpdateOfInheritedDocumentUsingFindAndUpdate() {
+    public function testUpdateOfInheritedDocumentUsingFindAndUpdate()
+    {
         $name = "Ferrari";
         $features = array(
             "Super Engine",

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
@@ -1,0 +1,66 @@
+<?php
+
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class _Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest {
+
+    public function testUpdateOfInheritedDocumentUsingFindAndUpdate() {
+        $name = "Ferrari";
+        $features = [
+            "Super Engine",
+            "Huge Wheels"
+        ];
+
+        //first query, create Car with name "Ferrari"
+        $this->dm->createQueryBuilder(__NAMESPACE__ . '\Car')
+            ->findAndUpdate()
+            ->upsert(true)
+            ->field('name')->equals($name)
+            ->sort('_id', -1)
+            ->field('features')->push($features[0])
+            ->getQuery()->execute();
+
+        //second query: update existing "Ferrari" with new feature
+        $this->dm->createQueryBuilder(__NAMESPACE__ . '\Car')
+            ->findAndUpdate()
+            ->upsert(true)
+            ->field('name')->equals($name)
+            ->sort('_id', -1)
+            ->field('features')->push($features[1])
+            ->getQuery()->execute();
+
+        $results = $this->dm->getRepository(__NAMESPACE__ . '\Car')->findAll();
+        $this->assertCount(1, $results);
+    }
+}
+
+/**
+ * @ODM\Document
+ * @ODM\InheritanceType("SINGLE_COLLECTION")
+ * @ODM\DiscriminatorField(fieldName="type")
+ * @ODM\DiscriminatorMap({"car"="Car", "bicycle"="Bicycle"})
+ */
+class Vehicle
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\String */
+    public $name;
+
+    /** @ODM\EmbedMany */
+    public $features;
+}
+
+/**
+ * @ODM\Document
+ */
+class Car extends Vehicle {}
+
+/**
+ * @ODM\Document
+ */
+class Bicycle extends Vehicle {}


### PR DESCRIPTION
Fix for error from #971 ticket. When looking for particular document, DocumentPersist use $in to query particular type of documents, that are inherited in "SINGLE_COLLECTION" way. It works great in case of looking for a file, but has no influence on document creation on upsert update. Added condition, which change "$in" into simple equation, if there is only one discriminator value.