### PR TITLE
Allow symfony 3.0 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "autoload": {
         "psr-0": { "Doctrine\\ODM\\MongoDB": "lib/" }
     },
+    "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/console": "~2.0",
+        "symfony/console": "~2.3|~3.0",
         "doctrine/annotations": "~1.0",
         "doctrine/collections": "~1.1",
         "doctrine/common": "2.4.*",
@@ -23,7 +23,7 @@
         "doctrine/mongodb": ">=1.1.5,<2.0"
     },
     "require-dev": {
-        "symfony/yaml": "~2.0"
+        "symfony/yaml": "~2.3|~3.0"
     },
     "suggest": {
         "symfony/yaml": "Enables the YAML metadata mapping driver"


### PR DESCRIPTION
Tests should tell if any deprecated interfaces of Symfony are used. If not, then the bundle is defacto compatible with 3.0