### PR TITLE
Store parent association before hydrating document

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -338,11 +338,12 @@ EOF
             \$embeddedMetadata = \$this->dm->getClassMetadata(\$className);
             \$return = \$embeddedMetadata->newInstance();
 
+            \$this->unitOfWork->setParentAssociation(\$return, \$this->class->fieldMappings['%2\$s'], \$document, '%1\$s');
+
             \$embeddedData = \$this->dm->getHydratorFactory()->hydrate(\$return, \$embeddedDocument, \$hints);
             \$embeddedId = \$embeddedMetadata->identifier && isset(\$embeddedData[\$embeddedMetadata->identifier]) ? \$embeddedData[\$embeddedMetadata->identifier] : null;
 
             \$this->unitOfWork->registerManaged(\$return, \$embeddedId, \$embeddedData);
-            \$this->unitOfWork->setParentAssociation(\$return, \$this->class->fieldMappings['%2\$s'], \$document, '%1\$s');
 
             \$this->class->reflFields['%2\$s']->setValue(\$document, \$return);
             \$hydratedData['%2\$s'] = \$return;

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -646,13 +646,14 @@ class DocumentPersister
                 $embeddedMetadata = $this->dm->getClassMetadata($className);
                 $embeddedDocumentObject = $embeddedMetadata->newInstance();
 
+                $this->uow->setParentAssociation($embeddedDocumentObject, $mapping, $owner, $mapping['name'] . '.' . $key);
+
                 $data = $this->hydratorFactory->hydrate($embeddedDocumentObject, $embeddedDocument);
                 $id = $embeddedMetadata->identifier && isset($data[$embeddedMetadata->identifier])
                     ? $data[$embeddedMetadata->identifier]
                     : null;
 
                 $this->uow->registerManaged($embeddedDocumentObject, $id, $data);
-                $this->uow->setParentAssociation($embeddedDocumentObject, $mapping, $owner, $mapping['name'] . '.' . $key);
                 if ($mapping['strategy'] === 'set' || $mapping['strategy'] === 'atomicSet') {
                     $collection->set($key, $embeddedDocumentObject);
                 } else {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1152Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1152Test.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
+use Doctrine\ODM\MongoDB\Events;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class GH1152Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testParentAssociationsInPostLoad()
+    {
+        $listener = new GH1152Listener();
+        $this->dm->getEventManager()->addEventListener(Events::postLoad, $listener);
+
+        $parent = new GH1152Parent();
+        $parent->child = new GH1152Child();
+
+        $this->dm->persist($parent);
+        $this->dm->flush();
+
+        $this->dm->clear();
+
+        $parent = $this->dm->find(GH1152Parent::CLASSNAME, $parent->id);
+        $this->assertNotNull($parent);
+
+        $this->assertNotNull($parent->child->parentAssociation);
+        list($mapping, $parentAssociation, $fieldName) = $parent->child->parentAssociation;
+
+        $this->assertSame($parent, $parentAssociation);
+    }
+}
+
+/** @ODM\Document */
+class GH1152Parent
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedOne(targetDocument="GH1152Child") */
+    public $child;
+}
+
+/** @ODM\EmbeddedDocument */
+class GH1152Child
+{
+    public $parentAssociation;
+}
+
+class GH1152Listener
+{
+    public function postLoad(LifecycleEventArgs $args)
+    {
+        $dm = $args->getDocumentManager();
+        $document = $args->getDocument();
+
+        if (!$document instanceof GH1152Child) {
+            return;
+        }
+
+        $document->parentAssociation = $dm->getUnitOfWork()->getParentAssociation($document);
+    }
+}


### PR DESCRIPTION
This change stores the parent association in UnitOfWork before hydrating data into an embedded documents. This allows postLoad subscribers to use getParentAssociation to get information about the containing object.