### PR TITLE
Add proper return code to indicate errors in schema console commands

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
@@ -63,6 +63,7 @@ class CreateCommand extends AbstractCommand
         $this->timeout = isset($timeout) ? (int) $timeout : null;
 
         $sm = $this->getSchemaManager();
+        $isErrored = false;
 
         foreach ($create as $option) {
             try {
@@ -79,8 +80,11 @@ class CreateCommand extends AbstractCommand
                 ));
             } catch (\Exception $e) {
                 $output->writeln('<error>' . $e->getMessage() . '</error>');
+                $isErrored = true;
             }
         }
+
+        return ($isErrored) ? 255 : 0;
     }
 
     protected function processDocumentCollection(SchemaManager $sm, $document)

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
@@ -56,6 +56,7 @@ class DropCommand extends AbstractCommand
 
         $class = $input->getOption('class');
         $sm = $this->getSchemaManager();
+        $isErrored = false;
 
         foreach ($drop as $option) {
             try {
@@ -72,8 +73,11 @@ class DropCommand extends AbstractCommand
                 ));
             } catch (\Exception $e) {
                 $output->writeln('<error>' . $e->getMessage() . '</error>');
+                $isErrored = true;
             }
         }
+
+        return ($isErrored) ? 255 : 0;
     }
 
     protected function processDocumentCollection(SchemaManager $sm, $document)

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
@@ -55,6 +55,7 @@ class UpdateCommand extends AbstractCommand
         $this->timeout = isset($timeout) ? (int) $timeout : null;
 
         $sm = $this->getSchemaManager();
+        $isErrored = false;
 
         try {
             if (isset($class)) {
@@ -66,7 +67,10 @@ class UpdateCommand extends AbstractCommand
             }
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
+            $isErrored = true;
         }
+
+        return ($isErrored) ? 255 : 0;
     }
 
     /**


### PR DESCRIPTION
This adds a proper return code in case a schema command throws an error. Without this, automated scripts (e.g. capifony) can't detect the error and act accordingly.