### PR TITLE
Prime references only from eagerCursor

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Cursor.php
+++ b/lib/Doctrine/ODM/MongoDB/Cursor.php
@@ -24,7 +24,6 @@ use Doctrine\MongoDB\Connection;
 use Doctrine\MongoDB\Cursor as BaseCursor;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Query\Query;
-use Doctrine\ODM\MongoDB\Query\ReferencePrimer;
 
 /**
  * Wrapper for the Doctrine\MongoDB\Cursor class.
@@ -77,27 +76,6 @@ class Cursor extends BaseCursor
      * @var array
      */
     private $unitOfWorkHints = array();
-
-    /**
-     * ReferencePrimer object for priming references
-     *
-     * @var ReferencePrimer
-     */
-    private $referencePrimer;
-
-    /**
-     * Primers
-     *
-     * @var array
-     */
-    private $primers = array();
-
-    /**
-     * Whether references have been primed
-     *
-     * @var bool
-     */
-    private $referencesPrimed = false;
 
     /**
      * Constructor.
@@ -240,8 +218,6 @@ class Cursor extends BaseCursor
      */
     public function current()
     {
-        $this->primeReferences();
-
         $current = $this->baseCursor->current();
 
         if ($current !== null && $this->hydrate) {
@@ -474,37 +450,5 @@ class Cursor extends BaseCursor
     {
         $this->baseCursor->timeout($ms);
         return $this;
-    }
-
-    /**
-     * @param array $primers
-     * @param ReferencePrimer $referencePrimer
-     * @return self
-     */
-    public function enableReferencePriming(array $primers, ReferencePrimer $referencePrimer)
-    {
-        $this->referencePrimer = $referencePrimer;
-        $this->primers = $primers;
-        return $this;
-    }
-
-    /**
-     * Prime references
-     */
-    protected function primeReferences()
-    {
-        if ($this->referencesPrimed || !$this->hydrate) {
-            return;
-        }
-
-        $this->referencesPrimed = true;
-
-        foreach ($this->primers as $fieldName => $primer) {
-            $this->rewind();
-            $primer = is_callable($primer) ? $primer : null;
-            $this->referencePrimer->primeReferences($this->class, $this, $fieldName, $this->unitOfWorkHints, $primer);
-        }
-
-        $this->rewind();
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/EagerCursor.php
+++ b/lib/Doctrine/ODM/MongoDB/EagerCursor.php
@@ -232,14 +232,13 @@ class EagerCursor extends BaseEagerCursor
      */
     protected function primeReferences()
     {
-        if ($this->referencesPrimed || !$this->hydrate) {
+        if ($this->referencesPrimed || !$this->hydrate || empty($this->primers)) {
             return;
         }
 
         $this->referencesPrimed = true;
 
         foreach ($this->primers as $fieldName => $primer) {
-            $this->rewind();
             $primer = is_callable($primer) ? $primer : null;
             $this->referencePrimer->primeReferences($this->class, $this, $fieldName, $this->unitOfWorkHints, $primer);
         }

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -147,9 +147,27 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
             throw new \InvalidArgumentException('$primer is not a boolean or callable');
         }
 
+        if (array_key_exists('eagerCursor', $this->query) && !$this->query['eagerCursor']) {
+            throw new \BadMethodCallException("Can't call prime() when setting eagerCursor to false");
+        }
+
+        $this->eagerCursor(true);
         $this->primers[$this->currentField] = $primer;
         return $this;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function eagerCursor($bool = true)
+    {
+        if ( ! $bool && ! empty($this->primers)) {
+            throw new \BadMethodCallException("Can't set eagerCursor to false when using reference primers");
+        }
+
+        return parent::eagerCursor($bool);
+    }
+
 
     /**
      * @param bool $bool

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH520Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH520Test.php
@@ -32,9 +32,12 @@ class GH520Test extends BaseTest
     {
         /* Since Query::getSingleResult() exists for Doctrine MongoDB's
          * IteratorAggregate interface, it executes the query and obtains an
-         * iterator before calling Iterator::getSingleResult(). If priming is
-         * configured, references among all documents in the result set will be
-         * primed -- not simply those in the first document.
+         * iterator before calling Iterator::getSingleResult(). Since priming
+         * implies an EagerCursor, all documents will be fetched and all of
+         * their references will be primed (not simply the first document and
+         * its references). As a result, users that wish to combine
+         * getSingleResult() with priming should also specify a limit on their
+         * queries.
          *
          * This behavior is not ideal, but a workaround would further complicate
          * ODM's Query class. A userland solution would be to simply enforce a
@@ -66,7 +69,7 @@ class GH520Test extends BaseTest
         $result = $query->getSingleResult();
 
         $this->assertContains($document2->id, $primedIds);
-        $this->assertNotContains($document4->id, $primedIds, 'Only the dataset being fetched should be primed');
+        $this->assertContains($document4->id, $primedIds, 'The entire dataset is fetched and primed');
     }
 }
 


### PR DESCRIPTION
This PR fixes a potential performance issue introduced with #1068. When using reference primers with non-eager cursors, the query would be executed multiple times, sometimes producing inconsistent results.
Using reference priming now implies using an eager cursor. Using eagerCursor = false and reference primers will result in an error.

Unfortunately, this re-introduces an issue described in #520, where calling ```getSingleResult()``` on a cursor with reference primers will always prime the entire result set.