### PR TITLE
Allow to use uptodate versions of Doctrine Common

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/console": "~2.0",
         "doctrine/annotations": "~1.0",
         "doctrine/collections": "~1.1",
-        "doctrine/common": "2.4.*",
+        "doctrine/common": "~2.4",
         "doctrine/cache": "~1.0",
         "doctrine/inflector": "~1.0",
         "doctrine/instantiator": "~1.0.1",


### PR DESCRIPTION
Doctrine Common 2.5 is available, and the ODM should allow using it. Otherwise it makes it impossible to install it alongside the ORM 2.5 (which requires new features of Common 2.5)