### PR TITLE
Fix regression with cursor counts

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Cursor.php
+++ b/lib/Doctrine/ODM/MongoDB/Cursor.php
@@ -226,7 +226,7 @@ class Cursor implements CursorInterface
      * @param boolean $foundOnly
      * @return integer
      */
-    public function count($foundOnly = true)
+    public function count($foundOnly = false)
     {
         return $this->baseCursor->count($foundOnly);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CursorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CursorTest.php
@@ -91,4 +91,26 @@ class CursorTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\EagerCursor', $cursor);
         $this->assertInstanceOf('Doctrine\MongoDB\EagerCursor', $cursor->getBaseCursor());
     }
+
+    public function testCountFoundOnlyBehavior()
+    {
+        $usernames = array('David', 'Xander', 'Alex', 'Kris', 'Jon');
+
+        foreach ($usernames as $username){
+            $user = new User();
+            $user->setUsername($username);
+            $this->dm->persist($user);
+        }
+
+        $this->dm->flush();
+
+        $cursor = $this->dm->createQueryBuilder('Documents\User')
+            ->sort('username', 'asc')
+            ->limit(2)
+            ->getQuery()
+            ->execute();
+
+        $this->assertEquals(5, $cursor->count());
+        $this->assertEquals(2, $cursor->count(true));
+    }
 }


### PR DESCRIPTION
This fixes a regression introduced in e2f23bc3eea11393995f0a799a02f34380201606 that causes wrong counts to be returned.
The default behavior for count() in a cursor is to return all elements, disregarding any skip/limit set.