### PR TITLE
Added support for dates with milliseconds

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
@@ -56,6 +56,9 @@ class DateTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             array(new \DateTime('1985-09-01 00:00:00'), new \DateTime('1985-09-01 00:00:00')),
             array(new \DateTime('2012-07-11T14:55:14-04:00'), new \DateTime('2012-07-11T19:55:14+01:00')),
             array(new \DateTime('@1342033881'), new \MongoDate(1342033881)),
+            array(\DateTime::createFromFormat('U.u', '100000000.123'), new \MongoDate(100000000, 123000)),
+            array(\DateTime::createFromFormat('U.u', '100000000.123000'), new \MongoDate(100000000, 123000)),
+            array(new \MongoDate(100000000, 123000), \DateTime::createFromFormat('U.u', '100000000.123')),
         );
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Types/DateTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Types/DateTypeTest.php
@@ -16,12 +16,23 @@ class DateTypeTest extends \PHPUnit_Framework_TestCase
         $mongoDate = new \MongoDate();
         $this->assertSame($mongoDate, $type->convertToDatabaseValue($mongoDate), 'MongoDate objects are not converted');
 
-        $yesterday = strtotime('yesterday');
-        $mongoDate = new \MongoDate($yesterday);
-        $dateTime = new \DateTime('@' . $yesterday);
+        $timestamp = 100000000.123;
+        $dateTime = \DateTime::createFromFormat('U.u', $timestamp);
+        $mongoDate = new \MongoDate(100000000, 123000);
         $this->assertEquals($mongoDate, $type->convertToDatabaseValue($dateTime), 'DateTime objects are converted to MongoDate objects');
-        $this->assertEquals($mongoDate, $type->convertToDatabaseValue($yesterday), 'Numeric timestamps are converted to MongoDate objects');
-        $this->assertEquals($mongoDate, $type->convertToDatabaseValue(date('c', $yesterday)), 'String dates are converted to MongoDate objects');
+        $this->assertEquals($mongoDate, $type->convertToDatabaseValue($timestamp), 'Numeric timestamps are converted to MongoDate objects');
+        $this->assertEquals($mongoDate, $type->convertToDatabaseValue('' . $timestamp), 'String dates are converted to MongoDate objects');
+        $this->assertEquals($mongoDate, $type->convertToDatabaseValue($mongoDate), 'MongoDate objects are converted to MongoDate objects');
+        $this->assertEquals(null, $type->convertToDatabaseValue(null), 'null are converted to null');
+    }
+
+    public function testConvertOldDate()
+    {
+        $type = Type::getType(Type::DATE);
+
+        $date = new \DateTime('1900-01-01 00:00:00.123', new \DateTimeZone('UTC'));
+        $timestamp = "-2208988800.123";
+        $this->assertEquals($type->convertToDatabaseValue($timestamp), $type->convertToDatabaseValue($date));
     }
 
     /**
@@ -41,6 +52,7 @@ class DateTypeTest extends \PHPUnit_Framework_TestCase
             'string' => array('whatever'),
             'bool'   => array(false),
             'object' => array(new \stdClass()),
+            'invalid string' => array('foo'),
         );
     }
 
@@ -86,14 +98,16 @@ class DateTypeTest extends \PHPUnit_Framework_TestCase
         $dateTime = new \DateTime('@' . $yesterday);
 
         return array(
+            array($dateTime, $dateTime),
             array($mongoDate, $dateTime),
             array($yesterday, $dateTime),
             array(date('c', $yesterday), $dateTime),
+            array(new \MongoDate(100000000, 123000), \DateTime::createFromFormat('U.u', '100000000.123')),
         );
     }
 
     private function assertTimestampEquals(\DateTime $expected, \DateTime $actual)
     {
-        $this->assertEquals($expected->getTimestamp(), $actual->getTimestamp());
+        $this->assertEquals($expected->format('U.u'), $actual->format('U.u'));
     }
 }


### PR DESCRIPTION
Fixes #1061 

Affects #1060 : now will overflow and the loaded date will be in 2036. Note that problem only appears when saving to and loading from Mongo, not when simply converting values.

Duplicate of #1028 (sorry, didn’t see).

Microseconds passed as MongoDate, DateTime, float or DateTime string (`'2000-01-01 00:00:00.123'`) are all handled.