### PR TITLE
require the yaml driver hard dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
+        "symfony/yaml": "~2.0",
         "symfony/console": "~2.0",
         "doctrine/annotations": "~1.0",
         "doctrine/collections": "~1.1",
@@ -21,12 +22,6 @@
         "doctrine/inflector": "~1.0",
         "doctrine/instantiator": "~1.0.1",
         "doctrine/mongodb": ">=1.1.5,<2.0"
-    },
-    "require-dev": {
-        "symfony/yaml": "~2.0"
-    },
-    "suggest": {
-        "symfony/yaml": "Enables the YAML metadata mapping driver"
     },
     "autoload": {
         "psr-0": { "Doctrine\\ODM\\MongoDB": "lib/" }


### PR DESCRIPTION
I know this was removed long time ago in this PR https://github.com/doctrine/mongodb-odm/commit/c17ee1c30c869763e327de905f10f92b8b37e2c3#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780, but i guess since its a hard dependency of the yaml driver, it should be downloaded no matter if you're not using the yaml driver or not.

If the desired behavior is to download it only if you'll use the yaml driver, then the driver should be moved to another library, and then be optional in your app composer.json