### PR TITLE
[docs] Fix 'raw_type' to 'raw'.

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -170,7 +170,7 @@ Here is a quick overview of the built-in mapping types:
 -  ``int``
 -  ``key``
 -  ``object_id``
--  ``raw_type``
+-  ``raw``
 -  ``string``
 -  ``timestamp``
 
@@ -198,6 +198,7 @@ This list explains some of the less obvious mapping types:
 -  ``id``: string to MongoId by default, but other formats are possible
 -  ``timestamp``: string to MongoTimestamp
 -  ``increment``: integer in both PHP and MongoDB
+-  ``raw``: any type
 
 .. note::
     


### PR DESCRIPTION
As seen here, the type should be `raw`: https://github.com/doctrine/mongodb-odm/blob/94bc60445c95f627228fa7e72cc9958f70c033eb/lib/Doctrine/ODM/MongoDB/Types/Type.php#L57