### PR TITLE
Fix changeset handling for new documents

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -803,7 +803,9 @@ class UnitOfWork implements PropertyChangedListener
                     : $changeSet;
 
                 $this->originalDocumentData[$oid] = $actualData;
-                $this->documentUpdates[$oid] = $document;
+                if ( ! isset($this->documentInsertions[$oid])) {
+                    $this->documentUpdates[$oid] = $document;
+                }
             }
         }
 
@@ -831,7 +833,7 @@ class UnitOfWork implements PropertyChangedListener
                         $oid2 = spl_object_hash($obj);
                         if (isset($this->documentChangeSets[$oid2])) {
                             $this->documentChangeSets[$oid][$mapping['fieldName']] = array($value, $value);
-                            if ( ! $isNewDocument) {
+                            if ( ! $isNewDocument && ! isset($this->documentInsertions[$oid])) {
                                 $this->documentUpdates[$oid] = $document;
                             }
                             break;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH999Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH999Test.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
+use Doctrine\ODM\MongoDB\Events;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class GH999Test extends BaseTest
+{
+    public function testModifyingInFlushHandler()
+    {
+        $this->dm->getEventManager()->addEventListener(array(Events::onFlush), new GH999Listener());
+
+        $document = new GH999Document('name');
+        $this->dm->persist($document);
+        $this->dm->flush();
+    }
+}
+
+class GH999Listener
+{
+    public function onFlush(OnFlushEventArgs $args) {
+        $dm = $args->getDocumentManager();
+
+        foreach ($dm->getUnitOfWork()->getScheduledDocumentInsertions() as $document) {
+            $document->setName('name #changed');
+            $metadata = $dm->getClassMetadata(get_class($document));
+            $dm->getUnitOfWork()->recomputeSingleDocumentChangeSet($metadata, $document);
+        }
+    }
+}
+
+/** @ODM\Document @ODM\HasLifecycleCallbacks */
+class GH999Document
+{
+    /** @ODM\Id */
+    private $id;
+
+    /** @ODM\String */
+    private $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /** @ODM\PostUpdate */
+    public function postUpdate()
+    {
+        throw new \Exception('Did not expect postUpdate to be called when persisting a new document');
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -347,22 +347,22 @@ class UnitOfWorkTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             array(
                 null,
                 array('bar' => 'foo'),
-                true
+                false
             ),
             array(
                 array('foo' => 'bar'),
                 null,
-                true
+                false
             ),
             array(
                 array('foo' => 'bar'),
                 array('bar' => 'foo'),
-                true
+                false
             ),
             array(
                 array('foo' => 'bar'),
                 array('foo' => 'foo'),
-                true
+                false
             ),
             array(
                 array('foo' => 'bar'),
@@ -372,17 +372,17 @@ class UnitOfWorkTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             array(
                 array('foo' => 'bar'),
                 array('foo' => true),
-                true
+                false
             ),
             array(
                 array('foo' => 'bar'),
                 array('foo' => 99),
-                true
+                false
             ),
             array(
                 array('foo' => 99),
                 array('foo' => true),
-                true
+                false
             ),
             array(
                 array('foo' => true),


### PR DESCRIPTION
This fixes an issue that occurs when modifying a newly persisted document in an onFlush() event handler.
The issue causes the insertion to be treated as an update even though only an insert needs to be done. Thus, postUpdate listeners are called which is not correct.