### PR TITLE
Replacing contents of EmbedMany+atomicSet with a new ArrayCollection fails with "Cannot update 'chapters' and 'chapters' at the same time"

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1133Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1133Test.php
@@ -6,13 +6,13 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\QueryLogger;
 
-class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1133Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
     public function testReplacementOfEmbedManyElements()
     {
         // Create a book with a single chapter.
-        $book = new GHXXXXBook();
-        $book->chapters->add(new GHXXXXChapter('A'));
+        $book = new GH1133Book();
+        $book->chapters->add(new GH1133Chapter('A'));
 
         // Save it.
         $this->dm->persist($book);
@@ -20,19 +20,19 @@ class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         // Simulate another PHP request which loads this record.
         $this->dm->clear();
-        $book = $this->dm->getRepository(GHXXXXBook::CLASSNAME)->findOneBy(array('_id' => $book->id));
+        $book = $this->dm->getRepository(GH1133Book::CLASSNAME)->findOneBy(array('_id' => $book->id));
 
         // Developers commonly attempt to replace the contents of an EmbedMany with a new ArrayCollection like this:
         $replacementChatpers = new ArrayCollection();
         $replacementChatpers->add($book->chapters->first());
-        $replacementChatpers->add(new GHXXXXChapter('B'));
+        $replacementChatpers->add(new GH1133Chapter('B'));
         $book->chapters = $replacementChatpers;
 
         $this->dm->flush(); // <- Currently getting "Cannot update 'chapters' and 'chapters' at the same time" failures.
 
         // Simulate another PHP request.
         $this->dm->clear();
-        $book = $this->dm->getRepository(GHXXXXBook::CLASSNAME)->findOneBy(array('_id' => $book->id));
+        $book = $this->dm->getRepository(GH1133Book::CLASSNAME)->findOneBy(array('_id' => $book->id));
 
         // Verify we see chapters A and B.
         $discoveredChapterTitles = array();
@@ -45,14 +45,14 @@ class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 }
 
 /** @ODM\Document */
-class GHXXXXBook
+class GH1133Book
 {
     const CLASSNAME = __CLASS__;
 
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedMany(targetDocument="GHXXXXChapter", strategy="atomicSet") */
+    /** @ODM\EmbedMany(targetDocument="GH1133Chapter", strategy="atomicSet") */
     public $chapters;
 
     public function __construct()
@@ -62,7 +62,7 @@ class GHXXXXBook
 }
 
 /** @ODM\EmbeddedDocument */
-class GHXXXXChapter
+class GH1133Chapter
 {
     /** @ODM\String */
     public $name;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GHXXXXTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GHXXXXTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\QueryLogger;
+
+class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testReplacementOfEmbedManyElements()
+    {
+        // Create a book with a single chapter.
+        $book = new GHXXXXBook();
+        $book->chapters->add(new GHXXXXChapter('A'));
+
+        // Save it.
+        $this->dm->persist($book);
+        $this->dm->flush();
+
+        // Simulate another PHP request which loads this record.
+        $this->dm->clear();
+        $book = $this->dm->getRepository(GHXXXXBook::CLASSNAME)->findOneBy(array('_id' => $book->id));
+
+        // Developers commonly attempt to replace the contents of an EmbedMany with a new ArrayCollection like this:
+        $replacementChatpers = new ArrayCollection();
+        $replacementChatpers->add($book->chapters->first());
+        $replacementChatpers->add(new GHXXXXChapter('B'));
+        $book->chapters = $replacementChatpers;
+
+        $this->dm->flush(); // <- Currently getting "Cannot update 'chapters' and 'chapters' at the same time" failures.
+
+        // Simulate another PHP request.
+        $this->dm->clear();
+        $book = $this->dm->getRepository(GHXXXXBook::CLASSNAME)->findOneBy(array('_id' => $book->id));
+
+        // Verify we see chapters A and B.
+        $discoveredChapterTitles = array();
+        foreach ($book->chapters as $thisChapter) {
+            $discoveredChapterTitles[] = $thisChapter->name;
+        }
+        $this->assertTrue(in_array('A', $discoveredChapterTitles));
+        $this->assertTrue(in_array('B', $discoveredChapterTitles));
+    }
+}
+
+/** @ODM\Document */
+class GHXXXXBook
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedMany(targetDocument="GHXXXXChapter", strategy="atomicSet") */
+    public $chapters;
+
+    public function __construct()
+    {
+        $this->chapters = new ArrayCollection();
+    }
+}
+
+/** @ODM\EmbeddedDocument */
+class GHXXXXChapter
+{
+    /** @ODM\String */
+    public $name;
+
+    public function __construct($name)
+    {
+        $this->pages = new ArrayCollection();
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
I have just attempted to use the new strategy="atomicSet" against my codebase. The first problem I have encountered is that developers like to create a new ArrayCollection and then overwrite the contents of the current embedded collection. This is not compatible with the new atomicSet strategy.

```
phpunit ./tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1133Test.php
```
returns:
```
phpunit ./tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1133Test.php 
PHPUnit 4.1.6-9-gbe3530d by Sebastian Bergmann.

Configuration read from /mongodb-odm/phpunit.xml

E

Time: 448 ms, Memory: 3.25Mb

There was 1 error:

1) Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH1133Test::testReplacementOfEmbedManyElements
MongoWriteConcernException: localhost:27017: Cannot update 'chapters' and 'chapters' at the same time

/mongodb-odm/vendor/doctrine/mongodb/lib/Doctrine/MongoDB/Collection.php:1335
/mongodb-odm/vendor/doctrine/mongodb/lib/Doctrine/MongoDB/Collection.php:783
/mongodb-odm/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php:407
/mongodb-odm/lib/Doctrine/ODM/MongoDB/UnitOfWork.php:1202
/mongodb-odm/lib/Doctrine/ODM/MongoDB/UnitOfWork.php:453
/mongodb-odm/lib/Doctrine/ODM/MongoDB/DocumentManager.php:526
/mongodb-odm/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1133Test.php:31

FAILURES!
Tests: 1, Assertions: 0, Errors: 1.
```
