### PR TITLE
Add defaultDiscriminatorValue to mapping

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -178,6 +178,29 @@ in MongoDB. The property will be a DateTime when loaded from the database.
     /** @Date */
     private $createdAt;
 
+@DefaultDiscriminatorValue
+--------------------------
+
+This annotation can be used when using `@DiscriminatorField`_. It will be used
+as a fallback value if a document has no discriminator field set. This must
+correspond to a value from a discriminator map.
+
+.. code-block:: php
+
+    <?php
+
+    /**
+     * @Document
+     * @InheritanceType("SINGLE_COLLECTION")
+     * @DiscriminatorField("type")
+     * @DiscriminatorMap({"person" = "Person", "employee" = "Employee"})
+     * @DefaultDiscriminatorValue("person")
+     */
+    class Person
+    {
+        // ...
+    }
+
 @DiscriminatorField
 -------------------
 
@@ -344,6 +367,9 @@ Optional attributes:
 -
     discriminatorMap - Map of discriminator values to class names.
 -
+    defaultDiscriminatorValue - A default value for discriminatorField if no value
+    has been set in the embedded document.
+-
     strategy - The strategy used to persist changes to the collection. Possible
     values are ``addToSet``, ``pushAll``, ``set``, and ``setArray``. ``pushAll``
     is the default. See :ref:`collection_strategies` for more information.
@@ -359,7 +385,8 @@ Optional attributes:
      *     discriminatorMap={
      *         "book"="Documents\BookTag",
      *         "song"="Documents\SongTag"
-     *     }
+     *     },
+     *     defaultDiscriminatorValue="book"
      * )
      */
     private $tags = array();
@@ -394,6 +421,9 @@ Optional attributes:
     value within the embedded document.
 -
     discriminatorMap - Map of discriminator values to class names.
+-
+    defaultDiscriminatorValue - A default value for discriminatorField if no value
+    has been set in the embedded document.
 
 .. code-block:: php
 
@@ -405,7 +435,8 @@ Optional attributes:
      *     discriminatorMap={
      *         "user"="Documents\User",
      *         "author"="Documents\Author"
-     *     }
+     *     },
+     *     defaultDiscriminatorValue="user"
      * )
      */
     private $creator;
@@ -1066,6 +1097,9 @@ Optional attributes:
 -
     discriminatorMap - Map of discriminator values to class names.
 -
+    defaultDiscriminatorValue - A default value for discriminatorField if no value
+    has been set in the embedded document.
+-
     inversedBy - The field name of the inverse side. Only allowed on owning side.
 -
     mappedBy - The field name of the owning side. Only allowed on the inverse side.
@@ -1098,7 +1132,8 @@ Optional attributes:
      *     discriminatorMap={
      *         "book"="Documents\BookItem",
      *         "song"="Documents\SongItem"
-     *     }
+     *     },
+     *     defaultDiscriminatorValue="book"
      * )
      */
     private $cart;
@@ -1126,6 +1161,9 @@ Optional attributes:
 -
     discriminatorMap - Map of discriminator values to class names.
 -
+    defaultDiscriminatorValue - A default value for discriminatorField if no value
+    has been set in the embedded document.
+-
     inversedBy - The field name of the inverse side. Only allowed on owning side.
 -
     mappedBy - The field name of the owning side. Only allowed on the inverse side.
@@ -1152,7 +1190,8 @@ Optional attributes:
      *     discriminatorMap={
      *         "book"="Documents\BookItem",
      *         "song"="Documents\SongItem"
-     *     }
+     *     },
+     *     defaultDiscriminatorValue="book"
      * )
      */
     private $cart;

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -183,7 +183,7 @@ in MongoDB. The property will be a DateTime when loaded from the database.
 
 This annotation can be used when using `@DiscriminatorField`_. It will be used
 as a fallback value if a document has no discriminator field set. This must
-correspond to a value from a discriminator map.
+correspond to a value from the configured discriminator map.
 
 .. code-block:: php
 

--- a/docs/en/reference/embedded-mapping.rst
+++ b/docs/en/reference/embedded-mapping.rst
@@ -220,6 +220,54 @@ class name in each embedded document:
               download: DownloadTask
               build: BuildTask
 
+If you have embedded documents without a discriminator value that need to be
+treated correctly you can optionally specify a default value for the
+discriminator:
+
+.. configuration-block::
+
+    .. code-block:: php
+
+        <?php
+
+        /** @Document */
+        class User
+        {
+            // ..
+
+            /**
+             * @EmbedMany(
+             *   discriminatorMap={
+             *     "download"="DownloadTask",
+             *     "build"="BuildTask"
+             *   },
+             *   defaultDiscriminatorValue="download"
+             * )
+             */
+            private $tasks = array();
+
+            // ...
+        }
+
+    .. code-block:: xml
+
+        <embed-many fieldName="tasks">
+            <discriminator-map>
+                <discriminator-mapping value="download" class="DownloadTask" />
+                <discriminator-mapping value="build" class="BuildTask" />
+            </discriminator-map>
+            <default-discriminator-value value="download" />
+        </embed-many>
+
+    .. code-block:: yaml
+
+        embedMany:
+          tasks:
+            discriminatorMap:
+              download: DownloadTask
+              build: BuildTask
+            defaultDiscriminatorValue: download
+
 Cascading Operations
 --------------------
 

--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -148,6 +148,75 @@ would get an Employee instance back:
 Even though we queried for a Person, Doctrine will know to return an Employee
 instance because of the discriminator map!
 
