### PR TITLE
ReferenceMany's sort should not be used with some strategies

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -1158,6 +1158,11 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
                 (isset($mapping['mappedBy']) || isset($mapping['inversedBy']))) {
             throw MappingException::owningAndInverseReferencesRequireTargetDocument($this->name, $mapping['fieldName']);
         }
+
+        if (isset($mapping['reference']) && $mapping['type'] === 'many' && ! isset($mapping['mappedBy'])
+            && ! empty($mapping['sort']) && ! CollectionHelper::usesSet($mapping['strategy'])) {
+            throw MappingException::referenceManySortMustNotBeUsedWithNonSetCollectionStrategy($this->name, $mapping['fieldName'], $mapping['strategy']);
+        }
         
         if ($this->isEmbeddedDocument && $mapping['type'] === 'many' && CollectionHelper::isAtomic($mapping['strategy'])) {
             throw MappingException::atomicCollectionStrategyNotAllowed($mapping['strategy'], $this->name, $mapping['fieldName']);

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -244,4 +244,15 @@ class MappingException extends BaseMappingException
     {
         return new self("You must not change identifier field's type: $className::$fieldName");
     }
+
+    /**
+     * @param string $className
+     * @param string $fieldName
+     * @param string $strategy
+     * @return MappingException
+     */
+    public static function referenceManySortMustNotBeUsedWithNonSetCollectionStrategy($className, $fieldName, $strategy)
+    {
+        return new self("ReferenceMany's sort can not be used with addToSet and pushAll strategies, $strategy used in $className::$fieldName");
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataInfoTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataInfoTest.php
@@ -312,6 +312,22 @@ class ClassMetadataInfoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             'type' => 'string'
         ));
     }
+
+    /**
+     * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
+     * @expectedExceptionMessage ReferenceMany's sort can not be used with addToSet and pushAll strategies, pushAll used in stdClass::ref
+     */
+    public function testReferenceManySortMustNotBeUsedWithNonSetCollectionStrategy()
+    {
+        $cm = new ClassMetadataInfo('stdClass');
+        $cm->mapField(array(
+            'fieldName' => 'ref',
+            'reference' => true,
+            'strategy' => 'pushAll',
+            'type' => 'many',
+            'sort' => array('foo' => 1)
+        ));
+    }
 }
 
 class TestCustomRepositoryClass extends DocumentRepository

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -44,10 +44,10 @@ class User extends BaseDocument
     /** @ODM\ReferenceMany(targetDocument="Group", cascade={"all"}, strategy="addToSet") */
     protected $uniqueGroups;
 
-    /** @ODM\ReferenceMany(targetDocument="Group", name="groups", sort={"name"="asc"}) */
+    /** @ODM\ReferenceMany(targetDocument="Group", name="groups", sort={"name"="asc"}, strategy="setArray") */
     protected $sortedAscGroups;
 
-    /** @ODM\ReferenceMany(targetDocument="Group", name="groups", sort={"name"="desc"}) */
+    /** @ODM\ReferenceMany(targetDocument="Group", name="groups", sort={"name"="desc"}, strategy="setArray") */
     protected $sortedDescGroups;
 
     /** @ODM\ReferenceOne(targetDocument="Account", cascade={"all"}) */


### PR DESCRIPTION
Fixes #623. Strategies using `$set` should be ok as they are setting whole collection so it will just become sorted in the database, others could unset wrong index. 

I was wondering whether to revive #524 but that would be perfect if indeed all references would be unique (or using `addToSet` strategy) but I'm not sure if we can assume someone is not depending on having multiple references...