### PR TITLE
Don't import annotations whose names are reserved words in PHP7+

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php
@@ -37,12 +37,17 @@ require_once __DIR__ . '/AbstractField.php';
 require_once __DIR__ . '/Field.php';
 require_once __DIR__ . '/Id.php';
 require_once __DIR__ . '/Hash.php';
-require_once __DIR__ . '/Bool.php';
+
+// Don't import annotations whose names are reserved words in PHP7+
+if (PHP_VERSION_ID < 70000) {
+    require_once __DIR__ . '/Bool.php';
+    require_once __DIR__ . '/Int.php';
+    require_once __DIR__ . '/Float.php';
+    require_once __DIR__ . '/String.php';
+}
+
 require_once __DIR__ . '/Boolean.php';
-require_once __DIR__ . '/Int.php';
 require_once __DIR__ . '/Integer.php';
-require_once __DIR__ . '/Float.php';
-require_once __DIR__ . '/String.php';
 require_once __DIR__ . '/Date.php';
 require_once __DIR__ . '/Key.php';
 require_once __DIR__ . '/Timestamp.php';


### PR DESCRIPTION
Fixes #1168