### PR TITLE
Snapshot persistent collection before clearing.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -327,7 +327,7 @@ class PersistentCollection implements BaseCollection
     public function getDeleteDiff()
     {
         return array_udiff_assoc(
-            $this->snapshot,
+            ($this->isCleared) ? array() : $this->snapshot,
             $this->coll->toArray(),
             function ($a, $b) { return $a === $b ? 0 : 1; }
         );
@@ -343,7 +343,7 @@ class PersistentCollection implements BaseCollection
     {
         return array_udiff_assoc(
             $this->coll->toArray(),
-            $this->snapshot,
+            ($this->isCleared) ? array() : $this->snapshot,
             function ($a, $b) { return $a === $b ? 0 : 1; }
         );
     }

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -327,7 +327,7 @@ class PersistentCollection implements BaseCollection
     public function getDeleteDiff()
     {
         return array_udiff_assoc(
-            ($this->isCleared) ? array() : $this->snapshot,
+            $this->snapshot,
             $this->coll->toArray(),
             function ($a, $b) { return $a === $b ? 0 : 1; }
         );
@@ -343,7 +343,7 @@ class PersistentCollection implements BaseCollection
     {
         return array_udiff_assoc(
             $this->coll->toArray(),
-            ($this->isCleared) ? array() : $this->snapshot,
+            $this->snapshot,
             function ($a, $b) { return $a === $b ? 0 : 1; }
         );
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionClearSnapshotTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionClearSnapshotTest.php
@@ -45,11 +45,5 @@ class PersistentCollectionClearSnapshotTest extends \Doctrine\ODM\MongoDB\Tests\
         $this->assertTrue($this->developer->getProjects()->isCleared());
         $this->assertTrue($this->developer->getProjects()->isInitialized());
         $this->assertSame($this->developer->getProjects()->getSnapshot()[0], $this->project);
-        $this->assertSame($this->developer->getProjects()->getDeleteDiff()[0], $this->project);
-
-        $this->developer->getProjects()->add($this->projectTwo);
-
-        $this->assertNotNull($this->developer->getProjects()->getInsertDiff());
-        $this->assertSame($this->developer->getProjects()->getInsertDiff()[0], $this->projectTwo);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionClearSnapshotTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionClearSnapshotTest.php
@@ -11,6 +11,8 @@ class PersistentCollectionClearSnapshotTest extends \Doctrine\ODM\MongoDB\Tests\
 {
     private $project;
 
+    private $projectTwo;
+
     private $developer;
 
     public function setUp()
@@ -18,16 +20,19 @@ class PersistentCollectionClearSnapshotTest extends \Doctrine\ODM\MongoDB\Tests\
         parent::setUp();
 
         $project = new Project('project x');
+        $project2 = new Project('secondProject');
 
         $developer = new Developer('Martha Facka');
         $developer->getProjects()->add($project);
 
         $this->dm->persist($project);
         $this->dm->persist($developer);
+        $this->dm->persist($project2);
         $this->dm->flush();
         $this->dm->clear();
 
         $this->project = $this->dm->find(get_class($project), $project->getId());
+        $this->projectTwo = $this->dm->find(get_class($project2), $project2->getId());
         $this->developer = $this->dm->find(get_class($developer), $developer->getId());
     }
 
@@ -40,5 +45,11 @@ class PersistentCollectionClearSnapshotTest extends \Doctrine\ODM\MongoDB\Tests\
         $this->assertTrue($this->developer->getProjects()->isCleared());
         $this->assertTrue($this->developer->getProjects()->isInitialized());
         $this->assertSame($this->developer->getProjects()->getSnapshot()[0], $this->project);
+        $this->assertSame($this->developer->getProjects()->getDeleteDiff()[0], $this->project);
+
+        $this->developer->getProjects()->add($this->projectTwo);
+
+        $this->assertNotNull($this->developer->getProjects()->getInsertDiff());
+        $this->assertSame($this->developer->getProjects()->getInsertDiff()[0], $this->projectTwo);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionClearSnapshotTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionClearSnapshotTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Documents\CmsUser;
+use Documents\CmsGroup;
+use Documents\Developer;
+use Documents\Project;
+
+class PersistentCollectionClearSnapshotTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    private $project;
+
+    private $developer;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $project = new Project('project x');
+
+        $developer = new Developer('Martha Facka');
+        $developer->getProjects()->add($project);
+
+        $this->dm->persist($project);
+        $this->dm->persist($developer);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $this->project = $this->dm->find(get_class($project), $project->getId());
+        $this->developer = $this->dm->find(get_class($developer), $developer->getId());
+    }
+
+    public function testPersistentCollectionClearTakeSnapshot()
+    {
+        $this->assertFalse($this->developer->getProjects()->isCleared());
+
+        $this->developer->getProjects()->clear();
+
+        $this->assertTrue($this->developer->getProjects()->isCleared());
+        $this->assertTrue($this->developer->getProjects()->isInitialized());
+        $this->assertSame($this->developer->getProjects()->getSnapshot()[0], $this->project);
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionClearSnapshotTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionClearSnapshotTest.php
@@ -39,7 +39,8 @@ class PersistentCollectionClearSnapshotTest extends \Doctrine\ODM\MongoDB\Tests\
 
         $this->assertTrue($this->developer->getProjects()->isCleared());
         $this->assertTrue($this->developer->getProjects()->isInitialized());
-        $this->assertSame($this->developer->getProjects()->getSnapshot()[0], $this->project);
+        $snapshot = $this->developer->getProjects()->getSnapshot();
+        $this->assertSame($snapshot[0], $this->project);
 
         $this->dm->persist($this->developer);
         $this->dm->flush();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionClearSnapshotTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionClearSnapshotTest.php
@@ -11,28 +11,23 @@ class PersistentCollectionClearSnapshotTest extends \Doctrine\ODM\MongoDB\Tests\
 {
     private $project;
 
-    private $projectTwo;
-
     private $developer;
 
     public function setUp()
     {
         parent::setUp();
 
-        $project = new Project('project x');
-        $project2 = new Project('secondProject');
+        $project = new Project('doctrine');
 
-        $developer = new Developer('Martha Facka');
+        $developer = new Developer('John Doe');
         $developer->getProjects()->add($project);
 
         $this->dm->persist($project);
         $this->dm->persist($developer);
-        $this->dm->persist($project2);
         $this->dm->flush();
         $this->dm->clear();
 
         $this->project = $this->dm->find(get_class($project), $project->getId());
-        $this->projectTwo = $this->dm->find(get_class($project2), $project2->getId());
         $this->developer = $this->dm->find(get_class($developer), $developer->getId());
     }
 
@@ -45,5 +40,12 @@ class PersistentCollectionClearSnapshotTest extends \Doctrine\ODM\MongoDB\Tests\
         $this->assertTrue($this->developer->getProjects()->isCleared());
         $this->assertTrue($this->developer->getProjects()->isInitialized());
         $this->assertSame($this->developer->getProjects()->getSnapshot()[0], $this->project);
+
+        $this->dm->persist($this->developer);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $this->assertFalse($this->developer->getProjects()->isCleared());
+        $this->assertFalse($this->developer->getProjects()->isDirty());
     }
 }


### PR DESCRIPTION
This PR aims to change the way a persistent collection is cleared.
Currently, calling ```clear()``` will clear the collection and take a snapshot, which leaves event subscribers unable to work with objects that would be removed from the collection (e.g. reference counting). To avoid deleting all elements of the collection one by one, and retain the original clear functionality, ```clear()``` no longer makes a snapshot *after* clearing the collection and instead makes one *before*. This way an event subscriber can work with all objects that are removed from the collection, while still providing the original functionality in ```getInsertDiff()``` and ```getDeleteDiff()```.