### PR TITLE
Discriminator map support for simple references

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -309,7 +309,7 @@ class DocumentPersister
             unset($data['$set']);
         }
 
-        /* If there are no modifiers remaining, we're upserting a document with 
+        /* If there are no modifiers remaining, we're upserting a document with
          * an identifier as its only field. Since a document with the identifier
          * may already exist, the desired behavior is "insert if not exists" and
          * NOOP otherwise. MongoDB 2.6+ does not allow empty modifiers, so $set
@@ -648,7 +648,6 @@ class DocumentPersister
 
     private function loadReferenceManyCollectionOwningSide(PersistentCollection $collection)
     {
-        $hints = $collection->getHints();
         $mapping = $collection->getMapping();
         $groupedIds = array();
 
@@ -664,58 +663,24 @@ class DocumentPersister
             }
             $id = $this->dm->getClassMetadata($className)->getPHPIdentifierValue($mongoId);
 
-            // create a reference to the class and id
             $reference = $this->dm->getReference($className, $id);
 
-            // no custom sort so add the references right now in the order they are embedded
-            if ( ! $sorted) {
+            /* If the reference has custom sort, remember IDs to execute the query later.
+             * Otherwise add the references right now in the order they are embedded.
+             */
+            if ($sorted) {
+                $groupedIds[$className][] = $mongoId;
+            } else {
                 if ($mapping['strategy'] === 'set') {
                     $collection->set($key, $reference);
                 } else {
                     $collection->add($reference);
                 }
             }
-
-            // only query for the referenced object if it is not already initialized or the collection is sorted
-            if (($reference instanceof Proxy && ! $reference->__isInitialized__) || $sorted) {
-                $groupedIds[$className][] = $mongoId;
-            }
         }
-        foreach ($groupedIds as $className => $ids) {
-            $class = $this->dm->getClassMetadata($className);
-            $mongoCollection = $this->dm->getDocumentCollection($className);
-            $criteria = $this->cm->merge(
-                array('_id' => array('$in' => array_values($ids))),
-                $this->dm->getFilterCollection()->getFilterCriteria($class),
-                isset($mapping['criteria']) ? $mapping['criteria'] : array()
-            );
-            $criteria = $this->uow->getDocumentPersister($className)->prepareQueryOrNewObj($criteria);
-            $cursor = $mongoCollection->find($criteria);
-            if (isset($mapping['sort'])) {
-                $cursor->sort($mapping['sort']);
-            }
-            if (isset($mapping['limit'])) {
-                $cursor->limit($mapping['limit']);
-            }
-            if (isset($mapping['skip'])) {
-                $cursor->skip($mapping['skip']);
-            }
-            if ( ! empty($hints[Query::HINT_SLAVE_OKAY])) {
-                $cursor->slaveOkay(true);
-            }
-            if ( ! empty($hints[Query::HINT_READ_PREFERENCE])) {
-                $cursor->setReadPreference($hints[Query::HINT_READ_PREFERENCE], $hints[Query::HINT_READ_PREFERENCE_TAGS]);
-            }
-            $documents = $cursor->toArray(false);
-            foreach ($documents as $documentData) {
-                $document = $this->uow->getById($documentData['_id'], $class);
-                $data = $this->hydratorFactory->hydrate($document, $documentData);
-                $this->uow->setOriginalDocumentData($document, $data);
-                $document->__isInitialized__ = true;
-                if ($sorted) {
-                    $collection->add($document);
-                }
-            }
+
+        if ($sorted && count($groupedIds)) {
+            $this->loadActualDataForSortedReferenceManyCollectionByIds($collection, $groupedIds);
         }
     }
 
@@ -1215,5 +1180,60 @@ class DocumentPersister
             }
         }
         return $discriminatorValues;
