### PR TITLE
Functional test to exhibit bug: strategy="atomicSet" does not atomically update a database record

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
@@ -8,37 +8,37 @@ use Doctrine\Common\Collections\ArrayCollection as ArrayCollection;
 
 class VersionTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
-//    public function testVersioningWhenManipulatingEmbedMany()
-//    {
-//        $expectedVersion = 1;
-//        $doc = new VersionedDocument();
-//        $doc->name = 'test';
-//        $doc->embedMany[] = new VersionedEmbeddedDocument('embed 1');
-//        $doc->embedMany[] = new VersionedEmbeddedDocument('embed 2');
-//        $this->dm->persist($doc);
-//        $this->dm->flush();
-//        $this->assertEquals($expectedVersion++, $doc->version);
-//
-//        $doc->embedMany[] = new VersionedEmbeddedDocument('embed 3');
-//        $this->dm->flush();
-//        $this->assertEquals($expectedVersion++, $doc->version);
-//
-//        $doc->embedMany[0]->embedMany[] = new VersionedEmbeddedDocument('deeply embed 1');
-//        $this->dm->flush();
-//        $this->assertEquals($expectedVersion++, $doc->version);
-//
-//        unset($doc->embedMany[1]);
-//        $this->dm->flush();
-//        $this->assertEquals($expectedVersion++, $doc->version);
-//
-//        $doc->embedMany->clear();
-//        $this->dm->flush();
-//        $this->assertEquals($expectedVersion++, $doc->version);
-//
-//        $doc->embedMany = null;
-//        $this->dm->flush();
-//        $this->assertEquals($expectedVersion++, $doc->version);
-//    }
+    public function testVersioningWhenManipulatingEmbedMany()
+    {
+        $expectedVersion = 1;
+        $doc = new VersionedDocument();
+        $doc->name = 'test';
+        $doc->embedMany[] = new VersionedEmbeddedDocument('embed 1');
+        $doc->embedMany[] = new VersionedEmbeddedDocument('embed 2');
+        $this->dm->persist($doc);
+        $this->dm->flush();
+        $this->assertEquals($expectedVersion++, $doc->version);
+
+        $doc->embedMany[] = new VersionedEmbeddedDocument('embed 3');
+        $this->dm->flush();
+        $this->assertEquals($expectedVersion++, $doc->version);
+
+        $doc->embedMany[0]->embedMany[] = new VersionedEmbeddedDocument('deeply embed 1');
+        $this->dm->flush();
+        $this->assertEquals($expectedVersion++, $doc->version);
+
+        unset($doc->embedMany[1]);
+        $this->dm->flush();
+        $this->assertEquals($expectedVersion++, $doc->version);
+
+        $doc->embedMany->clear();
+        $this->dm->flush();
+        $this->assertEquals($expectedVersion++, $doc->version);
+
+        $doc->embedMany = null;
+        $this->dm->flush();
+        $this->assertEquals($expectedVersion++, $doc->version);
+    }
 
     public function testAtomicSetWorksAsExpected()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
@@ -3,39 +3,94 @@
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\Common\Collections\ArrayCollection as ArrayCollection;
 
 class VersionTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
