### PR TITLE
implementation for https://github.com/doctrine/mongodb-odm/issues/1106

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -260,7 +260,10 @@ class PersistentCollection implements BaseCollection
     {
         $this->owner = $document;
         $this->mapping = $mapping;
-        $this->typeClass = $this->dm->getClassMetadata($this->mapping['targetDocument']);
+
+        if (!empty($this->mapping['targetDocument'])) {
+            $this->typeClass = $this->dm->getClassMetadata($this->mapping['targetDocument']);
+        }
     }
 
     /**
@@ -346,9 +349,14 @@ class PersistentCollection implements BaseCollection
 
     /**
      * @return ClassMetadata
+     * @throws MongoDBException
      */
     public function getTypeClass()
     {
+        if (empty($this->typeClass)) {
+            throw new MongoDBException('targetDocument option is required for typeClass');
+        }
+
         return $this->typeClass;
     }
 

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -102,6 +102,11 @@ class PersistentCollection implements BaseCollection
     private $hints = array();
 
     /**
+     * @var ClassMetadata
+     */
+    private $typeClass;
+
+    /**
      * @param BaseCollection $coll
      * @param DocumentManager $dm
      * @param UnitOfWork $uow
@@ -255,6 +260,7 @@ class PersistentCollection implements BaseCollection
     {
         $this->owner = $document;
         $this->mapping = $mapping;
+        $this->typeClass = $this->dm->getClassMetadata($this->mapping['targetDocument']);
     }
 
     /**
@@ -330,11 +336,17 @@ class PersistentCollection implements BaseCollection
         return $this->owner;
     }
 
+    /**
+     * @return array
+     */
     public function getMapping()
     {
         return $this->mapping;
     }
 
+    /**
+     * @return ClassMetadata
+     */
     public function getTypeClass()
     {
         return $this->typeClass;

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -261,7 +261,7 @@ class PersistentCollection implements BaseCollection
         $this->owner = $document;
         $this->mapping = $mapping;
 
-        if (!empty($this->mapping['targetDocument'])) {
+        if ( ! empty($this->mapping['targetDocument'])) {
             $this->typeClass = $this->dm->getClassMetadata($this->mapping['targetDocument']);
         }
     }
@@ -354,7 +354,7 @@ class PersistentCollection implements BaseCollection
     public function getTypeClass()
     {
         if (empty($this->typeClass)) {
-            throw new MongoDBException('targetDocument option is required for typeClass');
+            throw new MongoDBException('Specifying targetDocument is required for the ClassMetadata to be obtained.');
         }
 
         return $this->typeClass;

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -9,6 +9,9 @@ use Doctrine\MongoDB\Connection;
 
 abstract class BaseTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var DocumentManager
+     */
     protected $dm;
     protected $uow;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -501,7 +501,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     }
 
     /**
-     * @expectedException MongoDBException
+     * @expectedException \Doctrine\ODM\MongoDB\MongoDBException
      */
     public function testTypeClassMissing()
     {
@@ -695,7 +695,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testNotSameCollectionThrowsException()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -522,7 +522,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         /** @var $test FavoritesUser */
-        $test = $this->dm->getDocumentCollection('Documents\Functional\FavoritesUser')->findOne(array('name' => 'favorites'));
+        $test = $this->dm->find('Documents\Functional\FavoritesUser', $user->getId());
 
         /** @var $collection PersistentCollection */
         $collection = $test->getFavorites();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\PersistentCollection;
+use Documents\Bars\Bar;
 use Documents\Bars\Location;
 use Documents\User;
 use Documents\Account;
@@ -542,7 +543,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $test = $this->dm->find('Documents\Bars\Bar', $bar->getId());
 
         /** @var $collection PersistentCollection */
-        $collection = $test->getFavorites();
+        $collection = $test->getLocations();
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\Mapping\ClassMetadata', $collection->getTypeClass());
     }
 

--- a/tests/Documents/Functional/FavoritesUser.php
+++ b/tests/Documents/Functional/FavoritesUser.php
@@ -35,7 +35,7 @@ class FavoritesUser
 
     public function getId()
     {
-        return $this->getId();
+        return $this->id;
     }
 
     public function setFavorite($favorite)

--- a/tests/Documents/Functional/FavoritesUser.php
+++ b/tests/Documents/Functional/FavoritesUser.php
@@ -33,6 +33,11 @@ class FavoritesUser
     /** @ODM\EmbedOne */
     private $embed;
 
+    public function getId()
+    {
+        return $this->getId();
+    }
+
     public function setFavorite($favorite)
     {
         $this->favorite = $favorite;


### PR DESCRIPTION
Set typeClass once owner information is passed to collection

-> this does not require any change outside of the Persistent Collection
-> also fixed usage of ODM in https://github.com/sonata-project/SonataAdminBundle/pull/2985