+    }
+
+    /**
+     * @param PersistentCollection $collection
+     * @param array $groupedIds
+     *
+     * @throws \Doctrine\ODM\MongoDB\MongoDBException
+     */
+    private function loadActualDataForSortedReferenceManyCollectionByIds(
+        PersistentCollection $collection,
+        array $groupedIds
+    ) {
+        $mapping = $collection->getMapping();
+        $hints = $collection->getHints();
+
+        foreach ($groupedIds as $className => $ids) {
+            $class = $this->dm->getClassMetadata($className);
+            $mongoCollection = $this->dm->getDocumentCollection($className);
+            $criteria = $this->cm->merge(
+                array('_id' => array('$in' => array_values($ids))),
+                $this->dm->getFilterCollection()->getFilterCriteria($class),
+                isset($mapping['criteria']) ? $mapping['criteria'] : array()
+            );
+            $criteria = $this->uow->getDocumentPersister($className)->prepareQueryOrNewObj(
+                $criteria
+            );
+            $cursor = $mongoCollection->find($criteria);
+            if (isset($mapping['sort'])) {
+                $cursor->sort($mapping['sort']);
+            }
+            if (isset($mapping['limit'])) {
+                $cursor->limit($mapping['limit']);
+            }
+            if (isset($mapping['skip'])) {
+                $cursor->skip($mapping['skip']);
+            }
+            if (!empty($hints[Query::HINT_SLAVE_OKAY])) {
+                $cursor->slaveOkay(true);
+            }
+            if (!empty($hints[Query::HINT_READ_PREFERENCE])) {
+                $cursor->setReadPreference(
+                    $hints[Query::HINT_READ_PREFERENCE],
+                    $hints[Query::HINT_READ_PREFERENCE_TAGS]
+                );
+            }
+            $documents = $cursor->toArray(false);
+            foreach ($documents as $documentData) {
+                $docId = $documentData['_id'];
+                $document = $this->uow->getById($docId, $class);
+                $data = $this->hydratorFactory->hydrate($document, $documentData);
+                $this->uow->setOriginalDocumentData($document, $data);
+                $document->__isInitialized__ = true;
+                $collection->add($document);
+            }
+        }
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -42,6 +42,8 @@ class Query extends \Doctrine\MongoDB\Query\Query
     const HINT_SLAVE_OKAY = 2;
     const HINT_READ_PREFERENCE = 3;
     const HINT_READ_PREFERENCE_TAGS = 4;
+    /* Ignore discriminator map during creation or refresh. */
+    const HINT_IGNORE_DISCRIMINATOR = 5;
 
     /**
      * The DocumentManager instance.

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
@@ -102,7 +102,7 @@ class NestedDocumentsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $test = $this->dm->getRepository(__NAMESPACE__.'\Hierarchy')->findOneBy(array('name' => 'Root'));
- 
+
         $this->assertNotNull($test);
         $child1 = $test->getChild('Child 1')->setName('Child 1 Changed');
         $child2 = $test->getChild('Child 2')->setName('Child 2 Changed');
@@ -170,7 +170,7 @@ class Hierarchy
             return $this->children[$name];
         }
         foreach ($this->children as $child) {
-            if ($child->name === $name) {
+            if ($child->getName() === $name) {
                 return $child;
             }
         }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
@@ -175,6 +175,8 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue($groups[1] instanceof Group);
 
         $this->assertTrue($groups->isInitialized());
+        $this->assertFalse($groups[0]->__isInitialized__);
+        $this->assertFalse($groups[1]->__isInitialized__);
 
         unset($groups[0]);
         $groups[1]->setName('test');
@@ -191,7 +193,7 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals('test', $groups[0]->getName());
         $this->assertEquals(1, count($groups));
     }
-    
+
     public function testFlushInitializesEmptyPersistentCollection()
     {
         $user = new User();
@@ -221,7 +223,7 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->persist($user);
         $this->dm->flush();
         $this->dm->clear();
-        
+
         $user = $this->dm->getRepository('Documents\User')->find($user->getId());
 
         $user->addGroup(new Group('Group 1'));
@@ -274,6 +276,8 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue($groups[1] instanceof Group);
 
         $this->assertTrue($groups->isInitialized());
+        $this->assertFalse($groups[0]->__isInitialized__);
+        $this->assertFalse($groups[1]->__isInitialized__);
 
         unset($groups[0]);
         $groups[1]->setName('test');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SimpleReferenceDiscriminatorsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SimpleReferenceDiscriminatorsTest.php
@@ -1,0 +1,244 @@
+<?php
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Proxy\Proxy;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class SimpleReferenceDiscriminatorsTest extends BaseTest
+{
+    /** @var DocumentManager */
+    protected $dm;
+
+    public function testCollectionInitializationWithProxies()
+    {
+        $quiz = new Quiz;
+        $this->persistQuizWithQuestions($quiz);
+
+        $receivedQuiz = $this->dm->find(get_class($quiz), $quiz->id);
+
+        $this->assertCount(2, $receivedQuiz->questions);
+        $this->assertContainsOnlyInstancesOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $receivedQuiz->questions);
+        $this->assertContainsOnlyInstancesOf(__NAMESPACE__ . '\BasicQuestion', $receivedQuiz->questions);
+        $this->assertFalse($receivedQuiz->questions[0] instanceof AdvancedQuestion);
+        $this->assertFalse($receivedQuiz->questions[0]->__isInitialized__);
+        $this->assertFalse($receivedQuiz->questions[1]->__isInitialized__);
+    }
+
+    public function testProxiesInitialization()
+    {
+        $quiz = new Quiz;
+        list($q1, $q2) = $this->persistQuizWithQuestions($quiz);
+
+        $receivedQuiz = $this->dm->find(get_class($quiz), $quiz->id);
+
+        $this->assertCount(2, $receivedQuiz->questions);
+        $this->assertEquals($q1->text, $receivedQuiz->questions[0]->text);
+        $this->assertEquals($q2->text, $receivedQuiz->questions[1]->text);
+    }
+
+    public function testPreloadedDocumentsAreUsed()
+    {
+        $quiz = new Quiz;
+        list($q1, $q2) = $this->persistQuizWithQuestions($quiz);
+
+        // Collect queries to make sure we are not issuing redundant ones
+        $findQueries = array();
+        $logger = function($q) use (&$findQueries) {
+            isset($q['find']) && $findQueries[] = $q;
+        };
+        $dm = $this->getNewDmWithLogger($logger);
+
+        // Load questions to the identity map (2 queries)
+        $dm->find(get_class($q1), $q1->id);
+        $dm->find(get_class($q2), $q2->id);
+        $this->assertCount(2, $findQueries);
+
+        // Find the quiz — another query
+        $receivedQuiz = $dm->find(get_class($quiz), $quiz->id);
+        $this->assertCount(3, $findQueries);
+
+        // Collection initialization should use loaded documents, no queries needed
+        $this->assertFalse($q1 instanceof Proxy);
+        $this->assertFalse($q2 instanceof Proxy);
+        $this->assertEquals($q1->text, $receivedQuiz->questions[0]->text);
+        $this->assertEquals($q2->text, $receivedQuiz->questions[1]->text);
+        $this->assertCount(3, $findQueries);
+    }
+
+    public function testProxiesAreNotReplacedAfterOriginalDocumentLoadedToIdentityMap()
+    {
+        $quiz = new Quiz;
+        list($q1,) = $this->persistQuizWithQuestions($quiz);
+
+        // Find the quiz and initialize questions collection with proxies
+        $receivedQuiz = $this->dm->find(get_class($quiz), $quiz->id);
+        iterator_to_array($receivedQuiz->questions);
+
+        // Load the first question separately.
+        // It should be the new instance of AdvancedQuestion, not the one of proxies we just created.
+        $receivedQ1 = $this->dm->find(get_class($q1), $q1->id);
+        $this->assertTrue($receivedQ1 instanceof AdvancedQuestion);
+        $this->assertFalse($receivedQ1 instanceof Proxy);
+
+        $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $receivedQuiz->questions[0]);
+        $this->assertFalse($receivedQuiz->questions[0]->__isInitialized__);
+
+        // Initialize proxy
+        $receivedQuiz->questions[0]->text;
+
+        // Since we could not replace the proxy by another instance,
+        // we should have initialized proxy of BasicQuestion by now.
+        $this->assertFalse($receivedQuiz->questions[0] instanceof AdvancedQuestion);
+        $this->assertTrue($receivedQuiz->questions[0]->__isInitialized__);
+    }
+
+    public function testPriming()
+    {
+        $quiz = new Quiz;
+        $this->persistQuizWithQuestions($quiz);
+
+        $qb = $this->dm->createQueryBuilder(get_class($quiz))
+            ->field('id')->equals($quiz->id)
+            ->field('questions')->prime(true);
+        $receivedQuiz = $qb->getQuery()->execute()->getSingleResult();
+
+        $this->assertCount(2, $receivedQuiz->questions);
+        $this->assertFalse($receivedQuiz->questions[0] instanceof Proxy);
+        $this->assertTrue($receivedQuiz->questions[0] instanceof AdvancedQuestion);
+        $this->assertFalse($receivedQuiz->questions[1] instanceof Proxy);
+        $this->assertTrue($receivedQuiz->questions[1] instanceof BasicQuestion);
+    }
+
+    public function testReferenceOne()
+    {
+        $question = new BasicQuestion;
+        $answer = $this->persistQuestionWithAnswer($question);
+
+        $receivedQuestion = $this->dm->find(get_class($question), $question->id);
+
+        $this->assertTrue($receivedQuestion->answer instanceof Proxy);
+        $this->assertFalse($receivedQuestion->answer instanceof CorrectAnswer);
+        $this->assertTrue($receivedQuestion->answer instanceof Answer);
+        $this->assertFalse($receivedQuestion->answer->__isInitialized__);
+        $this->assertEquals($answer->text, $receivedQuestion->answer->text);
+    }
+
+    public function testReferenceOnePreload()
+    {
+        $question = new BasicQuestion;
+        $answer = $this->persistQuestionWithAnswer($question);
+
+        $this->dm->find(get_class($answer), $answer->id);
+        $receivedQuestion = $this->dm->find(get_class($question), $question->id);
+
+        $this->assertTrue($receivedQuestion->answer instanceof CorrectAnswer);
+    }
+
+    /**
+     * @param Quiz $quiz
+     *
+     * @return QuestionAbstract[]
+     */
+    private function persistQuizWithQuestions(Quiz $quiz)
+    {
+        $q1 = new AdvancedQuestion;
+        $q2 = new BasicQuestion;
+        $q1->text = 'q1 text';
+        $q2->text = 'q2 text';
+        $this->dm->persist($q1);
+        $this->dm->persist($q2);
+        $quiz->questions->add($q1);
+        $quiz->questions->add($q2);
+        $this->dm->persist($quiz);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        return array($q1, $q2);
+    }
+
+    /**
+     * @param BasicQuestion $question
+     *
+     * @return CorrectAnswer
+     */
+    private function persistQuestionWithAnswer(BasicQuestion $question)
+    {
+        $a = new CorrectAnswer;
+        $a->text = 'a text';
+        $this->dm->persist($a);
+        $question->answer = $a;
+        $this->dm->persist($question);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        return $a;
+    }
+
+    /**
+     * @param $logger
+     *
+     * @return DocumentManager
+     */
+    private function getNewDmWithLogger($logger)
+    {
+        $this->dm->getConfiguration()->setLoggerCallable($logger);
+        $dm = DocumentManager::create($this->dm->getConnection(), $this->dm->getConfiguration());
+
+        return $dm;
+    }
+}
+
+/**
+ * @ODM\Document(collection="rdt_quiz_questions")
+ * @ODM\InheritanceType("SINGLE_COLLECTION")
+ * @ODM\DiscriminatorField(name="type")
+ * @ODM\DiscriminatorMap({"advanced"="AdvancedQuestion", "basic"="BasicQuestion"})
+ */
+class BasicQuestion
+{
+    /** @ODM\Id */
+    public $id;
+    /** @ODM\String */
+    public $text;
+    /** @ODM\ReferenceOne(targetDocument="Answer", simple=true) */
+    public $answer;
+}
+
+/** @ODM\Document */
+class AdvancedQuestion extends BasicQuestion
+{}
+
+/** @ODM\Document(collection="rdt_quiz") */
+class Quiz
+{
+    /** @ODM\Id */
+    public $id;
+    /** @ODM\ReferenceMany(targetDocument="BasicQuestion", simple=true) */
+    public $questions;
+
+    public function __construct()
+    {
+        $this->questions = new ArrayCollection;
+    }
+}
+
+/**
+ * @ODM\Document(collection="rdt_quiz_answers")
+ * @ODM\InheritanceType("SINGLE_COLLECTION")
+ * @ODM\DiscriminatorField(name="correct")
+ * @ODM\DiscriminatorMap({true="CorrectAnswer", false="Answer"})
+ */
+class Answer
+{
+    /** @ODM\Id */
+    public $id;
+    /** @ODM\String */
+    public $text;
+}
+
+/** @ODM\Document */
+class CorrectAnswer extends Answer
+{}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH593Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH593Test.php
@@ -3,7 +3,6 @@
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ODM\MongoDB\DocumentNotFoundException;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 class GH593Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
@@ -19,6 +18,7 @@ class GH593Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $filter->setParameter('value', false);
     }
 