+If your document structure has changed and you've added discriminators after
+already having a bunch of documents, you can specify a default value for the
+discriminator field:
+
+.. configuration-block::
+
+    .. code-block:: php
+
+        <?php
+
+        namespace Documents;
+
+        /**
+         * @Document
+         * @InheritanceType("SINGLE_COLLECTION")
+         * @DiscriminatorField("type")
+         * @DiscriminatorMap({"person"="Person", "employee"="Employee"})
+         * @DefaultDiscriminatorValue("person")
+         */
+        class Person
+        {
+            // ...
+        }
+
+        /**
+         * @Document
+         */
+        class Employee extends Person
+        {
+            // ...
+        }
+
+    .. code-block:: xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+        <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                        http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+          <document name="Documents\Person" inheritance-type="SINGLE_COLLECTION">
+            <discriminator-field name="type" />
+            <discriminator-map>
+                <discriminator-mapping value="person" class="Person" />
+                <discriminator-mapping value="employee" class="Employee" />
+            </discriminator-map>
+            <default-discriminator-value value="person" />
+          </document>
+        </doctrine-mongo-mapping>
+
+        <?xml version="1.0" encoding="UTF-8"?>
+        <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                        http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+          <document name="Documents\Employee">
+          </document>
+        </doctrine-mongo-mapping>
+
+    .. code-block:: yaml
+
+        Documents\Person:
+          type: document
+          inheritanceType: SINGLE_COLLECTION
+          discriminatorField: type
+          defaultDiscriminatorValue: person
+          discriminatorMap:
+            person: Person
+            employee: Employee
+
 .. _collection_per_class_inheritance:
 
 Collection Per Class Inheritance

--- a/docs/en/reference/reference-mapping.rst
+++ b/docs/en/reference/reference-mapping.rst
@@ -244,6 +244,53 @@ class name with each reference:
               album: Documents\Album
               song: Documents\Song
 
+If you have references without a discriminator value that need to be treated
+correctly you can optionally specify a default value for the discriminator:
+
+.. configuration-block::
+
+    .. code-block:: php
+
+        <?php
+
+        /** @Document */
+        class User
+        {
+            // ..
+
+            /**
+             * @ReferenceMany(
+             *   discriminatorMap={
+             *     "album"="Album",
+             *     "song"="Song"
+             *   },
+             *   defaultDiscriminatorValue="album"
+             * )
+             */
+            private $favorites = array();
+
+            // ...
+        }
+
+    .. code-block:: xml
+
+        <reference-many fieldName="favorites">
+            <discriminator-map>
+                <discriminator-mapping value="album" class="Documents\Album" />
+                <discriminator-mapping value="song" class="Documents\Song" />
+            </discriminator-map>
+            <default-discriminator-value value="album" />
+        </reference-many>
+
+    .. code-block:: yaml
+
+        referenceMany:
+          favorites:
+            discriminatorMap:
+              album: Documents\Album
+              song: Documents\Song
+            defaultDiscriminatorValue: album
+
 .. _simple_references:
 
 Simple References

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -39,6 +39,7 @@
       <xs:element name="reference-many" type="odm:reference-many" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
       <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
+      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
       <xs:element name="lifecycle-callbacks" type="odm:lifecycle-callbacks" minOccurs="0"/>
       <xs:element name="also-load-methods" type="odm:also-load-methods" minOccurs="0"/>
       <xs:element name="indexes" type="odm:indexes" minOccurs="0"/>
@@ -91,6 +92,7 @@
     <xs:sequence>
       <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
       <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
+      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
@@ -102,6 +104,7 @@
     <xs:sequence>
       <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
       <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
+      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
@@ -114,6 +117,7 @@
       <xs:element name="cascade" type="odm:cascade-type" minOccurs="0" />
       <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
       <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
+      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
       <xs:element name="sort" type="odm:sort-map" minOccurs="0" />
       <xs:element name="criteria" type="odm:criteria-map" minOccurs="0" />
     </xs:sequence>
@@ -133,6 +137,7 @@
       <xs:element name="cascade" type="odm:cascade-type" minOccurs="0" />
       <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
       <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
+      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
       <xs:element name="sort" type="odm:sort-map" minOccurs="0" />
       <xs:element name="criteria" type="odm:criteria-map" minOccurs="0" />
     </xs:sequence>
@@ -211,6 +216,10 @@
 
   <xs:complexType name="discriminator-field">
     <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="default-discriminator-value">
+    <xs:attribute name="value" type="xs:NMTOKEN" use="required"/>
   </xs:complexType>
 
   <xs:simpleType name="lifecycle-callback-type">

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DefaultDiscriminatorValue.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DefaultDiscriminatorValue.php
@@ -19,14 +19,9 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
+use Doctrine\Common\Annotations\Annotation;
+
 /** @Annotation */
