### PR TITLE
Ensure atomic collection updates use only one query

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2701,10 +2701,14 @@ class UnitOfWork implements PropertyChangedListener
     
     /**
      * INTERNAL:
-     * Unschedules a collection from being updated deleted when this UnitOfWork commits.
-     * Effectively this is used for atomicSet and atomicSetArray update strategies.
-     * The method doesn't remove $coll from $this->hasScheduledCollections because
-     * it is called only from DocumentPersister resolving that very document
+     * Unschedules a collection from being deleted when this UnitOfWork commits.
+     * This is mainly used for the atomicSet and atomicSetArray strategies and
+     * called from DocumentPersister and PersistenceBuilder.
+     *
+     * This does not remove $coll from $this->hasScheduledCollections because
+     * DocumentPersister will already have called hasScheduledCollections()
+     * before deciding to include any collections with an atomic strategy in its
+     * update query.
      * 
      * @param \Doctrine\ODM\MongoDB\PersistentCollection $coll
      */
@@ -2729,10 +2733,14 @@ class UnitOfWork implements PropertyChangedListener
     
     /**
      * INTERNAL:
-     * Unschedules a collection from being updated update when this UnitOfWork commits.
-     * Effectively this is used for atomicSet and atomicSetArray update strategies.
-     * The method doesn't remove $coll from $this->hasScheduledCollections because
-     * it is called only from DocumentPersister resolving that very document
+     * Unschedules a collection from being updated when this UnitOfWork commits.
+     * This is mainly used for the atomicSet and atomicSetArray strategies and
+     * called from DocumentPersister and PersistenceBuilder.
+     *
+     * This does not remove $coll from $this->hasScheduledCollections because
+     * DocumentPersister will already have called hasScheduledCollections()
+     * before deciding to include any collections with an atomic strategy in its
+     * update query.
      * 
      * @param \Doctrine\ODM\MongoDB\PersistentCollection $coll
      */

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -19,6 +19,11 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
      */
     protected $uow;
 
