### PR TITLE
[Docs] Fix @EmbedOne annotation reference

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -381,8 +381,6 @@ Optional attributes:
     value within the embedded document.
 -
     discriminatorMap - Map of discriminator values to class names.
--
-    strategy - The strategy to use to persist the reference. Possible values are ``set`` and ``pushAll``; ``pushAll`` is the default.
 
 .. code-block:: php
 
@@ -390,15 +388,14 @@ Optional attributes:
 
     /**
      * @EmbedOne(
-     *     strategy="set",
      *     discriminatorField="type",
      *     discriminatorMap={
-     *         "book"="Documents\BookTag",
-     *         "song"="Documents\SongTag"
+     *         "user"="Documents\User",
+     *         "author"="Documents\Author"
      *     }
      * )
      */
-    private $tags = array();
+    private $creator;
 
 Depending on the embedded document's class, a value of ``user`` or ``author``
 will be stored in the ``type`` field and used to reconstruct the proper class


### PR DESCRIPTION
As far as I remember ``strategy`` has no effect for ``@EmbedOne`` annotation (and it doesn't exist in corresponding Annotation definition) and example code was copied from ``@EmbedMany`` while its explaination was refering to totally different code