-final class EmbedMany extends AbstractField
+final class DefaultDiscriminatorValue extends Annotation
 {
-    public $type = 'many';
-    public $embedded = true;
-    public $targetDocument;
-    public $discriminatorField;
-    public $discriminatorMap;
-    public $defaultDiscriminatorValue;
-    public $strategy = 'pushAll'; // pushAll, set
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php
@@ -26,6 +26,7 @@ require_once __DIR__ . '/InheritanceType.php';
 require_once __DIR__ . '/DiscriminatorField.php';
 require_once __DIR__ . '/DiscriminatorMap.php';
 require_once __DIR__ . '/DiscriminatorValue.php';
+require_once __DIR__ . '/DefaultDiscriminatorValue.php';
 require_once __DIR__ . '/Indexes.php';
 require_once __DIR__ . '/AbstractIndex.php';
 require_once __DIR__ . '/Index.php';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/EmbedOne.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/EmbedOne.php
@@ -27,4 +27,5 @@ final class EmbedOne extends AbstractField
     public $targetDocument;
     public $discriminatorField;
     public $discriminatorMap;
+    public $defaultDiscriminatorValue;
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Inheritance.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Inheritance.php
@@ -27,4 +27,5 @@ final class Inheritance extends Annotation
     public $type = 'NONE';
     public $discriminatorMap = array();
     public $discriminatorField;
+    public $defaultDiscriminatorValue;
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceMany.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceMany.php
@@ -28,6 +28,7 @@ final class ReferenceMany extends AbstractField
     public $targetDocument;
     public $discriminatorField;
     public $discriminatorMap;
+    public $defaultDiscriminatorValue;
     public $cascade;
     public $orphanRemoval;
     public $inversedBy;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceOne.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceOne.php
@@ -28,6 +28,7 @@ final class ReferenceOne extends AbstractField
     public $targetDocument;
     public $discriminatorField;
     public $discriminatorMap;
+    public $defaultDiscriminatorValue;
     public $cascade;
     public $orphanRemoval;
     public $inversedBy;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -131,6 +131,7 @@ class ClassMetadata extends ClassMetadataInfo
             $serialized[] = 'discriminatorField';
             $serialized[] = 'discriminatorValue';
             $serialized[] = 'discriminatorMap';
+            $serialized[] = 'defaultDiscriminatorValue';
             $serialized[] = 'parentClasses';
             $serialized[] = 'subClasses';
         }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -133,6 +133,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             $class->setInheritanceType($parent->inheritanceType);
             $class->setDiscriminatorField($parent->discriminatorField);
             $class->setDiscriminatorMap($parent->discriminatorMap);
+            $class->setDefaultDiscriminatorValue($parent->defaultDiscriminatorValue);
             $class->setIdGeneratorType($parent->generatorType);
             $this->addInheritedFields($class, $parent);
             $this->addInheritedIndexes($class, $parent);

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -347,6 +347,14 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
     public $discriminatorField;
 
     /**
+     * READ-ONLY: The default value for discriminatorField in case it's not set in the document
+     *
+     * @var string
+     * @see discriminatorField
+     */
+    public $defaultDiscriminatorValue;
+
+    /**
      * READ-ONLY: Whether this class describes the mapping of a mapped superclass.
      *
      * @var boolean
@@ -684,6 +692,29 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
                 }
             }
         }
+    }
+
+    /**
+     * Sets the default discriminator value to be used for this class
+     * Used for JOINED and SINGLE_TABLE inheritance mapping strategies if the document has no discriminator value
+     *
+     * @param string $defaultDiscriminatorValue
+     *
+     * @throws MappingException
+     */
+    public function setDefaultDiscriminatorValue($defaultDiscriminatorValue)
+    {
+        if ($defaultDiscriminatorValue === null) {
+            $this->defaultDiscriminatorValue = null;
+
+            return;
+        }
+
+        if (!array_key_exists($defaultDiscriminatorValue, $this->discriminatorMap)) {
+            throw MappingException::invalidDiscriminatorValue($defaultDiscriminatorValue, $this->name);
+        }
+
+        $this->defaultDiscriminatorValue = $defaultDiscriminatorValue;
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -100,6 +100,8 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 $class->setDiscriminatorValue($annot->value);
             } elseif ($annot instanceof ODM\ChangeTrackingPolicy) {
                 $class->setChangeTrackingPolicy(constant('Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata::CHANGETRACKING_'.$annot->value));
+            } elseif ($annot instanceof ODM\DefaultDiscriminatorValue) {
+                $class->setDefaultDiscriminatorValue($annot->value);
             }
 
         }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -107,6 +107,9 @@ class XmlDriver extends FileDriver
             }
             $class->setDiscriminatorMap($map);
         }
+        if (isset($xmlRoot->{'default-discriminator-value'})) {
+            $class->setDefaultDiscriminatorValue((string) $xmlRoot->{'default-discriminator-value'}['value']);
+        }
         if (isset($xmlRoot->{'indexes'})) {
             foreach ($xmlRoot->{'indexes'}->{'index'} as $index) {
                 $this->addIndex($class, $index);
@@ -262,6 +265,9 @@ class XmlDriver extends FileDriver
                 $mapping['discriminatorMap'][(string) $attr['value']] = (string) $attr['class'];
             }
         }
+        if (isset($embed->{'default-discriminator-value'})) {
+            $mapping['defaultDiscriminatorValue'] = (string) $embed->{'default-discriminator-value'}['value'];
+        }
         if (isset($attributes['not-saved'])) {
             $mapping['notSaved'] = ('true' === (string) $attributes['not-saved']);
         }
@@ -306,6 +312,9 @@ class XmlDriver extends FileDriver
                 $attr = $discriminatorMapping->attributes();
                 $mapping['discriminatorMap'][(string) $attr['value']] = (string) $attr['class'];
             }
