### PR TITLE
Broken test for #949

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH949Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH949Test.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @author Josh Worden <solocommand@gmail.com>
+ * @since 6/16/15
+ */
+class GH949Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    protected $group;
+
+    public function testDisconnectedReferencesAfterClear()
+    {
+        // Create our test docs
+        $ref = new GH949Reference();
+        $doc = new GH949Document($ref);
+
+        // Persist/flush/clear
+        $this->dm->persist($ref);
+        $this->dm->persist($doc);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        // After clearing, create a new document using the existing reference model
+        $doc2 = new GH949Document($ref);
+
+        $this->dm->persist($doc2);
+
+        // Because the $doc2->ref is referencing a document that is
+        // cleared from the identity map, this will throw an exception.
+        $this->dm->flush();
+    }
+}
+
+/** @ODM\Document */
+class GH949Document
+{
+    /** @ODM\Id */
+    protected $id;
+
+    /** @ODM\ReferenceOne(targetDocument="GH949Reference") */
+    public $ref;
+
+    public function __construct(GH949Reference $ref)
+    {
+        $this->ref = $ref;
+    }
+}
+
+/** @ODM\Document */
+class GH949Reference
+{
+    /** @ODM\Id */
+    protected $id;
+}


### PR DESCRIPTION
This includes a requested broken test demonstrating the failure reported in #949.

When attempting to persist a document containing a reference that previously existed in the identity map (after a flush/clear) a `RuntimeException: Cannot create a DBRef without an identifier. UnitOfWork::getDocumentIdentifier() did not return an identifier for class x` exception is thrown.

I've run into this issue myself several times, as @vmattila pointed out it seems to stem from retaining an existing document that had been retrieved from the database (or persisted with a flush/clear afterwards), and attempting to persist a new document with the old document referenced (rather than retrieving it again after the clear in the UoW).