### PR TITLE
Implement "also load methods" in Yaml and XML drivers.

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -40,6 +40,7 @@
       <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
       <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
       <xs:element name="lifecycle-callbacks" type="odm:lifecycle-callbacks" minOccurs="0"/>
+      <xs:element name="also-load-methods" type="odm:also-load-methods" minOccurs="0"/>
       <xs:element name="indexes" type="odm:indexes" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="db" type="xs:NMTOKEN" />
@@ -254,5 +255,17 @@
     </xs:sequence>
   </xs:complexType>
 
+
+  <xs:complexType name="also-load-method">
+    <xs:attribute name="method" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="field" type="xs:NMTOKEN" use="required"/>
+  </xs:complexType>
+
+
+  <xs:complexType name="also-load-methods">
+    <xs:sequence>
+      <xs:element name="also-load-method" type="odm:also-load-method" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
 
 </xs:schema>

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -163,6 +163,11 @@ class XmlDriver extends FileDriver
                 $class->addLifecycleCallback((string) $lifecycleCallback['method'], constant('Doctrine\ODM\MongoDB\Events::' . (string) $lifecycleCallback['type']));
             }
         }
+        if (isset($xmlRoot->{'also-load-methods'})) {
+            foreach ($xmlRoot->{'also-load-methods'}->{'also-load-method'} as $alsoLoadMethod) {
+                $class->registerAlsoLoadMethod((string) $alsoLoadMethod['method'], (string) $alsoLoadMethod['field']);
+            }
+        }
     }
 
     private function addFieldMapping(ClassMetadataInfo $class, $mapping)

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
@@ -147,6 +147,11 @@ class YamlDriver extends FileDriver
                 }
             }
         }
+        if (isset($element['alsoLoadMethods'])) {
+            foreach ($element['alsoLoadMethods'] as $methodName => $fieldName) {
+                $class->registerAlsoLoadMethod($methodName, $fieldName);
+            }
+        }
     }
 
     private function addFieldMapping(ClassMetadataInfo $class, $mapping)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -210,6 +210,13 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             $classMetadata->lifecycleCallbacks
         );
 
+        $this->assertEquals(
+            array(
+                "doStuffOnAlsoLoad" => array("unmappedField"),
+            ),
+            $classMetadata->alsoLoadMethods
+        );
+
         $classMetadata = new ClassMetadata('TestDocuments\EmbeddedDocument');
         $this->driver->loadMetadataForClass('TestDocuments\EmbeddedDocument', $classMetadata);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.User.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.User.dcm.xml
@@ -34,5 +34,8 @@
           <lifecycle-callback method="doStuffOnPostPersist" type="postPersist" />
           <lifecycle-callback method="doOtherStuffOnPostPersist" type="postPersist" />
         </lifecycle-callbacks>
+        <also-load-methods>
+            <also-load-method method="doStuffOnAlsoLoad" field="unmappedField" />
+        </also-load-methods>
     </document>
 </doctrine-mongo-mapping>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/yaml/TestDocuments.User.dcm.yml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/yaml/TestDocuments.User.dcm.yml
@@ -37,3 +37,6 @@ TestDocuments\User:
   lifecycleCallbacks:
     prePersist: [doStuffOnPrePersist]
     postPersist: [doStuffOnPostPersist, doOtherStuffOnPostPersist]
+  alsoLoadMethods:
+    doStuffOnAlsoLoad: unmappedField
+


### PR DESCRIPTION
The Yaml and XML drivers currently do not implements the also load methods mapping. I personally only wanted the feature for the Yaml driver, but I've created a pull request implementing it for both Drivers, with updates to XML schema too. I did both at the same time for simplicity in adding the test below.

I've also extended the current AbstractDriverTest unit test and supporting fixtures to add in the new elements, and test they get set on the resulting ClassMetaData. I was unsure if this was the correct place to be testing this.

As a side note also, I think the current TestDocuments.User.dcm.xml fixture does not validate as correct XML in the tool I used, I think because the embed* and reference* elements are out of order compared to the schema. I didn't want to "fix" it, because a) I have no idea what I'm talking about with XML and XML schemas, and b) incase there is a reason for it being this way.