### PR TITLE
Functional test to demonstrate "Cannot update 'chapters.0.status' and 'chapters' at the same time" atomicSet glitch

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1141Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1141Test.php
@@ -6,13 +6,13 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\QueryLogger;
 
-class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1141Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
     public function testReplacementOfEmbedManyElements()
     {
         // Create a book with a single chapter.
-        $book = new GHXXXXBook();
-        $book->chapters->add(new GHXXXXChapter('A'));
+        $book = new GH1141Book();
+        $book->chapters->add(new GH1141Chapter('A'));
 
         // Save it.
         $this->dm->persist($book);
@@ -20,7 +20,7 @@ class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         // Simulate another PHP request which loads this record.
         $this->dm->clear();
-        $book = $this->dm->getRepository(GHXXXXBook::CLASSNAME)->findOneBy(array('_id' => $book->id));
+        $book = $this->dm->getRepository(GH1141Book::CLASSNAME)->findOneBy(array('_id' => $book->id));
 
         $firstChapter = $book->chapters->first();
         $firstChapter->name = "First chapter A";
@@ -28,14 +28,14 @@ class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         // Developers commonly attempt to replace the contents of an EmbedMany with a new ArrayCollection like this:
         $replacementChatpers = new ArrayCollection();
         $replacementChatpers->add($firstChapter);
-        $replacementChatpers->add(new GHXXXXChapter('Second chapter B'));
+        $replacementChatpers->add(new GH1141Chapter('Second chapter B'));
         $book->chapters = $replacementChatpers;
 
         $this->dm->flush(); // <- Currently getting "Cannot update 'chapters' and 'chapters' at the same time" failures.
 
         // Simulate another PHP request.
         $this->dm->clear();
-        $book = $this->dm->getRepository(GHXXXXBook::CLASSNAME)->findOneBy(array('_id' => $book->id));
+        $book = $this->dm->getRepository(GH1141Book::CLASSNAME)->findOneBy(array('_id' => $book->id));
 
         // Verify we see chapters A and B.
         $discoveredChapterTitles = array();
@@ -48,14 +48,14 @@ class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 }
 
 /** @ODM\Document */
-class GHXXXXBook
+class GH1141Book
 {
     const CLASSNAME = __CLASS__;
 
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedMany(targetDocument="GHXXXXChapter", strategy="atomicSet") */
+    /** @ODM\EmbedMany(targetDocument="GH1141Chapter", strategy="atomicSet") */
     public $chapters;
 
     public function __construct()
@@ -65,7 +65,7 @@ class GHXXXXBook
 }
 
 /** @ODM\EmbeddedDocument */
-class GHXXXXChapter
+class GH1141Chapter
 {
     /** @ODM\String */
     public $name;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GHXXXXTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GHXXXXTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\QueryLogger;
+
+class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testReplacementOfEmbedManyElements()
+    {
+        // Create a book with a single chapter.
+        $book = new GHXXXXBook();
+        $book->chapters->add(new GHXXXXChapter('A'));
+
+        // Save it.
+        $this->dm->persist($book);
+        $this->dm->flush();
+
+        // Simulate another PHP request which loads this record.
+        $this->dm->clear();
+        $book = $this->dm->getRepository(GHXXXXBook::CLASSNAME)->findOneBy(array('_id' => $book->id));
+
+        $firstChapter = $book->chapters->first();
+        $firstChapter->name = "First chapter A";
+
+        // Developers commonly attempt to replace the contents of an EmbedMany with a new ArrayCollection like this:
+        $replacementChatpers = new ArrayCollection();
+        $replacementChatpers->add($firstChapter);
+        $replacementChatpers->add(new GHXXXXChapter('Second chapter B'));
+        $book->chapters = $replacementChatpers;
+
+        $this->dm->flush(); // <- Currently getting "Cannot update 'chapters' and 'chapters' at the same time" failures.
+
+        // Simulate another PHP request.
+        $this->dm->clear();
+        $book = $this->dm->getRepository(GHXXXXBook::CLASSNAME)->findOneBy(array('_id' => $book->id));
+
+        // Verify we see chapters A and B.
+        $discoveredChapterTitles = array();
+        foreach ($book->chapters as $thisChapter) {
+            $discoveredChapterTitles[] = $thisChapter->name;
+        }
+        $this->assertTrue(in_array('First chapter A', $discoveredChapterTitles));
+        $this->assertTrue(in_array('Second chapter B', $discoveredChapterTitles));
+    }
+}
+
+/** @ODM\Document */
+class GHXXXXBook
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedMany(targetDocument="GHXXXXChapter", strategy="atomicSet") */
+    public $chapters;
+
+    public function __construct()
+    {
+        $this->chapters = new ArrayCollection();
+    }
+}
+
+/** @ODM\EmbeddedDocument */
+class GHXXXXChapter
+{
+    /** @ODM\String */
+    public $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
Here's another blocker I have run into with strategy=atomicSet

This exact same code passes if you use strategy=set so hopefully there's a small fix that can be made to add support for this sequence of events when using atomicSet.

Repro:
```
phpunit ./tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1141Test.php
```
returns:
```
PHPUnit 4.1.6-9-gbe3530d by Sebastian Bergmann.

Configuration read from /mongodb-odm/phpunit.xml

E

Time: 332 ms, Memory: 3.25Mb

There was 1 error:

1) Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH1141Test::testReplacementOfEmbedManyElements
MongoWriteConcernException: localhost:27017: Cannot update 'chapters.0.name' and 'chapters' at the same time

/mongodb-odm/vendor/doctrine/mongodb/lib/Doctrine/MongoDB/Collection.php:1335
/mongodb-odm/vendor/doctrine/mongodb/lib/Doctrine/MongoDB/Collection.php:783
/mongodb-odm/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php:407
/mongodb-odm/lib/Doctrine/ODM/MongoDB/UnitOfWork.php:1205
/mongodb-odm/lib/Doctrine/ODM/MongoDB/UnitOfWork.php:453
/mongodb-odm/lib/Doctrine/ODM/MongoDB/DocumentManager.php:526
/mongodb-odm/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1141Test.php:34

FAILURES!
Tests: 1, Assertions: 0, Errors: 1.
```