### PR TITLE
Check if embedded document is not part of atomic set query

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1141Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1141Test.php
@@ -4,7 +4,6 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\QueryLogger;
 
 class GH1141Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1141Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1141Test.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\QueryLogger;
+
+class GH1141Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testReplacementOfEmbedManyElements()
+    {
+        // Create a book with a single chapter.
+        $book = new GH1141Book();
+        $book->chapters->add(new GH1141Chapter('A'));
+
+        // Save it.
+        $this->dm->persist($book);
+        $this->dm->flush();
+
+        // Simulate another PHP request which loads this record.
+        $this->dm->clear();
+        $book = $this->dm->getRepository(GH1141Book::CLASSNAME)->findOneBy(array('_id' => $book->id));
+
+        $firstChapter = $book->chapters->first();
+        $firstChapter->name = "First chapter A";
+
+        // Developers commonly attempt to replace the contents of an EmbedMany with a new ArrayCollection like this:
+        $replacementChatpers = new ArrayCollection();
+        $replacementChatpers->add($firstChapter);
+        $replacementChatpers->add(new GH1141Chapter('Second chapter B'));
+        $book->chapters = $replacementChatpers;
+
+        $this->dm->flush(); // <- Currently getting "Cannot update 'chapters' and 'chapters' at the same time" failures.
+
+        // Simulate another PHP request.
+        $this->dm->clear();
+        $book = $this->dm->getRepository(GH1141Book::CLASSNAME)->findOneBy(array('_id' => $book->id));
+
+        // Verify we see chapters A and B.
+        $discoveredChapterTitles = array();
+        foreach ($book->chapters as $thisChapter) {
+            $discoveredChapterTitles[] = $thisChapter->name;
+        }
+        $this->assertTrue(in_array('First chapter A', $discoveredChapterTitles));
+        $this->assertTrue(in_array('Second chapter B', $discoveredChapterTitles));
+    }
+}
+
+/** @ODM\Document */
+class GH1141Book
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedMany(targetDocument="GH1141Chapter", strategy="atomicSet") */
+    public $chapters;
+
+    public function __construct()
+    {
+        $this->chapters = new ArrayCollection();
+    }
+}
+
+/** @ODM\EmbeddedDocument */
+class GH1141Chapter
+{
+    /** @ODM\String */
+    public $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
Closes #1141 (@blockjon's test is included in this PR)

For the record it was working for `set` strategy but there were 2 queries issued - first to update `chapters.0.status` from `DocumentPersister` and later to update whole `chapters` collection from `CollectionPersister`. I think it's worth fixing, but I've ran into some problems and decided it's outside of scope of this PR.