### PR TITLE
Adding atomicSet and atomicSetArray collection strategies

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -1232,6 +1232,8 @@ Alias of `@Index`_, with the ``unique`` option set by default.
     /** @String @UniqueIndex */
     private $email;
 
+.. _annotations_reference_version:
+
 @Version
 --------
 

--- a/docs/en/reference/collection-strategies.rst
+++ b/docs/en/reference/collection-strategies.rst
@@ -45,12 +45,38 @@ strategy, but will first numerically reindex the collection to ensure that it is
 stored as a BSON array.
 
 ``pushAll``
-------------
+-----------
 
 The ``pushAll`` strategy uses MongoDB's `$pushAll`_ operator to insert
 elements into the array. MongoDB does not allow elements to be added and removed
 from an array in a single operation, so this strategy relies on multiple update
 queries to remove and insert elements (in that order).
+
+``atomicSet``
+-------------
+
+The ``atomicSet`` strategy uses MongoDB's `$set`_ operator to update the entire
+collection with a single update query. Unlike with ``set`` strategy there will
+be only one query for updating both parent document and collection itself. This
+strategy can be especially useful when dealing with high concurrency and 
+:ref:`versioned documents <annotations_reference_version>`.
+
+.. note::
+
+    The ``atomicSet`` and ``atomicSetArray`` strategies may only be used for 
+    collections mapped directly in a top-level document.
+
+``atomicSetArray``
+------------------
+
+The ``atomicSetArray`` strategy works exactly like ``atomicSet`` strategy,  but 
+will first numerically reindex the collection to ensure that it is stored as a 
+BSON array.
+
+.. note::
+
+    The ``atomicSet`` and ``atomicSetArray`` strategies may only be used for 
+    collections mapped directly in a top-level document.
 
 .. _`$addToSet`: http://docs.mongodb.org/manual/reference/operator/addToSet/
 .. _`$pushAll`: http://docs.mongodb.org/manual/reference/operator/pushAll/

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -1149,6 +1149,11 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
         if (isset($mapping['reference']) && ! empty($mapping['simple']) && ! isset($mapping['targetDocument'])) {
             throw MappingException::simpleReferenceRequiresTargetDocument($this->name, $mapping['fieldName']);
         }
