### PR TITLE
Fix updating of embedded documents if their atomic collection is not dirty

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1153Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1153Test.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class GH1153Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testFailureToUpdateEmbeddedDocumentWithAtomicSet()
+    {
+        // Create a book with a single chapter.
+        $book = new GH1153Book();
+        $book->chapters->add(new GH1153Chapter('A'));
+
+        // Save it.
+        $this->dm->persist($book);
+        $this->dm->flush();
+
+        // Simulate another PHP request which loads this record.
+        $this->dm->clear();
+        $book = $this->dm->getRepository(GH1153Book::CLASSNAME)->findOneBy(array('_id' => $book->id));
+
+        // Modify the chapter's name.
+        $book->chapters->first()->name = "First chapter A";
+
+        $this->dm->flush();
+
+        // Simulate another PHP request & verify the change was saved.
+        $this->dm->clear();
+        $book = $this->dm->getRepository(GH1153Book::CLASSNAME)->findOneBy(array('_id' => $book->id));
+
+        $this->assertEquals('First chapter A', $book->chapters[0]->name, "The chapter title failed to update.");
+    }
+}
+
+/** @ODM\Document */
+class GH1153Book
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedMany(targetDocument="GH1153Chapter", strategy="atomicSet") */
+    public $chapters;
+
+    public function __construct()
+    {
+        $this->chapters = new ArrayCollection();
+    }
+}
+
+/** @ODM\EmbeddedDocument */
+class GH1153Chapter
+{
+    /** @ODM\String */
+    public $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
Fixes #1153 

For the record this PR can be considered as a hotfix for functionality that I've accidentally broken fixing #1141. I start to dislike the way we're managing atomic collection updates but I'm planning to fix it along with commit() flow I've described in https://github.com/doctrine/mongodb-odm/pull/1128#issuecomment-111864297 so I'm willing to merge this now and rewrite later.