+        }
+        if (isset($reference->{'default-discriminator-value'})) {
+            $mapping['defaultDiscriminatorValue'] = (string) $reference->{'default-discriminator-value'}['value'];
         }
         if (isset($reference->{'sort'})) {
             foreach ($reference->{'sort'}->{'sort'} as $sort) {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
@@ -87,6 +87,9 @@ class YamlDriver extends FileDriver
         if (isset($element['discriminatorMap'])) {
             $class->setDiscriminatorMap($element['discriminatorMap']);
         }
+        if (isset($element['defaultDiscriminatorValue'])) {
+            $class->setDefaultDiscriminatorValue($element['defaultDiscriminatorValue']);
+        }
         if (isset($element['changeTrackingPolicy'])) {
             $class->setChangeTrackingPolicy(constant('Doctrine\ODM\MongoDB\Mapping\ClassMetadata::CHANGETRACKING_'
                     . strtoupper($element['changeTrackingPolicy'])));
@@ -251,6 +254,9 @@ class YamlDriver extends FileDriver
         if (isset($embed['discriminatorMap'])) {
             $mapping['discriminatorMap'] = $embed['discriminatorMap'];
         }
+        if (isset($embed['defaultDiscriminatorValue'])) {
+            $mapping['defaultDiscriminatorValue'] = $embed['defaultDiscriminatorValue'];
+        }
         $this->addFieldMapping($class, $mapping);
     }
 
@@ -279,6 +285,9 @@ class YamlDriver extends FileDriver
         }
         if (isset($reference['discriminatorMap'])) {
             $mapping['discriminatorMap'] = $reference['discriminatorMap'];
+        }
+        if (isset($reference['defaultDiscriminatorValue'])) {
+            $mapping['defaultDiscriminatorValue'] = $reference['defaultDiscriminatorValue'];
         }
         if (isset($reference['sort'])) {
             $mapping['sort'] = $reference['sort'];

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -70,6 +70,18 @@ class MappingException extends BaseMappingException
         );
     }
 
+    /**
+     * Throws an exception that indicates a discriminator value does not exist in a map
+     *
+     * @param string $value The discriminator value that could not be found
+     * @param string $owningClass The class that declares the discriminator map
+     * @return self
+     */
+    public static function invalidDiscriminatorValue($value, $owningClass)
+    {
+        return new self("Discriminator value '$value' used in the declaration of class '$owningClass' does not exist.");
+    }
+
     public static function missingFieldName($className)
     {
         return new self("The Document class '$className' field mapping misses the 'fieldName' attribute.");

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1228,6 +1228,12 @@ class DocumentPersister
                 $discriminatorValues[] = $key;
             }
         }
+
+        // If a defaultDiscriminatorValue is set and it is among the discriminators being queries, add NULL to the list
+        if ($metadata->defaultDiscriminatorValue && (array_search($metadata->defaultDiscriminatorValue, $discriminatorValues)) !== false) {
+            $discriminatorValues[] = null;
+        }
+
         return $discriminatorValues;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -330,8 +330,15 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
             $documentNames = $documentName;
             $documentName = $documentNames[0];
 
-            $discriminatorField = $this->dm->getClassMetadata($documentName)->discriminatorField;
+            $metadata = $this->dm->getClassMetadata($documentName);
+            $discriminatorField = $metadata->discriminatorField;
             $discriminatorValues = $this->getDiscriminatorValues($documentNames);
+
+            // If a defaultDiscriminatorValue is set and it is among the discriminators being queries, add NULL to the list
+            if ($metadata->defaultDiscriminatorValue && (array_search($metadata->defaultDiscriminatorValue, $discriminatorValues)) !== false) {
+                $discriminatorValues[] = null;
+            }
+
             $this->field($discriminatorField)->in($discriminatorValues);
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
@@ -599,6 +599,7 @@ public function <methodName>()
                 'generateInheritanceAnnotation',
                 'generateDiscriminatorFieldAnnotation',
                 'generateDiscriminatorMapAnnotation',
+                'generateDefaultDiscriminatorValueAnnotation',
                 'generateChangeTrackingPolicyAnnotation'
             );
 
@@ -637,6 +638,13 @@ public function <methodName>()
             }
 
             return '@ODM\\DiscriminatorMap({' . implode(', ', $inheritanceClassMap) . '})';
