### PR TITLE
Use cursor for counting documents in inversed collections

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -484,10 +484,17 @@ class PersistentCollection implements BaseCollection
      */
     public function count()
     {
-        if ($this->mapping['isInverseSide']) {
-            $this->initialize();
+        $count = $this->coll->count();
+
+        // If this collection is inversed and not initialized, add the count returned from the database
+        if ($this->mapping['isInverseSide'] && ! $this->initialized) {
+            $documentPersister = $this->uow->getDocumentPersister(get_class($this->owner));
+            $count += empty($this->mapping['repositoryMethod'])
+                ? $documentPersister->createReferenceManyInverseSideQuery($this)->count()
+                : $documentPersister->createReferenceManyWithRepositoryMethodCursor($this)->count();
         }
-        return count($this->mongoData) + $this->coll->count();
+
+        return count($this->mongoData) + $count;
     }
 
     /**


### PR DESCRIPTION
Revisiting this once again. This change was previously introduced in #649 and subsequently reverted in #692 because it can return incorrect results in certain use cases.

Instead of ignoring elements added to the collection like before, the code now counts the elements stored in the collection. If the collection is inversed and has not been initialized, it uses a count command on the cursor to get the number of documents in the database and adds that to the number of elements in the collection. This should return accurate results as well as improve time and memory consumption considerably. Note that all variants have edge cases where the result of count() will be incorrect - this can not be avoided as long as documents are manually added to the collection.

@spantaleev I would appreciate your feedback on this. I use inverse references a lot, but wherever I use them I never manually add documents to them. It would help a lot if you could test this against the code where you previously ran into the issue of wrong counts.