### PR TITLE
Add missing namespace import

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -24,6 +24,7 @@ use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\MongoDB\Repository\DefaultRepositoryFactory;
+use Doctrine\ODM\MongoDB\Repository\RepositoryFactory;
 
 /**
  * Configuration class for the DocumentManager. When setting up your DocumentManager


### PR DESCRIPTION
The namespace for the ```RepositoryFactory``` class has not been imported - this causes fatal errors when working with Reflection on the class