### PR TITLE
[WIP] Investigating segfault with requireIndexes

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -217,6 +217,9 @@ class Query extends \Doctrine\MongoDB\Query\Query
      */
     public function execute()
     {
+        fprintf(STDERR, "isIndexRequired: %d\n", $this->isIndexRequired());
+        fprintf(STDERR, "isIndexed: %d\n", $this->isIndexed());
+        throw new MongoDBException;
         if ($this->isIndexRequired() && ! $this->isIndexed()) {
             throw MongoDBException::queryNotIndexed($this->class->name, $this->getUnindexedFields());
         }

--- a/tools/sandbox/segfault.php
+++ b/tools/sandbox/segfault.php
@@ -1,0 +1,30 @@
+<?php
+
+require_once __DIR__ . '/config.php';
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+// Your code here...
+
+try{
+$qb = $dm->createQueryBuilder('DoesNotRequireIndexesDocument')
+    ->field('notIndexed')->equals('test')
+    ->requireIndexes();
+$query = $qb->getQuery();
+$query->execute();
+} catch (Doctrine\ODM\MongoDB\MongoDBException $e) {}
+
+/**
+ * @ODM\Document(requireIndexes=false)
+ */
+class DoesNotRequireIndexesDocument
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\String @ODM\Index */
+    public $indexed;
+
+    /** @ODM\String */
+    public $notIndexed;
+}


### PR DESCRIPTION
### Note: don't merge this

Discovered with PHP 5.5.12-2ubuntu4.2 (cli) and PHP driver 1.6.4. This appears to be a PHP issue, rather than the driver, as it does not reproduce on 5.6. This seems connected to Collection::isFieldIndexed() fetching the collection indexes on each call. While that is inefficient and should probably be revised, a segfault is still not acceptable.

Backtrace follows:

