### PR TITLE
Fix : ensure embeded indexes creation when embeded more than one time

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -160,11 +160,17 @@ class SchemaManager
 
         $class = $this->dm->getClassMetadata($documentName);
         $indexes = $this->prepareIndexes($class);
+        $embeddedDocumentIndexes = array();
 
         // Add indexes from embedded & referenced documents
         foreach ($class->fieldMappings as $fieldMapping) {
             if (isset($fieldMapping['embedded']) && isset($fieldMapping['targetDocument'])) {
-                $embeddedIndexes = $this->doGetDocumentIndexes($fieldMapping['targetDocument'], $visited);
+                if (isset($embeddedDocumentIndexes[$fieldMapping['targetDocument']])) {
+                    $embeddedIndexes = $embeddedDocumentIndexes[$fieldMapping['targetDocument']];
+                } else {
+                    $embeddedIndexes = $this->doGetDocumentIndexes($fieldMapping['targetDocument'], $visited);
+                    $embeddedDocumentIndexes[$fieldMapping['targetDocument']] = $embeddedIndexes;
+                }
                 foreach ($embeddedIndexes as $embeddedIndex) {
                     foreach ($embeddedIndex['keys'] as $key => $value) {
                         $embeddedIndex['keys'][$fieldMapping['name'] . '.' . $key] = $value;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
@@ -42,6 +42,12 @@ class IndexesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->assertTrue(isset($indexes[1]['keys']['embedded.embeddedMany.name']));
         $this->assertEquals(1, $indexes[1]['keys']['embedded.embeddedMany.name']);
+
+        $this->assertTrue(isset($indexes[2]['keys']['embedded_secondary.name']));
+        $this->assertEquals(1, $indexes[2]['keys']['embedded_secondary.name']);
+
+        $this->assertTrue(isset($indexes[3]['keys']['embedded_secondary.embeddedMany.name']));
+        $this->assertEquals(1, $indexes[3]['keys']['embedded_secondary.embeddedMany.name']);
     }
 
     public function testDiscriminatorIndexes()
@@ -309,6 +315,9 @@ class DocumentWithEmbeddedIndexes
 
     /** @ODM\EmbedOne(targetDocument="EmbeddedDocumentWithIndexes") */
     public $embedded;
+
+    /** @ODM\EmbedOne(targetDocument="EmbeddedDocumentWithIndexes") */
+    public $embedded_secondary;
 }
 
 /**


### PR DESCRIPTION
Question | Answer
-------- | ------
Bug fix ? | yes
New feature ? | no
BC breaks ? | no
Tests pass ? | yes

In a case like this : 

```php

/** @ODM\Document */
class DocumentWithEmbeddedIndexes
{
    /** @ODM\Id */
    public $id;

    /** @ODM\String */
    public $name;

    /** @ODM\EmbedOne(targetDocument="EmbeddedDocumentWithIndexes") */
    public $embedded;

    /** @ODM\EmbedOne(targetDocument="EmbeddedDocumentWithIndexes") */
    public $embedded_secondary;
}

// .....

/** @ODM\EmbeddedDocument */
class EmbeddedDocumentWithIndexes
{
    /** @ODM\String @ODM\Index */
    public $name;

    /** @ODM\EmbedMany(targetDocument="EmbeddedManyDocumentWithIndexes") */
    public $embeddedMany;
}
```

The indexes for the embeddedDocument "embedded_secondary" were not created because of their presence in the visited array in doGetDocumentIndexes