### PR TITLE
Add suport for querying using object ids (#1179)

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -978,6 +978,10 @@ class DocumentPersister
 
             // No further preparation unless we're dealing with a simple reference
             if (empty($mapping['reference']) || empty($mapping['simple'])) {
+                if (empty($mapping['embedded']) && $mapping['type'] !== Type::HASH && $mapping['type'] !== Type::RAW) {
+                    return array($fieldName, is_object($value) ? (string) $value : $value);
+                }
+
                 return array($fieldName, $value);
             }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\ODM\MongoDB\QueryBuilder;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 
 class QueryTest extends BaseTest
 {
@@ -170,6 +171,25 @@ class QueryTest extends BaseTest
         $this->assertTrue(array_key_exists('eO.eO.e1.eO.eP.pO._id', $debug));
         $this->assertEquals($mongoId, $debug['eO.eO.e1.eO.eP.pO._id']);
     }
+
+    public function testQueryUsingObject()
+    {
+        Type::addType('account_code', __NAMESPACE__ . '\AccountCodeType');
+
+        $account = new Account();
+        $account->code = new AccountCode(10);
+        $this->dm->persist($account);
+        $this->dm->flush();
+
+        $this->dm->clear();
+
+        $qb = $this->dm
+            ->createQueryBuilder(__NAMESPACE__ . '\Account')
+            ->field('code')
+            ->equals($account->code);
+
+        $this->assertEquals($account, $qb->getQuery()->getSingleResult());
+    }
 }
 
 /** @ODM\Document(collection="people") */
@@ -217,4 +237,46 @@ class EmbedTest
 
     /** @ODM\EmbedOne(name="eP", targetDocument="Doctrine\ODM\MongoDB\Tests\Pet") */
     public $pet;
+}
+
+class AccountCodeType extends Type
+{
+    public function convertToDatabaseValue($value)
+    {
+        return $value->code;
+    }
+
+    public function convertToPHPValue($value)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return new AccountCode($value);
+    }
+}
+
+class AccountCode
+{
+    public $code;
+
+    public function __construct($code)
+    {
+        $this->code = (string) $code;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->code;
+    }
+}
+
+/** @ODM\Document */
+class Account
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\Field(type="account_code") */
+    public $code;
 }


### PR DESCRIPTION
This PR aims to fix the issue #1179.

Follows the same strategy adopted by Doctrine ORM:

> The UnitOfWork internally assumes that entity identifiers are castable to string. Hence, when using custom types that map to PHP objects as IDs, such objects must implement the `__toString()` magic method.

Includes unit tests.