### PR TITLE
Yet another sharding support implementation

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -60,7 +60,7 @@
   <xs:complexType name="field">
     <xs:sequence>
       <xs:element name="id-generator-option" type="odm:id-generator-option" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>  
+    </xs:sequence>
     <xs:attribute name="id" type="xs:boolean" default="false" />
     <xs:attribute name="name" type="xs:NMTOKEN" />
     <xs:attribute name="type" type="xs:NMTOKEN" default="string" />
@@ -82,7 +82,7 @@
     <xs:attribute name="sparse" type="xs:boolean" />
     <xs:attribute name="unique" type="xs:boolean" />
   </xs:complexType>
-  
+
   <xs:complexType name="id-generator-option">
     <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
     <xs:attribute name="value" type="xs:string" use="required"/>
@@ -275,6 +275,22 @@
     </xs:sequence>
   </xs:complexType>
 
+  <xs:complexType name="shard-key">
+    <xs:sequence>
+      <xs:element name="key" type="odm:shard-key-key" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="option" type="odm:shard-key-option" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="shard-key-key">
+    <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="order" type="xs:NMTOKEN" default="asc" />
+  </xs:complexType>
+
+  <xs:complexType name="shard-key-option">
+    <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="value" type="xs:NMTOKEN" use="required" />
+  </xs:complexType>
 
   <xs:complexType name="also-load-method">
     <xs:attribute name="method" type="xs:NMTOKEN" use="required"/>

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -281,6 +281,8 @@
       <xs:element name="key" type="odm:shard-key-key" minOccurs="1" maxOccurs="unbounded"/>
       <xs:element name="option" type="odm:shard-key-option" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
+    <xs:attribute name="unique" type="xs:boolean"/>
+    <xs:attribute name="numInitialChunks" type="xs:integer"/>
   </xs:complexType>
 
   <xs:complexType name="shard-key-key">

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -55,6 +55,7 @@
     <xs:attribute name="change-tracking-policy" type="odm:change-tracking-policy" />
     <xs:attribute name="require-indexes" type="xs:boolean" />
     <xs:attribute name="slave-okay" type="xs:boolean" />
+    <xs:attribute name="shard-key" type="odm:shard-key" />
   </xs:complexType>
 
   <xs:complexType name="field">

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -43,6 +43,7 @@
       <xs:element name="lifecycle-callbacks" type="odm:lifecycle-callbacks" minOccurs="0"/>
       <xs:element name="also-load-methods" type="odm:also-load-methods" minOccurs="0"/>
       <xs:element name="indexes" type="odm:indexes" minOccurs="0"/>
+      <xs:element name="shard-key" type="odm:shard-key" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="db" type="xs:NMTOKEN" />
     <xs:attribute name="name" type="xs:string" />
@@ -55,7 +56,6 @@
     <xs:attribute name="change-tracking-policy" type="odm:change-tracking-policy" />
     <xs:attribute name="require-indexes" type="xs:boolean" />
     <xs:attribute name="slave-okay" type="xs:boolean" />
-    <xs:attribute name="shard-key" type="odm:shard-key" />
   </xs:complexType>
 
   <xs:complexType name="field">

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php
@@ -80,3 +80,4 @@ require_once __DIR__ . '/PreLoad.php';
 require_once __DIR__ . '/PostLoad.php';
 require_once __DIR__ . '/PreFlush.php';
 require_once __DIR__ . '/HasLifecycleCallbacks.php';
