### PR TITLE
DocumentRepository->findBy doesn't work when array is passed

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
@@ -17,4 +17,18 @@ class DocumentRepositoryTest extends BaseTest
         $this->assertNull($criteria->getWhereExpression());
         $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $repository->matching($criteria));
     }
+    
+    public function testFindByManyIds()
+    {
+        $t1 = new \Documents\Task('test');;
+        $this->dm->persist($t1);
+        $this->dm->flush();
+        $r = $this->dm->getRepository('Documents\Task');
+        
+        $results = $r->findBy(array('id' => $t1->getId()));
+        $this->assertCount(1, $results);
+        
+        $results = $r->findBy(array('id' => array($t1->getId())));
+        $this->assertCount(1, $results);
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
@@ -28,6 +28,9 @@ class DocumentRepositoryTest extends BaseTest
         $results = $r->findBy(array('id' => $t1->getId()));
         $this->assertCount(1, $results);
         
+        $results = $r->findBy(array('id' => array('$in' => array($t1->getId()))));
+        $this->assertCount(1, $results);
+        
         $results = $r->findBy(array('id' => array($t1->getId())));
         $this->assertCount(1, $results);
     }


### PR DESCRIPTION
Failing test case for https://github.com/symfony/symfony/issues/13961