### PR TITLE
[Docs] Added @Version to annotations reference

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -1141,3 +1141,15 @@ Defines a unique index on the given document.
     private $email;
 
 .. _`DBRef`: http://docs.mongodb.org/manual/reference/database-references/#dbref
+
+@Version
+--------
+
+Marker annotation that defines a specified field as version attribute used in an optimistic locking scenario. It only works with @Int and @Date annotated fields. Combining @Version with @Id is not supported.
+
+.. code-block:: php
+
+    <?php
+
+    /** @Int @Version */
+    private $version;


### PR DESCRIPTION
Fixes #982 and also resolves #429 which I've just found.

The entry is modeled after ORM's definition. Also it would be good to port http://doctrine-orm.readthedocs.org/en/latest/reference/transactions-and-concurrency.html#locking-support to docs (or at least link if no one has spare time?)