### PR TITLE
Fix missing "nullable" option support

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
@@ -764,11 +764,12 @@ public function <methodName>()
             return;
         }
 
-        $description = ucfirst($type) . ' ' . $variableName;
-
-        $types = Type::getTypesMap();
-        $methodTypeHint = $typeHint && ! isset($types[$typeHint]) ? '\\' . $typeHint . ' ' : null;
-        $variableType = $typeHint ? $typeHint . ' ' : null;
+        $description    = ucfirst($type) . ' ' . $variableName;
+        $methodMetaData = $metadata->getFieldMapping($fieldName);
+        $isNullable     = isset($methodMetaData['nullable']) && $methodMetaData['nullable'];
+        $types          = Type::getTypesMap();
+        $methodTypeHint = (($type !== 'set' || !$isNullable) && $typeHint) && ! isset($types[$typeHint]) ? '\\' . $typeHint . ' ' : null;
+        $variableType   = $typeHint ? $typeHint . ' ' : null;
 
         $replacements = array(
             '<description>'    => $description,


### PR DESCRIPTION
If I want an optional document reference (with nullable=true), this will not set the setter argument type.