+    /** @expectedException \Doctrine\ODM\MongoDB\DocumentNotFoundException */
     public function testReferenceManyOwningSidePreparesFilterCriteria()
     {
         $class = __NAMESPACE__ . '\GH593User';
@@ -52,18 +52,14 @@ class GH593Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertCount(2, $user1following);
 
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $user1following[0]);
-        $this->assertTrue($user1following[0]->__isInitialized());
         $this->assertEquals($user2->getId(), $user1following[0]->getId());
+        $this->assertFalse($user1following[0]->__isInitialized());
 
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $user1following[1]);
-        $this->assertFalse($user1following[1]->__isInitialized());
         $this->assertEquals($user3->getId(), $user1following[1]->getId());
+        $this->assertFalse($user1following[1]->__isInitialized());
 
-        try {
-            $user1following[1]->__load();
-            $this->fail('Expected DocumentNotFoundException for filtered Proxy object');
-        } catch (DocumentNotFoundException $e) {
-        }
+        $user1following[1]->__load();
     }
 
     public function testReferenceManyInverseSidePreparesFilterCriteria()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
@@ -3,11 +3,11 @@
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ODM\MongoDB\DocumentNotFoundException;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 class GH602Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
+    /** @expectedException \Doctrine\ODM\MongoDB\DocumentNotFoundException */
     public function testReferenceManyOwningSidePreparesFilterCriteriaForDifferentClass()
     {
         $thingClass = __NAMESPACE__ . '\GH602Thing';
@@ -43,18 +43,14 @@ class GH602Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertCount(2, $user1likes);
 
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $user1likes[0]);
-        $this->assertTrue($user1likes[0]->__isInitialized());
         $this->assertEquals($thing1->getId(), $user1likes[0]->getId());
