### PR TITLE
Functional test to demonstrate Doctrine ODM queries load inconsistent data from the database while a concurrent request is writing to the same record

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -439,8 +439,6 @@ class UnitOfWork implements PropertyChangedListener
             }
         }
 
-
-
         if ($this->documentInsertions) {
             foreach ($commitOrder as $class) {
                 if ($class->isEmbeddedDocument) {
@@ -450,15 +448,11 @@ class UnitOfWork implements PropertyChangedListener
             }
         }
 
-        // surface incremented here along with version
-
         if ($this->documentUpdates) {
             foreach ($commitOrder as $class) {
                 $this->executeUpdates($class, $options);
             }
         }
-
-        // end of surface and version increment
 
         // Extra updates that were requested by persisters.
         if ($this->extraUpdates) {
@@ -476,14 +470,10 @@ class UnitOfWork implements PropertyChangedListener
             $concurrentPHPRequestSimulatedLogic();
         }
 
-        // This is where the embedded documents are updated
-
         // Collection updates (deleteRows, updateRows, insertRows)
         foreach ($this->collectionUpdates as $collectionToUpdate) {
             $this->getCollectionPersister()->update($collectionToUpdate, $options);
         }
-
-        // Updates to embedded documents are finished here
 
         // Document deletions come last and need to be in reverse commit order
         if ($this->documentDeletions) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -58,13 +58,6 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
         $config = $this->getConfiguration();
         $conn = new Connection(DOCTRINE_MONGODB_SERVER, array(), $config);
 
-        $config->setLoggerCallable(array($this, 'queryTriggeredHandler'));
-
         return DocumentManager::create($conn, $config);
-    }
-
-    public function queryTriggeredHandler($event)
-    {
-        error_log(json_encode($event) . "\n", 3, "/var/log/lyft/mongo.log");
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -58,6 +58,13 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
         $config = $this->getConfiguration();
         $conn = new Connection(DOCTRINE_MONGODB_SERVER, array(), $config);
 
+        $config->setLoggerCallable(array($this, 'queryTriggeredHandler'));
+
         return DocumentManager::create($conn, $config);
+    }
+
+    public function queryTriggeredHandler($event)
+    {
+        error_log(json_encode($event) . "\n", 3, "/var/log/lyft/mongo.log");
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
@@ -3,9 +3,19 @@
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Documents\Phonenumber;
 
 class VersionTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
+    public function tearDown()
+    {
+        global $concurrentRequestLogic;
+        if (isset($concurrentRequestLogic)) {
+            unset($concurrentRequestLogic);
+        }
+        unset($concurrentRequestLogic);
+        parent::tearDown();
+    }
     public function testVersioningWhenManipulatingEmbedMany()
     {
         $expectedVersion = 1;
@@ -36,6 +46,45 @@ class VersionTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $doc->embedMany = null;
         $this->dm->flush();
         $this->assertEquals($expectedVersion++, $doc->version);
+    }
+
+    /**
+     * The ODM does not save database records with embedded documents in an atomic fashion.
+     *
+     * Even with ODM versioning, a concurrent PHP request which happens to load a Mongo record while another PHP
+     * request is writing the same record will load an incomplete and inconsistent version of the Mongo record into a
+     * Doctrine ODM model. This has been a repeated cause of data loss and corruption.
+     */
+    public function testDataConsistencyUsingEmbeddedDocuments()
+    {
+        global $concurrentPHPRequestSimulatedLogic;
+
+        $user = new \Documents\UserVersioned();
+        $this->dm->persist($user);
+        $this->dm->flush($user);
+        $this->dm->clear();
+
+        // Imagine a PHP request comes in which modifies the user object.
+        $request1dm = $this->createTestDocumentManager();
+        $request1User = $request1dm->find('Documents\UserVersioned', $user->getId());
+        $request1User->setUsername('apple');
+        $request1User->addPhonenumber(new PhoneNumber('1111111111'));
+
+        // Simulate a concurrent PHP request for the user record.
+        $request2dm = $this->createTestDocumentManager();
+        $request2User = null;
+        $concurrentPHPRequestSimulatedLogic = function () use ($request2dm, $user, &$request2User) {
+            // Simulate a concurrent request loading the database record triggered while request #1 is writing the record.
+            $request2User = $request2dm->find('Documents\UserVersioned', $user->getId());
+        };
+
+        // Trigger the flush event by PHP request #1.
+        $request1dm->flush($request1User);
+
+        // Prove that concurrent requests can load version #2 of the record in a consistent state.
+        $this->assertEquals(2, $request2User->version);
+        $this->assertEquals("apple", $request2User->getUsername());
+        $this->assertEquals(1, $request2User->getPhonenumbers()->count(), "Version #2 of the versioned user object should have a phone number embedded document. However, {$request2User->getPhonenumbers()->count()} phone number embedded documents were found");
     }
 }
 

--- a/tests/Documents/UserVersioned.php
+++ b/tests/Documents/UserVersioned.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Documents;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document(collection="usersversioned")
+ */
+class UserVersioned extends BaseDocument
+{
+    /** @ODM\Id */
+    protected $id;
+
+    /** @ODM\Version @ODM\Int */
+    public $version;
+
+    /** @ODM\Field(type="string") */
+    protected $username;
+
+    /** @ODM\EmbedMany(strategy="set",targetDocument="Phonenumber") */
+    protected $phonenumbers;
+
+    public function __construct()
+    {
+        $this->phonenumbers = new ArrayCollection();
+    }
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getPhonenumbers()
+    {
+        return $this->phonenumbers;
+    }
+
+    public function addPhonenumber(Phonenumber $phonenumber)
+    {
+        $this->phonenumbers[] = $phonenumber;
+    }
+
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    public function setUsername($username)
+    {
+        return $this->username = $username;
+    }
+}


### PR DESCRIPTION
The ODM does not save database records with embedded documents in an atomic fashion.

Even with ODM versioning, a concurrent PHP request which loads a Mongo record while another PHP request is writing the same record will load an incomplete and inconsistent version of the Mongo record into a Doctrine ODM model. This has been a repeated cause of data loss and corruption.

Repro steps:

Run this unit test:

```
phpunit --filter testDataConsistencyUsingEmbeddedDocuments ./tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
```

Result:
```
PHPUnit 4.1.6 by Sebastian Bergmann.

Configuration read from /srv/repos/instant-server/extrashared/mongodb-odm/phpunit.xml

F

Time: 9.38 seconds, Memory: 3.75Mb

There was 1 failure:

1) Doctrine\ODM\MongoDB\Tests\Functional\VersionTest::testDataConsistencyUsingEmbeddedDocuments
Version #2 of the versioned user object should have a phone number embedded document. However, 0 phone number embedded documents were found
Failed asserting that 0 matches expected 1.

/srv/repos/instant-server/extrashared/mongodb-odm/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php:87

FAILURES!
Tests: 1, Assertions: 3, Failures: 1.
```