### PR TITLE
Fixed wrong MappedSuperclass Annotation on odm:generate:documents

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
@@ -501,7 +501,7 @@ public function <methodName>()
             $lines[] = ' *';
 
             if ($metadata->isMappedSuperclass) {
-                $lines[] = ' * @ODM\\MappedSupperClass';
+                $lines[] = ' * @ODM\\MappedSuperclass';
             } elseif ($metadata->isEmbeddedDocument) {
                 $lines[] = ' * @ODM\\EmbeddedDocument';
             } else {


### PR DESCRIPTION
I fixed a typo/error in annotation generation for MappedSuperclass. It now matches the one used in the tests - so I guess this one is right.