### PR TITLE
Fix PersistentCollection::add usage with set strategy

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -524,6 +524,13 @@ class PersistentCollection implements BaseCollection
      */
     public function add($value)
     {
+        /* Initialize the collection before calling add() so this append operation
+         * uses the appropriate key. Otherwise, we risk overwriting original data
+         * when $newObjects are re-added in a later call to initialize().
+         */
+        if (isset($this->mapping['strategy']) && ($this->mapping['strategy'] === 'set' || $this->mapping['strategy'] === 'atomicSet')) {
+            $this->initialize();
+        }
         $this->coll->add($value);
         $this->changed();
         return true;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class GH1117Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testAddOnUninitializedCollection()
+    {
+        $doc = new GH1117Document();
+        $doc->embeds->add(new GH1117EmbeddedDocument('one'));
+        $this->dm->persist($doc);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $doc = $this->dm->getRepository(get_class($doc))->find($doc->id);
+        $doc->embeds->add(new GH1117EmbeddedDocument('two'));
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $doc = $this->dm->getRepository(get_class($doc))->find($doc->id);
+        $this->assertCount(2, $doc->embeds);
+        $this->assertEquals('one', $doc->embeds[0]->value);
+        $this->assertEquals('two', $doc->embeds[1]->value);
+    }
+}
+
+/**
+ * @ODM\Document
+ */
+class GH1117Document
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedMany(strategy="set", targetDocument="GH1117EmbeddedDocument") */
+    public $embeds;
+
+    public function __construct()
+    {
+        $this->embeds = new ArrayCollection();
+    }
+}
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class GH1117EmbeddedDocument
+{
+    /** @ODM\String */
+    public $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+}


### PR DESCRIPTION
This is alternative solution for #1117 (closes #1116) which runs `initialize()` while `PersistentCollection::add` is subject to data loss because of data merging strategy