+require_once __DIR__ . '/ShardKey.php';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ShardKey.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ShardKey.php
@@ -25,6 +25,6 @@ use Doctrine\Common\Annotations\Annotation;
 final class ShardKey extends Annotation
 {
     public $keys = array();
-    public $unique = false;
+    public $unique;
     public $numInitialChunks;
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ShardKey.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ShardKey.php
@@ -19,14 +19,12 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
+use Doctrine\Common\Annotations\Annotation;
+
 /** @Annotation */
-final class Document extends AbstractDocument
+final class ShardKey extends Annotation
 {
-    public $db;
-    public $collection;
-    public $repositoryClass;
-    public $indexes = array();
-    public $requireIndexes = false;
-    public $shardKey;
-    public $slaveOkay;
+    public $fields = array();
+    public $unique = false;
+    public $numInitialChunks;
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ShardKey.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ShardKey.php
@@ -24,7 +24,7 @@ use Doctrine\Common\Annotations\Annotation;
 /** @Annotation */
 final class ShardKey extends Annotation
 {
-    public $fields = array();
+    public $keys = array();
     public $unique = false;
     public $numInitialChunks;
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -20,7 +20,6 @@
 namespace Doctrine\ODM\MongoDB\Mapping;
 
 use Doctrine\Instantiator\Instantiator;
-use Doctrine\ODM\MongoDB\LockException;
 
 /**
  * A <tt>ClassMetadata</tt> instance holds all the object-document mapping metadata
@@ -115,6 +114,7 @@ class ClassMetadata extends ClassMetadataInfo
             'generatorOptions',
             'idGenerator',
             'indexes',
+            'shardKey',
         );
 
         // The rest of the metadata is only serialized if necessary.

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -348,7 +348,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         if ($parentClass->isSharded()) {
             $subClass->setShardKey(
-                $parentClass->shardKey['fields'],
+                $parentClass->shardKey['keys'],
                 $parentClass->shardKey['options']
             );
         }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -138,6 +138,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             $this->addInheritedFields($class, $parent);
             $this->addInheritedRelations($class, $parent);
             $this->addInheritedIndexes($class, $parent);
+            $this->setInheritedShardKey($class, $parent);
             $class->setIdentifier($parent->identifier);
             $class->setVersioned($parent->isVersioned);
             $class->setVersionField($parent->versionField);
@@ -334,6 +335,22 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         foreach ($parentClass->indexes as $index) {
             $subClass->addIndex($index['keys'], $index['options']);
+        }
+    }
+
+    /**
+     * Adds inherited shard key to the subclass mapping.
+     *
+     * @param ClassMetadata $subClass
+     * @param ClassMetadata $parentClass
+     */
+    private function setInheritedShardKey(ClassMetadata $subClass, ClassMetadata $parentClass)
+    {
+        if ($parentClass->isSharded()) {
+            $subClass->setShardKey(
+                $parentClass->shardKey['fields'],
+                $parentClass->shardKey['options']
+            );
         }
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -194,7 +194,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
     public $indexes = array();
 
     /**
-     * READ-ONLY: Fields and options describing shard key. Only for sharded collections.
+     * READ-ONLY: Keys and options describing shard key. Only for sharded collections.
      */
     public $shardKey;
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -21,7 +21,6 @@ namespace Doctrine\ODM\MongoDB\Mapping;
 
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 use Doctrine\ODM\MongoDB\LockException;
-use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Proxy\Proxy;
 use Doctrine\ODM\MongoDB\Types\Type;
 use InvalidArgumentException;
@@ -193,6 +192,11 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
      * READ-ONLY: The array of indexes for the document collection.
      */
     public $indexes = array();
+
+    /**
+     * READ-ONLY: Fields and options describing shard key. Only for sharded collections.
+     */
+    public $shardKey;
 
     /**
      * READ-ONLY: Whether or not queries on this document should require indexes.
@@ -799,6 +803,61 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
     }
 
     /**
+     * Set shard key for this Document.
+     *
+     * @param array $fields  Array of fields for shard key.
+     * @param array $options Array of sharding options.
+     *
+     * @throws MappingException
+     */
+    public function setShardKey(array $fields, array $options = array())
+    {
+        if ($this->inheritanceType == self::INHERITANCE_TYPE_SINGLE_COLLECTION && !is_null($this->shardKey)) {
+            throw MappingException::shardKeyInSingleCollInheritanceSubclass($this->getName());
+        }
+
+        if ($this->isEmbeddedDocument) {
+            throw MappingException::embeddedDocumentCantHaveShardKey($this->getName());
+        }
+
+        $this->shardKey = array(
+            'fields' => array_map(function($value) {
+                if ($value == 1 || $value == -1) {
+                    return (int) $value;
+                }
+                if (is_string($value)) {
+                    $lower = strtolower($value);
+                    if ($lower === 'asc') {
+                        return 1;
+                    } elseif ($lower === 'desc') {
+                        return -1;
+                    }
+                }
+                return $value;
+            }, $fields),
+            'options' => $options
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function getShardKey()
+    {
+        return $this->shardKey;
+    }
+
+    /**
+     * Checks whether this document has shard key or not.
+     *
+     * @return bool
+     */
+    public function isSharded()
+    {
+        return $this->shardKey ? true : false;
+    }
+
+    /**
      * Sets the change tracking policy used by this class.
      *
      * @param integer $policy
@@ -1112,7 +1171,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
         $mapping['isCascadeRefresh'] = in_array('refresh', $cascades);
         $mapping['isCascadeMerge'] = in_array('merge', $cascades);
         $mapping['isCascadeDetach'] = in_array('detach', $cascades);
-        
+
         if (isset($mapping['type']) && $mapping['type'] === 'file') {
             $mapping['file'] = true;
         }
@@ -1514,7 +1573,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
             //so the proxy needs to be loaded first.
             $document->__load();
         }
-        
+
         $this->reflFields[$field]->setValue($document, $value);
     }
 
@@ -1531,7 +1590,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
         if ($document instanceof Proxy && $field !== $this->identifier && ! $document->__isInitialized()) {
             $document->__load();
         }
-        
+
         return $this->reflFields[$field]->getValue($document);
     }
 
@@ -1701,7 +1760,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
      * value to use depending on the column type.
      *
      * @param array $mapping   The version field mapping array
-     * 
+     *
      * @throws LockException
      */
     public function setVersionMapping(array &$mapping)

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -805,12 +805,12 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
     /**
      * Set shard key for this Document.
      *
-     * @param array $fields  Array of fields for shard key.
+     * @param array $keys Array of document keys.
      * @param array $options Array of sharding options.
      *
      * @throws MappingException
      */
-    public function setShardKey(array $fields, array $options = array())
+    public function setShardKey(array $keys, array $options = array())
     {
         if ($this->inheritanceType == self::INHERITANCE_TYPE_SINGLE_COLLECTION && !is_null($this->shardKey)) {
             throw MappingException::shardKeyInSingleCollInheritanceSubclass($this->getName());
@@ -821,7 +821,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
         }
 
         $this->shardKey = array(
-            'fields' => array_map(function($value) {
+            'keys' => array_map(function($value) {
                 if ($value == 1 || $value == -1) {
                     return (int) $value;
                 }
@@ -834,7 +834,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
                     }
                 }
                 return $value;
-            }, $fields),
+            }, $keys),
             'options' => $options
         );
     }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -1602,8 +1602,6 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
      * @return array  The field mapping.
      *
      * @throws MappingException if the $fieldName is not found in the fieldMappings array
-     *
-     * @throws MappingException
      */
     public function getFieldMapping($fieldName)
     {
@@ -1611,6 +1609,26 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
             throw MappingException::mappingNotFound($this->name, $fieldName);
         }
         return $this->fieldMappings[$fieldName];
+    }
+
+    /**
+     * Gets the field mapping by its DB name.
+     * E.g. it returns identifier's mapping when called with _id.
+     *
+     * @param string $dbFieldName
+     *
+     * @return array
+     * @throws MappingException
+     */
+    public function getFieldMappingByDbFieldName($dbFieldName)
+    {
+        foreach ($this->fieldMappings as $mapping) {
+            if ($mapping['name'] == $dbFieldName) {
+                return $mapping;
+            }
+        }
+
+        throw MappingException::mappingNotFoundByDbName($this->name, $dbFieldName);
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -19,10 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping;
 
-use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 use Doctrine\ODM\MongoDB\LockException;
 use Doctrine\ODM\MongoDB\Proxy\Proxy;
 use Doctrine\ODM\MongoDB\Types\Type;
+use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 use InvalidArgumentException;
 
 /**
@@ -522,7 +522,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
         if ($this->isEmbeddedDocument) {
             return;
         }
-        
+
         if ($repositoryClassName && strpos($repositoryClassName, '\\') === false && strlen($this->namespace)) {
             $repositoryClassName = $this->namespace . '\\' . $repositoryClassName;
         }
@@ -818,6 +818,12 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
 
         if ($this->isEmbeddedDocument) {
             throw MappingException::embeddedDocumentCantHaveShardKey($this->getName());
+        }
+
+        foreach ($keys as $field) {
+            if ($this->getTypeOfField($field) == 'increment') {
+                throw MappingException::noIncrementFieldsAllowedInShardKey($this->getName());
+            }
         }
 
         $this->shardKey = array(
@@ -1219,7 +1225,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
             && ! empty($mapping['sort']) && ! CollectionHelper::usesSet($mapping['strategy'])) {
             throw MappingException::referenceManySortMustNotBeUsedWithNonSetCollectionStrategy($this->name, $mapping['fieldName'], $mapping['strategy']);
         }
-        
+
         if ($this->isEmbeddedDocument && $mapping['type'] === 'many' && CollectionHelper::isAtomic($mapping['strategy'])) {
             throw MappingException::atomicCollectionStrategyNotAllowed($mapping['strategy'], $this->name, $mapping['fieldName']);
         }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -245,9 +245,15 @@ class AnnotationDriver extends AbstractAnnotationDriver
         $class->addIndex($keys, $options);
     }
 
-    private function setShardKey(ClassMetadataInfo $class, $shardKey)
+    /**
+     * @param ClassMetadataInfo $class
+     * @param ODM\ShardKey      $shardKey
+     *
+     * @throws MappingException
+     */
+    private function setShardKey(ClassMetadataInfo $class, ODM\ShardKey $shardKey)
     {
-        $fields = $shardKey->fields;
+        $keys = $shardKey->keys;
         $options = array();
         $allowed = array('unique', 'numInitialChunks');
         foreach ($allowed as $name) {
@@ -256,7 +262,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
             }
         }
 
-        $class->setShardKey($fields, $options);
+        $class->setShardKey($keys, $options);
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -102,6 +102,8 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 $class->setChangeTrackingPolicy(constant('Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata::CHANGETRACKING_'.$annot->value));
             } elseif ($annot instanceof ODM\DefaultDiscriminatorValue) {
                 $class->setDefaultDiscriminatorValue($annot->value);
+            } elseif ($annot instanceof ODM\ShardKey) {
+                $this->setShardKey($class, $annot);
             }
 
         }
@@ -117,6 +119,9 @@ class AnnotationDriver extends AbstractAnnotationDriver
         if ($documentAnnot instanceof ODM\MappedSuperclass) {
             $class->isMappedSuperclass = true;
         } elseif ($documentAnnot instanceof ODM\EmbeddedDocument) {
+            if ($class->isSharded()) {
+                throw MappingException::embeddedDocumentCantHaveShardKey($class->getName());
+            }
             $class->isEmbeddedDocument = true;
         }
         if (isset($documentAnnot->db)) {
@@ -238,6 +243,20 @@ class AnnotationDriver extends AbstractAnnotationDriver
         }
         $options = array_merge($options, $index->options);
         $class->addIndex($keys, $options);
+    }
+
+    private function setShardKey(ClassMetadataInfo $class, $shardKey)
+    {
+        $fields = $shardKey->fields;
+        $options = array();
+        $allowed = array('unique', 'numInitialChunks');
+        foreach ($allowed as $name) {
+            if (isset($shardKey->$name)) {
+                $options[$name] = $shardKey->$name;
+            }
+        }
+
+        $class->setShardKey($fields, $options);
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -395,9 +395,11 @@ class XmlDriver extends FileDriver
         if (isset($xmlShardkey->{'option'})) {
             $allowed = array('unique', 'numInitialChunks');
             foreach ($xmlShardkey->{'option'} as $option) {
-                if ( ! in_array($option['name'], $allowed, true)) {
+                $name = (string) $option['name'];
+                if ( ! in_array($name, $allowed, true)) {
                     continue;
                 }
+
                 $value = (string) $option['value'];
                 if ($value === 'true') {
                     $value = true;
@@ -406,7 +408,7 @@ class XmlDriver extends FileDriver
                 } elseif (is_numeric($value)) {
                     $value = preg_match('/^[-]?\d+$/', $value) ? (integer) $value : (float) $value;
                 }
-                $options[$option['name']] = $value;
+                $options[$name] = $value;
             }
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -386,20 +386,24 @@ class XmlDriver extends FileDriver
 
     private function setShardKey(ClassMetadataInfo $class, \SimpleXmlElement $xmlShardkey)
     {
+        $attributes = $xmlShardkey->attributes();
+
         $keys = array();
+        $options = array();
         foreach ($xmlShardkey->{'key'} as $key) {
             $keys[(string) $key['name']] = isset($key['order']) ? (string)$key['order'] : 'asc';
         }
 
-        $options = array();
-        if (isset($xmlShardkey->{'option'})) {
-            $allowed = array('unique', 'numInitialChunks');
-            foreach ($xmlShardkey->{'option'} as $option) {
-                $name = (string) $option['name'];
-                if ( ! in_array($name, $allowed, true)) {
-                    continue;
-                }
+        if (isset($attributes['unique'])) {
+            $options['unique'] = ('true' === (string) $attributes['unique']);
+        }
 
+        if (isset($attributes['numInitialChunks'])) {
+            $options['numInitialChunks'] = (int) $attributes['numInitialChunks'];
+        }
+
+        if (isset($xmlShardkey->{'option'})) {
+            foreach ($xmlShardkey->{'option'} as $option) {
                 $value = (string) $option['value'];
                 if ($value === 'true') {
                     $value = true;
@@ -408,7 +412,7 @@ class XmlDriver extends FileDriver
                 } elseif (is_numeric($value)) {
                     $value = preg_match('/^[-]?\d+$/', $value) ? (integer) $value : (float) $value;
                 }
-                $options[$name] = $value;
+                $options[(string) $option['name']] = $value;
             }
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
@@ -79,6 +79,9 @@ class YamlDriver extends FileDriver
                 $class->addIndex($index['keys'], isset($index['options']) ? $index['options'] : array());
             }
         }
+        if (isset($element['shardKey'])) {
+            $this->setShardKey($class, $element['shardKey']);
+        }
         if (isset($element['inheritanceType'])) {
             $class->setInheritanceType(constant('Doctrine\ODM\MongoDB\Mapping\ClassMetadata::INHERITANCE_TYPE_' . strtoupper($element['inheritanceType'])));
         }
@@ -334,5 +337,23 @@ class YamlDriver extends FileDriver
     protected function loadMappingFile($file)
     {
         return Yaml::parse(file_get_contents($file));
+    }
+
+    private function setShardKey(ClassMetadataInfo $class, array $shardKey)
+    {
+        $keys = $shardKey['keys'];
+        $options = array();
+
+        if (isset($shardKey['options'])) {
+            $allowed = array('unique', 'numInitialChunks');
+            foreach ($shardKey['options'] as $name => $value) {
+                if ( ! in_array($name, $allowed, true)) {
+                    continue;
+                }
+                $options[$name] = $value;
+            }
+        }
+
+        $class->setShardKey($keys, $options);
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -262,7 +262,7 @@ class MappingException extends BaseMappingException
      */
     public static function shardKeyInSingleCollInheritanceSubclass($subclassName)
     {
-        return new self("Shard key definition in subclass is forbidden in case of single collection inheritance: $subclassName");
+        return new self("Shard key overriding in subclass is forbidden for single collection inheritance: $subclassName");
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -255,4 +255,22 @@ class MappingException extends BaseMappingException
     {
         return new self("ReferenceMany's sort can not be used with addToSet and pushAll strategies, $strategy used in $className::$fieldName");
     }
+
+    /**
+     * @param $subclassName
+     * @return MappingException
+     */
+    public static function shardKeyInSingleCollInheritanceSubclass($subclassName)
+    {
+        return new self("Shard key definition in subclass is forbidden in case of single collection inheritance: $subclassName");
+    }
+
+    /**
+     * @param $className
+     * @return MappingException
+     */
+    public static function embeddedDocumentCantHaveShardKey($className)
+    {
+        return new self("Embedded document can't have shard key: $className");
+    }
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -283,4 +283,13 @@ class MappingException extends BaseMappingException
     {
         return new self("Embedded document can't have shard key: $className");
     }
+
+    /**
+     * @param string $className
+     * @return MappingException
+     */
+    public static function noIncrementFieldsAllowedInShardKey($className)
+    {
+        return new self("No increment fields allowed in the shard key: $className");
+    }
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -58,6 +58,16 @@ class MappingException extends BaseMappingException
     }
 
     /**
+     * @param string $className
+     * @param string $dbFieldName
+     * @return MappingException
+     */
+    public static function mappingNotFoundByDbName($className, $dbFieldName)
+    {
+        return new self("No mapping found for field by DB name '$dbFieldName' in class '$className'.");
+    }
+
+    /**
      * @param string $document
      * @param string $fieldName
      * @return MappingException

--- a/lib/Doctrine/ODM/MongoDB/MongoDBException.php
+++ b/lib/Doctrine/ODM/MongoDB/MongoDBException.php
@@ -144,4 +144,50 @@ class MongoDBException extends \Exception
         }
         return new self(sprintf('%s type requires value of type %s, %s given', $type, $expected, $gotType));
     }
+
+    /**
+     * @param string $field
+     * @param string $className
+     * @return MongoDBException
+     */
+    public static function shardKeyFieldCannotBeChanged($field, $className)
+    {
+        return new self(sprintf('Shard key field "%s" cannot be changed. Class: %s', $field, $className));
+    }
+
+    /**
+     * @param string $field
+     * @param string $className
+     * @return MongoDBException
+     */
+    public static function shardKeyFieldMissing($field, $className)
+    {
+        return new self(sprintf('Shard key field "%s" is missing. Class: %s.', $field, $className));
+    }
+
+    /**
+     * @param string $dbName
+     * @param string $errorMessage
+     * @return MongoDBException
+     */
+    public static function failedToEnableSharding($dbName, $errorMessage)
+    {
+        return new self(sprintf('Failed to enable sharding for database "%s". Error from MongoDB: %s',
+            $dbName,
+            $errorMessage
+        ));
+    }
+
+    /**
+     * @param string $className
+     * @param string $errorMessage
+     * @return MongoDBException
+     */
+    public static function failedToEnsureDocumentSharding($className, $errorMessage)
+    {
+        return new self(sprintf('Failed to ensure sharding for document "%s". Error from MongoDB: %s',
+            $className,
+            $errorMessage
+        ));
+    }
 }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -546,15 +546,15 @@ class DocumentPersister
         }
 
         $shardKey = $this->class->getShardKey();
-        $shardKeyFields = array_keys($shardKey['fields']);
+        $shardKeyKeys = array_keys($shardKey['keys']);
 
         $data = $this->uow->getDocumentActualData($document);
 
         $shardKeyQueryPart = array();
-        foreach ($shardKeyFields as $field) {
-            $this->guardShardKeyFieldInvariants($document, $options, $field, $data);
-            $mapping = $this->class->fieldMappings[$field];
-            $value = Type::getType($mapping['type'])->convertToDatabaseValue($data[$field]);
+        foreach ($shardKeyKeys as $key) {
+            $this->guardShardKeyInvariants($document, $options, $key, $data);
+            $mapping = $this->class->fieldMappings[$key];
+            $value = Type::getType($mapping['type'])->convertToDatabaseValue($data[$key]);
             $shardKeyQueryPart[$mapping['name']] = $value;
         }
 
@@ -1309,7 +1309,7 @@ class DocumentPersister
      *
      * @throws MongoDBException
      */
-    private function guardShardKeyFieldInvariants($document, array $options, $shardKeyField, $actualDocumentData)
+    private function guardShardKeyInvariants($document, array $options, $shardKeyField, $actualDocumentData)
     {
         $dcs = $this->uow->getDocumentChangeSet($document);
         $isUpdate = $this->uow->isScheduledForUpdate($document);

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -366,11 +366,20 @@ class DocumentPersister
     public function update($document, array $options = array())
     {
         $id = $this->uow->getDocumentIdentifier($document);
+        $id = $this->class->getDatabaseIdentifierValue($id);
         $update = $this->pb->prepareUpdateData($document);
 
-        $id = $this->class->getDatabaseIdentifierValue($id);
         $shardKeyQueryPart = $this->getShardKeyQuery($document, $options);
         $query = array_merge(array('_id' => $id), $shardKeyQueryPart);
+
+        foreach (array_keys($query) as $field) {
+            unset($update['$set'][$field]);
+        }
+
+        if (empty($update['$set'])) {
+            unset($update['$set']);
+        }
+
 
         // Include versioning logic to set the new version value in the database
         // and to ensure the version has not changed since this document object instance
@@ -402,10 +411,6 @@ class DocumentPersister
                 } else {
                     $query[$lockMapping['name']] = array('$exists' => false);
                 }
-            }
-
-            foreach (array_keys($query) as $field) {
-                unset($update['$set'][$field]);
             }
 
             $result = $this->collection->update($query, $update, $options);
@@ -1313,16 +1318,18 @@ class DocumentPersister
         $dcs = $this->uow->getDocumentChangeSet($document);
         $isUpdate = $this->uow->isScheduledForUpdate($document);
 
+        $fieldMapping = $this->class->getFieldMappingByDbFieldName($shardKeyField);
+        $fieldName = $fieldMapping['fieldName'];
+
         if ($isUpdate
-            && isset($dcs[$shardKeyField])
-            && $dcs[$shardKeyField][0] != $dcs[$shardKeyField][1]
+            && isset($dcs[$fieldName])
+            && $dcs[$fieldName][0] != $dcs[$fieldName][1]
             && (!isset($options['upsert']) || $options['upsert'] === true)
         ) {
             throw MongoDBException::shardKeyFieldCannotBeChanged($shardKeyField, $this->class->getName());
         }
 
-        $fieldMapping = $this->class->getFieldMappingByDbFieldName($shardKeyField);
-        if (!isset($actualDocumentData[$fieldMapping['fieldName']])) {
+        if (!isset($actualDocumentData[$fieldName])) {
             throw MongoDBException::shardKeyFieldMissing($shardKeyField, $this->class->getName());
         }
     }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -365,12 +365,9 @@ class DocumentPersister
      */
     public function update($document, array $options = array())
     {
-        $id = $this->uow->getDocumentIdentifier($document);
-        $id = $this->class->getDatabaseIdentifierValue($id);
         $update = $this->pb->prepareUpdateData($document);
 
-        $shardKeyQueryPart = $this->getShardKeyQuery($document, $options);
-        $query = array_merge(array('_id' => $id), $shardKeyQueryPart);
+        $query = $this->getQueryForDocument($document, $options);
 
         foreach (array_keys($query) as $field) {
             unset($update['$set'][$field]);
@@ -432,8 +429,7 @@ class DocumentPersister
      */
     public function delete($document, array $options = array())
     {
-        $id = $this->uow->getDocumentIdentifier($document);
-        $query = array('_id' => $this->class->getDatabaseIdentifierValue($id));
+        $query = $this->getQueryForDocument($document, $options);
 
         if ($this->class->isLockable) {
             $query[$this->class->lockField] = array('$exists' => false);
@@ -449,13 +445,12 @@ class DocumentPersister
     /**
      * Refreshes a managed document.
      *
-     * @param array $id The identifier of the document.
      * @param object $document The document to refresh.
      */
-    public function refresh($id, $document)
+    public function refresh($document)
     {
-        $class = $this->dm->getClassMetadata(get_class($document));
-        $data = $this->collection->findOne(array('_id' => $id));
+        $query = $this->getQueryForDocument($document);
+        $data = $this->collection->findOne($query);
         $data = $this->hydratorFactory->hydrate($document, $data);
         $this->uow->setOriginalDocumentData($document, $data);
     }
@@ -1303,8 +1298,8 @@ class DocumentPersister
     }
 
     /**
-     * If the document is new, we can ignore shard key field value, otherwise throw an exception.
-     * Also shard key field should be presented in actual document data.
+     * If the document is new, ignore shard key field value, otherwise throw an exception.
+     * Also, shard key field should be presented in actual document data.
      *
      * @param object $document
      * @param array  $options
@@ -1332,5 +1327,24 @@ class DocumentPersister
         if (!isset($actualDocumentData[$fieldName])) {
             throw MongoDBException::shardKeyFieldMissing($shardKeyField, $this->class->getName());
         }
+    }
+
+    /**
+     * Get shard key aware query for single document.
+     *
+     * @param object $document
+     * @param array  $options
+     *
+     * @return array
+     */
+    private function getQueryForDocument($document, array $options = array())
+    {
+        $id = $this->uow->getDocumentIdentifier($document);
+        $id = $this->class->getDatabaseIdentifierValue($id);
+
+        $shardKeyQueryPart = $this->getShardKeyQuery($document, $options);
+        $query = array_merge(array('_id' => $id), $shardKeyQueryPart);
+
+        return $query;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -28,6 +28,7 @@ use Doctrine\ODM\MongoDB\Hydrator\HydratorFactory;
 use Doctrine\ODM\MongoDB\LockException;
 use Doctrine\ODM\MongoDB\LockMode;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\PersistentCollection;
 use Doctrine\ODM\MongoDB\Proxy\Proxy;
 use Doctrine\ODM\MongoDB\Query\CriteriaMerger;
@@ -291,9 +292,10 @@ class DocumentPersister
                 }
                 $data['$set'][$versionMapping['name']] = $nextVersion;
             }
-            
+
             try {
-                $this->executeUpsert($data, $options);
+                $shardKeyQueryPart = $this->getShardKeyQuery($document, $options);
+                $this->executeUpsert($data, $options, $shardKeyQueryPart);
                 $this->handleCollections($document, $options);
                 unset($this->queuedUpserts[$oid]);
             } catch (\MongoException $e) {
@@ -304,23 +306,27 @@ class DocumentPersister
     }
 
     /**
-     * Executes a single upsert in {@link executeInserts}
+     * Executes a single upsert in {@link executeUpserts}
      *
      * @param array $data
      * @param array $options
+     * @param array $shardKeyQueryPart
      */
-    private function executeUpsert(array $data, array $options)
+    private function executeUpsert(array $data, array $options, array $shardKeyQueryPart = array())
     {
         $options['upsert'] = true;
-        $criteria = array('_id' => $data['$set']['_id']);
-        unset($data['$set']['_id']);
+        $criteria = array_merge(array('_id' => $data['$set']['_id']), $shardKeyQueryPart);
+
+        foreach (array_keys($criteria) as $field) {
+            unset($data['$set'][$field]);
+        }
 
         // Do not send an empty $set modifier
         if (empty($data['$set'])) {
             unset($data['$set']);
         }
 
-        /* If there are no modifiers remaining, we're upserting a document with 
+        /* If there are no modifiers remaining, we're upserting a document with
          * an identifier as its only field. Since a document with the identifier
          * may already exist, the desired behavior is "insert if not exists" and
          * NOOP otherwise. MongoDB 2.6+ does not allow empty modifiers, so $set
@@ -363,7 +369,8 @@ class DocumentPersister
         $update = $this->pb->prepareUpdateData($document);
 
         $id = $this->class->getDatabaseIdentifierValue($id);
-        $query = array('_id' => $id);
+        $shardKeyQueryPart = $this->getShardKeyQuery($document, $options);
+        $query = array_merge(array('_id' => $id), $shardKeyQueryPart);
 
         // Include versioning logic to set the new version value in the database
         // and to ensure the version has not changed since this document object instance
@@ -395,6 +402,10 @@ class DocumentPersister
                 } else {
                     $query[$lockMapping['name']] = array('$exists' => false);
                 }
+            }
+
+            foreach (array_keys($query) as $field) {
+                unset($update['$set'][$field]);
             }
 
             $result = $this->collection->update($query, $update, $options);
@@ -519,6 +530,35 @@ class DocumentPersister
         }
 
         return $cursor;
+    }
+
+    /**
+     * @param object $document
+     * @param array $options
+     *
+     * @return array
+     * @throws MongoDBException
+     */
+    public function getShardKeyQuery($document, array $options = array())
+    {
+        if ( ! $this->class->isSharded()) {
+            return array();
+        }
+
+        $shardKey = $this->class->getShardKey();
+        $shardKeyFields = array_keys($shardKey['fields']);
+
+        $data = $this->uow->getDocumentActualData($document);
+
+        $shardKeyQueryPart = array();
+        foreach ($shardKeyFields as $field) {
+            $this->guardShardKeyFieldInvariants($document, $options, $field, $data);
+            $mapping = $this->class->fieldMappings[$field];
+            $value = Type::getType($mapping['type'])->convertToDatabaseValue($data[$field]);
+            $shardKeyQueryPart[$mapping['name']] = $value;
+        }
+
+        return $shardKeyQueryPart;
     }
 
     /**
@@ -778,7 +818,7 @@ class DocumentPersister
     private function loadReferenceManyWithRepositoryMethod(PersistentCollection $collection)
     {
         $cursor = $this->createReferenceManyWithRepositoryMethodCursor($collection);
-        $mapping = $collection->getMapping();        
+        $mapping = $collection->getMapping();
         $documents = $cursor->toArray(false);
         foreach ($documents as $key => $obj) {
             if (CollectionHelper::isHash($mapping['strategy'])) {
@@ -1255,6 +1295,35 @@ class DocumentPersister
         // Take new snapshots from visited collections
         foreach ($this->uow->getVisitedCollections($document) as $coll) {
             $coll->takeSnapshot();
+        }
+    }
+
+    /**
+     * If the document is new, we can ignore shard key field value, otherwise throw an exception.
+     * Also shard key field should be presented in actual document data.
+     *
+     * @param object $document
+     * @param array  $options
+     * @param string $shardKeyField
+     * @param array  $actualDocumentData
+     *
+     * @throws MongoDBException
+     */
+    private function guardShardKeyFieldInvariants($document, array $options, $shardKeyField, $actualDocumentData)
+    {
+        $dcs = $this->uow->getDocumentChangeSet($document);
+        $isUpdate = $this->uow->isScheduledForUpdate($document);
+
+        if ($isUpdate
+            && isset($dcs[$shardKeyField])
+            && $dcs[$shardKeyField][0] != $dcs[$shardKeyField][1]
+            && (!isset($options['upsert']) || $options['upsert'] === true)
+        ) {
+            throw MongoDBException::shardKeyFieldCannotBeChanged($shardKeyField, $this->class->getName());
+        }
+
+        if (!isset($actualDocumentData[$shardKeyField])) {
+            throw MongoDBException::shardKeyFieldMissing($shardKeyField, $this->class->getName());
         }
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -23,7 +23,6 @@ use Doctrine\Common\EventManager;
 use Doctrine\MongoDB\CursorInterface;
 use Doctrine\ODM\MongoDB\Cursor;
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 use Doctrine\ODM\MongoDB\Hydrator\HydratorFactory;
 use Doctrine\ODM\MongoDB\LockException;
 use Doctrine\ODM\MongoDB\LockMode;
@@ -35,6 +34,7 @@ use Doctrine\ODM\MongoDB\Query\CriteriaMerger;
 use Doctrine\ODM\MongoDB\Query\Query;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Doctrine\ODM\MongoDB\UnitOfWork;
+use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 
 /**
  * The DocumentPersister is responsible for persisting documents.
@@ -443,9 +443,12 @@ class DocumentPersister
     /**
      * Refreshes a managed document.
      *
+     * @param string $id
      * @param object $document The document to refresh.
+     *
+     * @deprecated The first argument is deprecated.
      */
-    public function refresh($document)
+    public function refresh($id, $document)
     {
         $query = $this->getQueryForDocument($document);
         $data = $this->collection->findOne($query);

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -297,7 +297,7 @@ class DocumentPersister
     private function executeUpsert($document, array $options)
     {
         $options['upsert'] = true;
-        $criteria = $this->getQueryForDocument($document, $options);
+        $criteria = $this->getQueryForDocument($document);
 
         $data = $this->pb->prepareUpsertData($document);
 
@@ -365,7 +365,7 @@ class DocumentPersister
     {
         $update = $this->pb->prepareUpdateData($document);
 
-        $query = $this->getQueryForDocument($document, $options);
+        $query = $this->getQueryForDocument($document);
 
         foreach (array_keys($query) as $field) {
             unset($update['$set'][$field]);
@@ -427,7 +427,7 @@ class DocumentPersister
      */
     public function delete($document, array $options = array())
     {
-        $query = $this->getQueryForDocument($document, $options);
+        $query = $this->getQueryForDocument($document);
 
         if ($this->class->isLockable) {
             $query[$this->class->lockField] = array('$exists' => false);
@@ -532,12 +532,11 @@ class DocumentPersister
 
     /**
      * @param object $document
-     * @param array $options
      *
      * @return array
      * @throws MongoDBException
      */
-    public function getShardKeyQuery($document, array $options = array())
+    public function getShardKeyQuery($document)
     {
         if ( ! $this->class->isSharded()) {
             return array();
@@ -550,7 +549,7 @@ class DocumentPersister
         $shardKeyQueryPart = array();
         foreach ($keys as $key) {
             $mapping = $this->class->getFieldMappingByDbFieldName($key);
-            $this->guardShardKeyInvariants($document, $options, $key, $data);
+            $this->guardMissingShardKey($document, $key, $data);
             $value = Type::getType($mapping['type'])->convertToDatabaseValue($data[$mapping['fieldName']]);
             $shardKeyQueryPart[$key] = $value;
         }
@@ -1300,13 +1299,12 @@ class DocumentPersister
      * Also, shard key field should be presented in actual document data.
      *
      * @param object $document
-     * @param array  $options
      * @param string $shardKeyField
      * @param array  $actualDocumentData
      *
      * @throws MongoDBException
      */
-    private function guardShardKeyInvariants($document, array $options, $shardKeyField, $actualDocumentData)
+    private function guardMissingShardKey($document, $shardKeyField, $actualDocumentData)
     {
         $dcs = $this->uow->getDocumentChangeSet($document);
         $isUpdate = $this->uow->isScheduledForUpdate($document);
@@ -1314,11 +1312,7 @@ class DocumentPersister
         $fieldMapping = $this->class->getFieldMappingByDbFieldName($shardKeyField);
         $fieldName = $fieldMapping['fieldName'];
 
-        if ($isUpdate
-            && isset($dcs[$fieldName])
-            && $dcs[$fieldName][0] != $dcs[$fieldName][1]
-            && (!isset($options['upsert']) || $options['upsert'] === true)
-        ) {
+        if ($isUpdate && isset($dcs[$fieldName]) && $dcs[$fieldName][0] != $dcs[$fieldName][1]) {
             throw MongoDBException::shardKeyFieldCannotBeChanged($shardKeyField, $this->class->getName());
         }
 
@@ -1331,16 +1325,15 @@ class DocumentPersister
      * Get shard key aware query for single document.
      *
      * @param object $document
-     * @param array  $options
      *
      * @return array
      */
-    private function getQueryForDocument($document, array $options = array())
+    private function getQueryForDocument($document)
     {
         $id = $this->uow->getDocumentIdentifier($document);
         $id = $this->class->getDatabaseIdentifierValue($id);
 
-        $shardKeyQueryPart = $this->getShardKeyQuery($document, $options);
+        $shardKeyQueryPart = $this->getShardKeyQuery($document);
         $query = array_merge(array('_id' => $id), $shardKeyQueryPart);
 
         return $query;

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -492,18 +492,18 @@ class SchemaManager
      * Ensure collections are sharded for all documents that can be loaded with the
      * metadata factory.
      *
-     * @param array $options
+     * @param array $indexOptions Options for `ensureIndex` command. It's performed on an existing collections
      *
      * @throws MongoDBException
      */
-    public function ensureSharding(array $options = array())
+    public function ensureSharding(array $indexOptions = array())
     {
         foreach ($this->metadataFactory->getAllMetadata() as $class) {
             if ($class->isMappedSuperclass || !$class->isSharded()) {
                 continue;
             }
 
-            $this->ensureDocumentSharding($class->name, $options);
+            $this->ensureDocumentSharding($class->name, $indexOptions);
         }
     }
 
@@ -511,11 +511,11 @@ class SchemaManager
      * Ensure sharding for collection by document name.
      *
      * @param string $documentName
-     * @param array  $options Options for `ensureIndex` command.
+     * @param array  $indexOptions Options for `ensureIndex` command. It's performed on an existing collections.
      *
      * @throws MongoDBException
      */
-    public function ensureDocumentSharding($documentName, array $options = array())
+    public function ensureDocumentSharding($documentName, array $indexOptions = array())
     {
         $class = $this->dm->getClassMetadata($documentName);
         if ( ! $class->isSharded()) {
@@ -530,7 +530,7 @@ class SchemaManager
             $try = 0;
 
             if ($result['ok'] != 1 && isset($result['proposedKey'])) {
-                $this->dm->getDocumentCollection($documentName)->ensureIndex($result['proposedKey'], $options);
+                $this->dm->getDocumentCollection($documentName)->ensureIndex($result['proposedKey'], $indexOptions);
                 $done = false;
                 $try++;
             }

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -526,7 +526,7 @@ class SchemaManager
         $result = $adminDb->command(
             array(
                 'shardCollection' => $dbName . '.' . $class->getCollection(),
-                'key' => $this->getDbShardKeyForShardedClass($class)
+                'key' => $shardKey['keys']
             ),
             $shardKey['options']
         );
@@ -551,23 +551,5 @@ class SchemaManager
         if ($result['ok'] != 1 && $result['errmsg'] !== 'already enabled') {
             throw MongoDBException::failedToEnableSharding($dbName, $result['errmsg']);
         }
-    }
-
-    /**
-     * @param ClassMetadata $shardedClass
-     *
-     * @return array
-     */
-    private function getDbShardKeyForShardedClass($shardedClass)
-    {
-        $shardKey = $shardedClass->getShardKey();
-        $dbFieldNames = array_map(
-            function ($field) use ($shardedClass) {
-                return $shardedClass->fieldMappings[$field]['name'];
-            },
-            array_keys($shardKey['keys'])
-        );
-
-        return array_combine($dbFieldNames, $shardKey['keys']);
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -491,15 +491,19 @@ class SchemaManager
     /**
      * Ensure collections are sharded for all documents that can be loaded with the
      * metadata factory.
+     *
+     * @param array $options
+     *
+     * @throws MongoDBException
      */
-    public function ensureSharding()
+    public function ensureSharding(array $options = array())
     {
         foreach ($this->metadataFactory->getAllMetadata() as $class) {
             if ($class->isMappedSuperclass || !$class->isSharded()) {
                 continue;
             }
 
-            $this->ensureDocumentSharding($class->name);
+            $this->ensureDocumentSharding($class->name, $options);
         }
     }
 

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -504,32 +504,33 @@ class SchemaManager
     }
 
     /**
-     * Ensure shard key for given document conforms its metadata.
-     * Also enable sharding for document's database.
+     * Ensure sharding for collection by document name.
      *
-     * @param $documentName
+     * @param string $documentName
+     * @param array  $options Options for `ensureIndex` command.
      *
      * @throws MongoDBException
      */
-    public function ensureDocumentSharding($documentName)
+    public function ensureDocumentSharding($documentName, array $options = array())
     {
         $class = $this->dm->getClassMetadata($documentName);
         if ( ! $class->isSharded()) {
             return;
         }
 
-        $dbName = $this->dm->getDocumentDatabase($documentName)->getName();
-        $this->enableShardingForDb($dbName);
+        $this->enableShardingForDbByDocumentName($documentName);
 
-        $shardKey = $class->getShardKey();
-        $adminDb = $this->dm->getConnection()->selectDatabase('admin');
-        $result = $adminDb->command(
-            array(
-                'shardCollection' => $dbName . '.' . $class->getCollection(),
-                'key' => $shardKey['keys']
-            ),
-            $shardKey['options']
-        );
+        do {
+            $result = $this->runShardCollectionCommand($documentName);
+            $done = true;
+            $try = 0;
+
+            if ($result['ok'] != 1 && isset($result['proposedKey'])) {
+                $this->dm->getDocumentCollection($documentName)->ensureIndex($result['proposedKey'], $options);
+                $done = false;
+                $try++;
+            }
+        } while (!$done && $try < 2);
 
         if ($result['ok'] != 1 && $result['errmsg'] !== 'already sharded') {
             throw MongoDBException::failedToEnsureDocumentSharding($documentName, $result['errmsg']);
@@ -537,19 +538,43 @@ class SchemaManager
     }
 
     /**
-     * Enable sharding for database.
+     * Enable sharding for database which contains documents with given name.
      *
-     * @param $dbName
+     * @param string $documentName
      *
      * @throws MongoDBException
      */
-    public function enableShardingForDb($dbName)
+    public function enableShardingForDbByDocumentName($documentName)
     {
+        $dbName = $this->dm->getDocumentDatabase($documentName)->getName();
         $adminDb = $this->dm->getConnection()->selectDatabase('admin');
         $result = $adminDb->command(array('enableSharding' => $dbName));
 
         if ($result['ok'] != 1 && $result['errmsg'] !== 'already enabled') {
             throw MongoDBException::failedToEnableSharding($dbName, $result['errmsg']);
         }
+    }
+
+    /**
+     * @param $documentName
+     *
+     * @return array
+     */
+    private function runShardCollectionCommand($documentName)
+    {
+        $class = $this->dm->getClassMetadata($documentName);
+        $dbName = $this->dm->getDocumentDatabase($documentName)->getName();
+        $shardKey = $class->getShardKey();
+        $adminDb = $this->dm->getConnection()->selectDatabase('admin');
+
+        $result = $adminDb->command(
+            array(
+                'shardCollection' => $dbName . '.' . $class->getCollection(),
+                'key'             => $shardKey['keys']
+            ),
+            $shardKey['options']
+        );
+
+        return $result;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -487,4 +487,87 @@ class SchemaManager
 
         return true;
     }
+
+    /**
+     * Ensure collections are sharded for all documents that can be loaded with the
+     * metadata factory.
+     */
+    public function ensureSharding()
+    {
+        foreach ($this->metadataFactory->getAllMetadata() as $class) {
+            if ($class->isMappedSuperclass || !$class->isSharded()) {
+                continue;
+            }
+
+            $this->ensureDocumentSharding($class->name);
+        }
+    }
+
+    /**
+     * Ensure shard key for given document conforms its metadata.
+     * Also enable sharding for document's database.
+     *
+     * @param $documentName
+     *
+     * @throws MongoDBException
+     */
+    public function ensureDocumentSharding($documentName)
+    {
+        $class = $this->dm->getClassMetadata($documentName);
+        if ( ! $class->isSharded()) {
+            return;
+        }
+
+        $dbName = $this->dm->getDocumentDatabase($documentName)->getName();
+        $this->enableShardingForDb($dbName);
+
+        $shardKey = $class->getShardKey();
+        $adminDb = $this->dm->getConnection()->selectDatabase('admin');
+        $result = $adminDb->command(
+            array(
+                'shardCollection' => $dbName . '.' . $class->getCollection(),
+                'key' => $this->getDbShardKeyForShardedClass($class)
+            ),
+            $shardKey['options']
+        );
+
+        if ($result['ok'] != 1 && $result['errmsg'] !== 'already sharded') {
+            throw MongoDBException::failedToEnsureDocumentSharding($documentName, $result['errmsg']);
+        }
+    }
+
+    /**
+     * Enable sharding for database.
+     *
+     * @param $dbName
+     *
+     * @throws MongoDBException
+     */
+    public function enableShardingForDb($dbName)
+    {
+        $adminDb = $this->dm->getConnection()->selectDatabase('admin');
+        $result = $adminDb->command(array('enableSharding' => $dbName));
+
+        if ($result['ok'] != 1 && $result['errmsg'] !== 'already enabled') {
+            throw MongoDBException::failedToEnableSharding($dbName, $result['errmsg']);
+        }
+    }
+
+    /**
+     * @param ClassMetadata $shardedClass
+     *
+     * @return array
+     */
+    private function getDbShardKeyForShardedClass($shardedClass)
+    {
+        $shardKey = $shardedClass->getShardKey();
+        $dbFieldNames = array_map(
+            function ($field) use ($shardedClass) {
+                return $shardedClass->fieldMappings[$field]['name'];
+            },
+            array_keys($shardKey['fields'])
+        );
+
+        return array_combine($dbFieldNames, $shardKey['fields']);
+    }
 }

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -565,9 +565,9 @@ class SchemaManager
             function ($field) use ($shardedClass) {
                 return $shardedClass->fieldMappings[$field]['name'];
             },
-            array_keys($shardKey['fields'])
+            array_keys($shardKey['keys'])
         );
 
-        return array_combine($dbFieldNames, $shardKey['fields']);
+        return array_combine($dbFieldNames, $shardKey['keys']);
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -175,10 +175,10 @@ class UnitOfWork implements PropertyChangedListener
      * @var array
      */
     private $collectionUpdates = array();
-    
+
     /**
      * A list of documents related to collections scheduled for update or deletion
-     * 
+     *
      * @var array
      */
     private $hasScheduledCollections = array();
@@ -446,7 +446,7 @@ class UnitOfWork implements PropertyChangedListener
         $this->collectionDeletions =
         $this->visitedCollections =
         $this->scheduledForDirtyCheck =
-        $this->orphanRemovals = 
+        $this->orphanRemovals =
         $this->hasScheduledCollections = array();
     }
 
@@ -2448,7 +2448,7 @@ class UnitOfWork implements PropertyChangedListener
             $this->collectionUpdates =
             $this->collectionDeletions =
             $this->parentAssociations =
-            $this->orphanRemovals = 
+            $this->orphanRemovals =
             $this->hasScheduledCollections = array();
         } else {
             $visited = array();
@@ -2523,11 +2523,11 @@ class UnitOfWork implements PropertyChangedListener
     {
         return isset($this->collectionDeletions[spl_object_hash($coll)]);
     }
-    
+
     /**
      * INTERNAL:
      * Unschedules a collection from being deleted when this UnitOfWork commits.
-     * 
+     *
      * @param \Doctrine\ODM\MongoDB\PersistentCollection $coll
      */
     public function unscheduleCollectionDeletion(PersistentCollection $coll)
@@ -2561,11 +2561,11 @@ class UnitOfWork implements PropertyChangedListener
             $this->scheduleCollectionOwner($coll);
         }
     }
-    
+
     /**
      * INTERNAL:
      * Unschedules a collection from being updated when this UnitOfWork commits.
-     * 
+     *
      * @param \Doctrine\ODM\MongoDB\PersistentCollection $coll
      */
     public function unscheduleCollectionUpdate(PersistentCollection $coll)
@@ -2577,7 +2577,7 @@ class UnitOfWork implements PropertyChangedListener
             unset($this->hasScheduledCollections[spl_object_hash($topmostOwner)][$oid]);
         }
     }
-    
+
     /**
      * Checks whether a PersistentCollection is scheduled for update.
      *
@@ -2604,22 +2604,22 @@ class UnitOfWork implements PropertyChangedListener
                 ? $this->visitedCollections[$oid]
                 : array();
     }
-    
+
     /**
      * INTERNAL:
      * Gets PersistentCollections that are scheduled to update and related to $document
-     * 
+     *
      * @param object $document
      * @return array
      */
     public function getScheduledCollections($document)
     {
         $oid = spl_object_hash($document);
-        return isset($this->hasScheduledCollections[$oid]) 
+        return isset($this->hasScheduledCollections[$oid])
                 ? $this->hasScheduledCollections[$oid]
                 : array();
     }
-    
+
     /**
      * Checks whether the document is related to a PersistentCollection
      * scheduled for update or deletion.
@@ -2631,7 +2631,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         return isset($this->hasScheduledCollections[spl_object_hash($document)]);
     }
-    
+
     /**
      * Marks the PersistentCollection's top-level owner as having a relation to
      * a collection scheduled for update or deletion.
@@ -2642,7 +2642,7 @@ class UnitOfWork implements PropertyChangedListener
      * If the collection is nested within atomic collection, it is immediately
      * unscheduled and atomic one is scheduled for update instead. This makes
      * calculating update data way easier.
-     * 
+     *
      * @param PersistentCollection $coll
      */
     private function scheduleCollectionOwner(PersistentCollection $coll)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,7 @@
     <groups>
         <exclude>
             <group>performance</group>
+            <group>sharding</group>
         </exclude>
     </groups>
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -6,17 +6,13 @@ use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\MongoDB\Connection;
+use Doctrine\ODM\MongoDB\UnitOfWork;
 
 abstract class BaseTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var \Doctrine\ODM\MongoDB\DocumentManager
-     */
+    /** @var DocumentManager */
     protected $dm;
-    
-    /**
-     * @var \Doctrine\ODM\MongoDB\UnitOfWork
-     */
+    /** @var UnitOfWork */
     protected $uow;
 
     public function setUp()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class EnsureShardingTest extends BaseTest
+{
+    /**
+     * @group sharding
+     */
+    public function testEnsureShardingForNewCollection()
+    {
+        $class = __NAMESPACE__ . '\ShardedOne';
+        $this->dm->getSchemaManager()->ensureDocumentSharding($class);
+
+        $collection = $this->dm->getDocumentCollection($class);
+        $indexes = $collection->getIndexInfo();
+        $stats = $this->dm->getDocumentDatabase($class)->command(array('collstats' => $collection->getName()));
+
+        $this->assertCount(2, $indexes);
+        $this->assertSame(array('k' => 1), $indexes[1]['key']);
+        $this->assertTrue($stats['sharded']);
+    }
+
+    /**
+     * @group sharding
+     */
+    public function testEnsureShardingForCollectionWithDocuments()
+    {
+        $class = __NAMESPACE__ . '\ShardedOne';
+        $collection = $this->dm->getDocumentCollection($class);
+        $doc = array('title' => 'hey', 'k' => 'hi');
+        $collection->insert($doc);
+
+        $this->dm->getSchemaManager()->ensureDocumentSharding($class);
+
+        $indexes = $collection->getIndexInfo();
+        $stats = $this->dm->getDocumentDatabase($class)->command(array('collstats' => $collection->getName()));
+
+        $this->assertCount(2, $indexes);
+        $this->assertSame(array('k' => 1), $indexes[1]['key']);
+        $this->assertTrue($stats['sharded']);
+    }
+}
+
+/**
+ * @ODM\Document
+ * @ODM\ShardKey(keys={"k"="asc"})
+ */
+class ShardedOne
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\String */
+    public $title = 'test';
+
+    /** @ODM\String(name="k") */
+    public $key = 'testing';
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
@@ -12,7 +12,7 @@ class EnsureShardingTest extends BaseTest
      */
     public function testEnsureShardingForNewCollection()
     {
-        $class = __NAMESPACE__ . '\ShardedOne';
+        $class = 'Documents\Sharded\ShardedOne';
         $this->dm->getSchemaManager()->ensureDocumentSharding($class);
 
         $collection = $this->dm->getDocumentCollection($class);
@@ -29,7 +29,7 @@ class EnsureShardingTest extends BaseTest
      */
     public function testEnsureShardingForCollectionWithDocuments()
     {
-        $class = __NAMESPACE__ . '\ShardedOne';
+        $class = 'Documents\Sharded\ShardedOne';
         $collection = $this->dm->getDocumentCollection($class);
         $doc = array('title' => 'hey', 'k' => 'hi');
         $collection->insert($doc);
@@ -43,20 +43,4 @@ class EnsureShardingTest extends BaseTest
         $this->assertSame(array('k' => 1), $indexes[1]['key']);
         $this->assertTrue($stats['sharded']);
     }
-}
-
-/**
- * @ODM\Document
- * @ODM\ShardKey(keys={"k"="asc"})
- */
-class ShardedOne
-{
-    /** @ODM\Id */
-    public $id;
-
-    /** @ODM\String */
-    public $title = 'test';
-
-    /** @ODM\String(name="k") */
-    public $key = 'testing';
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
@@ -41,6 +41,7 @@ class ReadPreferenceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     }
 
     /**
+     * @group replication_lag
      * @dataProvider provideReadPreferenceHints
      */
     public function testHintIsSetOnQuery($readPreference, array $tags = null)
@@ -62,6 +63,7 @@ class ReadPreferenceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     }
 
     /**
+     * @group replication_lag
      * @dataProvider provideReadPreferenceHints
      */
     public function testHintIsSetOnCursor($readPreference, array $tags = null)
@@ -87,6 +89,7 @@ class ReadPreferenceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     }
 
     /**
+     * @group replication_lag
      * @dataProvider provideReadPreferenceHints
      */
     public function testHintIsSetOnPersistentCollection($readPreference, array $tags = null)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
@@ -246,6 +246,9 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals(0, $invoked, 'Primer was not invoked when all references were already managed.');
     }
 
+    /**
+     * @group replication_lag
+     */
     public function testPrimeReferencesInvokesPrimer()
     {
         $group1 = new Group();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
@@ -112,6 +112,20 @@ class ShardKeyTest extends BaseTest
     }
 
     /**
+     * @group sharding
+     * @expectedException \Doctrine\ODM\MongoDB\MongoDBException
+     */
+    public function testUpdateWithUpsertTrue()
+    {
+        $o = new ShardedOne();
+        $this->dm->persist($o);
+        $this->dm->flush();
+
+        $o->key = 'testing2';
+        $this->dm->flush(null, array('upsert' => true));
+    }
+
+    /**
      * Replace DM with the one with enabled query logging
      *
      * @param $queries

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
@@ -75,7 +75,6 @@ class ShardKeyTest extends BaseTest
 /**
  * @ODM\Document
  * @ODM\ShardKey(keys={"k"="asc"})
- * @ODM\Index(keys={"k"="asc"})
  */
 class ShardedOne
 {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
@@ -3,8 +3,8 @@
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\Sharded\ShardedOne;
 
 class ShardKeyTest extends BaseTest
 {
@@ -13,7 +13,7 @@ class ShardKeyTest extends BaseTest
         parent::setUp();
 
         $schemaManager = $this->dm->getSchemaManager();
-        $schemaManager->ensureDocumentSharding(__NAMESPACE__ . '\ShardedOne');
+        $schemaManager->ensureDocumentSharding('Documents\Sharded\ShardedOne');
     }
 
     /**
@@ -28,7 +28,7 @@ class ShardKeyTest extends BaseTest
         $this->dm->persist($o);
         $this->dm->flush();
 
-        /** @var ShardedOne $o */
+        /** @var \Documents\Sharded\ShardedOne $o */
         $o = $this->dm->find(get_class($o), $o->id);
         $o->title = 'test2';
         $this->dm->flush();
@@ -128,20 +128,4 @@ class ShardKeyTest extends BaseTest
             $this->dm->getConfiguration()
         );
     }
-}
-
-/**
- * @ODM\Document
- * @ODM\ShardKey(keys={"k"="asc"})
- */
-class ShardedOne
-{
-    /** @ODM\Id */
-    public $id;
-
-    /** @ODM\String */
-    public $title = 'test';
-
-    /** @ODM\String(name="k") */
-    public $key = 'testing';
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
@@ -5,7 +5,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class ShardingTest extends BaseTest
+class ShardKeyTest extends BaseTest
 {
     public function setUp()
     {
@@ -74,7 +74,8 @@ class ShardingTest extends BaseTest
 
 /**
  * @ODM\Document
- * @ODM\ShardKey(keys={"key"="asc"})
+ * @ODM\ShardKey(keys={"k"="asc"})
+ * @ODM\Index(keys={"k"="asc"})
  */
 class ShardedOne
 {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardingTest.php
@@ -74,7 +74,7 @@ class ShardingTest extends BaseTest
 
 /**
  * @ODM\Document
- * @ODM\ShardKey(fields={"key"="asc"})
+ * @ODM\ShardKey(keys={"key"="asc"})
  */
 class ShardedOne
 {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardingTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class ShardingTest extends BaseTest
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        /** @var SchemaManager $schemaManager */
+        $schemaManager = $this->dm->getSchemaManager();
+        $schemaManager->ensureDocumentSharding(__NAMESPACE__ . '\ShardedOne');
+    }
+
+    /**
+     * @group sharding
+     */
+    public function testUpdateAfterSave()
+    {
+        $o = new ShardedOne();
+        $o->title = 'test';
+        $o->key = 'testing';
+        $this->dm->persist($o);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        /** @var ShardedOne $o */
+        $o = $this->dm->find(get_class($o), $o->id);
+        $o->title = 'test2';
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $o = $this->dm->find(get_class($o), $o->id);
+
+        $this->assertEquals('test2', $o->title);
+    }
+
+    /**
+     * @group sharding
+     */
+    public function testUpsert()
+    {
+        $o = new ShardedOne();
+        $o->id = new \MongoId();
+        $o->title = 'test';
+        $o->key = 'testing';
+        $this->dm->persist($o);
+        $this->dm->flush();
+    }
+
+    /**
+     * @group sharding
+     * @expectedException \Doctrine\ODM\MongoDB\MongoDBException
+     */
+    public function testUpdateWithShardKeyChangeException()
+    {
+        $o = new ShardedOne();
+        $o->title = 'test';
+        $o->key = 'testing';
+        $this->dm->persist($o);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $o = $this->dm->find(get_class($o), $o->id);
+        $o->key = 'testing2';
+
+        $this->dm->flush();
+    }
+}
+
+/**
+ * @ODM\Document
+ * @ODM\ShardKey(fields={"key"="asc"})
+ */
+class ShardedOne
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\String */
+    public $title;
+
+    /** @ODM\String(name="k") */
+    public $key;
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SlaveOkayTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SlaveOkayTest.php
@@ -20,6 +20,9 @@ class SlaveOkayTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
     }
 
+    /**
+     * @group replication_lag
+     */
     public function testHintIsNotSetByDefault()
     {
         $cursor = $this->dm->getRepository('Documents\User')
@@ -36,6 +39,7 @@ class SlaveOkayTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     }
 
     /**
+     * @group replication_lag
      * @dataProvider provideSlaveOkayHints
      */
     public function testHintIsSetOnQuery($slaveOkay)
@@ -55,6 +59,7 @@ class SlaveOkayTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     }
 
     /**
+     * @group replication_lag
      * @dataProvider provideSlaveOkayHints
      */
     public function testHintIsSetOnCursor($slaveOkay)
@@ -75,6 +80,7 @@ class SlaveOkayTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     }
 
     /**
+     * @group replication_lag
      * @dataProvider provideSlaveOkayHints
      */
     public function testHintIsSetOnPersistentCollection($slaveOkay)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SlaveOkayTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SlaveOkayTest.php
@@ -48,6 +48,9 @@ class SlaveOkayTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->assertSlaveOkayHint($slaveOkay, $cursor->getHints());
 
+        // Workaround replication lag
+        usleep(1000);
+
         $user = $cursor->getSingleResult();
 
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\PersistentCollection', $user->getGroups());
@@ -67,6 +70,9 @@ class SlaveOkayTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $cursor->setHints(array(Query::HINT_SLAVE_OKAY => $slaveOkay));
 
         $this->assertSlaveOkayHint($slaveOkay, $cursor->getHints());
+
+        // Workaround replication lag
+        usleep(1000);
 
         $user = $cursor->getSingleResult();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SlaveOkayTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SlaveOkayTest.php
@@ -48,9 +48,6 @@ class SlaveOkayTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->assertSlaveOkayHint($slaveOkay, $cursor->getHints());
 
-        // Workaround replication lag
-        usleep(1000);
-
         $user = $cursor->getSingleResult();
 
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\PersistentCollection', $user->getGroups());
@@ -70,9 +67,6 @@ class SlaveOkayTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $cursor->setHints(array(Query::HINT_SLAVE_OKAY => $slaveOkay));
 
         $this->assertSlaveOkayHint($slaveOkay, $cursor->getHints());
-
-        // Workaround replication lag
-        usleep(1000);
 
         $user = $cursor->getSingleResult();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -327,8 +327,8 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
     {
         $shardKey = $class->getShardKey();
 
-        $this->assertTrue(isset($shardKey['fields']['name']), 'Shard key field is not mapped');
-        $this->assertEquals(1, $shardKey['fields']['name'], 'Wrong value for shard key field');
+        $this->assertTrue(isset($shardKey['keys']['name']), 'Shard key is not mapped');
+        $this->assertEquals(1, $shardKey['keys']['name'], 'Wrong value for shard key');
 
         $this->assertTrue(isset($shardKey['options']['unique']), 'Shard key option is not mapped');
         $this->assertTrue($shardKey['options']['unique'], 'Shard key option has wrong value');
@@ -344,7 +344,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
  * @ODM\DefaultDiscriminatorValue("default")
  * @ODM\HasLifecycleCallbacks
  * @ODM\Indexes(@ODM\Index(keys={"createdAt"="asc"},expireAfterSeconds=3600))
- * @ODM\ShardKey(fields={"name"="asc"},unique=true,numInitialChunks=4096)
+ * @ODM\ShardKey(keys={"name"="asc"},unique=true,numInitialChunks=4096)
  */
 class AbstractMappingDriverUser
 {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -3,8 +3,6 @@
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
-use Doctrine\ODM\MongoDB\Mapping\Driver\YamlDriver;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
@@ -320,6 +318,23 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
 
         return $class;
     }
+
+    /**
+     * @depends testIndexes
+     * @param ClassMetadata $class
+     */
+    public function testShardKey($class)
+    {
+        $shardKey = $class->getShardKey();
+
+        $this->assertTrue(isset($shardKey['fields']['name']), 'Shard key field is not mapped');
+        $this->assertEquals(1, $shardKey['fields']['name'], 'Wrong value for shard key field');
+
+        $this->assertTrue(isset($shardKey['options']['unique']), 'Shard key option is not mapped');
+        $this->assertTrue($shardKey['options']['unique'], 'Shard key option has wrong value');
+        $this->assertTrue(isset($shardKey['options']['numInitialChunks']), 'Shard key option is not mapped');
+        $this->assertEquals(4096, $shardKey['options']['numInitialChunks'], 'Shard key option has wrong value');
+    }
 }
 
 /**
@@ -329,6 +344,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
  * @ODM\DefaultDiscriminatorValue("default")
  * @ODM\HasLifecycleCallbacks
  * @ODM\Indexes(@ODM\Index(keys={"createdAt"="asc"},expireAfterSeconds=3600))
+ * @ODM\ShardKey(fields={"name"="asc"},unique=true,numInitialChunks=4096)
  */
 class AbstractMappingDriverUser
 {
@@ -519,5 +535,6 @@ class AbstractMappingDriverUser
         $metadata->addIndex(array('email' => 'desc'), array('unique' => true, 'dropDups' => true));
         $metadata->addIndex(array('mysqlProfileId' => 'desc'), array('unique' => true, 'dropDups' => true));
         $metadata->addIndex(array('createdAt' => 'asc'), array('expireAfterSeconds' => 3600));
+        $metadata->setShardKey(array('name' => 'asc'), array('unique' => true, 'numInitialChunks' => 4096));
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
@@ -3,7 +3,6 @@
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 class AnnotationDriverTest extends AbstractMappingDriverTest
@@ -140,6 +139,15 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $this->assertNotContains($extraneousClassName, $classes);
     }
 
+    /**
+     * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
+     * @expectedExceptionMessage Embedded document can't have shard key
+     */
+    public function testEmbeddedClassCantHaveShardKey()
+    {
+        $this->dm->getClassMetadata(__NAMESPACE__ . '\AnnotationDriverEmbeddedWithShardKey');
+    }
+
     protected function _loadDriverForCMSDocuments()
     {
         $annotationDriver = $this->_loadDriver();
@@ -186,4 +194,14 @@ class AnnotationDriverTestChild extends AnnotationDriverTestParent
 {
     /** @ODM\String */
     public $bar;
+}
+
+/**
+ * @ODM\EmbeddedDocument
+ * @ODM\ShardKey(fields={"foo"="asc"})
+ */
+class AnnotationDriverEmbeddedWithShardKey
+{
+    /** @ODM\String */
+    public $foo;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
@@ -198,7 +198,7 @@ class AnnotationDriverTestChild extends AnnotationDriverTestParent
 
 /**
  * @ODM\EmbeddedDocument
- * @ODM\ShardKey(fields={"foo"="asc"})
+ * @ODM\ShardKey(keys={"foo"="asc"})
  */
 class AnnotationDriverEmbeddedWithShardKey
 {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataInfoTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataInfoTest.php
@@ -399,6 +399,20 @@ class ClassMetadataInfoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $cm->isEmbeddedDocument = true;
         $cm->setShardKey(array('id' => 'asc'));
     }
+
+    /**
+     * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
+     * @expectedExceptionMessage No increment fields allowed in the shard key
+     */
+    public function testNoIncrementFieldsAllowedInShardKey()
+    {
+        $cm = new ClassMetadataInfo('stdClass');
+        $cm->mapField(array(
+            'fieldName' => 'inc',
+            'type' => 'increment'
+        ));
+        $cm->setShardKey(array('inc'));
+    }
 }
 
 class TestCustomRepositoryClass extends DocumentRepository

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataInfoTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataInfoTest.php
@@ -352,7 +352,7 @@ class ClassMetadataInfoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     /**
      * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
-     * @expectedExceptionMessage Shard key definition in subclass is forbidden in case of single collection inheritance: stdClass
+     * @expectedExceptionMessage Shard key overriding in subclass is forbidden for single collection inheritance
      */
     public function testSetShardKeyForClassWithSingleCollectionInheritanceWhichAlreadyHasIt()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataInfoTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataInfoTest.php
@@ -336,7 +336,7 @@ class ClassMetadataInfoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $shardKey = $cm->getShardKey();
 
-        $this->assertEquals(array('id' => 1), $shardKey['fields']);
+        $this->assertEquals(array('id' => 1), $shardKey['keys']);
     }
 
     public function testSetShardKeyForClassWithSingleCollectionInheritance()
@@ -347,7 +347,7 @@ class ClassMetadataInfoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $shardKey = $cm->getShardKey();
 
-        $this->assertEquals(array('id' => 1), $shardKey['fields']);
+        $this->assertEquals(array('id' => 1), $shardKey['keys']);
     }
 
     /**
@@ -371,7 +371,7 @@ class ClassMetadataInfoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $shardKey = $cm->getShardKey();
 
-        $this->assertEquals(array('id' => 1), $shardKey['fields']);
+        $this->assertEquals(array('id' => 1), $shardKey['keys']);
     }
 
     public function testIsNotShardedIfThereIsNoShardKey()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -31,6 +31,7 @@ class ClassMetadataTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $cm->setFile('customFileProperty');
         $cm->setDistance('customDistanceProperty');
         $cm->setSlaveOkay(true);
+        $cm->setShardKey(array('_id' => '1'));
         $cm->setCollectionCapped(true);
         $cm->setCollectionMax(1000);
         $cm->setCollectionSize(500);
@@ -57,6 +58,7 @@ class ClassMetadataTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals('customFileProperty', $cm->file);
         $this->assertEquals('customDistanceProperty', $cm->distance);
         $this->assertTrue($cm->slaveOkay);
+        $this->assertEquals(array('keys' => array('_id' => 1), 'options' => array()), $cm->getShardKey());
         $mapping = $cm->getFieldMapping('phonenumbers');
         $this->assertEquals('Documents\Bar', $mapping['targetDocument']);
         $this->assertTrue($cm->getCollectionCapped());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -4,7 +4,6 @@ namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
-use Doctrine\ODM\MongoDB\Events;
 
 class ClassMetadataTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Mapping;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class ShardKeyInheritanceMappingTest extends BaseTest
+{
+    private $factory;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->factory = new ClassMetadataFactory();
+        $this->factory->setDocumentManager($this->dm);
+        $this->factory->setConfiguration($this->dm->getConfiguration());
+    }
+
+
+    public function testShardKeyFromMappedSuperclass()
+    {
+        $class = $this->factory->getMetadataFor(__NAMESPACE__ . '\\ShardedSubclass');
+
+        $this->assertTrue($class->isSharded());
+        $this->assertEquals(array('keys' => array('_id' => 1), 'options' => array()), $class->getShardKey());
+    }
+
+    public function testShardKeySingleCollectionInheritance()
+    {
+        $class = $this->factory->getMetadataFor(__NAMESPACE__ . '\\ShardedSingleCollInheritance2');
+
+        $this->assertTrue($class->isSharded());
+        $this->assertEquals(array('keys' => array('_id' => 1), 'options' => array()), $class->getShardKey());
+    }
+
+    /**
+     * @expectedException Doctrine\ODM\MongoDB\Mapping\MappingException
+     */
+    public function testShardKeySingleCollectionInheritanceOverriding()
+    {
+        $this->factory->getMetadataFor(__NAMESPACE__ . '\\ShardedSingleCollInheritance3');
+    }
+
+    public function testShardKeyCollectionPerClassInheritance()
+    {
+        $class = $this->factory->getMetadataFor(__NAMESPACE__ . '\\ShardedCollectionPerClass2');
+
+        $this->assertTrue($class->isSharded());
+        $this->assertEquals(array('keys' => array('_id' => 1), 'options' => array()), $class->getShardKey());
+    }
+
+    public function testShardKeyCollectionPerClassInheritanceOverriding()
+    {
+        $class = $this->factory->getMetadataFor(__NAMESPACE__ . '\\ShardedCollectionPerClass3');
+
+        $this->assertTrue($class->isSharded());
+        $this->assertEquals(array('keys' => array('_id' => 'hashed'), 'options' => array()), $class->getShardKey());
+    }
+}
+
+
+/**
+ * @ODM\MappedSuperclass
+ * @ODM\ShardKey(keys={"_id"="asc"})
+ */
+class ShardedSuperclass
+{
+    /** @ODM\String */
+    private $name;
+}
+
+/** @ODM\Document */
+class ShardedSubclass extends ShardedSuperclass
+{
+    /** @ODM\Id */
+    private $id;
+}
+
+/**
+ * @ODM\Document
+ * @ODM\InheritanceType("SINGLE_COLLECTION")
+ * @ODM\ShardKey(keys={"_id"="asc"})
+ */
+class ShardedSingleCollInheritance1
+{
+    /** @ODM\Id */
+    private $id;
+}
+
+/**
+ * @ODM\Document
+ */
+class ShardedSingleCollInheritance2 extends ShardedSingleCollInheritance1
+{}
+
+/**
+ * @ODM\Document
+ * @ODM\ShardKey(keys={"_id"="hashed"})
+ */
+class ShardedSingleCollInheritance3 extends ShardedSingleCollInheritance1
+{}
+
+/**
+ * @ODM\Document
+ * @ODM\InheritanceType("COLLECTION_PER_CLASS")
+ * @ODM\ShardKey(keys={"_id"="asc"})
+ */
+class ShardedCollectionPerClass1
+{
+    /** @ODM\Id */
+    private $id;
+}
+
+/**
+ * @ODM\Document
+ */
+class ShardedCollectionPerClass2 extends ShardedCollectionPerClass1
+{}
+
+/**
+ * @ODM\Document
+ * @ODM\ShardKey(keys={"_id"="hashed"})
+ */
+class ShardedCollectionPerClass3 extends ShardedCollectionPerClass1
+{}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
@@ -67,5 +67,10 @@
             <lifecycle-callback method="doOtherStuffOnPrePersistToo" type="prePersist" />
             <lifecycle-callback method="doStuffOnPostPersist" type="postPersist" />
         </lifecycle-callbacks>
+        <shard-key>
+            <key name="name" order="asc"/>
+            <option name="unique" value="true"/>
+            <option name="numInitialChunks" value="4096"/>
+        </shard-key>
     </document>
 </doctrine-mongo-mapping>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.yml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.yml
@@ -46,6 +46,12 @@ Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser:
       options:
         unique: true
         dropDups: true
+  shardKey:
+    keys:
+      name: asc
+    options:
+      unique: true
+      numInitialChunks: 4096
   referenceOne:
     address:
       targetDocument: Address

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
@@ -63,7 +63,7 @@ class DocumentPersisterGetShardKeyQueryTest extends BaseTest
 
 /**
  * @ODM\Document
- * @ODM\ShardKey(fields={"int"="asc","string"="asc","bool"="asc","float"="asc"})
+ * @ODM\ShardKey(keys={"int"="asc","string"="asc","bool"="asc","float"="asc"})
  */
 class ShardedByScalars
 {
@@ -85,7 +85,7 @@ class ShardedByScalars
 
 /**
  * @ODM\Document
- * @ODM\ShardKey(fields={"oid"="asc","bin"="asc","date"="asc"})
+ * @ODM\ShardKey(keys={"oid"="asc","bin"="asc","date"="asc"})
  */
 class ShardedByObjects
 {
@@ -104,7 +104,7 @@ class ShardedByObjects
 
 /**
  * @ODM\Document
- * @ODM\ShardKey(fields={"identifier"="ask"})
+ * @ODM\ShardKey(keys={"identifier"="ask"})
  */
 class ShardedById
 {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Persisters;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class DocumentPersisterGetShardKeyQueryTest extends BaseTest
+{
+    public function testGetShardKeyQueryScalars()
+    {
+        $o = new ShardedByScalars();
+        $o->int = 1;
+        $o->string = 'hi';
+        $o->bool = true;
+        $o->float = 1.2;
+
+        /** @var DocumentPersister $persister */
+        $persister = $this->uow->getDocumentPersister(get_class($o));
+
+        $this->assertSame(
+            array('int' => $o->int, 'string' => $o->string, 'bool' => $o->bool, 'float' => $o->float),
+            $persister->getShardKeyQuery($o)
+        );
+    }
+
+    public function testGetShardKeyQueryObjects()
+    {
+        $o = new ShardedByObjects();
+        $o->oid = '54ca2c4c81fec698130041a7';
+        $o->bin = 'hi';
+        $o->date = new \DateTime();
+
+        /** @var DocumentPersister $persister */
+        $persister = $this->uow->getDocumentPersister(get_class($o));
+
+        $shardKeyQuery = $persister->getShardKeyQuery($o);
+
+        $this->assertInstanceOf('MongoId', $shardKeyQuery['oid']);
+        $this->assertSame($o->oid, $shardKeyQuery['oid']->{'$id'});
+
+        $this->assertInstanceOf('MongoBinData', $shardKeyQuery['bin']);
+        $this->assertSame($o->bin, $shardKeyQuery['bin']->bin);
+
+        $this->assertInstanceOf('MongoDate', $shardKeyQuery['date']);
+        $this->assertSame($o->date->getTimestamp(), $shardKeyQuery['date']->sec);
+        $this->assertSame(0, $shardKeyQuery['date']->usec);
+    }
+
+    public function testShardById()
+    {
+        $o = new ShardedById();
+        $o->identifier = new \MongoId();
+
+        /** @var DocumentPersister $persister */
+        $persister = $this->uow->getDocumentPersister(get_class($o));
+        $shardKeyQuery = $persister->getShardKeyQuery($o);
+
+        $this->assertSame(array('_id' => $o->identifier), $shardKeyQuery);
+    }
+}
+
+/**
+ * @ODM\Document
+ * @ODM\ShardKey(fields={"int"="asc","string"="asc","bool"="asc","float"="asc"})
+ */
+class ShardedByScalars
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\Int */
+    public $int;
+
+    /** @ODM\String */
+    public $string;
+
+    /** @ODM\Boolean */
+    public $bool;
+
+    /** @ODM\Float */
+    public $float;
+}
+
+/**
+ * @ODM\Document
+ * @ODM\ShardKey(fields={"oid"="asc","bin"="asc","date"="asc"})
+ */
+class ShardedByObjects
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\ObjectId */
+    public $oid;
+
+    /** @ODM\Bin */
+    public $bin;
+
+    /** @ODM\Date */
+    public $date;
+}
+
+/**
+ * @ODM\Document
+ * @ODM\ShardKey(fields={"identifier"="ask"})
+ */
+class ShardedById
+{
+    /** @ODM\Id */
+    public $identifier;
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
@@ -104,7 +104,7 @@ class ShardedByObjects
 
 /**
  * @ODM\Document
- * @ODM\ShardKey(keys={"identifier"="ask"})
+ * @ODM\ShardKey(keys={"_id"="asc"})
  */
 class ShardedById
 {

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -391,8 +391,11 @@ class SchemaManagerTest extends \PHPUnit_Framework_TestCase
         $connMock = $this->getMockConnection();
         $connMock->method('selectDatabase')->with('admin')->willReturn($adminDBMock);
         $this->dm->connection = $connMock;
+        $dbMock = $this->getMockDatabase();
+        $dbMock->method('getName')->willReturn('db');
+        $this->dm->documentDatabases = array('Documents\Sharded\ShardedUser' => $dbMock);
 
-        $this->schemaManager->enableShardingForDb('db');
+        $this->schemaManager->enableShardingForDbByDocumentName('Documents\Sharded\ShardedUser');
     }
 
     /**
@@ -410,8 +413,11 @@ class SchemaManagerTest extends \PHPUnit_Framework_TestCase
         $connMock = $this->getMockConnection();
         $connMock->method('selectDatabase')->with('admin')->willReturn($adminDBMock);
         $this->dm->connection = $connMock;
+        $dbMock = $this->getMockDatabase();
+        $dbMock->method('getName')->willReturn('db');
+        $this->dm->documentDatabases = array('Documents\Sharded\ShardedUser' => $dbMock);
 
-        $this->schemaManager->enableShardingForDb('db');
+        $this->schemaManager->enableShardingForDbByDocumentName('Documents\Sharded\ShardedUser');
     }
 
     public function testEnableShardingForDbIgnoresAlreadyShardedError()
@@ -425,8 +431,11 @@ class SchemaManagerTest extends \PHPUnit_Framework_TestCase
         $connMock = $this->getMockConnection();
         $connMock->method('selectDatabase')->with('admin')->willReturn($adminDBMock);
         $this->dm->connection = $connMock;
+        $dbMock = $this->getMockDatabase();
+        $dbMock->method('getName')->willReturn('db');
+        $this->dm->documentDatabases = array('Documents\Sharded\ShardedUser' => $dbMock);
 
-        $this->schemaManager->enableShardingForDb('db');
+        $this->schemaManager->enableShardingForDbByDocumentName('Documents\Sharded\ShardedUser');
     }
 
     private function getMockCollection()

--- a/tests/Documents/Sharded/ShardedOne.php
+++ b/tests/Documents/Sharded/ShardedOne.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Documents\Sharded;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document(collection="sharded.one")
+ * @ODM\ShardKey(keys={"k"="asc"})
+ */
+class ShardedOne
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\String */
+    public $title = 'test';
+
+    /** @ODM\String(name="k") */
+    public $key = 'testing';
+}

--- a/tests/Documents/Sharded/ShardedUser.php
+++ b/tests/Documents/Sharded/ShardedUser.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Documents\Sharded;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document(collection="users")
+ * @ODM\ShardKey(fields={"id"="hashed"})
+ */
+class ShardedUser
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\String */
+    public $name;
+}

--- a/tests/Documents/Sharded/ShardedUser.php
+++ b/tests/Documents/Sharded/ShardedUser.php
@@ -5,7 +5,7 @@ namespace Documents\Sharded;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
- * @ODM\Document(collection="users")
+ * @ODM\Document(collection="sharded.users")
  * @ODM\ShardKey(keys={"_id"="hashed"})
  */
 class ShardedUser

--- a/tests/Documents/Sharded/ShardedUser.php
+++ b/tests/Documents/Sharded/ShardedUser.php
@@ -6,7 +6,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
  * @ODM\Document(collection="users")
- * @ODM\ShardKey(keys={"id"="hashed"})
+ * @ODM\ShardKey(keys={"_id"="hashed"})
  */
 class ShardedUser
 {

--- a/tests/Documents/Sharded/ShardedUser.php
+++ b/tests/Documents/Sharded/ShardedUser.php
@@ -6,7 +6,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
  * @ODM\Document(collection="users")
- * @ODM\ShardKey(fields={"id"="hashed"})
+ * @ODM\ShardKey(keys={"id"="hashed"})
  */
 class ShardedUser
 {


### PR DESCRIPTION
This one is inspired by #691.

Brief summary:
* `shardKey` property was added to `ClassMetadataInfo`, mapping support were added to all drivers. It's a hash with `keys` and `options`. `keys` was originally called `fields`, but I decided to conform to the indexes definition.
* `shardKey` is class-based, since we need to keep the order of the keys to ensure compound index.
* `ensureSharding` method were added to `SchemaManager`. It's similar to `ensureIndex`. For non-empty collections it will run `ensureIndex` and retry `shardCollection` again.
* `DocumentPersister` uses `shardKey` to generate query part for `upsert`, `update`, `remove`, `findOne`.

I tried to cover all the new code with both unit and functional tests. Tests were run against sharded clusters of MongoDB 2.2.3, 2.4.9 and 2.6.5. Functional tests were tagged to avoid running against non-sharded setup.

Now I'm testing it on production. I'd like to receive some feedback from you guys to improve or change something.