### PR TITLE
Move reference priming to Cursor

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -255,15 +255,14 @@ class Query extends \Doctrine\MongoDB\Query\Query
             is_array($results) && isset($results['_id'])) {
 
             $results = $uow->getOrCreateDocument($this->class->name, $results, $this->unitOfWorkHints);
-        }
 
-        if ( ! empty($this->primers)) {
-            $referencePrimer = new ReferencePrimer($this->dm, $uow);
+            if ( ! empty($this->primers)) {
+                $referencePrimer = new ReferencePrimer($this->dm, $uow);
 
-            foreach ($this->primers as $fieldName => $primer) {
-                $primer = is_callable($primer) ? $primer : null;
-                $documents = $results instanceof Iterator ? $results : array($results);
-                $referencePrimer->primeReferences($this->class, $documents, $fieldName, $this->unitOfWorkHints, $primer);
+                foreach ($this->primers as $fieldName => $primer) {
+                    $primer = is_callable($primer) ? $primer : null;
+                    $referencePrimer->primeReferences($this->class, array($results), $fieldName, $this->unitOfWorkHints, $primer);
+                }
             }
         }
 
@@ -300,6 +299,11 @@ class Query extends \Doctrine\MongoDB\Query\Query
 
         $cursor->hydrate($this->hydrate);
         $cursor->setHints($this->unitOfWorkHints);
+
+        if ( ! empty($this->primers)) {
+            $referencePrimer = new ReferencePrimer($this->dm, $this->dm->getUnitOfWork());
+            $cursor->enableReferencePriming($this->primers, $referencePrimer);
+        }
 
         return $cursor;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH520Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH520Test.php
@@ -66,7 +66,7 @@ class GH520Test extends BaseTest
         $result = $query->getSingleResult();
 
         $this->assertContains($document2->id, $primedIds);
-        $this->assertContains($document4->id, $primedIds);
+        $this->assertNotContains($document4->id, $primedIds, 'Only the dataset being fetched should be primed');
     }
 }
 


### PR DESCRIPTION
This PR moves reference priming from the ```Query::execute``` method to the cursor which iterates over the results (as described in #1065). This increases performance when iterating over part of a large query result (e.g. by setting ```skip``` and ```limit``` on the returned cursor before iterating) as it will not prime references for the entire result set.
Note that using ```prime``` for ```findAndUpdate``` and ```findAndRemove``` will prime references when executing the query since it will not return a cursor.
This also fixes a side effect of #520 where using ```getSingleResult()``` on a query without ```limit``` in combination with ```prime``` would prime references for all documents returned in the query instead of just the one returned by ```getSingleResult()```.

Feedback is greatly appreciated, I'd really appreciate it if some people using reference priming could run their test suite against the branch and post some results.

NB: I'm not too happy with having to duplicate functionality in ```Cursor``` and ```EagerCursor```, unfortunately I can't think of another way since the two classes don't share an interface.