### PR TITLE
Documentation: Fix binary mapping type names

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -188,7 +188,7 @@ This list explains some of the less obvious mapping types:
 -  ``bin_bytearray``: string to MongoBinData instance with a "byte array" type
 -  ``bin_custom``: string to MongoBinData instance with a "custom" type
 -  ``bin_func``: string to MongoBinData instance with a "function" type
--  ``bin_md5``: string to MongoBinData instance with a "md5" typ
+-  ``bin_md5``: string to MongoBinData instance with a "md5" type
 -  ``bin_uuid``: string to MongoBinData instance with a "uuid" type
 -  ``collection``: numerically indexed array to MongoDB array
 -  ``date``: DateTime to MongoDate

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -150,11 +150,12 @@ an MongoDB type. You can even write your own custom mapping types.
 
 Here is a quick overview of the built-in mapping types:
 
--  ``bin_data_custom``
--  ``bin_data_func``
--  ``bin_data_md5``
--  ``bin_data``
--  ``bin_data_uuid``
+-  ``bin``
+-  ``bin_bytearray``
+-  ``bin_custom``
+-  ``bin_func``
+-  ``bin_md5``
+-  ``bin_uuid``
 -  ``boolean``
 -  ``collection``
 -  ``custom_id``
@@ -183,11 +184,12 @@ You can read more about the available MongoDB types on `php.net <http://us.php.n
 Generally, the name of each built-in mapping type hints as to how the value will be converted.
 This list explains some of the less obvious mapping types:
 
--  ``bin_data_custom``: string to MongoBinData instance with a "custom" type
--  ``bin_data_func``: string to MongoBinData instance with a "function" type
--  ``bin_data_md5``: string to MongoBinData instance with a "md5" type
--  ``bin_data``: string to MongoBinData instance with a "byte array" type
--  ``bin_data_uuid``: string to MongoBinData instance with a "uuid" type
+-  ``bin``: string to MongoBinData instance with a "byte array" type
+-  ``bin_bytearray``: string to MongoBinData instance with a "byte array" type
+-  ``bin_custom``: string to MongoBinData instance with a "custom" type
+-  ``bin_func``: string to MongoBinData instance with a "function" type
+-  ``bin_md5``: string to MongoBinData instance with a "md5" typ
+-  ``bin_uuid``: string to MongoBinData instance with a "uuid" type
 -  ``collection``: numerically indexed array to MongoDB array
 -  ``date``: DateTime to MongoDate
 -  ``hash``: associative array to MongoDB object


### PR DESCRIPTION
The documentation on the names of binary mapping types is wrong/outdated. This PR fixes the issue.