+    /**
+     * @var QueryLogger
+     */
+    protected $ql;
+
     public function setUp()
     {
         $this->dm = $this->createTestDocumentManager();
@@ -51,6 +56,9 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
 
         $config->addFilter('testFilter', 'Doctrine\ODM\MongoDB\Tests\Query\Filter\Filter');
         $config->addFilter('testFilter2', 'Doctrine\ODM\MongoDB\Tests\Query\Filter\Filter');
+
+        $this->ql = new QueryLogger();
+        $config->setLoggerCallable(array($this->ql, 'log'));
 
         return $config;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -19,11 +19,6 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
      */
     protected $uow;
 
-    /**
-     * @var QueryLogger
-     */
-    protected $ql;
-
     public function setUp()
     {
         $this->dm = $this->createTestDocumentManager();
@@ -56,9 +51,6 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
 
         $config->addFilter('testFilter', 'Doctrine\ODM\MongoDB\Tests\Query\Filter\Filter');
         $config->addFilter('testFilter2', 'Doctrine\ODM\MongoDB\Tests\Query\Filter\Filter');
-
-        $this->ql = new QueryLogger();
-        $config->setLoggerCallable(array($this->ql, 'log'));
 
         return $config;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
@@ -211,6 +211,9 @@ class AtomicUser
     
     /** @ODM\String */
     public $name;
+
+    /** @ODM\Int @ODM\Version */
+    public $version = 1;
     
     /** @ODM\String */
     public $surname;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
@@ -100,7 +100,7 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals('Malarz', $user->surname);
         $this->assertCount(0, $user->phonenumbers);
     }
-    
+
     public function testAtomicSetArray()
     {
         $user = new AtomicUser('Maciej');
@@ -198,7 +198,7 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->persist($user);
         $this->dm->flush();
         $this->assertCount(1, $this->ql, 'Inserting a document with nested embed-many collections requires one query');
-        
+
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
         $this->assertCount(1, $user->inception);
         $this->assertEquals($user->inception[0]->value, 'start');
@@ -223,28 +223,28 @@ class AtomicUser
 {
     /** @ODM\Id */
     public $id;
-    
+
     /** @ODM\String */
     public $name;
 
     /** @ODM\Int @ODM\Version */
     public $version = 1;
-    
+
     /** @ODM\String */
     public $surname;
-    
+
     /** @ODM\EmbedMany(strategy="atomicSet", targetDocument="Documents\Phonenumber") */
     public $phonenumbers;
-    
+
     /** @ODM\EmbedMany(strategy="atomicSetArray", targetDocument="Documents\Phonenumber") */
     public $phonenumbersArray;
-    
+
     /** @ODM\EmbedMany(strategy="atomicSet", targetDocument="Documents\Phonebook") */
     public $phonebooks;
-    
+
     /** @ODM\EmbedMany(strategy="atomicSet", targetDocument="GonnaBeDeep") */
     public $inception;
-    
+
     public function __construct($name)
     {
         $this->name = $name;
@@ -261,13 +261,13 @@ class GonnaBeDeep
 {
     /** @ODM\String */
     public $value;
-    
+
     /** @ODM\EmbedOne(targetDocument="GonnaBeDeep") */
     public $one;
-    
+
     /** @ODM\EmbedMany(targetDocument="GonnaBeDeep") */
     public $many;
-    
+
     public function __construct($value)
     {
         $this->value = $value;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
@@ -31,7 +31,7 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testAtomicInsertAndUpdate()
     {
-        $user = new AtomicUser('Maciej');
+        $user = new AtomicSetUser('Maciej');
         $user->phonenumbers[] = new Phonenumber('12345678');
         $this->dm->persist($user);
         $this->dm->flush();
@@ -60,7 +60,7 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testAtomicUpsert()
     {
-        $user = new AtomicUser('Maciej');
+        $user = new AtomicSetUser('Maciej');
         $user->id = new \MongoId();
         $user->phonenumbers[] = new Phonenumber('12345678');
         $this->dm->persist($user);
@@ -76,7 +76,7 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testAtomicCollectionUnset()
     {
-        $user = new AtomicUser('Maciej');
+        $user = new AtomicSetUser('Maciej');
         $user->phonenumbers[] = new Phonenumber('12345678');
         $this->dm->persist($user);
         $this->dm->flush();
@@ -103,7 +103,7 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testAtomicSetArray()
     {
-        $user = new AtomicUser('Maciej');
+        $user = new AtomicSetUser('Maciej');
         $user->phonenumbersArray[1] = new Phonenumber('12345678');
         $user->phonenumbersArray[2] = new Phonenumber('87654321');
         $this->dm->persist($user);
@@ -131,7 +131,7 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testAtomicCollectionWithAnotherNested()
     {
-        $user = new AtomicUser('Maciej');
+        $user = new AtomicSetUser('Maciej');
         $privateBook = new Phonebook('Private');
         $privateBook->addPhonenumber(new Phonenumber('12345678'));
         $user->phonebooks[] = $privateBook;
@@ -187,14 +187,14 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     
     public function testWeNeedToGoDeeper()
     {
-        $user = new AtomicUser('Maciej');
-        $user->inception[0] = new GonnaBeDeep('start');
-        $user->inception[0]->one = new GonnaBeDeep('start.one');
-        $user->inception[0]->one->many[] = new GonnaBeDeep('start.one.many.0');
-        $user->inception[0]->one->many[] = new GonnaBeDeep('start.one.many.1');
-        $user->inception[0]->one->one = new GonnaBeDeep('start.one.one');
-        $user->inception[0]->one->one->many[] = new GonnaBeDeep('start.one.one.many.0');
-        $user->inception[0]->one->one->many[0]->many[] = new GonnaBeDeep('start.one.one.many.0.many.0');
+        $user = new AtomicSetUser('Maciej');
+        $user->inception[0] = new AtomicSetInception('start');
+        $user->inception[0]->one = new AtomicSetInception('start.one');
+        $user->inception[0]->one->many[] = new AtomicSetInception('start.one.many.0');
+        $user->inception[0]->one->many[] = new AtomicSetInception('start.one.many.1');
+        $user->inception[0]->one->one = new AtomicSetInception('start.one.one');
+        $user->inception[0]->one->one->many[] = new AtomicSetInception('start.one.one.many.0');
+        $user->inception[0]->one->one->many[0]->many[] = new AtomicSetInception('start.one.one.many.0.many.0');
         $this->dm->persist($user);
         $this->dm->flush();
         $this->assertCount(1, $this->ql, 'Inserting a document with nested embed-many collections requires one query');
@@ -219,7 +219,7 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 /**
  * @ODM\Document
  */
-class AtomicUser
+class AtomicSetUser
 {
     /** @ODM\Id */
     public $id;
@@ -242,7 +242,7 @@ class AtomicUser
     /** @ODM\EmbedMany(strategy="atomicSet", targetDocument="Documents\Phonebook") */
     public $phonebooks;
 
-    /** @ODM\EmbedMany(strategy="atomicSet", targetDocument="GonnaBeDeep") */
+    /** @ODM\EmbedMany(strategy="atomicSet", targetDocument="AtomicSetInception") */
     public $inception;
 
     public function __construct($name)
@@ -257,15 +257,15 @@ class AtomicUser
 /**
  * @ODM\EmbeddedDocument
  */
-class GonnaBeDeep
+class AtomicSetInception
 {
     /** @ODM\String */
     public $value;
 
-    /** @ODM\EmbedOne(targetDocument="GonnaBeDeep") */
+    /** @ODM\EmbedOne(targetDocument="AtomicSetInception") */
     public $one;
 
-    /** @ODM\EmbedMany(targetDocument="GonnaBeDeep") */
+    /** @ODM\EmbedMany(targetDocument="AtomicSetInception") */
     public $many;
 
     public function __construct($value)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
@@ -20,6 +20,7 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user->phonenumbers[] = new Phonenumber('12345678');
         $this->dm->persist($user);
         $this->dm->flush();
+        $this->assertEquals(1, $this->ql->count());
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -29,7 +30,9 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $user->surname = "Malarz";
         $user->phonenumbers[] = new Phonenumber('87654321');
+        $this->ql->reset();
         $this->dm->flush();
+        $this->assertEquals(1, $this->ql->count());
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -47,6 +50,7 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user->phonenumbers[] = new Phonenumber('12345678');
         $this->dm->persist($user);
         $this->dm->flush();
+        $this->assertEquals(1, $this->ql->count());
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -61,6 +65,7 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user->phonenumbers[] = new Phonenumber('12345678');
         $this->dm->persist($user);
         $this->dm->flush();
+        $this->assertEquals(1, $this->ql->count());
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -70,7 +75,9 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $user->surname = "Malarz";
         $user->phonenumbers = null;
+        $this->ql->reset();
         $this->dm->flush();
+        $this->assertEquals(1, $this->ql->count());
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -86,6 +93,7 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user->phonenumbersArray[2] = new Phonenumber('87654321');
         $this->dm->persist($user);
         $this->dm->flush();
+        $this->assertEquals(1, $this->ql->count());
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -95,13 +103,15 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals('87654321', $user->phonenumbersArray[1]->getPhonenumber());
 
         unset($user->phonenumbersArray[0]);
+        $this->ql->reset();
         $this->dm->flush();
+        $this->assertEquals(1, $this->ql->count());
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
         $this->assertCount(1, $user->phonenumbersArray);
         $this->assertEquals('87654321', $user->phonenumbersArray[0]->getPhonenumber());
-        $this->assertFalse(isset($newUser->phonenumbersArray[1]));
+        $this->assertFalse(isset($user->phonenumbersArray[1]));
     }
 
     public function testAtomicCollectionWithAnotherNested()
@@ -112,6 +122,7 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user->phonebooks[] = $privateBook;
         $this->dm->persist($user);
         $this->dm->flush();
+        $this->assertEquals(1, $this->ql->count());
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -126,7 +137,9 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $publicBook = new Phonebook('Public');
         $publicBook->addPhonenumber(new Phonenumber('10203040'));
         $user->phonebooks[] = $publicBook;
+        $this->ql->reset();
         $this->dm->flush();
+        $this->assertEquals(1, $this->ql->count());
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -142,7 +155,9 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals('10203040', $publicBook->getPhonenumbers()->get(0)->getPhonenumber());
 
         $privateBook->getPhonenumbers()->clear();
+        $this->ql->reset();
         $this->dm->flush();
+        $this->assertEquals(1, $this->ql->count());
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -167,6 +182,7 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user->inception[0]->one->one->many[0]->many[] = new GonnaBeDeep('start.one.one.many.0.many.0');
         $this->dm->persist($user);
         $this->dm->flush();
+        $this->assertEquals(1, $this->ql->count());
         
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
         $this->assertCount(1, $user->inception);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
@@ -15,6 +15,9 @@ use Documents\Phonenumber;
  */
 class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
+    /**
+     * @var Doctrine\ODM\MongoDB\Tests\QueryLogger
+     */
     private $ql;
 
     protected function getConfiguration()
@@ -213,6 +216,27 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals($user->inception[0]->one->one->many[0]->value, 'start.one.one.many.0');
         $this->assertCount(1, $user->inception[0]->one->one->many[0]->many);
         $this->assertEquals($user->inception[0]->one->one->many[0]->many[0]->value, 'start.one.one.many.0.many.0');
+
+        unset($user->inception[0]->one->many[0]);
+        $user->inception[0]->one->one->many[0]->many[] = new AtomicSetInception('start.one.one.many.0.many.1');
+        $this->ql->clear();
+        $this->dm->flush();
+        $this->assertCount(1, $this->ql, 'Updating nested collections on various levels requires one query');
+
+        $user = $this->dm->getRepository(get_class($user))->find($user->id);
+        $this->assertCount(1, $user->inception);
+        $this->assertEquals($user->inception[0]->value, 'start');
+        $this->assertNotNull($user->inception[0]->one);
+        $this->assertEquals($user->inception[0]->one->value, 'start.one');
+        $this->assertCount(1, $user->inception[0]->one->many);
+        $this->assertEquals($user->inception[0]->one->many[1]->value, 'start.one.many.1');
+        $this->assertNotNull($user->inception[0]->one->one);
+        $this->assertEquals($user->inception[0]->one->one->value, 'start.one.one');
+        $this->assertCount(1, $user->inception[0]->one->one->many);
+        $this->assertEquals($user->inception[0]->one->one->many[0]->value, 'start.one.one.many.0');
+        $this->assertCount(2, $user->inception[0]->one->one->many[0]->many);
+        $this->assertEquals($user->inception[0]->one->one->many[0]->many[0]->value, 'start.one.one.many.0.many.0');
+        $this->assertEquals($user->inception[0]->one->one->many[0]->many[1]->value, 'start.one.one.many.0.many.1');
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1113Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1113Test.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\QueryLogger;
+
+class GH1113Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    private $ql;
+
+    protected function getConfiguration()
+    {
+        if ( ! isset($this->ql)) {
+            $this->ql = new QueryLogger();
+        }
+
+        $config = parent::getConfiguration();
+        $config->setLoggerCallable($this->ql);
+
+        return $config;
+    }
+
+    public function testAtomicSetUpdatesAllNestedCollectionsInOneQuery()
+    {
+        // Create a book which has one chapter with one page.
+        $chapter1 = new GH1113Chapter();
+        $chapter1->addPage(new GH1113Page(1));
+        $book = new GH1113Book('title');
+        $book->addChapter($chapter1);
+
+        $this->dm->persist($book);
+
+        // Saving this book should result in 1 query since we use strategy="atomicSet"
+        $this->dm->flush();
+        $this->assertCount(1, $this->ql, 'Inserting a book with one chapter and page requires one query');
+
+        // Simulate another PHP request which loads this record and tries to add an embedded document two levels deep...
+        $this->dm->clear();
+        $book = $this->dm->getRepository(GH1113Book::CLASSNAME)->findOneBy(array('_id' => $book->id));
+
+        // Now we add a new "page" to the only chapter in this book.
+        $firstChapter = $book->chapters->first();
+        $firstChapter->addPage(new GH1113Page(2));
+
+        // Updating this book should result in 1 query since we use strategy="atomicSet"
+        $this->ql->clear();
+        $this->dm->flush();
+        $this->assertCount(1, $this->ql, 'Adding a page to the first chapter of the book requires one query');
+    }
+}
+
+/** @ODM\Document */
+class GH1113Book
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\Int @ODM\Version */
+    public $version = 1;
+
+    /** @ODM\String */
+    public $name;
+
+    /** @ODM\EmbedMany(targetDocument="GH1113Chapter", strategy="atomicSet") */
+    public $chapters;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+        $this->chapters = new ArrayCollection();
+    }
+
+    public function addChapter(GH1113Chapter $chapter)
+    {
+        $this->chapters->add($chapter);
+    }
+}
+
+/** @ODM\EmbeddedDocument */
+class GH1113Chapter
+{
+    /** @ODM\EmbedMany(targetDocument="GH1113Page") */
+    public $pages;
+
+    public function __construct()
+    {
+        $this->pages = new ArrayCollection();
+    }
+
+    public function addPage(GH1113Page $page)
+    {
+        $this->pages->add($page);
+    }
+}
+
+/** @ODM\EmbeddedDocument */
+class GH1113Page
+{
+    /** @ODM\Int */
+    public $pageNumber;
+
+    public function __construct($pageNumber)
+    {
+        $this->pageNumber = $pageNumber;
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryLogger.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryLogger.php
@@ -2,34 +2,46 @@
 
 namespace Doctrine\ODM\MongoDB\Tests;
 
-class QueryLogger
+class QueryLogger implements \Countable
 {
     private $queries = array();
 
+    /**
+     * Log a query.
+     *
+     * @param array $query
+     */
+    public function __invoke(array $query)
+    {
+        $this->queries[] = $query;
+    }
+
+    /**
+     * Clears the logged queries.
+     */
+    public function clear()
+    {
+        $this->queries = array();
+    }
+
+    /**
+     * Returns the number of logged queries.
+     *
+     * @see php.net/countable.count
+     * @return integer
+     */
     public function count()
     {
         return count($this->queries);
     }
 
-    public function countAndReset()
-    {
-        $cnt = $this->count();
-        $this->reset();
-        return $cnt;
-    }
-
-    public function log($q)
-    {
-        $this->queries[] = $q;
-    }
-
+    /**
+     * Returns the logged queries.
+     *
+     * @return array
+     */
     public function getAll()
     {
         return $this->queries;
-    }
-
-    public function reset()
-    {
-        $this->queries = array();
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryLogger.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryLogger.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests;
+
+class QueryLogger
+{
+    private $queries = array();
+
+    public function count()
+    {
+        return count($this->queries);
+    }
+
+    public function countAndReset()
+    {
+        $cnt = $this->count();
+        $this->reset();
+        return $cnt;
+    }
+
+    public function log($q)
+    {
+        $this->queries[] = $q;
+    }
+
+    public function getAll()
+    {
+        return $this->queries;
+    }
+
+    public function reset()
+    {
+        $this->queries = array();
+    }
+}


### PR DESCRIPTION
Incorporates tests from PR #1113 (issue #1114) and query logging added in @malarzm's own branch.