### PR TITLE
[Travis] PHP 5.3 run all, 5.4 to 5.6 only stable driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,16 @@ php:
   - 5.6
 
 env:
-  - MONGO_VERSION=1.2.12
-  - MONGO_VERSION=1.3.7
-  - MONGO_VERSION=1.4.5
   - MONGO_VERSION=stable
+  
+matrix:
+  include:
+    - php: 5.3
+      env: MONGO_VERSION=1.2.12
+    - php: 5.3
+      env: MONGO_VERSION=1.3.7
+    - php: 5.3
+      env: MONGO_VERSION=1.4.5
 
 services: mongodb
 


### PR DESCRIPTION
Travis matrix is quite big, as discussed with @jmikola this configuration will be enough for ODM