### PR TITLE
Don't compute changesets for uninitialized proxies

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -989,6 +989,11 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function recomputeSingleDocumentChangeSet(ClassMetadata $class, $document)
     {
+        // Ignore uninitialized proxy objects
+        if ($document instanceof Proxy && ! $document->__isInitialized__) {
+            return;
+        }
+
         $oid = spl_object_hash($document);
 
         if ( ! isset($this->documentStates[$oid]) || $this->documentStates[$oid] != self::STATE_MANAGED) {


### PR DESCRIPTION
This fixes an issue where calling ```recomputeSingleDocumentChangeSet``` with an uninitialized proxy object would generate a changeset that rewrites the entire document.