### PR TITLE
Fix incorrect behavior of EagerCursor::count() method with foundOnly false flag

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/EagerCursor.php
+++ b/lib/Doctrine/ODM/MongoDB/EagerCursor.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ODM\MongoDB;
 
+use Doctrine\MongoDB\EagerCursor as BaseEagerCursor;
+
 /**
  * EagerCursor wraps a Cursor instance and fetches all of its results upon
  * initialization.
@@ -29,4 +31,18 @@ namespace Doctrine\ODM\MongoDB;
  */
 class EagerCursor extends Cursor
 {
+    /**
+     * Workaround to use base cursor of \Doctrine\MongoDB\EagerCursor count method
+     * since \Doctrine\MongoDB\EagerCursor::count() method does not support $foundOnly = false flag
+     * {@inheritdoc}
+     */
+    public function count($foundOnly = false)
+    {
+        if (false === $foundOnly && $this->getBaseCursor() instanceof BaseEagerCursor) {
+            return $this->getBaseCursor()->getCursor()->count($foundOnly);
+        } else {
+            return parent::count($foundOnly);
+        }
+    }
+
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EagerCursorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EagerCursorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\EagerCursor;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\User;
+
+class EagerCursorTest extends BaseTest
+{
+    public function testCountFoundOnlyBehaviorWithPrimingEnabled()
+    {
+        $usernames = array('David', 'Xander', 'Alex', 'Kris', 'Jon');
+
+        foreach ($usernames as $username){
+            $user = new User();
+            $user->setUsername($username);
+            $this->dm->persist($user);
+        }
+
+        $this->dm->flush();
+
+        /* @var EagerCursor $cursor */
+        $cursor = $this->dm->createQueryBuilder('Documents\User')
+            ->sort('username', 'asc')
+            ->field('groups')->prime(true)
+            ->limit(2)
+            ->getQuery()
+            ->execute();
+
+        $this->assertInstanceOf('\Doctrine\ODM\MongoDB\EagerCursor', $cursor);
+
+        $this->assertEquals(5, $cursor->count());
+        $this->assertEquals(2, $cursor->count(true));
+    }
+}


### PR DESCRIPTION
This PR fixes issue:

Given document collection has 5 elements
When i create query with limit 2
And priming is enabled
And query is executed
Then eager cursor is returned
When count method is called with foundOnly false flag
Then count 5 is expected to be returned
But count 2 is returned instead

This happens because _\Doctrine\MongoDB\EagerCursor_ that is used as base cursor of _\Doctrine\ODM\MongoDB\EagerCursor_ does not support _$foundOnly_ flag in _count()_ method