### PR TITLE
feature/atomic-many-updates flaw - Functional test to demonstrate Doctrine ODM queries load inconsistent data from the database while a concurrent request is writing to the same record

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -463,6 +463,13 @@ class UnitOfWork implements PropertyChangedListener
         foreach ($this->collectionDeletions as $collectionToDelete) {
             $this->getCollectionPersister()->delete($collectionToDelete, $options);
         }
+
+        // This hack allows me to fire simulated concurrent PHP logic from my functional test allowing me to demonstrate a concurrency problem.
+        global $concurrentPHPRequestSimulatedLogic;
+        if (get_class($document) == 'Documents\UserVersionedDemo' && is_callable($concurrentPHPRequestSimulatedLogic) && $document->getUsername() == 'apple' && $document->version == 2) {
+            $concurrentPHPRequestSimulatedLogic();
+        }
+
         // Collection updates (deleteRows, updateRows, insertRows)
         foreach ($this->collectionUpdates as $collectionToUpdate) {
             $this->getCollectionPersister()->update($collectionToUpdate, $options);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
@@ -3,9 +3,20 @@
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Documents\PhonenumberDemo;
 
 class VersionTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
+    public function tearDown()
+    {
+        global $concurrentRequestLogic;
+        if (isset($concurrentRequestLogic)) {
+            unset($concurrentRequestLogic);
+        }
+        unset($concurrentRequestLogic);
+        parent::tearDown();
+    }
+
     public function testVersioningWhenManipulatingEmbedMany()
     {
         $expectedVersion = 1;
@@ -36,6 +47,41 @@ class VersionTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $doc->embedMany = null;
         $this->dm->flush();
         $this->assertEquals($expectedVersion++, $doc->version);
+    }
+
+    /**
+     * The ODM does not save database records with embedded documents in an atomic fashion.
+     *
+     * Even with ODM versioning, a concurrent PHP request which happens to load a Mongo record while another PHP
+     * request is writing the same record will load an incomplete and inconsistent version of the Mongo record into a
+     * Doctrine ODM model. This has been a repeated cause of data loss and corruption.
+     */
+    public function testDataConsistencyUsingEmbeddedDocuments()
+    {
+        global $concurrentPHPRequestSimulatedLogic;
+        $user = new \Documents\UserVersionedDemo();
+        $this->dm->persist($user);
+        $this->dm->flush($user);
+        $this->dm->clear();
+        // Imagine a PHP request comes in which modifies the user object.
+        $request1dm = $this->createTestDocumentManager();
+        $request1User = $request1dm->find('Documents\UserVersionedDemo', $user->getId());
+        $request1User->setUsername('apple');
+        $request1User->addPhonenumber(new PhonenumberDemo('1111111111'));
+        // Simulate a concurrent PHP request for the user record.
+        $request2dm = $this->createTestDocumentManager();
+        $request2User = null;
+        $concurrentPHPRequestSimulatedLogic = function () use ($request2dm, $user, &$request2User) {
+            // Simulate a concurrent request loading the database record triggered while request #1 is writing the record.
+            $request2User = $request2dm->find('Documents\UserVersionedDemo', $user->getId());
+        };
+        // Trigger the flush event by PHP request #1.
+        $request1dm->flush($request1User);
+        
+        // Prove that concurrent requests can load version #2 of the record in a consistent state.
+        $this->assertEquals(2, $request2User->version);
+        $this->assertEquals("apple", $request2User->getUsername());
+        $this->assertEquals(1, $request2User->getPhonenumbers()->count(), "Version #2 of the versioned user object should have a phone number embedded document. However, {$request2User->getPhonenumbers()->count()} phone number embedded documents were found");
     }
 }
 

--- a/tests/Documents/PhonenumberDemo.php
+++ b/tests/Documents/PhonenumberDemo.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Documents;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/** @ODM\EmbeddedDocument */
+class PhonenumberDemo
+{
+    /** @ODM\String */
+    private $phonenumber;
+
+    public function getPhonenumber()
+    {
+        return $this->phonenumber;
+    }
+
+    public function setPhonenumber($phonenumber)
+    {
+        $this->phonenumber = $phonenumber;
+    }
+}

--- a/tests/Documents/UserVersionedDemo.php
+++ b/tests/Documents/UserVersionedDemo.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Documents;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document(collection="userversioneddemo")
+ */
+class UserVersionedDemo extends BaseDocument
+{
+    /** @ODM\Id */
+    protected $id;
+
+    /** @ODM\Version @ODM\Int */
+    public $version;
+
+    /** @ODM\Field(type="string") */
+    protected $username;
+
+    /** @ODM\EmbedMany(strategy="set",targetDocument="PhonenumberDemo") */
+    protected $phonenumbers;
+
+    public function __construct()
+    {
+        $this->phonenumbers = new ArrayCollection();
+    }
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getPhonenumbers()
+    {
+        return $this->phonenumbers;
+    }
+
+    public function addPhonenumber(PhonenumberDemo $phonenumber)
+    {
+        $this->phonenumbers[] = $phonenumber;
+    }
+
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    public function setUsername($username)
+    {
+        return $this->username = $username;
+    }
+}


### PR DESCRIPTION
This PR's branch has linage to feature/atomic-many-updates. I created it to demonstrate that the atomic feature that you are shooting for seems not to solve for a key data inconsistency problem I am grappling with.

The ODM does not save database records with embedded documents in an atomic fashion.

Even with ODM versioning, a concurrent PHP request which loads a Mongo record while another PHP request is writing the same record will load an incomplete and inconsistent version of the Mongo record into a Doctrine ODM model. This has been a repeated cause of data loss and corruption.

Repro steps:

Run this unit test:

```
phpunit --filter testDataConsistencyUsingEmbeddedDocuments ./tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php 
```

Result:
```
PHPUnit 4.1.6 by Sebastian Bergmann.

Configuration read from /srv/repos/instant-server/extrashared/mongodb-odm/phpunit.xml

F

Time: 315 ms, Memory: 3.25Mb

There was 1 failure:

1) Doctrine\ODM\MongoDB\Tests\Functional\VersionTest::testDataConsistencyUsingEmbeddedDocuments
Version #2 of the versioned user object should have a phone number embedded document. However, 0 phone number embedded documents were found
Failed asserting that 0 matches expected 1.

/srv/repos/instant-server/extrashared/mongodb-odm/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php:84

FAILURES!
Tests: 1, Assertions: 3, Failures: 1.
```