+        $this->assertFalse($user1likes[0]->__isInitialized());
 
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $user1likes[1]);
-        $this->assertFalse($user1likes[1]->__isInitialized());
         $this->assertEquals($thing2->getId(), $user1likes[1]->getId());
+        $this->assertFalse($user1likes[1]->__isInitialized());
 
-        try {
-            $user1likes[1]->__load();
-            $this->fail('Expected DocumentNotFoundException for filtered Proxy object');
-        } catch (DocumentNotFoundException $e) {
-        }
+        $user1likes[1]->__load();
     }
 
     public function testReferenceManyInverseSidePreparesFilterCriteriaForDifferentClass()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
@@ -53,14 +53,16 @@ class GH852Test extends BaseTest
          * by DocumentPersister::loadReferenceManyCollectionOwningSide().
          */
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $parent->refMany[0]);
-        $this->assertTrue($parent->refMany[0]->__isInitialized());
         $this->assertEquals($idGenerator('childB'), $parent->refMany[0]->id);
+        $this->assertFalse($parent->refMany[0]->__isInitialized());
         $this->assertEquals('childB', $parent->refMany[0]->name);
+        $this->assertTrue($parent->refMany[0]->__isInitialized());
 
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $parent->refMany[1]);
-        $this->assertTrue($parent->refMany[1]->__isInitialized());
         $this->assertEquals($idGenerator('childC'), $parent->refMany[1]->id);