-    public function testVersioningWhenManipulatingEmbedMany()
+//    public function testVersioningWhenManipulatingEmbedMany()
+//    {
+//        $expectedVersion = 1;
+//        $doc = new VersionedDocument();
+//        $doc->name = 'test';
+//        $doc->embedMany[] = new VersionedEmbeddedDocument('embed 1');
+//        $doc->embedMany[] = new VersionedEmbeddedDocument('embed 2');
+//        $this->dm->persist($doc);
+//        $this->dm->flush();
+//        $this->assertEquals($expectedVersion++, $doc->version);
+//
+//        $doc->embedMany[] = new VersionedEmbeddedDocument('embed 3');
+//        $this->dm->flush();
+//        $this->assertEquals($expectedVersion++, $doc->version);
+//
+//        $doc->embedMany[0]->embedMany[] = new VersionedEmbeddedDocument('deeply embed 1');
+//        $this->dm->flush();
+//        $this->assertEquals($expectedVersion++, $doc->version);
+//
+//        unset($doc->embedMany[1]);
+//        $this->dm->flush();
+//        $this->assertEquals($expectedVersion++, $doc->version);
+//
+//        $doc->embedMany->clear();
+//        $this->dm->flush();
+//        $this->assertEquals($expectedVersion++, $doc->version);
+//
+//        $doc->embedMany = null;
+//        $this->dm->flush();
+//        $this->assertEquals($expectedVersion++, $doc->version);
+//    }
+
+    public function testAtomicSetWorksAsExpected()
     {
-        $expectedVersion = 1;
-        $doc = new VersionedDocument();
-        $doc->name = 'test';
-        $doc->embedMany[] = new VersionedEmbeddedDocument('embed 1');
-        $doc->embedMany[] = new VersionedEmbeddedDocument('embed 2');
-        $this->dm->persist($doc);
-        $this->dm->flush();
-        $this->assertEquals($expectedVersion++, $doc->version);
+        global $queries_detected;
 
-        $doc->embedMany[] = new VersionedEmbeddedDocument('embed 3');
-        $this->dm->flush();
-        $this->assertEquals($expectedVersion++, $doc->version);
-        
-        $doc->embedMany[0]->embedMany[] = new VersionedEmbeddedDocument('deeply embed 1');
-        $this->dm->flush();
-        $this->assertEquals($expectedVersion++, $doc->version);
-        
-        unset($doc->embedMany[1]);
-        $this->dm->flush();
-        $this->assertEquals($expectedVersion++, $doc->version);
+        $dm = $this->dm;
 
-        $doc->embedMany->clear();
-        $this->dm->flush();
-        $this->assertEquals($expectedVersion++, $doc->version); 
-        
-        $doc->embedMany = null;
-        $this->dm->flush();
-        $this->assertEquals($expectedVersion++, $doc->version);
+        // Create a book which has one chapter with one page.
+        $chapter1 = new Chapter();
+        $chapter1->addPage(new Page(1));
+        $book = new Book('HARRY POTTER');
+        $book->addChapter($chapter1);
+
+        $dm->persist($book);
+
+        // Saving this book should result in 1 query since we use strategy="atomicFlush"
+        $queries_detected = [];
+        $dm->flush();
+        $this->assertEquals(1, count($queries_detected));
+
+        $id = $book->id;
+
+        // Simulate another PHP request which loads this record and tries to add an embedded document two levels deep...
+        $dm->clear();
+        $book = $dm->getRepository('Doctrine\ODM\MongoDB\Tests\Functional\Book')->findOneBy(array('_id' => $id));
+
+        // Now we add a new "page" to the only chapter in this book.
+        $firstChapter = $book->getChapters()->first();
+        $firstChapter->addPage(new Page(2));
+
+        // Updating this book should result in 1 query since we use strategy="atomicFlush"
+        $queries_detected = [];
+        $dm->flush();
+        $num_queries = count($queries_detected);
+
+        $this->assertEquals(1, $num_queries, "Despite use of atomicSet, $num_queries queries were detected when flushing this change. We expected only one query. This will result in data loss and corruption.");
+    }
+
+    protected function getConfiguration()
+    {
+        $config = parent::getConfiguration();
+        $config->setLoggerCallable(array($this, 'notifyQueryTriggered'));
+        return $config;
+    }
+
+    public function notifyQueryTriggered($event)
+    {
+        global $queries_detected;
+        if ($queries_detected == null) {
+            $queries_detected = [];
+        }
+        $queries_detected[] = $event;
     }
 }
 
@@ -77,5 +132,90 @@ class VersionedEmbeddedDocument
     {
         $this->value = $value;
         $this->embedMany = new \Doctrine\Common\Collections\ArrayCollection();
+    }
+}
+
+// --
+
+/**
+ * @ODM\Document
+ */
+class Book
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\Int @ODM\Version */
+    public $version = 1;
+
+    /** @ODM\String */
+    public $name;
+
+    /**
+     * @ODM\EmbedMany(
+     *  targetDocument="Chapter",
+     *  strategy="atomicSet"
+     * )
+     */
+    public $chapters;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+        $this->chapters = new ArrayCollection();
+    }
+
+    public function addChapter(Chapter $chapter)
+    {
+        $this->chapters->add($chapter);
+    }
+
+    public function getChapters()
+    {
+        return $this->chapters;
+    }
+}
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class Chapter
+{
+    /**
+     * @ODM\EmbedMany(
+     *  targetDocument="Chapter"
+     * )
+     */
+    public $pages;
+
+    public function __construct()
+    {
+        $this->pages = new ArrayCollection();
+    }
+
+    public function addPage(Page $page)
+    {
+        $this->pages->add($page);
+    }
+
+    public function getPages()
+    {
+        return $this->pages;
+    }
+}
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class Page
+{
+    /**
+     * @ODM\Int
+     */
+    public $page_number;
+
+    public function __construct($page_number)
+    {
+        $this->page_number = $page_number;
     }
 }


### PR DESCRIPTION
Beta13 introduced @malarzm 's https://github.com/doctrine/mongodb-odm/pull/1096 which helps make Doctrine ODM atomically insert and update records.

I was just checking my application and in which I have been experiencing data loss & corruption but I see the problem is still not fixed, even with atomicSet enabled using beta13.

I believe the problem may be that the solution introduced in https://github.com/doctrine/mongodb-odm/pull/1096 does not correctly handle embedMany's that are nested inside each other when changes are made to the embedded collection which is 2 levels down.

In this PR, I demonstrate this problem by creating a Book object which has 1 Chapter .. and where the chapter has 1 Page.  (book->chapters->pages) When I insert the object using strategy="atomicSet", everything is saved in a single atomic operation - this is very very good.

However, when I load the object from the database and try to add a new Page to the chapter, Doctrine executes two separate queries. For me, this means continued data loss & corruption.

Here's how to reproduce the failing test:
```
phpunit --filter testAtomicSetWorksAsExpected
```
output:
```
PHPUnit 4.1.6 by Sebastian Bergmann.

Configuration read from /mongodb-odm/phpunit.xml

F

Time: 1.44 seconds, Memory: 21.25Mb

There was 1 failure:

1) Doctrine\ODM\MongoDB\Tests\Functional\VersionTest::testAtomicSetWorksAsExpected
Despite use of atomicSet, 2 queries were detected when flushing this change. We expected only one query.
Failed asserting that 2 matches expected 1.

/mongodb-odm/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php:77

FAILURES!
Tests: 1, Assertions: 2, Failures: 1.

```