### PR TITLE
Functional test: atomicSet updates to embedded documents do not work

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1153Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1153Test.php
@@ -5,13 +5,13 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1153Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
     public function testFailureToUpdateEmbeddedDocumentWithAtomicSet()
     {
         // Create a book with a single chapter.
-        $book = new GHXXXXBook();
-        $book->chapters->add(new GHXXXXChapter('A'));
+        $book = new GH1153Book();
+        $book->chapters->add(new GH1153Chapter('A'));
 
         // Save it.
         $this->dm->persist($book);
@@ -19,7 +19,7 @@ class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         // Simulate another PHP request which loads this record.
         $this->dm->clear();
-        $book = $this->dm->getRepository(GHXXXXBook::CLASSNAME)->findOneBy(array('_id' => $book->id));
+        $book = $this->dm->getRepository(GH1153Book::CLASSNAME)->findOneBy(array('_id' => $book->id));
 
         // Modify the chapter's name.
         $book->chapters->first()->name = "First chapter A";
@@ -28,21 +28,21 @@ class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         // Simulate another PHP request & verify the change was saved.
         $this->dm->clear();
-        $book = $this->dm->getRepository(GHXXXXBook::CLASSNAME)->findOneBy(array('_id' => $book->id));
+        $book = $this->dm->getRepository(GH1153Book::CLASSNAME)->findOneBy(array('_id' => $book->id));
 
         $this->assertEquals('First chapter A', $book->chapters[0]->name, "The chapter title failed to update.");
     }
 }
 
 /** @ODM\Document */
-class GHXXXXBook
+class GH1153Book
 {
     const CLASSNAME = __CLASS__;
 
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedMany(targetDocument="GHXXXXChapter", strategy="atomicSet") */
+    /** @ODM\EmbedMany(targetDocument="GH1153Chapter", strategy="atomicSet") */
     public $chapters;
 
     public function __construct()
@@ -52,7 +52,7 @@ class GHXXXXBook
 }
 
 /** @ODM\EmbeddedDocument */
-class GHXXXXChapter
+class GH1153Chapter
 {
     /** @ODM\String */
     public $name;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GHXXXXTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GHXXXXTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testFailureToUpdateEmbeddedDocumentWithAtomicSet()
+    {
+        // Create a book with a single chapter.
+        $book = new GHXXXXBook();
+        $book->chapters->add(new GHXXXXChapter('A'));
+
+        // Save it.
+        $this->dm->persist($book);
+        $this->dm->flush();
+
+        // Simulate another PHP request which loads this record.
+        $this->dm->clear();
+        $book = $this->dm->getRepository(GHXXXXBook::CLASSNAME)->findOneBy(array('_id' => $book->id));
+
+        // Modify the chapter's name.
+        $book->chapters->first()->name = "First chapter A";
+
+        $this->dm->flush();
+
+        // Simulate another PHP request & verify the change was saved.
+        $this->dm->clear();
+        $book = $this->dm->getRepository(GHXXXXBook::CLASSNAME)->findOneBy(array('_id' => $book->id));
+
+        $this->assertEquals('First chapter A', $book->chapters[0]->name, "The chapter title failed to update.");
+    }
+}
+
+/** @ODM\Document */
+class GHXXXXBook
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedMany(targetDocument="GHXXXXChapter", strategy="atomicSet") */
+    public $chapters;
+
+    public function __construct()
+    {
+        $this->chapters = new ArrayCollection();
+    }
+}
+
+/** @ODM\EmbeddedDocument */
+class GHXXXXChapter
+{
+    /** @ODM\String */
+    public $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
Making a change to the embedded document in this test fails to update the MongoDB record.

This test passes if strategy="set" is used.

repro:
```
phpunit --filter testFailureToUpdateEmbeddedDocumentWithAtomicSet
```
emits:
```
PHPUnit 4.1.6-9-gbe3530d by Sebastian Bergmann.

Configuration read from /mongodb-odm/phpunit.xml

F

Time: 1.41 seconds, Memory: 21.75Mb

There was 1 failure:

1) Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GHXXXXTest::testFailureToUpdateEmbeddedDocumentWithAtomicSet
The chapter title failed to update.
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'First chapter A'
+'A'

/mongodb-odm/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GHXXXXTest.php:33

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```