### PR TITLE
Update annotations reference for @Timestamp clarification

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -1127,6 +1127,11 @@ Defines that the annotated instance variable holds a timestamp.
 
     /** @Timestamp */
     private $created;
+    
+.. note::
+
+    The timestamp annotation is intended for internal use (MongoDB uses it in the replication oplog).
+    If you're storing dates and times in your application, the @Date annotation.
 
 @UniqueIndex
 ------------

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -1131,7 +1131,7 @@ Defines that the annotated instance variable holds a timestamp.
 .. note::
 
     The timestamp annotation is intended for internal use (MongoDB uses it in the replication oplog).
-    If you're storing dates and times in your application, the @Date annotation.
+    If you're storing dates and times in your application, please use the @Date annotation.
 
 @UniqueIndex
 ------------


### PR DESCRIPTION
Fixes #974 

Added note that the @Timestamp annotation should not be used for storing Dates