### PR TITLE
[doc] Fix errors in sample code examples

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -91,7 +91,7 @@ to be designated as a document. This can be done through the
 
     .. code-block:: yaml
 
-        Doctrine\ODM\MongoDB\Tests\Mapping\User:
+        Documents\User:
           type: document
 
 By default, the document will be persisted to a database named

--- a/docs/en/reference/console-commands.rst
+++ b/docs/en/reference/console-commands.rst
@@ -25,7 +25,7 @@ console command easily with the following code:
 
     // ... include Composer autoloader and configure DocumentManager instance
 
-    $helperSet = \Symfony\Component\Console\Helper\HelperSet(array(
+    $helperSet = new \Symfony\Component\Console\Helper\HelperSet(array(
         'dm' => new \Doctrine\ODM\MongoDB\Tools\Console\Helper\DocumentManagerHelper($dm),
     ));
 


### PR DESCRIPTION
- Fixes incorrect yaml namespace in `docs/en/reference/basic-mapping.rst`
- Adds new operator to object instantiation in ` docs/en/reference/console-commands.rst `