### PR TITLE
Set isDirty back to true after call to takeSnapshot()

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -185,13 +185,16 @@ class PersistentCollection implements BaseCollection
         $this->uow->loadCollection($this);
         $this->takeSnapshot();
 
-        // Reattach any NEW objects added through add()
-        foreach ($newObjects as $key => $obj) {
-            if ($this->mapping['strategy'] === 'set') {
-                $this->coll->set($key, $obj);
-            } else {
-                $this->coll->add($obj);
+        if (count($newObjects)) {
+            // Reattach any NEW objects added through add()
+            foreach ($newObjects as $key => $obj) {
+                if ($this->mapping['strategy'] === 'set') {
+                    $this->coll->set($key, $obj);
+                } else {
+                    $this->coll->add($obj);
+                }
             }
+            $this->isDirty = true;
         }
 
         $this->mongoData = array();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionCloneTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionCloneTest.php
@@ -102,7 +102,7 @@ class PersistentCollectionCloneTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user2->groups = $user1->groups;
         $user2->groups->add($group3);
 
-        $this->assertEQuals(1, count($user1->groups->getInsertDiff()));
+        $this->assertEquals(1, count($user1->groups->getInsertDiff()));
 
         $this->dm->persist($group3);
         $this->dm->flush();

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
@@ -50,4 +50,29 @@ class PersistentCollectionTest extends \PHPUnit_Framework_TestCase
     {
         return $this->getMock('Doctrine\Common\Collections\Collection');
     }
+
+    public function testIsDirtyAfterInitialize()
+    {
+        $collection = $this->getMockCollection();
+        $dm         = $this->getMockDocumentManager();
+        $uow        = $this->getMockUnitOfWork();
+        $pCollection = new PersistentCollection($collection, $dm, $uow);
+        $pCollection->setOwner($owner = new \stdClass, $mapping = [
+            'isOwningSide'   => false              ,
+            'targetDocument' => 'Not\A\Real\Class' ,
+            ]);
+        $pCollection->setInitialized(false);
+        $this->assertFalse($pCollection->isInitialized());
+        $this->assertFalse($pCollection->isDirty());
+        $document = new \stdClass;
+        $collection->expects($this->any())
+            ->method('toArray')
+            ->will($this->returnValue($document))
+            ;
+        $pCollection->add($document);
+        $this->assertTrue($pCollection->isDirty());
+        $pCollection->initialize();
+        $this->assertTrue($pCollection->isDirty());
+    }
+
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
@@ -57,10 +57,10 @@ class PersistentCollectionTest extends \PHPUnit_Framework_TestCase
         $dm         = $this->getMockDocumentManager();
         $uow        = $this->getMockUnitOfWork();
         $pCollection = new PersistentCollection($collection, $dm, $uow);
-        $pCollection->setOwner($owner = new \stdClass, $mapping = [
+        $pCollection->setOwner($owner = new \stdClass, $mapping = array(
             'isOwningSide'   => false              ,
             'targetDocument' => 'Not\A\Real\Class' ,
-            ]);
+            ));
         $pCollection->setInitialized(false);
         $this->assertFalse($pCollection->isInitialized());
         $this->assertFalse($pCollection->isDirty());


### PR DESCRIPTION
This commit removed a line of code setting isDirty to true:
https://github.com/doctrine/mongodb-odm/commit/bd573cb7def6ab22df8c465b0d79003d26e28046
I think this line was necessary because takeSnapshot() always sets isDirty to false.  Therefore, if there have been objects added, it needs to be set to its original value.