### PR TITLE
Add millisecond support for Date mapping type

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/DateType.php
@@ -58,6 +58,7 @@ class DateType extends Type
         }
         if ($value instanceof \MongoDate) {
             $date = \DateTime::createFromFormat('U.u', sprintf('%d.%06d', $value->sec, $value->usec));
+            $date->setTimezone(new \DateTimeZone(date_default_timezone_get()));
         } elseif (is_numeric($value)) {
             $date = new \DateTime();
             $date->setTimestamp($value);
@@ -76,6 +77,6 @@ class DateType extends Type
 
     public function closureToPHP()
     {
-        return 'if ($value instanceof \MongoDate) { $return = \DateTime::createFromFormat(\'U.u\', sprintf(\'%d.%06d\', $value->sec, $value->usec)); } elseif (is_numeric($value)) { $return = new \DateTime(); $return->setTimestamp($value); } elseif ($value instanceof \DateTime) { $return = $value; } else { $return = new \DateTime($value); }';
+        return 'if ($value instanceof \MongoDate) { $return = \DateTime::createFromFormat(\'U.u\', sprintf(\'%d.%06d\', $value->sec, $value->usec)); $return->setTimezone(new \DateTimeZone(date_default_timezone_get())); } elseif (is_numeric($value)) { $return = new \DateTime(); $return->setTimestamp($value); } elseif ($value instanceof \DateTime) { $return = $value; } else { $return = new \DateTime($value); }';
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/DateType.php
@@ -76,6 +76,6 @@ class DateType extends Type
 
     public function closureToPHP()
     {
-        return 'if ($value instanceof \MongoDate) { $return = \DateTime::createFromFormat(\'u.U\', sprintf(\'%d.%06d\', $value->sec, $value->usec)); } elseif (is_numeric($value)) { $return = new \DateTime(); $return->setTimestamp($value); } elseif ($value instanceof \DateTime) { $return = $value; } else { $return = new \DateTime($value); }';
+        return 'if ($value instanceof \MongoDate) { $return = \DateTime::createFromFormat(\'U.u\', sprintf(\'%d.%06d\', $value->sec, $value->usec)); } elseif (is_numeric($value)) { $return = new \DateTime(); $return->setTimestamp($value); } elseif ($value instanceof \DateTime) { $return = $value; } else { $return = new \DateTime($value); }';
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/DateType.php
@@ -57,8 +57,9 @@ class DateType extends Type
             return null;
         }
         if ($value instanceof \MongoDate) {
-            $date = \DateTime::createFromFormat('U.u', sprintf('%u.%06u', $value->sec, $value->usec));
-            $date->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+            $date = new \DateTime();
+            $date->setTimestamp($value->sec);
+            $date = \DateTime::createFromFormat('Y-m-d H:i:s.u', sprintf('%s.%06d', $date->format('Y-m-d H:i:s'), $value->usec));
         } elseif (is_numeric($value)) {
             $date = new \DateTime();
             $date->setTimestamp($value);
@@ -77,6 +78,6 @@ class DateType extends Type
 
     public function closureToPHP()
     {
-        return 'if ($value instanceof \MongoDate) { $return = \DateTime::createFromFormat(\'U.u\', sprintf(\'%u.%06u\', $value->sec, $value->usec)); $return->setTimezone(new \DateTimeZone(date_default_timezone_get())); } elseif (is_numeric($value)) { $return = new \DateTime(); $return->setTimestamp($value); } elseif ($value instanceof \DateTime) { $return = $value; } else { $return = new \DateTime($value); }';
+        return 'if ($value instanceof \MongoDate) { $return = new \DateTime(); $return->setTimestamp($value->sec); $return = \DateTime::createFromFormat(\'Y-m-d H:i:s.u\', sprintf(\'%s.%06d\', $return->format(\'Y-m-d H:i:s\'), $value->usec)); } elseif (is_numeric($value)) { $return = new \DateTime(); $return->setTimestamp($value); } elseif ($value instanceof \DateTime) { $return = $value; } else { $return = new \DateTime($value); }';
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/DateType.php
@@ -57,7 +57,7 @@ class DateType extends Type
             return null;
         }
         if ($value instanceof \MongoDate) {
-            $date = \DateTime::createFromFormat('U.u', sprintf('%d.%06d', $value->sec, $value->usec));
+            $date = \DateTime::createFromFormat('U.u', sprintf('%u.%06u', $value->sec, $value->usec));
             $date->setTimezone(new \DateTimeZone(date_default_timezone_get()));
         } elseif (is_numeric($value)) {
             $date = new \DateTime();
@@ -77,6 +77,6 @@ class DateType extends Type
 
     public function closureToPHP()
     {
-        return 'if ($value instanceof \MongoDate) { $return = \DateTime::createFromFormat(\'U.u\', sprintf(\'%d.%06d\', $value->sec, $value->usec)); $return->setTimezone(new \DateTimeZone(date_default_timezone_get())); } elseif (is_numeric($value)) { $return = new \DateTime(); $return->setTimestamp($value); } elseif ($value instanceof \DateTime) { $return = $value; } else { $return = new \DateTime($value); }';
+        return 'if ($value instanceof \MongoDate) { $return = \DateTime::createFromFormat(\'U.u\', sprintf(\'%u.%06u\', $value->sec, $value->usec)); $return->setTimezone(new \DateTimeZone(date_default_timezone_get())); } elseif (is_numeric($value)) { $return = new \DateTime(); $return->setTimestamp($value); } elseif ($value instanceof \DateTime) { $return = $value; } else { $return = new \DateTime($value); }';
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/DateType.php
@@ -57,7 +57,7 @@ class DateType extends Type
             return null;
         }
         if ($value instanceof \MongoDate) {
-            $date = \DateTime::createFromFormat('u.U', sprintf('%d.%06d', $value->sec, $value->usec));
+            $date = \DateTime::createFromFormat('U.u', sprintf('%d.%06d', $value->sec, $value->usec));
         } elseif (is_numeric($value)) {
             $date = new \DateTime();
             $date->setTimestamp($value);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
@@ -13,8 +13,8 @@ class DateTypeTest extends \PHPUnit_Framework_TestCase
         $date = \DateTime::createFromFormat('U.u', '1423743340.626000'); // "seconds.microseconds"
 
         $this->assertNull($type->convertToDatabaseValue(null), 'null is not converted');
-        $this->assertEquals(1423743340, $type->convertToDatabaseValue($time)->sec);
-        $this->assertEquals(626000, $type->convertToDatabaseValue($time)->usec);
+        $this->assertEquals(1423743340, $type->convertToDatabaseValue($date)->sec);
+        $this->assertEquals(626000, $type->convertToDatabaseValue($date)->usec);
     }
 
     public function testConvertToPHPValue()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Types;
+
+use Doctrine\ODM\MongoDB\Types\Type;
+
+class DateTypeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConvertToDatabaseValue()
+    {
+        $type = Type::getType('date');
+
+        $date = \DateTime::createFromFormat('U.u', '1423743340.626000'); // "seconds.microseconds"
+
+        $this->assertNull($type->convertToDatabaseValue(null), 'null is not converted');
+        $this->assertEquals(1423743340, $type->convertToDatabaseValue($time)->sec);
+        $this->assertEquals(626000, $type->convertToDatabaseValue($time)->usec));
+    }
+
+    public function testConvertToPHPValue()
+    {
+        $type = Type::getType('date');
+
+        $date = new \MongoDate(1423743340, 626000);
+
+        $this->assertNull($type->convertToPHPValue(null), 'null is not converted');
+        $this->assertEquals('1423743340.626000', $type->convertToPHPValue($date)->format('U.u'));
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
@@ -14,7 +14,7 @@ class DateTypeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($type->convertToDatabaseValue(null), 'null is not converted');
         $this->assertEquals(1423743340, $type->convertToDatabaseValue($time)->sec);
-        $this->assertEquals(626000, $type->convertToDatabaseValue($time)->usec));
+        $this->assertEquals(626000, $type->convertToDatabaseValue($time)->usec);
     }
 
     public function testConvertToPHPValue()


### PR DESCRIPTION
Both MongoDB and the PHP DateTime class support milliseconds, but currently this information is lost in the date mapping type.

This patch will transfer the millisecond information between PHP and MongoDB.