### PR TITLE
Allows DateType to be more easily extended.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/DateType.php
@@ -44,7 +44,7 @@ class DateType extends Type
         if ($value instanceof \DateTime || $value instanceof \DateTimeInterface) {
             return $value;
         } elseif ($value instanceof \MongoDate) {
-            $datetime = self::craftDateTime($value->sec, $value->usec);
+            $datetime = static::craftDateTime($value->sec, $value->usec);
         } elseif (is_numeric($value)) {
             $seconds = $value;
             $microseconds = 0;
@@ -54,7 +54,7 @@ class DateType extends Type
                 $microseconds = (int) str_pad((int) $microseconds, 6, '0'); // ensure microseconds
             }
 
-            $datetime = self::craftDateTime($seconds, $microseconds);
+            $datetime = static::craftDateTime($seconds, $microseconds);
         } elseif (is_string($value)) {
             try {
                 $datetime = new \DateTime($value);
@@ -87,7 +87,7 @@ class DateType extends Type
             return $value;
         }
 
-        $datetime = self::getDateTime($value);
+        $datetime = static::getDateTime($value);
 
         return new \MongoDate($datetime->format('U'), $datetime->format('u'));
     }
@@ -98,16 +98,16 @@ class DateType extends Type
             return null;
         }
 
-        return self::getDateTime($value);
+        return static::getDateTime($value);
     }
 
     public function closureToMongo()
     {
-        return 'if ($value === null || $value instanceof \MongoDate) { $return = $value; } else { $datetime = \\'.__CLASS__.'::getDateTime($value); $return = new \MongoDate($datetime->format(\'U\'), $datetime->format(\'u\')); }';
+        return 'if ($value === null || $value instanceof \MongoDate) { $return = $value; } else { $datetime = \\'.static::class.'::getDateTime($value); $return = new \MongoDate($datetime->format(\'U\'), $datetime->format(\'u\')); }';
     }
 
     public function closureToPHP()
     {
-        return 'if ($value === null) { $return = null; } else { $return = \\'.__CLASS__.'::getDateTime($value); }';
+        return 'if ($value === null) { $return = null; } else { $return = \\'.static::class.'::getDateTime($value); }';
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/DateType.php
@@ -103,11 +103,11 @@ class DateType extends Type
 
     public function closureToMongo()
     {
-        return 'if ($value === null || $value instanceof \MongoDate) { $return = $value; } else { $datetime = \\'.static::class.'::getDateTime($value); $return = new \MongoDate($datetime->format(\'U\'), $datetime->format(\'u\')); }';
+        return 'if ($value === null || $value instanceof \MongoDate) { $return = $value; } else { $datetime = \\'.get_class($this).'::getDateTime($value); $return = new \MongoDate($datetime->format(\'U\'), $datetime->format(\'u\')); }';
     }
 
     public function closureToPHP()
     {
-        return 'if ($value === null) { $return = null; } else { $return = \\'.static::class.'::getDateTime($value); }';
+        return 'if ($value === null) { $return = null; } else { $return = \\'.get_class($this).'::getDateTime($value); }';
     }
 }


### PR DESCRIPTION
Uses late static binding to allow `DateType` to be extended without the need to duplicate methods unnecessarily.

In my application, I want to use [nesbot/carbon](https://github.com/briannesbitt/carbon) in place of `DateTime` objects with all of my dates on the PHP side of things. I wanted this change to be universal, so rather than implementing a totally new custom type, I chose to override the original `date` type.

In doing so, I found that the `DateType` makes too many references to itself, both via `self::` and through the output of `__CLASS__` when generating the hydrator, making extension difficult. With the proposed changes, my extension remains extremely tidy:

```php
use Carbon\Carbon;
use Doctrine\ODM\MongoDB\Types\DateType;

class CarbonDateType extends DateType
{
    public static function getDateTime($value)
    {
        return Carbon::instance(parent::getDateTime($value));
    }
}
```

`DateTypeTest` passes all assertions, only skipping 32 or 64 bit respectively. I ran into a lot of other errors running PHPUnit as a whole, looking into those further to determine if that's on my end or what, so I apologize if I missed a related test that happens to fail.

If I can improve this pull request in any way, please let me know! Congratulations on your 1.0 release recently. :beers: 