### PR TITLE
Make easier PSR-4 compliance

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/DocumentRepositoryGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/DocumentRepositoryGenerator.php
@@ -59,12 +59,20 @@ class <className> extends DocumentRepository
         return str_replace(array_keys($variables), array_values($variables), self::$template);
     }
 
-    public function writeDocumentRepositoryClass($fullClassName, $outputDirectory)
+    public function writeDocumentRepositoryClass($fullClassName, $outputDirectory, $outputDirectoryNamespace = null)
     {
         $code = $this->generateDocumentRepositoryClass($fullClassName);
-
+        
+        if (null === $outputDirectoryNamespace) {
+            $relativeClassName = $fullClassName;
+        } else {
+            $relativeClassName = preg_replace(
+                '/^'.str_replace('\\', '\\\\', $outputDirectoryNamespace).'\\\\/', '', $fullClassName
+            );
+        }
+        
         $path = $outputDirectory . DIRECTORY_SEPARATOR
-              . str_replace('\\', \DIRECTORY_SEPARATOR, $fullClassName) . '.php';
+              . str_replace('\\', \DIRECTORY_SEPARATOR, $relativeClassName) . '.php';
         $dir = dirname($path);
 
         if ( ! is_dir($dir)) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/DocumentRepositoryGeneratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/DocumentRepositoryGeneratorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Tools;
+
+use Doctrine\ODM\MongoDB\Tools\DocumentGenerator;
+use Doctrine\ODM\MongoDB\Tools\DocumentRepositoryGenerator;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
+
+class DocumentRepositoryGeneratorTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    /**
+     * @var string
+     */
+    private $tmpDir;
+
+    /**
+     * @var DocumentRepositoryGenerator
+     */
+    private $generator;
+
+    /**
+     * @var string
+     */
+    private $testBucket;
+
+    /**
+     * @var string
+     */
+    private $testBucketPath;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->tmpDir = sys_get_temp_dir();
+
+        // We create a temporary directory for each test
+        $this->testBucket = uniqid("doctrine_mongo_odm_");
+        $this->testBucketPath = $this->tmpDir . DIRECTORY_SEPARATOR . $this->testBucket;
+        mkdir($this->testBucketPath);
+
+        $this->generator = new DocumentRepositoryGenerator();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        if (isset($this->testBucketPath) && !empty($this->testBucketPath)) {
+            $ri = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->testBucketPath));
+            foreach ($ri AS $file) {
+                /* @var $file \SplFileInfo */
+                if ($file->isFile()) {
+                    \unlink($file->getPathname());
+                }
+            }
+            rmdir($this->testBucketPath);
+        }
+    }
+
+    public function testPersistedDocumentRepositoryClassWithSimpleNamespaceMapping()
+    {
+        $namespace = $this->testBucket;
+
+        $this->generator->writeDocumentRepositoryClass($namespace . '\\TestDocumentRepository', $this->tmpDir);
+
+        $this->assertFileExists($this->testBucketPath . DIRECTORY_SEPARATOR ."TestDocumentRepository.php");
+    }
+
+    public function testPersistedDocumentRepositoryClassWithArbitraryNamespaceMapping()
+    {
+        $namespace = 'A\B\C\D';
+
+        $this->generator->writeDocumentRepositoryClass(
+            $namespace . '\\TestDocumentRepository', $this->testBucketPath, $namespace
+        );
+
+        $this->assertFileExists($this->testBucketPath . DIRECTORY_SEPARATOR ."TestDocumentRepository.php");
+    }
+}


### PR DESCRIPTION
In order to make possible a clean fix in the DoctrineMongoDBBundle project I have added an extra parameter to the DocumentRepositoryGenerator->writeDocumentRepositoryClass method.

This extra parameter allows to generate classes in directories that doesn't directly map the namespace structure.