+        
+        if ($this->isEmbeddedDocument && isset($mapping['strategy']) &&
+                ($mapping['strategy'] === 'atomicSet' || $mapping['strategy'] === 'atomicSetArray')) {
+            throw MappingException::atomicCollectionStrategyNotAllowed($mapping['strategy'], $this->name, $mapping['fieldName']);
+        }
 
         if (isset($mapping['reference']) && $mapping['type'] === 'one') {
             $mapping['association'] = self::REFERENCE_ONE;
@@ -1235,6 +1240,10 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
      */
     public function mapManyEmbedded(array $mapping)
     {
+        if ($this->isEmbeddedDocument && isset($mapping['strategy']) &&
+                ($mapping['strategy'] === 'atomicSet' || $mapping['strategy'] === 'atomicSetArray')) {
+            throw MappingException::atomicCollectionStrategyNotAllowed($mapping['strategy'], $this->name, $mapping['fieldName']);
+        }
         $mapping['embedded'] = true;
         $mapping['type'] = 'many';
         $this->mapField($mapping);
@@ -1259,6 +1268,10 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
      */
     public function mapManyReference(array $mapping)
     {
+        if ($this->isEmbeddedDocument && isset($mapping['strategy']) &&
+                ($mapping['strategy'] === 'atomicSet' || $mapping['strategy'] === 'atomicSetArray')) {
+            throw MappingException::atomicCollectionStrategyNotAllowed($mapping['strategy'], $this->name, $mapping['fieldName']);
+        }
         $mapping['reference'] = true;
         $mapping['type'] = 'many';
         $this->mapField($mapping);

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -173,4 +173,9 @@ class MappingException extends BaseMappingException
     {
         return new self("Target document must be specified for simple reference: $className::$fieldName");
     }
+    
+    public static function atomicCollectionStrategyNotAllowed($strategy, $className, $fieldName)
+    {
+        return new self("$strategy collection strategy can be used only in top level document, used in $className::$fieldName");
+    }
 }

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -188,7 +188,7 @@ class PersistentCollection implements BaseCollection
         // Reattach any NEW objects added through add()
         if ($newObjects) {
             foreach ($newObjects as $key => $obj) {
-                if ($this->mapping['strategy'] === 'set') {
+                if ($this->mapping['strategy'] === 'set' || $this->mapping['strategy'] === 'atomicSet') {
                     $this->coll->set($key, $obj);
                 } else {
                     $this->coll->add($obj);

--- a/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
@@ -375,7 +375,7 @@ class PersistenceBuilder
                         })->toArray();
 
                         // Numerical reindexing may be necessary to ensure BSON array storage
-                        if (in_array($mapping['strategy'], array('setArray', 'pushAll', 'addToSet'))) {
+                        if (in_array($mapping['strategy'], array('atomicSetArray', 'setArray', 'pushAll', 'addToSet'))) {
                             $value = array_values($value);
                         }
                         break;

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -937,7 +937,7 @@ class UnitOfWork implements PropertyChangedListener
             $state = $this->getDocumentState($entry, self::STATE_NEW);
 
             // Handle "set" strategy for multi-level hierarchy
-            $pathKey = $mapping['strategy'] !== 'set' ? $count : $key;
+            $pathKey = ($mapping['strategy'] !== 'set' && $mapping['strategy'] !== 'atomicSet') ? $count : $key;
             $path = $mapping['type'] === 'many' ? $mapping['name'] . '.' . $pathKey : $mapping['name'];
 
             $count++;
@@ -2698,6 +2698,22 @@ class UnitOfWork implements PropertyChangedListener
     {
         return in_array($coll, $this->collectionDeletions, true);
     }
+    
+    /**
+     * INTERNAL:
+     * Unschedules a collection from being updated deleted when this UnitOfWork commits.
+     * Effectively this is used for atomicSet and atomicSetArray update strategies.
+     * The method doesn't remove $coll from $this->hasScheduledCollections because
+     * it is called only from DocumentPersister resolving that very document
+     * 
+     * @param \Doctrine\ODM\MongoDB\PersistentCollection $coll
+     */
+    public function unscheduleCollectionDeletion(PersistentCollection $coll)
+    {
+        if (($key = array_search($coll, $this->collectionDeletions, true)) !== false) {
+            unset($this->collectionDeletions[$key]);
+        }
+    }
 
     /**
      * INTERNAL:
@@ -2712,6 +2728,22 @@ class UnitOfWork implements PropertyChangedListener
     }
     
     /**
+     * INTERNAL:
+     * Unschedules a collection from being updated update when this UnitOfWork commits.
+     * Effectively this is used for atomicSet and atomicSetArray update strategies.
+     * The method doesn't remove $coll from $this->hasScheduledCollections because
+     * it is called only from DocumentPersister resolving that very document
+     * 
+     * @param \Doctrine\ODM\MongoDB\PersistentCollection $coll
+     */
+    public function unscheduleCollectionUpdate(PersistentCollection $coll)
+    {
+        if (($key = array_search($coll, $this->collectionUpdates, true)) !== false) {
+            unset($this->collectionUpdates[$key]);
+        }
+    }
+    
+    /**
      * Checks whether a PersistentCollection is scheduled for update.
      *
      * @param PersistentCollection $coll
@@ -2720,6 +2752,21 @@ class UnitOfWork implements PropertyChangedListener
     public function isCollectionScheduledForUpdate(PersistentCollection $coll)
     {
         return in_array($coll, $this->collectionUpdates, true);
+    }
+    
+    /**
+     * INTERNAL:
+     * Gets PersistentCollections that are scheduled to update and related to $document
+     * 
+     * @param object $document
+     * @return array
+     */
+    public function getScheduledCollections($document)
+    {
+        $oid = spl_object_hash($document);
+        return isset($this->hasScheduledCollections[$oid]) 
+                ? $this->hasScheduledCollections[$oid]
+                : array();
     }
     
     /**
@@ -2752,8 +2799,9 @@ class UnitOfWork implements PropertyChangedListener
             list(, $document, ) = $this->getParentAssociation($document);
             $class = $this->dm->getClassMetadata(get_class($document));
         }
+        $oid = spl_object_hash($document);
 
-        $this->hasScheduledCollections[spl_object_hash($document)] = true;
+        $this->hasScheduledCollections[$oid][] = $coll;
 
         if ( ! $this->isDocumentScheduled($document)) {
             $this->scheduleForUpdate($document);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Documents\Phonebook;
+use Documents\Phonenumber;
+
+/**
+ * CollectionPersister will throw exception when collection with atomicSet
+ * or atomicSetArray should be handled by it. If no exception was thrown it
+ * means that collection update was handled by DocumentPersister.
+ */
+class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testAtomicInsertAndUpdate()
+    {
+        $user = new AtomicUser('Maciej');
+        $user->phonenumbers['home'] = new Phonenumber('12345678');
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $user->surname = "Malarz";
+        $user->phonenumbers['work'] = new Phonenumber('87654321');
+        $this->dm->flush();
+        $this->dm->clear();
+        $newUser = $this->dm->getRepository(get_class($user))->find($user->id);
+        $this->assertEquals('Maciej', $newUser->name);
+        $this->assertEquals('Malarz', $newUser->surname);
+        $this->assertCount(2, $newUser->phonenumbers);
+        $this->assertNotNull($newUser->phonenumbers->get('home'));
+        $this->assertNotNull($newUser->phonenumbers->get('work'));
+    }
+    
+    public function testAtomicUpsert()
+    {
+        $user = new AtomicUser('Maciej');
+        $user->id = new \MongoId();
+        $user->phonenumbers[] = new Phonenumber('12345678');
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $this->dm->clear();
+        $newUser = $this->dm->getRepository(get_class($user))->find($user->id);
+        $this->assertEquals('Maciej', $newUser->name);
+        $this->assertCount(1, $newUser->phonenumbers);
+    }
+    
+    public function testAtomicCollectionUnset()
+    {
+        $user = new AtomicUser('Maciej');
+        $user->phonenumbers[] = new Phonenumber('12345678');
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $user->surname = "Malarz";
+        $user->phonenumbers = null;
+        $this->dm->flush();
+        $this->dm->clear();
+        $newUser = $this->dm->getRepository(get_class($user))->find($user->id);
+        $this->assertEquals('Maciej', $newUser->name);
+        $this->assertEquals('Malarz', $newUser->surname);
+        $this->assertCount(0, $newUser->phonenumbers);
+    }
+    
+    public function testAtomicSetArray()
+    {
+        $user = new AtomicUser('Maciej');
+        $user->phonenumbersArray[] = new Phonenumber('12345678');
+        $user->phonenumbersArray[] = new Phonenumber('87654321');
+        $this->dm->persist($user);
+        $this->dm->flush();
+        unset($user->phonenumbersArray[0]);
+        $this->dm->flush();
+        $this->dm->clear();
+        $newUser = $this->dm->getRepository(get_class($user))->find($user->id);
+        $this->assertCount(1, $newUser->phonenumbersArray);
+        $this->assertFalse(isset($newUser->phonenumbersArray[1]));
+    }
+    
+    public function testAtomicCollectionWithAnotherNested()
+    {
+        $user = new AtomicUser('Maciej');
+        $phonebook = new Phonebook('Private');
+        $phonebook->addPhonenumber(new Phonenumber('12345678'));
+        $user->phonebooks['private'] = $phonebook;
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $this->dm->clear();
+        $newUser = $this->dm->getRepository(get_class($user))->find($user->id);
+        $this->assertNotNull($newUser->phonebooks->get('private'));
+        $this->assertCount(1, $newUser->phonebooks->get('private')->getPhonenumbers());
+    }
+}
+
+/**
+ * @ODM\Document
+ */
+class AtomicUser
+{
+    /** @ODM\Id */
+    public $id;
+    
+    /** @ODM\String */
+    public $name;
+    
+    /** @ODM\String */
+    public $surname;
+    
+    /** @ODM\EmbedMany(strategy="atomicSet", targetDocument="Documents\Phonenumber") */
+    public $phonenumbers;
+    
+    /** @ODM\EmbedMany(strategy="atomicSetArray", targetDocument="Documents\Phonenumber") */
+    public $phonenumbersArray;
+    
+    /** @ODM\EmbedMany(strategy="atomicSet", targetDocument="Documents\Phonebook") */
+    public $phonebooks;
+    
+    public function __construct($name)
+    {
+        $this->name = $name;
+        $this->phonenumbers = new ArrayCollection();
+        $this->phonenumbersArray = new ArrayCollection();
+        $this->phonebooks = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataInfoTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataInfoTest.php
@@ -234,6 +234,23 @@ class ClassMetadataInfoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             'simple' => true,
         ));
     }
+    
+    /**
+     * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
+     * @expectedExceptionMessage atomicSet collection strategy can be used only in top level document, used in stdClass::many
+     */
+    public function testAtomicCollectionUpdateUsageInEmbeddedDocument()
+    {
+        $cm = new ClassMetadataInfo('stdClass');
+        $cm->isEmbeddedDocument = true;
+
+        $cm->mapField(array(
+            'fieldName' => 'many',
+            'reference' => true,
+            'type' => 'many',
+            'strategy' => 'atomicSet',
+        ));
+    }
 }
 
 class TestCustomRepositoryClass extends DocumentRepository

--- a/tests/Documents/Phonebook.php
+++ b/tests/Documents/Phonebook.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Documents;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/** @ODM\EmbeddedDocument */
+class Phonebook
+{
+    /** @ODM\String */
+    private $title;
+    
+    /** @ODM\EmbedMany(targetDocument="Phonenumber") */
+    private $phonenumbers;
+    
+    public function __construct($title)
+    {
+        $this->title = $title;
+        $this->phonenumbers = new ArrayCollection();
+    }
+    
+    public function getTitle()
+    {
+        return $this->title;
+    }
+    
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+    
+    public function addPhonenumber(Phonenumber $phonenumber)
+    {
+        $this->phonenumbers->add($phonenumber);
+    }
+    
+    public function getPhonenumbers()
+    {
+        return $this->phonenumbers;
+    }
+    
+    public function removePhonenumber(Phonenumber $phonenumber)
+    {
+        $this->phonenumbers->removeElement($phonenumber);
+    }
+}


### PR DESCRIPTION
This is an early implementation of how ``atomicSet`` and ``atomicSetArray`` could work in my opinion. There are some things that needs to be done

- [x] ~~maybe add `atomic=true` flag to mapping instead of new strategy (or change existing `$set` behaviour)~~
- [x] inserts
- [x] updates
- [x] upserts
- [x] removing collection
- [x] ~~collection within collection with different strategies~~ throw exception if used in embedded documents
- [x] more tests
- [x] docs

cc @jwage @jmikola @alcaeus @lavoiesl @blockjon

If this PR will reach its final form it will resolve #1009, #437, #1095 and #1094  