### PR TITLE
Do not schedule collection for deletion if it is to be $set later

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1307,15 +1307,6 @@ class DocumentPersister
              * parent of a scheduled child, the following calls are NOPs.
              */
             $this->uow->unscheduleCollectionUpdate($coll);
-            /* TODO: The collection may have been scheduled for both update and
-             * deletion if the PersistentCollection instance was changed. Since
-             * we're including the collection's update in an atomic $set, the
-             * $unset is unnecessary and we can unschedule the deletion.
-             *
-             * This can be removed if UnitOfWork is ever fixed to not schedule
-             * collections for both updates and deletions.
-             */
-            $this->uow->unscheduleCollectionDeletion($coll);
         }
 
         foreach ($atomicCollDeletes as $coll) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class GH1011Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testClearCollection()
+    {
+        $doc = new GH1011Document();
+        $doc->embeds->add(new GH1011Embedded('test1'));
+        $this->dm->persist($doc);
+        $this->dm->flush();
+        $doc->embeds->clear();
+        $doc->embeds->add(new GH1011Embedded('test2'));
+        $this->uow->computeChangeSets();
+        $this->assertTrue($this->uow->isCollectionScheduledForUpdate($doc->embeds));
+        $this->assertFalse($this->uow->isCollectionScheduledForDeletion($doc->embeds));
+    }
+
+    public function testReplaceCollection()
+    {
+        $doc = new GH1011Document();
+        $doc->embeds->add(new GH1011Embedded('test1'));
+        $this->dm->persist($doc);
+        $this->dm->flush();
+        $oldCollection = $doc->embeds;
+        $doc->embeds = new ArrayCollection();
+        $doc->embeds->add(new GH1011Embedded('test2'));
+        $this->uow->computeChangeSets();
+        $this->assertTrue($this->uow->isCollectionScheduledForUpdate($doc->embeds));
+        $this->assertFalse($this->uow->isCollectionScheduledForDeletion($oldCollection));
+    }
+}
+
+/** @ODM\Document */
+class GH1011Document
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedMany(targetDocument="GH1011Embedded", strategy="set") */
+    public $embeds;
+
+    public function __construct()
+    {
+        $this->embeds = new ArrayCollection();
+    }
+}
+
+/** @ODM\EmbeddedDocument */
+class GH1011Embedded
+{
+    /** @ODM\String */
+    public $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
Fixes #1011 and closes #434 and closes #1133. It also takes care for similar situation we faced with `atomic` collections, two tests added in `AtomicSetTest` are relevant to removed lines in `DocumentPersister`