### PR TITLE
Add missing serialization of MetadataClass properties

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -164,6 +164,12 @@ class ClassMetadata extends ClassMetadataInfo
             $serialized[] = 'distance';
         }
 
+        if ($this->collectionCapped) {
+            $serialized[] = 'collectionCapped';
+            $serialized[] = 'collectionSize';
+            $serialized[] = 'collectionMax';
+        }
+
         return $serialized;
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -31,6 +31,9 @@ class ClassMetadataTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $cm->setFile('customFileProperty');
         $cm->setDistance('customDistanceProperty');
         $cm->setSlaveOkay(true);
+        $cm->setCollectionCapped(true);
+        $cm->setCollectionMax(1000);
+        $cm->setCollectionSize(500);
         $this->assertTrue(is_array($cm->getFieldMapping('phonenumbers')));
         $this->assertEquals(1, count($cm->fieldMappings));
         $this->assertEquals(1, count($cm->associationMappings));
@@ -56,6 +59,9 @@ class ClassMetadataTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue($cm->slaveOkay);
         $mapping = $cm->getFieldMapping('phonenumbers');
         $this->assertEquals('Documents\Bar', $mapping['targetDocument']);
+        $this->assertTrue($cm->getCollectionCapped());
+        $this->assertEquals(1000, $cm->getCollectionMax());
+        $this->assertEquals(500, $cm->getCollectionSize());
     }
 
     public function testOwningSideAndInverseSide()


### PR DESCRIPTION
In case a collection is marked as capped the related properties ```collectionCapped```, ```collectionSize``` and ```collectionMax``` are not serialized what results in wrong collection creations if the metadata has already been cached.