### PR TITLE
Reindex numerically PersistentCollection after save

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -269,10 +269,20 @@ class PersistentCollection implements BaseCollection
 
     /**
      * INTERNAL:
-     * Tells this collection to take a snapshot of its current state.
+     * Tells this collection to take a snapshot of its current state reindexing
+     * itself numerically if using save strategy that is enforcing BSON array.
+     * Reindexing is safe as snapshot is taken only after synchronizing collection
+     * with database or clearing it.
      */
     public function takeSnapshot()
     {
+        if (CollectionHelper::isList($this->mapping['strategy'])) {
+            $array = $this->coll->toArray();
+            $this->coll->clear();
+            foreach ($array as $document) {
+                $this->coll->add($document);
+            }
+        }
         $this->snapshot = $this->coll->toArray();
         $this->isDirty = false;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH944Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH944Test.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class GH944Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testIssue()
+    {
+        $d = new GH944Document();
+        $d->data->add(new GH944Embedded('1'));
+        $d->data->add(new GH944Embedded('2'));
+        $this->dm->persist($d);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $d = $this->dm->find(get_class($d), $d->id);
+        $this->assertEquals(2, count($d->data));
+        $d->removeByText('1');
+        $this->assertEquals(1, count($d->data));
+        $this->dm->flush();
+
+        $d = $this->dm->find(get_class($d), $d->id);
+        $this->assertEquals(1, count($d->data));
+        $d->removeByText('2');
+        $this->assertEquals(0, count($d->data));
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $d = $this->dm->find(get_class($d), $d->id);
+        $this->assertEquals(0, count($d->data));
+    }
+}
+
+/**
+ * @ODM\Document
+ */
+class GH944Document
+{
+    /** @ODM\Id(strategy="auto") */
+    public $id;
+
+    /** @ODM\EmbedMany */
+    public $data;
+
+    public function __construct()
+    {
+        $this->data = new ArrayCollection();
+    }
+
+    public function removeByText($text)
+    {
+        foreach ($this->data as $d) {
+            if ($d->text === $text) {
+                $this->data->removeElement($d);
+            }
+        }
+    }
+}
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class GH944Embedded
+{
+    /** @ODM\String */
+    public $text;
+
+    public function __construct($text)
+    {
+        $this->text = $text;
+    }
+}


### PR DESCRIPTION
Fixes #944 and brings `PersistentCollection` in line with what is in database although it will be a BC break if somebody relied on using old indexes.