### PR TITLE
Avoiding spl_object_hash collision problem Gh 1017

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -128,7 +128,7 @@ class UnitOfWork implements PropertyChangedListener
      * object ids by PHP for new objects after garbage collection
      * Keys are object ids (spl_object_hash).
      *
-     * @var type
+     * @var array
      */
     private $embeddedDocumentsKnown = array();
 

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -124,6 +124,15 @@ class UnitOfWork implements PropertyChangedListener
     private $documentStates = array();
 
     /**
+     * All known embeddedDocuments stored to prevent the reuse of their
+     * object ids by PHP for new objects after garbage collection
+     * Keys are object ids (spl_object_hash).
+     *
+     * @var type
+     */
+    private $embeddedDocumentsKnown = array();
+
+    /**
      * Map of documents that are scheduled for dirty checking at commit time.
      *
      * Documents are grouped by their class name, and then indexed by their SPL
@@ -1015,6 +1024,9 @@ class UnitOfWork implements PropertyChangedListener
             $this->documentIdentifiers[$oid] = $idValue;
         }
 
+        if ($class->isEmbeddedDocument) {
+            $this->embeddedDocumentsKnown[$oid] = $document;
+        }
         $this->documentStates[$oid] = self::STATE_MANAGED;
 
         if ($upsert) {
@@ -1056,6 +1068,9 @@ class UnitOfWork implements PropertyChangedListener
              */
             $oid = spl_object_hash($document);
             $this->documentIdentifiers[$oid] = $id;
+            if ($class->isEmbeddedDocument) {
+                $this->embeddedDocumentsKnown[$oid] = $document;
+            }
             $this->documentStates[$oid] = self::STATE_MANAGED;
             $this->originalDocumentData[$oid][$class->identifier] = $id;
             $this->addToIdentityMap($document);
@@ -2297,7 +2312,8 @@ class UnitOfWork implements PropertyChangedListener
                 unset($this->documentInsertions[$oid], $this->documentUpdates[$oid],
                     $this->documentDeletions[$oid], $this->documentIdentifiers[$oid],
                     $this->documentStates[$oid], $this->originalDocumentData[$oid],
-                    $this->parentAssociations[$oid], $this->documentUpserts[$oid]);
+                    $this->parentAssociations[$oid], $this->documentUpserts[$oid],
+                    $this->embeddedDocumentsKnown[$oid]);
                 break;
             case self::STATE_NEW:
             case self::STATE_DETACHED:
@@ -2620,6 +2636,7 @@ class UnitOfWork implements PropertyChangedListener
             $this->originalDocumentData =
             $this->documentChangeSets =
             $this->documentStates =
+            $this->embeddedDocumentsKnown =
             $this->scheduledForDirtyCheck =
             $this->documentInsertions =
             $this->documentUpserts =
@@ -2946,6 +2963,9 @@ class UnitOfWork implements PropertyChangedListener
             $this->documentIdentifiers[$oid] = $class->getPHPIdentifierValue($id);
         }
 
+        if ($class->isEmbeddedDocument) {
+            $this->embeddedDocumentsKnown[$oid] = $document;
+        }
         $this->documentStates[$oid] = self::STATE_MANAGED;
         $this->originalDocumentData[$oid] = $data;
         $this->addToIdentityMap($document);


### PR DESCRIPTION
This PR is about https://github.com/doctrine/mongodb-odm/issues/1017 
The problem it is intended to solve is described in the issue above. 
I am explaining it in a few words here too. UnitOfWork uses the spl_object_hash() values for documents as an internal identifier and stores document status and ID values in arrays indexed with these hash values.
Unfortunately, if EmbeddedDocuments are removed by garbage collection, their hash value is reused, so these internal metadata will be mixed up when a new document with matching hash is persisted.

This PR adds a new array to store new embedded documents until the UnitOfWork is cleared, so garbage collection doesn't destroy them, and the hash value won't be reused.
