### PR TITLE
pass file content instead of file path to Yaml parser

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
@@ -327,6 +327,6 @@ class YamlDriver extends FileDriver
      */
     protected function loadMappingFile($file)
     {
-        return Yaml::parse($file);
+        return Yaml::parse(file_get_contents($file));
     }
 }


### PR DESCRIPTION
Parsing file paths in Yaml is deprecated
https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Yaml/Yaml.php#L58