### PR TITLE
PersistentCollection serialization fix

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -613,7 +613,7 @@ class PersistentCollection implements BaseCollection
      */
     public function __sleep()
     {
-        return array('coll', 'initialized');
+        return array('coll', 'initialized', 'mongoData');
     }
 
     /* ArrayAccess implementation */


### PR DESCRIPTION
 Serialization fix to show representative string if collection is uninitialized. Related to [issue 1078](https://github.com/doctrine/mongodb-odm/issues/1078).