### PR TITLE
Unwrap EagerCursor from repositoryMethod

### DIFF
--- a/tests/Documents/BlogPost.php
+++ b/tests/Documents/BlogPost.php
@@ -38,6 +38,9 @@ class BlogPost
     /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", repositoryMethod="findManyComments") */
     public $repoComments;
 
+    /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", repositoryMethod="findManyCommentsEager") */
+    public $repoCommentsEager;
+
     /** @ODM\ReferenceOne(targetDocument="User", inversedBy="posts", nullable=true) */
     public $user;
 

--- a/tests/Documents/CommentRepository.php
+++ b/tests/Documents/CommentRepository.php
@@ -19,4 +19,13 @@ class CommentRepository extends DocumentRepository
     {
         return $this->getDocumentPersister()->loadAll();
     }
+
+    public function findManyCommentsEager()
+    {
+        return $this
+            ->createQueryBuilder()
+            ->eagerCursor(true)
+            ->getQuery()
+            ->getIterator();
+    }
 }


### PR DESCRIPTION
This PR is a fix for #1048. If a repositoryMethod returns an ```EagerCursor```, the ```DocumentPersister``` unwraps the nested ```Cursor``` instance and applies the ```sort()```, ```skip()``` and ```limit()``` to that cursor.