### PR TITLE
added backslash to FQCN in DocumentGenerator

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
@@ -633,7 +633,7 @@ public function <methodName>()
                 if ($code = $this->generateDocumentStubMethod($metadata, 'remove', $fieldMapping['fieldName'], isset($fieldMapping['targetDocument']) ? $fieldMapping['targetDocument'] : null)) {
                     $methods[] = $code;
                 }
-                if ($code = $this->generateDocumentStubMethod($metadata, 'get', $fieldMapping['fieldName'], 'Doctrine\Common\Collections\Collection')) {
+                if ($code = $this->generateDocumentStubMethod($metadata, 'get', $fieldMapping['fieldName'], '\Doctrine\Common\Collections\Collection')) {
                     $methods[] = $code;
                 }
             }


### PR DESCRIPTION
Hi,

the generated type hint for the get method of collections in documents generated with odm:generate:documents was missing a backslash at the beginning. This made it impossible (out of the box) to autocomplete on such methods.

Unit tests passed, since there seem to be none.

Cheers
Marko