### PR TITLE
Lock document only if found

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentRepository.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentRepository.php
@@ -138,9 +138,9 @@ class DocumentRepository implements ObjectRepository, Selectable
             if (!$this->class->isVersioned) {
                 throw LockException::notVersioned($this->documentName);
             }
-            $document = $this->getDocumentPersister()->load($criteria);
-
-            $this->uow->lock($document, $lockMode, $lockVersion);
+            if ($document = $this->getDocumentPersister()->load($criteria)) {
+                $this->uow->lock($document, $lockMode, $lockVersion);
+            }
 
             return $document;
         }

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\ODM\MongoDB\LockMode;
 
 /**
  * @author Rudolph Gottesheim <r.gottesheim@loot.at>
@@ -16,5 +17,15 @@ class DocumentRepositoryTest extends BaseTest
 
         $this->assertNull($criteria->getWhereExpression());
         $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $repository->matching($criteria));
+    }
+
+    public function testFindWithOptimisticLockAndNoDocumentFound()
+    {
+        $invalidId = 'test';
+
+        $repository = $this->dm->getRepository('Documents\VersionedDocument');
+
+        $document = $repository->find($invalidId, LockMode::OPTIMISTIC);
+        $this->assertNull($document);
     }
 }

--- a/tests/Documents/VersionedDocument.php
+++ b/tests/Documents/VersionedDocument.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Documents;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * Documents\VersionedDocument
+ *
+ * @ODM\Document
+ */
+class VersionedDocument extends BaseDocument
+{
+    /** @ODM\Id */
+    protected $id;
+
+    /** @ODM\Version @ODM\Int */
+    public $version;
+}


### PR DESCRIPTION
I have issue that some documents expire in mongodb and references return null.
Then $repository->find($invalidId, LockMode::OPTIMISTIC); throws exceptions when UnitOfWork tries to lock NULL. 