### PR TITLE
Do not prime references for single result when document is empty

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Cursor.php
+++ b/lib/Doctrine/ODM/MongoDB/Cursor.php
@@ -707,7 +707,7 @@ class Cursor implements CursorInterface
      */
     protected function primeReferencesForSingleResult($document)
     {
-        if ($this->referencesPrimed || ! $this->hydrate || empty($this->primers)) {
+        if ($this->referencesPrimed || ! $this->hydrate || empty($this->primers) || null === $document) {
             return;
         }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CursorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CursorTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\ODM\MongoDB\Cursor;
 use Documents\User;
 
 class CursorTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
@@ -112,5 +113,18 @@ class CursorTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->assertEquals(5, $cursor->count());
         $this->assertEquals(2, $cursor->count(true));
+    }
+
+    public function testPrimeEmptySingleResult()
+    {
+        /* @var Cursor $cursor */
+        $cursor = $this->dm->createQueryBuilder('Documents\User')
+            ->field('groups')->prime(true)
+            ->getQuery()
+            ->execute();
+
+        $result = $cursor->getSingleResult();
+
+        $this->assertNull($result);
     }
 }


### PR DESCRIPTION
This PR fixes issue
Given priming is enabled in query
And query result is empty
When _Cursor::getSingleResult()_ method is called
Then php error is triggered:
```
ReflectionProperty::getValue() expects parameter 1 to be object, null given
 ../mongodb-odm/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php:1535
 ../mongodb-odm/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php:140
 ../mongodb-odm/lib/Doctrine/ODM/MongoDB/Cursor.php:716
 ../mongodb-odm/lib/Doctrine/ODM/MongoDB/Cursor.php:347
 ../mongodb-odm/tests/Doctrine/ODM/MongoDB/Tests/Functional/CursorTest.php:126
```