### PR TITLE
[WIP] Implementing atomic many updates in CollectionPersister.

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicManyUpdatesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicManyUpdatesTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class AtomicManyUpdatesTest extends BaseTest
+{
+    public function testAtomicManyUpdates()
+    {
+        $doc = new AtomicManyUpdateDocument();
+        $doc->embedMany[] = new AtomicManyUpdateEmbeddedDocument();
+        $doc->embedMany[] = new AtomicManyUpdateEmbeddedDocument();
+
+        $this->dm->persist($doc);
+        $this->dm->flush();
+
+        $data = $this->getAtomicManyUpdateDocumentData($doc);
+        $this->assertCount(2, $data['embedMany']);
+
+        unset($doc->embedMany[1]);
+
+        $this->dm->flush();
+
+        $data = $this->getAtomicManyUpdateDocumentData($doc);
+        $this->assertCount(1, $data['embedMany']);
+
+        $doc->embedMany->clear();
+
+        $this->dm->flush();
+
+        $data = $this->getAtomicManyUpdateDocumentData($doc);
+        $this->assertFalse(isset($data['embedMany']));
+    }
+
+    private function getAtomicManyUpdateDocumentData(AtomicManyUpdateDocument $atomicManyUpdateDocument)
+    {
+        return $this->dm->getDocumentCollection('Doctrine\ODM\MongoDB\Tests\Functional\AtomicManyUpdateDocument')
+            ->findOne(array('_id' => new \MongoId($atomicManyUpdateDocument->id)));;
+    }
+}
+
+/**
+ * @ODM\Document
+ */
+class AtomicManyUpdateDocument
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedMany(targetDocument="AtomicManyUpdateEmbeddedDocument", strategy="atomic") */
+    public $embedMany = array();
+}
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class AtomicManyUpdateEmbeddedDocument
+{
+    /** @ODM\Id */
+    public $test;
+}


### PR DESCRIPTION
TODO:
- Add test for ReferenceMany. Same code handles both embed and reference so it should be the same.
- Updates to embed many documents using the atomic strategy should also be atomic and should not update based on the positional key.

This cannot be fully supported until we have this https://jira.mongodb.org/browse/SERVER-831

Given the following test document:

```
> db.test.insert({"test":[{"_id":ObjectId()}]})
> db.test.find().pretty()
{
    "_id" : ObjectId("5516e2f249bf305dfce8ca7c"),
    "test" : [
        {
            "_id" : ObjectId("5516e2f249bf305dfce8ca7b")
        }
    ]
}
```

With the atomic strategy the queries to remove a many document change to this:

```
> db.test.update({"_id" : ObjectId("5516e2f249bf305dfce8ca7c")}, {$pull:{"test":{"_id":ObjectId("5516e2f249bf305dfce8ca7b")}}})
```

From this:

```
> db.test.update({"_id" : ObjectId("5516d39235447e556557c694")}, {$unset:{"test.0":true}})
> db.test.update({"_id" : ObjectId("5516d39235447e556557c694")}, {$pull:{"test":null}})
```
