### PR TITLE
Query and Builder priming improvements

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -152,7 +152,6 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
             throw new \BadMethodCallException("Can't call prime() when setting eagerCursor to false");
         }
 
-        $this->eagerCursor(true);
         $this->primers[$this->currentField] = $primer;
         return $this;
     }

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -148,6 +148,12 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
             throw new \InvalidArgumentException('$primer is not a boolean or callable');
         }
 
+        if ($primer === false) {
+            unset($this->primers[$this->currentField]);
+
+            return $this;
+        }
+
         if (array_key_exists('eagerCursor', $this->query) && !$this->query['eagerCursor']) {
             throw new \BadMethodCallException("Can't call prime() when setting eagerCursor to false");
         }

--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -100,11 +100,17 @@ class Query extends \Doctrine\MongoDB\Query\Query
      */
     public function __construct(DocumentManager $dm, ClassMetadata $class, Collection $collection, array $query = array(), array $options = array(), $hydrate = true, $refresh = false, array $primers = array(), $requireIndexes = null)
     {
+        $primers = array_filter($primers);
+
+        if ( ! empty($primers)) {
+            $query['eagerCursor'] = true;
+        }
+
         parent::__construct($collection, $query, $options);
         $this->dm = $dm;
         $this->class = $class;
         $this->hydrate = $hydrate;
-        $this->primers = array_filter($primers);
+        $this->primers = $primers;
         $this->requireIndexes = $requireIndexes;
 
         $this->setRefresh($refresh);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
@@ -80,6 +80,15 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->eagerCursor(false);
     }
 
+    public function testFieldPrimingCanBeToggled()
+    {
+        $this->dm->createQueryBuilder('Documents\User')
+            ->field('account')
+            ->prime(true)
+            ->prime(false)
+            ->eagerCursor(false);
+    }
+
     /**
      * @expectedException BadMethodCallException
      */


### PR DESCRIPTION
 * Moves "priming implies eager cursor" logic to Query constructor, which is more reliable.
 * Removes unnecessary exception when disabling a primer via `Builder::prime()` and then disabling eager cursors.