+        $this->assertFalse($parent->refMany[1]->__isInitialized());
         $this->assertEquals('childC', $parent->refMany[1]->name);
+        $this->assertTrue($parent->refMany[1]->__isInitialized());
     }
 
     public function provideIdGenerators()

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -9,8 +9,6 @@ use Doctrine\ODM\MongoDB\UnitOfWork;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Persisters\PersistenceBuilder;
-use Doctrine\ODM\MongoDB\Tests\Mocks\ConnectionMock;
-use Doctrine\ODM\MongoDB\Tests\Mocks\UnitOfWorkMock;
 use Doctrine\ODM\MongoDB\Tests\Mocks\DocumentPersisterMock;
 use Documents\ForumUser;
 use Documents\ForumAvatar;


### PR DESCRIPTION
I'm a big fan of simple references since they allow to map the existing documents without any migration and to stop using ODM whenever needed. The fact that the Doctrine does not allow to use the discriminator map combined with simple references disappointed me. So I tried my best to implement that support and provide consistent behaviour for it.

This PR allows you to use references like so:
```php
/**
 * @ODM\Document
 * @ODM\InheritanceType("SINGLE_COLLECTION")
 * @ODM\DiscriminatorField(name="type")
 * @ODM\DiscriminatorMap({"advanced"="AdvancedQuestion", "basic"="BasicQuestion"})
 */
class BasicQuestion
{
    /** @ODM\Id */
    public $id;
    /** @ODM\String */
    public $text;
    /** @ODM\ReferenceOne(targetDocument="Answer", simple=true) */
    public $answer;
}

/** @ODM\Document */
class AdvancedQuestion extends BasicQuestion
{}

/** @ODM\Document */
class Quiz
{
    /** @ODM\Id */
    public $id;
    /** @ODM\ReferenceMany(targetDocument="BasicQuestion", simple=true) */
    public $questions;
}
```

During the initialization, the `questions` collection would be populated with:
* Uninitialized `BasicQuestion` proxies, if there were no loaded documents in the identity map. After the proxy initialization you will get all the data loaded to `BasicQuestion` proxies, but unfortunately not the object of resolved type.
* Documents of the proper type or its proxies, if they were loaded to the identity map.

You could always use priming to get the documents of the proper type.

Also, this PR is changing the way of collections initialization. Now collections are being filled with uninitialized proxies in all cases, except sorted references. It allows to iterate over the collection and use referenced document's IDs without issuing additional queries.

I would be grateful for any feedback.

Related issue: #432, PR with the test and the similar proposal: #645.