### PR TITLE
Functional test: atomicSet: "Cannot update 'chapters.0.name' and 'chapters' at the same time"

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1156Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1156Test.php
@@ -5,42 +5,42 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1156Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
     public function testReplacementOfIdentifiedEmbedManyElements()
     {
-        $book = new GHXXXXBook();
-        $book->chapters->add(new GHXXXXChapter('A'));
+        $book = new GH1156Book();
+        $book->chapters->add(new GH1156Chapter('A'));
 
         $this->dm->persist($book);
         $this->dm->flush();
         $this->dm->clear();
 
-        $book = $this->dm->getRepository(GHXXXXBook::CLASSNAME)->findOneBy(array('_id' => $book->id));
+        $book = $this->dm->getRepository(GH1156Book::CLASSNAME)->findOneBy(array('_id' => $book->id));
         $firstChapter = $book->chapters->first();
         $firstChapter->name = "Apple";
 
         // Add some pages.
-        $firstChapter->pages->add(new GHXXXXPage(1));
-        $firstChapter->pages->add(new GHXXXXPage(2));
+        $firstChapter->pages->add(new GH1156Page(1));
+        $firstChapter->pages->add(new GH1156Page(2));
 
         $this->dm->flush();
         $this->dm->clear();
 
-        $book = $this->dm->getRepository(GHXXXXBook::CLASSNAME)->findOneBy(array('_id' => $book->id));
+        $book = $this->dm->getRepository(GH1156Book::CLASSNAME)->findOneBy(array('_id' => $book->id));
         $this->assertEquals(2, $book->chapters->first()->pages->count());
     }
 }
 
 /** @ODM\Document */
-class GHXXXXBook
+class GH1156Book
 {
     const CLASSNAME = __CLASS__;
 
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedMany(targetDocument="GHXXXXChapter", strategy="atomicSet") */
+    /** @ODM\EmbedMany(targetDocument="GH1156Chapter", strategy="atomicSet") */
     public $chapters;
 
     public function __construct()
@@ -50,12 +50,12 @@ class GHXXXXBook
 }
 
 /** @ODM\EmbeddedDocument */
-class GHXXXXChapter
+class GH1156Chapter
 {
     /** @ODM\String */
     public $name;
 
-    /** @ODM\EmbedMany(targetDocument="GHXXXXPage") */
+    /** @ODM\EmbedMany(targetDocument="GH1156Page") */
     public $pages;
 
     public function __construct($name)
@@ -65,7 +65,7 @@ class GHXXXXChapter
 }
 
 /** @ODM\EmbeddedDocument */
-class GHXXXXPage
+class GH1156Page
 {
     /** @ODM\Id */
     public $id;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GHXXXXTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GHXXXXTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testReplacementOfIdentifiedEmbedManyElements()
+    {
+        $book = new GHXXXXBook();
+        $book->chapters->add(new GHXXXXChapter('A'));
+
+        $this->dm->persist($book);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $book = $this->dm->getRepository(GHXXXXBook::CLASSNAME)->findOneBy(array('_id' => $book->id));
+        $firstChapter = $book->chapters->first();
+        $firstChapter->name = "Apple";
+
+        // Add some pages.
+        $firstChapter->pages->add(new GHXXXXPage(1));
+        $firstChapter->pages->add(new GHXXXXPage(2));
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $book = $this->dm->getRepository(GHXXXXBook::CLASSNAME)->findOneBy(array('_id' => $book->id));
+        $this->assertEquals(2, $book->chapters->first()->pages->count());
+    }
+}
+
+/** @ODM\Document */
+class GHXXXXBook
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedMany(targetDocument="GHXXXXChapter", strategy="atomicSet") */
+    public $chapters;
+
+    public function __construct()
+    {
+        $this->chapters = new ArrayCollection();
+    }
+}
+
+/** @ODM\EmbeddedDocument */
+class GHXXXXChapter
+{
+    /** @ODM\String */
+    public $name;
+
+    /** @ODM\EmbedMany(targetDocument="GHXXXXPage") */
+    public $pages;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}
+
+/** @ODM\EmbeddedDocument */
+class GHXXXXPage
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\Integer */
+    public $number;
+
+    public function __construct($number)
+    {
+        $this->number = $number;
+    }
+}


### PR DESCRIPTION
I'm still blocked trying to get atomicSet to integrate with my codebase. I am currently blocked on a bug that emerges when you try to edit an embedded document and also add new embedded documents at the same time. This is similar to @malarzm 's https://github.com/doctrine/mongodb-odm/pull/1141

repro:
```
phpunit ./tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1156Test.php
```
returns:
```
PHPUnit 4.1.6-9-gbe3530d by Sebastian Bergmann.

Configuration read from /mongodb-odm/phpunit.xml

E

Time: 449 ms, Memory: 3.25Mb

There was 1 error:

1) Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH1156Test::testReplacementOfIdentifiedEmbedManyElements
MongoWriteConcernException: localhost:27017: Cannot update 'chapters.0.name' and 'chapters' at the same time

/mongodb-odm/vendor/doctrine/mongodb/lib/Doctrine/MongoDB/Collection.php:1335
/mongodb-odm/vendor/doctrine/mongodb/lib/Doctrine/MongoDB/Collection.php:783
/mongodb-odm/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php:407
/mongodb-odm/lib/Doctrine/ODM/MongoDB/UnitOfWork.php:1179
/mongodb-odm/lib/Doctrine/ODM/MongoDB/UnitOfWork.php:427
/mongodb-odm/lib/Doctrine/ODM/MongoDB/DocumentManager.php:526
/mongodb-odm/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1156Test.php:27

FAILURES!
Tests: 1, Assertions: 0, Errors: 1.
```