### PR TITLE
Straighten removing strategy from collection field

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractField.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractField.php
@@ -27,5 +27,4 @@ abstract class AbstractField extends Annotation
     public $type = 'string';
     public $nullable = false;
     public $options = array();
-    public $strategy;
 }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1044,7 +1044,8 @@ class DocumentPersister
             return array($fieldName, $value);
         }
 
-        if ($mapping['strategy'] === 'set' && isset($e[2])) {
+        if (isset($mapping['strategy']) && CollectionHelper::isHash($mapping['strategy'])
+                && isset($e[2])) {
             $objectProperty = $e[2];
             $objectPropertyPrefix = $e[1] . '.';
             $nextObjectProperty = implode('.', array_slice($e, 3));

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -907,7 +907,7 @@ class UnitOfWork implements PropertyChangedListener
             $state = $this->getDocumentState($entry, self::STATE_NEW);
 
             // Handle "set" strategy for multi-level hierarchy
-            $pathKey = CollectionHelper::isList($assoc['strategy']) ? $count : $key;
+            $pathKey = ! isset($assoc['strategy']) || CollectionHelper::isList($assoc['strategy']) ? $count : $key;
             $path = $assoc['type'] === 'many' ? $assoc['name'] . '.' . $pathKey : $assoc['name'];
 
             $count++;
@@ -2696,7 +2696,7 @@ class UnitOfWork implements PropertyChangedListener
             while (null !== ($parentAssoc = $this->getParentAssociation($parent))) {
                 list($mapping, $parent, ) = $parentAssoc;
             }
-            if (CollectionHelper::isAtomic($mapping['strategy'])) {
+            if (isset($mapping['strategy']) && CollectionHelper::isAtomic($mapping['strategy'])) {
                 $class = $this->dm->getClassMetadata(get_class($document));
                 $atomicCollection = $class->getFieldValue($document, $mapping['fieldName']);
                 $this->scheduleCollectionUpdate($atomicCollection);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH453Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH453Test.php
@@ -271,10 +271,10 @@ class GH453Document
     /** @ODM\Hash */
     public $hash;
 
-    /** @ODM\Collection(strategy="pushAll")) */
+    /** @ODM\Collection() */
     public $colPush;
 
-    /** @ODM\Collection(strategy="set") */
+    /** @ODM\Collection() */
     public $colSet;
 
     /** @ODM\EmbedMany(strategy="pushAll")) */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -40,12 +40,14 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
      */
     public function testFieldMappings($class)
     {
-        $this->assertEquals(13, count($class->fieldMappings));
+        $this->assertEquals(14, count($class->fieldMappings));
         $this->assertTrue(isset($class->fieldMappings['id']));
         $this->assertTrue(isset($class->fieldMappings['version']));
         $this->assertTrue(isset($class->fieldMappings['lock']));
         $this->assertTrue(isset($class->fieldMappings['name']));
         $this->assertTrue(isset($class->fieldMappings['email']));
+        $this->assertTrue(isset($class->fieldMappings['roles']));
+        $this->assertFalse(isset($class->fieldMappings['roles']['strategy']));
 
         return $class;
     }
@@ -141,7 +143,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
      */
     public function testAssocations($class)
     {
-        $this->assertEquals(13, count($class->fieldMappings));
+        $this->assertEquals(14, count($class->fieldMappings));
 
         return $class;
     }
@@ -399,6 +401,11 @@ class AbstractMappingDriverUser
      * @ODM\Date
      */
     public $createdAt;
+
+    /**
+     * @ODM\Collection
+     */
+    public $roles = array();
 
     /**
      * @ODM\PrePersist

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
@@ -18,6 +18,7 @@
         <field fieldName="email" type="string" unique="true" drop-dups="true" order="desc" />
         <field fieldName="mysqlProfileId" type="integer" unique="true" drop-dups="true" order="desc" />
         <field fieldName="createdAt" type="date" />
+        <field fieldName="roles" type="collection" />
         <indexes>
             <index unique="true">
                 <key name="username" order="desc" />

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.yml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.yml
@@ -31,6 +31,8 @@ Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser:
       index:
         order: asc
         expireAfterSeconds: 3600
+    roles:
+      type: collection
   indexes:
     index1:
       keys:

--- a/tests/Documents/Article.php
+++ b/tests/Documents/Article.php
@@ -22,7 +22,7 @@ class Article
     /** @ODM\Date */
     private $createdAt;
 
-    /** @ODM\Field(type="collection", strategy="set") */
+    /** @ODM\Field(type="collection") */
     private $tags = array();
 
     public function getId()

--- a/tests/Documents/Strategy.php
+++ b/tests/Documents/Strategy.php
@@ -10,7 +10,7 @@ class Strategy
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\Collection(strategy="set") */
+    /** @ODM\Collection() */
     public $logs = array();
 
     /** @ODM\EmbedMany(targetDocument="Message", strategy="set") */


### PR DESCRIPTION
Fixes #1174. This commit finishes removing "unused" strategy from `collection` field. People who are still using `strategy` combined with `collection` and annotation mapping will now start getting error because `AbstractField` no longer has that property (which was the reason why our tests were green but YML/XML mappings suffered as reported in #1174)

@redthor could you maybe run your test suite against this PR?