### PR TITLE
Fix PHP Notice due to undefined _attributes property

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -305,7 +305,7 @@ class Configuration extends \Doctrine\MongoDB\Configuration
      */
     public function setClassMetadataFactoryName($cmfName)
     {
-        $this->_attributes['classMetadataFactoryName'] = $cmfName;
+        $this->attributes['classMetadataFactoryName'] = $cmfName;
     }
 
     /**
@@ -315,10 +315,10 @@ class Configuration extends \Doctrine\MongoDB\Configuration
      */
     public function getClassMetadataFactoryName()
     {
-        if ( ! isset($this->_attributes['classMetadataFactoryName'])) {
-            $this->_attributes['classMetadataFactoryName'] = 'Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory';
+        if ( ! isset($this->attributes['classMetadataFactoryName'])) {
+            $this->attributes['classMetadataFactoryName'] = 'Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory';
         }
-        return $this->_attributes['classMetadataFactoryName'];
+        return $this->attributes['classMetadataFactoryName'];
     }
 
     /**


### PR DESCRIPTION
PHP Notice:  Undefined property: Doctrine\ODM\MongoDB\Configuration::$_attributes in ~/vendor/doctrine/mongodb-odm/lib/Doctrine/ODM/MongoDB/Configuration.php on line 319