### PR TITLE
Fixed events.rst Lifecycle Callbacks example

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -237,7 +237,7 @@ event occurs.
         /** @PrePersist */
         public function doStuffOnPrePersist()
         {
-            $this->createdAt = date('Y-m-d H:m:s');
+            $this->createdAt = date('Y-m-d H:i:s');
         }
     
         /** @PrePersist */


### PR DESCRIPTION
Because we know that `m` means month and not minutes.