```
#0  _zend_mm_free_int (heap=0x7f283b2e2920, p=0x7f283b2e2930) at /build/buildd/php5-5.5.12+dfsg/Zend/zend_alloc.c:2104
        mm_block = 0x7f283b2e2920
        next_block = 0xfe50766391a0
#1  0x00000000007b68f0 in i_zval_ptr_dtor (zval_ptr=<optimized out>) at /build/buildd/php5-5.5.12+dfsg/Zend/zend_execute.h:82
No locals.
#2  zend_vm_stack_clear_multiple (nested=<optimized out>) at /build/buildd/php5-5.5.12+dfsg/Zend/zend_execute.h:298
        q = 0x7f283b2e2930
#3  zend_do_fcall_common_helper_SPEC (execute_data=0x7f284ba1a390) at /build/buildd/php5-5.5.12+dfsg/Zend/zend_vm_execute.h:642
        opline = 0x7f283b3914f0
        fbc = 0x7f283b2e2930
#4  0x0000000000728d30 in execute_ex (execute_data=0x7f284ba1a390) at /build/buildd/php5-5.5.12+dfsg/Zend/zend_vm_execute.h:363
        ret = 1986236832
        original_in_execution = 1 '\001'
#5  0x00000000006ec548 in dtrace_execute_ex (execute_data=0x7f284ba1a390) at /build/buildd/php5-5.5.12+dfsg/Zend/zend_dtrace.c:73
        lineno = 0
        scope = 0x0
        filename = 0x0
        funcname = 0x0
        classname = 0x0
#6  0x00000000007b6bbc in zend_do_fcall_common_helper_SPEC (execute_data=0x7f284ba1a068) at /build/buildd/php5-5.5.12+dfsg/Zend/zend_vm_execute.h:584
        opline = 0x7f283b393ea8
        fbc = 0x7f283b390368
#7  0x0000000000728d30 in execute_ex (execute_data=0x7f284ba1a068) at /build/buildd/php5-5.5.12+dfsg/Zend/zend_vm_execute.h:363
        ret = 1986236832
        original_in_execution = 1 '\001'
#8  0x00000000006ec548 in dtrace_execute_ex (execute_data=0x7f284ba1a068) at /build/buildd/php5-5.5.12+dfsg/Zend/zend_dtrace.c:73
        lineno = 0
        scope = 0x0
        filename = 0x0
        funcname = 0x0
        classname = 0x0
#9  0x00000000007b6bbc in zend_do_fcall_common_helper_SPEC (execute_data=0x7f284ba19280) at /build/buildd/php5-5.5.12+dfsg/Zend/zend_vm_execute.h:584
        opline = 0x7f284ba4f2a0
        fbc = 0x7f283b391738
#10 0x0000000000728d30 in execute_ex (execute_data=0x7f284ba19280) at /build/buildd/php5-5.5.12+dfsg/Zend/zend_vm_execute.h:363
        ret = 1986236832
        original_in_execution = 0 '\000'
#11 0x00000000006ec548 in dtrace_execute_ex (execute_data=0x7f284ba19280) at /build/buildd/php5-5.5.12+dfsg/Zend/zend_dtrace.c:73
        lineno = 32552
        scope = 0x0
        filename = 0x0
        funcname = 0x0
        classname = 0x0
#12 0x00000000006fe280 in zend_execute_scripts (type=992880928, type@entry=8, retval=0x7f283b2e2930, retval@entry=0x0, file_count=993355904, file_count@entry=3)
    at /build/buildd/php5-5.5.12+dfsg/Zend/zend.c:1316
        files = {{gp_offset = 40, fp_offset = 32767, overflow_arg_area = 0x7fffd23de4b0, reg_save_area = 0x7fffd23de440}}
        i = 1
        file_handle = 0x7fffd23e0860
#13 0x000000000069c08b in php_execute_script (primary_file=0x7fffd23e0860) at /build/buildd/php5-5.5.12+dfsg/main/main.c:2506
        realfile = "/home/jmikola/workspace/doctrine/mongodb-odm/tools/sandbox/segfault.php\000P\n>\322\377\177\000\000\340\n>\322\377\177\000\000\340\n>\322\377\177\000\000@\016\356\000\000\000\000\000W\265\207K(\177\000\000\001", '\000' <repeats 15 times>, "О\241K(\177\000\000P%\232I(\177\000\000\300\v\356\000\000\000\000\000@\016\356\000\000\000\000\000\310\a>\322\377\177\000\000\065%\210K(\177\000\000p\310\325I(\177\000\000\000\000\000\000\000\000\000\000\034\000\000\000\000\000\000\000Ϛ"...
        __orig_bailout = 0x7fffd23e0a10
        __bailout = {{__jmpbuf = {140736720669200, -5312915656794798065, 140736720668520, 12129144, 1, 2, -5312915655647655921, 5312875320402544655}, __mask_was_saved = 0, __saved_mask = {
              __val = {139811014162272, 59, 140736720664256, 12129144, 1, 2, 952032754221003264, 4248842797, 140736720669408, 40134352, 140736720664256, 12129144, 1, 2, 6914764, 43763440}}}}
        prepend_file_p = 0x0
        append_file_p = 0x0
        prepend_file = {type = ZEND_HANDLE_FILENAME, filename = 0x0, opened_path = 0x0, handle = {fd = 0, fp = 0x0, stream = {handle = 0x0, isatty = 0, mmap = {len = 0, pos = 0, map = 0x0, 
                buf = 0x0, old_handle = 0x0, old_closer = 0x0}, reader = 0x0, fsizer = 0x0, closer = 0x0}}, free_filename = 0 '\000'}
        append_file = {type = ZEND_HANDLE_FILENAME, filename = 0x0, opened_path = 0x0, handle = {fd = 0, fp = 0x0, stream = {handle = 0x0, isatty = 0, mmap = {len = 0, pos = 0, map = 0x0, 
                buf = 0x0, old_handle = 0x0, old_closer = 0x0}, reader = 0x0, fsizer = 0x0, closer = 0x0}}, free_filename = 0 '\000'}
        old_cwd = 0x7fffd23de4b0 ""
        retval = 0
#14 0x00000000007b8880 in do_cli (argc=992880928, argv=0x7f283b2e2930) at /build/buildd/php5-5.5.12+dfsg/sapi/cli/php_cli.c:994
        __bailout = {{__jmpbuf = {40134960, 5312874442054076431, 12131760, 140736720673704, 140736720673700, 15479808, -5312915656796895217, 5312875168138430479}, __mask_was_saved = 0, 
            __saved_mask = {__val = {12032513, 12032537, 11931347, 11931368, 12032550, 12032570, 12032587, 12033141, 12032608, 12032622, 12032644, 12032663, 12032690, 12032719, 0, 
                7955998172649846063}}}}
        file_handle = {type = ZEND_HANDLE_MAPPED, filename = 0x26466d0 "segfault.php", opened_path = 0x0, handle = {fd = 1269099872, fp = 0x7f284ba4ed60, stream = {handle = 0x7f284ba4ed60, 
              isatty = 0, mmap = {len = 582, pos = 0, map = 0x7f284ba88000, buf = 0x7f284ba88000 <error: Cannot access memory at address 0x7f284ba88000>, old_handle = 0x29bc4b0, 
                old_closer = 0x713ef0 <zend_stream_stdio_closer>}, reader = 0x713f20 <zend_stream_stdio_reader>, fsizer = 0x713e70 <zend_stream_stdio_fsizer>, 
              closer = 0x713df0 <zend_stream_mmap_closer>}}, free_filename = 0 '\000'}
        request_started = 1
        exit_status = 0
        php_optarg = 0x0
        php_optind = 2
        arg_excp = 0x2646698
        lineno = 1
#15 0x0000000000461aad in main (argc=992880928, argv=0x7f283b2e2930) at /build/buildd/php5-5.5.12+dfsg/sapi/cli/php_cli.c:1378
        __bailout = {{__jmpbuf = {40134960, 5312874442054076431, 12131760, 140736720673704, 140736720673700, 15479808, -5312915657509926897, 5312875008178554895}, __mask_was_saved = 0, 
            __saved_mask = {__val = {139811008050176, 139811010218912, 139811044782176, 0, 139811044787488, 140736720673872, 140736720673856, 4131212846, 4409740, 4294967295, 139811042604375, 
                139811010306472, 139811044579800, 139811044786632, 139811010287272, 1}}}}
        c = 1986236832
        php_optarg = 0x0
        php_optind = 1
        ini_ignore = 0
```