+        }
+    }
+
+    private function generateDefaultDiscriminatorValueAnnotation(ClassMetadataInfo $metadata)
+    {
+        if ($metadata->inheritanceType === ClassMetadataInfo::INHERITANCE_TYPE_SINGLE_COLLECTION && isset($metadata->defaultDiscriminatorValue)) {
+            return '@ODM\\DefaultDiscriminatorValue("' . $metadata->defaultDiscriminatorValue . '")';
         }
     }
 

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2771,9 +2771,14 @@ class UnitOfWork implements PropertyChangedListener
     {
         $discriminatorField = isset($mapping['discriminatorField']) ? $mapping['discriminatorField'] : null;
 
+        $discriminatorValue = null;
         if (isset($discriminatorField, $data[$discriminatorField])) {
             $discriminatorValue = $data[$discriminatorField];
+        } elseif (isset($mapping['defaultDiscriminatorValue'])) {
+            $discriminatorValue = $mapping['defaultDiscriminatorValue'];
+        }
 
+        if ($discriminatorValue !== null) {
             return isset($mapping['discriminatorMap'][$discriminatorValue])
                 ? $mapping['discriminatorMap'][$discriminatorValue]
                 : $discriminatorValue;
@@ -2781,9 +2786,14 @@ class UnitOfWork implements PropertyChangedListener
 
         $class = $this->dm->getClassMetadata($mapping['targetDocument']);
 
+        $discriminatorValue = null;
         if (isset($class->discriminatorField, $data[$class->discriminatorField])) {
             $discriminatorValue = $data[$class->discriminatorField];
+        } elseif ($class->defaultDiscriminatorValue !== null) {
+            $discriminatorValue = $class->defaultDiscriminatorValue;
+        }
 
+        if ($discriminatorValue !== null) {
             return isset($class->discriminatorMap[$discriminatorValue])
                 ? $class->discriminatorMap[$discriminatorValue]
                 : $discriminatorValue;
@@ -2809,9 +2819,14 @@ class UnitOfWork implements PropertyChangedListener
         $class = $this->dm->getClassMetadata($className);
 
         // @TODO figure out how to remove this
+        $discriminatorValue = null;
         if (isset($class->discriminatorField, $data[$class->discriminatorField])) {
             $discriminatorValue = $data[$class->discriminatorField];
+        } elseif (isset($class->defaultDiscriminatorValue)) {
+            $discriminatorValue = $class->defaultDiscriminatorValue;
+        }
 
+        if ($discriminatorValue !== null) {
             $className = isset($class->discriminatorMap[$discriminatorValue])
                 ? $class->discriminatorMap[$discriminatorValue]
                 : $discriminatorValue;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class ReferenceDiscriminatorsDefaultValueTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * This test demonstrates a document without discriminator being treated with defaultDiscriminatorValue
+     */
+    public function testLoadDocumentWithDefaultValue()
+    {
+        // Create referenced document without discriminator value
+        $this->dm->persist($firstChildWithoutDiscriminator = new ChildDocumentWithoutDiscriminator('firstWithoutDiscriminator'));
+        $this->dm->persist($secondChildWithoutDiscriminator = new ChildDocumentWithoutDiscriminator('firstWithoutDiscriminator'));
+
+        $children = array($firstChildWithoutDiscriminator, $secondChildWithoutDiscriminator);
+        $this->dm->persist($parentWithoutDiscriminator = new ParentDocumentWithoutDiscriminator($children));
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $childWithDiscriminator = $this->dm->find(__NAMESPACE__ . '\ChildDocumentWithDiscriminator', $firstChildWithoutDiscriminator->getId());
+        $this->assertInstanceOf(__NAMESPACE__ . '\ChildDocumentWithDiscriminatorSimple', $childWithDiscriminator);
+        $this->assertSame('firstWithoutDiscriminator', $childWithDiscriminator->getType(), 'New mapping correctly loads legacy document');
+
+        $parentWithDiscriminator = $this->dm->find(__NAMESPACE__ . '\ParentDocumentWithDiscriminator', $parentWithoutDiscriminator->getId());
+        $this->assertNotNull($parentWithDiscriminator);
+        $this->assertInstanceOf(__NAMESPACE__ . '\ChildDocumentWithDiscriminatorSimple', $parentWithDiscriminator->getReferencedChild(), 'Referenced document correctly respects defaultDiscriminatorValue in referenceOne mapping');
+        $this->assertInstanceOf(__NAMESPACE__ . '\ChildDocumentWithDiscriminatorSimple', $parentWithDiscriminator->getEmbeddedChild(), 'Embedded document correctly respects defaultDiscriminatorValue in referenceOne mapping');
+
+        foreach ($parentWithDiscriminator->getReferencedChildren() as $child) {
+            $this->assertInstanceOf(__NAMESPACE__ . '\ChildDocumentWithDiscriminatorSimple', $child, 'Referenced document correctly respects defaultDiscriminatorValue in referenceMany mapping');
+        }
+
+        foreach ($parentWithDiscriminator->getEmbeddedChildren() as $child) {
+            $this->assertInstanceOf(__NAMESPACE__ . '\ChildDocumentWithDiscriminatorSimple', $child, 'Embedded document correctly respects defaultDiscriminatorValue in referenceMany mapping');
+        }
+    }
+
+    /**
+     * This test ensures that a discriminatorValue is stored in the database and overrides the default
+     */
+    public function testLoadDocumentWithDifferentChild()
+    {
+        $this->dm->persist($firstChildWithDiscriminator = new ChildDocumentWithDiscriminatorComplex('firstWithDiscriminator', 'veryComplex'));
+        $this->dm->persist($secondChildWithDiscriminator = new ChildDocumentWithDiscriminatorSimple('secondWithDiscriminator'));
+
+        $children = array($firstChildWithDiscriminator, $secondChildWithDiscriminator);
+        $this->dm->persist($parentWithDiscriminator = new ParentDocumentWithDiscriminator($children));
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $parentWithDiscriminator = $this->dm->find(__NAMESPACE__ . '\ParentDocumentWithDiscriminator', $parentWithDiscriminator->getId());
+        $this->assertNotNull($parentWithDiscriminator);
+        $this->assertInstanceOf(__NAMESPACE__ . '\ChildDocumentWithDiscriminatorComplex', $parentWithDiscriminator->getReferencedChild(), 'Referenced document respects discriminatorValue if it is present in referenceOne mapping');
+        $this->assertInstanceOf(__NAMESPACE__ . '\ChildDocumentWithDiscriminatorComplex', $parentWithDiscriminator->getEmbeddedChild(), 'Embedded document respects discriminatorValue if it is present in referenceOne mapping');
+
+        // Check referenceMany mapping
+        $referencedChildren = $parentWithDiscriminator->getReferencedChildren()->toArray();
+        $this->assertInstanceOf(__NAMESPACE__ . '\ChildDocumentWithDiscriminatorComplex', $referencedChildren[0], 'Referenced document respects discriminatorValue if it is present in referenceMany mapping');
+        $this->assertSame('firstWithDiscriminator', $referencedChildren[0]->getType());
+
+        $this->assertInstanceOf(__NAMESPACE__ . '\ChildDocumentWithDiscriminatorSimple', $referencedChildren[1], 'Referenced document respects discriminatorValue if it is present in referenceMany mapping');
+        $this->assertSame('secondWithDiscriminator', $referencedChildren[1]->getType());
+
+        // Check embedMany mapping
+        $referencedChildren = $parentWithDiscriminator->getEmbeddedChildren()->toArray();
+        $this->assertInstanceOf(__NAMESPACE__ . '\ChildDocumentWithDiscriminatorComplex', $referencedChildren[0], 'Referenced document respects discriminatorValue if it is present in referenceMany mapping');
+        $this->assertSame('firstWithDiscriminator', $referencedChildren[0]->getType());
+
+        $this->assertInstanceOf(__NAMESPACE__ . '\ChildDocumentWithDiscriminatorSimple', $referencedChildren[1], 'Referenced document respects discriminatorValue if it is present in referenceMany mapping');
+        $this->assertSame('secondWithDiscriminator', $referencedChildren[1]->getType());
+    }
+}
+
+// Unmapped superclasses
+/** @ODM\Document(collection="discriminator_parent") */
+abstract class ParentDocument
+{
+    /** @ODM\Id */
+    protected $id;
+
+    protected $referencedChild;
+
+    protected $referencedChildren;
+
+    protected $embeddedChild;
+
+    protected $embeddedChildren;
+
+    public function __construct(array $children)
+    {
+        $this->referencedChild = $children[0];
+        $this->referencedChildren = $children;
+        $this->embeddedChild = $children[0];
+        $this->embeddedChildren = $children;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getReferencedChild()
+    {
+        return $this->referencedChild;
+    }
+
+    public function getReferencedChildren()
+    {
+        return $this->referencedChildren;
+    }
+
+    public function getEmbeddedChild()
+    {
+        return $this->embeddedChild;
+    }
+
+    public function getEmbeddedChildren()
+    {
+        return $this->embeddedChildren;
+    }
+}
+
+/** @ODM\Document(collection="discriminator_child") */
+abstract class ChildDocument
+{
+    /** @ODM\Id */
+    protected $id;
+
+    /** @ODM\String */
+    protected $type;
+
+    public function __construct($type)
+    {
+        $this->type = $type;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+}
+
+// Documents without discriminators - used to create "legacy" data
+/** @ODM\Document(collection="discriminator_parent") */
+class ParentDocumentWithoutDiscriminator extends ParentDocument
+{
+    /** @ODM\ReferenceOne(targetDocument="ChildDocumentWithoutDiscriminator") */
+    protected $referencedChild;
+
+    /** @ODM\ReferenceMany(targetDocument="ChildDocumentWithoutDiscriminator") */
+    protected $referencedChildren;
+
+    /** @ODM\EmbedOne(targetDocument="ChildDocumentWithoutDiscriminator") */
+    protected $embeddedChild;
+
+    /** @ODM\EmbedMany(targetDocument="ChildDocumentWithoutDiscriminator") */
+    protected $embeddedChildren;
+}
+
+/** @ODM\Document(collection="discriminator_child") */
+class ChildDocumentWithoutDiscriminator extends ChildDocument
+{
+}
+
+// Documents with discriminators - these represent a "refactored" document structure
+/** @ODM\Document(collection="discriminator_parent") */
+class ParentDocumentWithDiscriminator extends ParentDocument
+{
+    /** @ODM\ReferenceOne(targetDocument="ChildDocumentWithDiscriminator") */
+    protected $referencedChild;
+
+    /** @ODM\ReferenceMany(targetDocument="ChildDocumentWithDiscriminator") */
+    protected $referencedChildren;
+
+    /** @ODM\EmbedOne(targetDocument="ChildDocumentWithDiscriminator") */
+    protected $embeddedChild;
+
+    /** @ODM\EmbedMany(targetDocument="ChildDocumentWithDiscriminator") */
+    protected $embeddedChildren;
+}
+
+/**
+ * @ODM\Document(collection="discriminator_child")
+ * @ODM\InheritanceType("SINGLE_COLLECTION")
+ * @ODM\DiscriminatorField(fieldName="discriminator")
+ * @ODM\DiscriminatorMap({"simple"="ChildDocumentWithDiscriminatorSimple", "complex"="ChildDocumentWithDiscriminatorComplex"})
+ * @ODM\DefaultDiscriminatorValue("simple")
+ */
+class ChildDocumentWithDiscriminator extends ChildDocument
+{
+
+}
+
+/** @ODM\Document(collection="discriminator_child") */
+class ChildDocumentWithDiscriminatorSimple extends ChildDocumentWithDiscriminator
+{
+}
+
+/** @ODM\Document(collection="discriminator_child") */
+class ChildDocumentWithDiscriminatorComplex extends ChildDocumentWithDiscriminatorSimple
+{
+    /** @ODM\String */
+    protected $value;
+
+    public function __construct($type, $value)
+    {
+        parent::__construct($type);
+        $this->value = $value;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -26,6 +26,7 @@ use Documents\Functional\PreUpdateTestSellable;
 use Documents\Functional\PreUpdateTestSeller;
 use Documents\Functional\SameCollection1;
 use Documents\Functional\SameCollection2;
+use Documents\Functional\SameCollection3;
 use Documents\Functional\SimpleEmbedAndReference;
 use Documents\Album;
 use Documents\Song;
@@ -605,6 +606,11 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->persist($test2);
         $this->dm->flush();
 
+        $test3 = new SameCollection3();
+        $test3->name = 'test3';
+        $this->dm->persist($test3);
+        $this->dm->flush();
+
         $test = $this->dm->getRepository('Documents\Functional\SameCollection1')->findOneBy(array('name' => 'test1'));
         $this->assertNotNull($test);
         $this->assertInstanceOf('Documents\Functional\SameCollection1', $test);
@@ -612,6 +618,10 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $test = $this->dm->getRepository('Documents\Functional\SameCollection2')->findOneBy(array('name' => 'test2'));
         $this->assertNotNull($test);
         $this->assertInstanceOf('Documents\Functional\SameCollection2', $test);
+
+        $test = $this->dm->getRepository('Documents\Functional\SameCollection1')->findOneBy(array('name' => 'test3'));
+        $this->assertNotNull($test);
+        $this->assertInstanceOf('Documents\Functional\SameCollection1', $test);
 
         $test = $this->dm->getRepository('Documents\Functional\SameCollection2')->findOneBy(array('name' => 'test1'));
         $this->assertNull($test);
@@ -622,15 +632,15 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         );
         $q = $qb->getQuery();
         $test = $q->execute();
-        $this->assertEquals(2, count($test));
+        $this->assertEquals(3, count($test));
 
         $test = $this->dm->getRepository('Documents\Functional\SameCollection1')->findAll();
-        $this->assertEquals(1, count($test));
+        $this->assertEquals(2, count($test));
 
         $qb = $this->dm->createQueryBuilder('Documents\Functional\SameCollection1');
         $query = $qb->getQuery();
         $test = $query->execute();
-        $this->assertEquals(1, count($test));
+        $this->assertEquals(2, count($test));
     }
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -224,10 +224,12 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
     {
         $this->assertTrue(isset($class->discriminatorField));
         $this->assertTrue(isset($class->discriminatorMap));
+        $this->assertTrue(isset($class->defaultDiscriminatorValue));
         $this->assertEquals('discr', $class->discriminatorField);
         $this->assertEquals(array(
             'default' => 'Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser',
         ), $class->discriminatorMap);
+        $this->assertEquals('default', $class->defaultDiscriminatorValue);
 
         return $class;
     }
@@ -240,11 +242,13 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
     {
         $this->assertTrue(isset($class->fieldMappings['otherPhonenumbers']['discriminatorField']));
         $this->assertTrue(isset($class->fieldMappings['otherPhonenumbers']['discriminatorMap']));
+        $this->assertTrue(isset($class->fieldMappings['otherPhonenumbers']['defaultDiscriminatorValue']));
         $this->assertEquals('discr', $class->fieldMappings['otherPhonenumbers']['discriminatorField']);
         $this->assertEquals(array(
             'home' => 'Doctrine\ODM\MongoDB\Tests\Mapping\HomePhonenumber',
             'work' => 'Doctrine\ODM\MongoDB\Tests\Mapping\WorkPhonenumber'
         ), $class->fieldMappings['otherPhonenumbers']['discriminatorMap']);
+        $this->assertEquals('home', $class->fieldMappings['otherPhonenumbers']['defaultDiscriminatorValue']);
 
         return $class;
     }
@@ -257,11 +261,13 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
     {
         $this->assertTrue(isset($class->fieldMappings['phonenumbers']['discriminatorField']));
         $this->assertTrue(isset($class->fieldMappings['phonenumbers']['discriminatorMap']));
+        $this->assertTrue(isset($class->fieldMappings['phonenumbers']['defaultDiscriminatorValue']));
         $this->assertEquals('discr', $class->fieldMappings['phonenumbers']['discriminatorField']);
         $this->assertEquals(array(
             'home' => 'Doctrine\ODM\MongoDB\Tests\Mapping\HomePhonenumber',
             'work' => 'Doctrine\ODM\MongoDB\Tests\Mapping\WorkPhonenumber'
         ), $class->fieldMappings['phonenumbers']['discriminatorMap']);
+        $this->assertEquals('home', $class->fieldMappings['phonenumbers']['defaultDiscriminatorValue']);
 
         return $class;
     }
@@ -318,6 +324,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
  * @ODM\Document(collection="cms_users")
  * @ODM\DiscriminatorField(fieldName="discr")
  * @ODM\DiscriminatorMap({"default"="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser"})
+ * @ODM\DefaultDiscriminatorValue("default")
  * @ODM\HasLifecycleCallbacks
  * @ODM\Indexes(@ODM\Index(keys={"createdAt"="asc"},expireAfterSeconds=3600))
  */
@@ -364,7 +371,7 @@ class AbstractMappingDriverUser
     public $address;
 
     /**
-     * @ODM\ReferenceMany(targetDocument="Phonenumber", cascade={"persist"}, discriminatorField="discr", discriminatorMap={"home"="HomePhonenumber", "work"="WorkPhonenumber"})
+     * @ODM\ReferenceMany(targetDocument="Phonenumber", cascade={"persist"}, discriminatorField="discr", discriminatorMap={"home"="HomePhonenumber", "work"="WorkPhonenumber"}, defaultDiscriminatorValue="home")
      */
     public $phonenumbers;
 
@@ -384,7 +391,7 @@ class AbstractMappingDriverUser
     public $embeddedPhonenumber;
 
     /**
-     * @ODM\EmbedMany(targetDocument="Phonenumber", discriminatorField="discr", discriminatorMap={"home"="HomePhonenumber", "work"="WorkPhonenumber"})
+     * @ODM\EmbedMany(targetDocument="Phonenumber", discriminatorField="discr", discriminatorMap={"home"="HomePhonenumber", "work"="WorkPhonenumber"}, defaultDiscriminatorValue="home")
      */
     public $otherPhonenumbers;
 
@@ -427,6 +434,7 @@ class AbstractMappingDriverUser
         $metadata->setDiscriminatorMap(array(
             'default' => __CLASS__,
         ));
+        $metadata->setDefaultDiscriminatorValue('default');
         $metadata->mapField(array(
             'id' => true,
             'fieldName' => 'id',
@@ -468,6 +476,7 @@ class AbstractMappingDriverUser
                 'home' => 'HomePhonenumber',
                 'work' => 'WorkPhonenumber'
             ),
+            'defaultDiscriminatorValue' => 'home',
         ));
         $metadata->mapManyReference(array(
             'fieldName' => 'morePhoneNumbers',
@@ -497,6 +506,7 @@ class AbstractMappingDriverUser
                 'home' => 'HomePhonenumber',
                 'work' => 'WorkPhonenumber',
            ),
+            'defaultDiscriminatorValue' => 'home',
         ));
         $metadata->addIndex(array('username' => 'desc'), array('unique' => true, 'dropDups' => false));
         $metadata->addIndex(array('email' => 'desc'), array('unique' => true, 'dropDups' => true));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
@@ -10,6 +10,7 @@
         <discriminator-map>
             <discriminator-mapping value="default" class="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser" />
         </discriminator-map>
+        <default-discriminator-value value="default" />
         <field fieldName="id" id="true" />
         <field fieldName="version" version="true" type="int" />
         <field fieldName="lock" lock="true" type="int" />
@@ -41,6 +42,7 @@
                 <discriminator-mapping value="home" class="HomePhonenumber" />
                 <discriminator-mapping value="work" class="WorkPhonenumber" />
             </discriminator-map>
+            <default-discriminator-value value="home" />
         </reference-many>
         <reference-many target-document="Group" field="groups">
             <cascade>
@@ -57,6 +59,7 @@
                 <discriminator-mapping value="home" class="HomePhonenumber" />
                 <discriminator-mapping value="work" class="WorkPhonenumber" />
             </discriminator-map>
+            <default-discriminator-value value="home" />
         </embed-many>
         <lifecycle-callbacks>
             <lifecycle-callback method="doStuffOnPrePersist" type="prePersist" />

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.yml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.yml
@@ -5,6 +5,7 @@ Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser:
     fieldName: discr
   discriminatorMap:
     default: Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser
+  defaultDiscriminatorValue: default
   fields:
     id:
       type: id
@@ -55,6 +56,7 @@ Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser:
       discriminatorMap:
         home: HomePhonenumber
         work: WorkPhonenumber
+      defaultDiscriminatorValue: home
     groups:
       targetDocument: Group
       cascade: [ all ]
@@ -72,6 +74,7 @@ Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser:
       discriminatorMap:
         home: HomePhonenumber
         work: WorkPhonenumber
+      defaultDiscriminatorValue: home
 
   lifecycleCallbacks:
     prePersist: [ doStuffOnPrePersist, doOtherStuffOnPrePersistToo ]

--- a/tests/Documents/Functional/SameCollection2.php
+++ b/tests/Documents/Functional/SameCollection2.php
@@ -8,6 +8,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  * @ODM\Document(collection="same_collection")
  * @ODM\DiscriminatorField(fieldName="type")
  * @ODM\DiscriminatorMap({"test1"="Documents\Functional\SameCollection1", "test2"="Documents\Functional\SameCollection2"})
+ * @ODM\DefaultDiscriminatorValue("test1")
  */
 class SameCollection2
 {

--- a/tests/Documents/Functional/SameCollection3.php
+++ b/tests/Documents/Functional/SameCollection3.php
@@ -5,12 +5,10 @@ namespace Documents\Functional;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
+ * Sample document without discriminator field to test defaultDiscriminatorValue
  * @ODM\Document(collection="same_collection")
- * @ODM\DiscriminatorField(fieldName="type")
- * @ODM\DiscriminatorMap({"test1"="Documents\Functional\SameCollection1", "test2"="Documents\Functional\SameCollection2"})
- * @ODM\DefaultDiscriminatorValue("test1")
  */
-class SameCollection1
+class SameCollection3
 {
     /** @ODM\Id */
     public $id;


### PR DESCRIPTION
When working with large databases, refactoring your documents can be quite difficult. When I tried to split up a large document into multiple smaller once using single_collection inheritance and discriminator maps I realized that I'd have to update every document and, even worse, every single reference to those documents and add the correct discriminator to all documents and references.

This PR introduces a ```defaultDiscriminatorValue``` mapping which can be used to specify a default discriminator value that will be used if a document or association has no discriminator set. This makes it unnecessary to update the database and instead lets the ODM do the lifting.
It works by adding ```null``` to the ```discriminatorValues``` in the query builder if a ```defaultDIscriminatorValue``` has been set and it is in the list of discriminators being queried. This allows queries to find documents without discriminator and treats them as documents of the chosen type.

The mapping is similar to the rest of the discriminator mappings:
* Annotations:
```
/**
 * @ODM\Document(collection="cms_users")
 * @ODM\DiscriminatorField(fieldName="discr")
 * @ODM\DiscriminatorMap({"default"="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser"})
 * @ODM\DefaultDiscriminatorValue("default")
 */
```
* YAML:
```
Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser:
  type: document
  collection: cms_users
  discriminatorField:
    fieldName: discr
  discriminatorMap:
    default: Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser
  defaultDiscriminatorValue: default
```
* XML:
```
<document name="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser" collection="cms_users">
    <discriminator-field name="discr" />
    <discriminator-map>
        <discriminator-mapping value="default" class="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser" />
    </discriminator-map>
    <default-discriminator-value value="default" />
</document>
```

What's missing?
* ~~Only the annotation reference has been written so far. The feature still needs to be documented in the respective sections about document inheritance and references.~~
* ~~More test cases. The test cases for discriminators are a bit spread out, so adding test cases is a bit cumbersome. A test to check that a single document without discriminator value is found has been added, but all of the association mapping stuff is still untested. I'd add that once I've gotten some feedback on the whole thing.~~