### PR TITLE
Wrong class is returned when using select() and single collection inheritance

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -170,6 +170,23 @@ class QueryTest extends BaseTest
         $this->assertTrue(array_key_exists('eO.eO.e1.eO.eP.pO._id', $debug));
         $this->assertEquals($mongoId, $debug['eO.eO.e1.eO.eP.pO._id']);
     }
+
+    public function testSelectVsSingleCollectionInheritance()
+    {
+        $p = new \Documents\SubProject('SubProject');
+        $this->dm->persist($p);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $test = $this->dm->createQueryBuilder()
+                ->find('Documents\Project')
+                ->select(array('name'))
+                ->field('id')->equals($p->getId())
+                ->getQuery()->getSingleResult();
+        $this->assertNotNull($test);
+        $this->assertInstanceOf('Documents\SubProject', $test);
+        $this->assertEquals('SubProject', $test->getName());
+    }
 }
 
 /** @ODM\Document(collection="people") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -187,6 +187,56 @@ class QueryTest extends BaseTest
         $this->assertInstanceOf('Documents\SubProject', $test);
         $this->assertEquals('SubProject', $test->getName());
     }
+
+    public function testEmptySelectVsSingleCollectionInheritance()
+    {
+        $p = new \Documents\SubProject('SubProject');
+        $this->dm->persist($p);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $test = $this->dm->createQueryBuilder()
+                ->find('Documents\Project')
+                ->select(array())
+                ->field('id')->equals($p->getId())
+                ->getQuery()->getSingleResult();
+        $this->assertNotNull($test);
+        $this->assertInstanceOf('Documents\SubProject', $test);
+        $this->assertEquals('SubProject', $test->getName());
+    }
+
+    public function testDiscriminatorFieldNotAddedWithoutHydration()
+    {
+        $p = new \Documents\SubProject('SubProject');
+        $this->dm->persist($p);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $test = $this->dm->createQueryBuilder()
+                ->find('Documents\Project')->hydrate(false)
+                ->select(array('name'))
+                ->field('id')->equals($p->getId())
+                ->getQuery()->getSingleResult();
+        $this->assertNotNull($test);
+        $this->assertEquals(array('_id', 'name'), array_keys($test));
+    }
+
+    public function testExcludeVsSingleCollectionInheritance()
+    {
+        $p = new \Documents\SubProject('SubProject');
+        $this->dm->persist($p);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $test = $this->dm->createQueryBuilder()
+                ->find('Documents\SubProject')
+                ->exclude(array('name', 'issues'))
+                ->field('id')->equals($p->getId())
+                ->getQuery()->getSingleResult();
+        $this->assertNotNull($test);
+        $this->assertInstanceOf('Documents\SubProject', $test);
+        $this->assertNull($test->getName());
+    }
 }
 
 /** @ODM\Document(collection="people") */


### PR DESCRIPTION
For now we're manually adding discriminator field in select() but it would be nice if ODM could do that for us. Originally we were hit by this because we were searching by parent class which is abstract and instance of it could not be created.

Closes #879 