### PR TITLE
Lifecycle callbacks should receive event arguments

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -153,7 +153,11 @@ the life-time of their registered documents.
 - 
    postUpdate - The postUpdate event occurs after the database update
    operations to document data.
-- 
+-
+   preLoad - The preLoad event occurs for a document before the
+   document has been loaded into the current DocumentManager from the
+   database or after the refresh operation has been applied to it.
+-
    postLoad - The postLoad event occurs for a document after the
    document has been loaded into the current DocumentManager from the
    database or after the refresh operation has been applied to it.
@@ -235,37 +239,44 @@ event occurs.
         private $createdAt;
     
         /** @PrePersist */
-        public function doStuffOnPrePersist()
+        public function doStuffOnPrePersist(\Doctrine\ODM\MongoDB\Event\LifecycleEventArgs $eventArgs)
         {
             $this->createdAt = date('Y-m-d H:i:s');
         }
     
         /** @PrePersist */
-        public function doOtherStuffOnPrePersist()
+        public function doOtherStuffOnPrePersist(\Doctrine\ODM\MongoDB\Event\LifecycleEventArgs $eventArgs)
         {
             $this->value = 'changed from prePersist callback!';
         }
     
         /** @PostPersist */
-        public function doStuffOnPostPersist()
+        public function doStuffOnPostPersist(\Doctrine\ODM\MongoDB\Event\LifecycleEventArgs $eventArgs)
         {
             $this->value = 'changed from postPersist callback!';
         }
+
+        /** @PreLoad */
+        public function doStuffOnPreLoad(\Doctrine\ODM\MongoDB\Event\PreLoadEventArgs $eventArgs)
+        {
+            $data =& $eventArgs->getData();
+            $data['value'] = 'changed from preLoad callback';
+        }
     
         /** @PostLoad */
-        public function doStuffOnPostLoad()
+        public function doStuffOnPostLoad(\Doctrine\ODM\MongoDB\Event\LifecycleEventArgs $eventArgs)
         {
             $this->value = 'changed from postLoad callback!';
         }
     
         /** @PreUpdate */
-        public function doStuffOnPreUpdate()
+        public function doStuffOnPreUpdate(\Doctrine\ODM\MongoDB\Event\PreUpdateEventArgs $eventArgs)
         {
             $this->value = 'changed from preUpdate callback!';
         }
 
         /** @PreFlush */
-        public function preFlush()
+        public function preFlush(\Doctrine\ODM\MongoDB\Event\PreFlushEventArgs $eventArgs)
         {
             $this->value = 'changed from preFlush callback!';
         }
@@ -343,6 +354,32 @@ Define the ``EventTest`` class:
         {
             $document = $eventArgs->getDocument();
             $document->setSomething();
+        }
+    }
+
+preLoad
+~~~~~~~
+
+.. code-block:: php
+
+    <?php
+
+    $test = new EventTest();
+    $evm = $dm->getEventManager();
+    $evm->addEventListener(Events::preLoad, $test);
+
+Define the ``EventTest`` class with a ``preLoad()`` method:
+
+.. code-block:: php
+
+    <?php
+
+    class EventTest
+    {
+        public function preLoad(\Doctrine\ODM\MongoDB\Event\PreLoadEventArgs $eventArgs)
+        {
+            $data =& $eventArgs->getData();
+            // do something
         }
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -431,7 +431,7 @@ EOF
         $metadata = $this->dm->getClassMetadata(get_class($document));
         // Invoke preLoad lifecycle events and listeners
         if ( ! empty($metadata->lifecycleCallbacks[Events::preLoad])) {
-            $args = array(&$data);
+            $args = array(new PreLoadEventArgs($document, $this->dm, $data));
             $metadata->invokeLifecycleCallbacks(Events::preLoad, $document, $args);
         }
         if ($this->evm->hasListeners(Events::preLoad)) {
@@ -458,7 +458,7 @@ EOF
 
         // Invoke the postLoad lifecycle callbacks and listeners
         if ( ! empty($metadata->lifecycleCallbacks[Events::postLoad])) {
-            $metadata->invokeLifecycleCallbacks(Events::postLoad, $document);
+            $metadata->invokeLifecycleCallbacks(Events::postLoad, $document, array(new LifecycleEventArgs($document, $this->dm)));
         }
         if ($this->evm->hasListeners(Events::postLoad)) {
             $this->evm->dispatchEvent(Events::postLoad, new LifecycleEventArgs($document, $this->dm));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleCallbacksTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleCallbacksTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\ODM\MongoDB\Tests\Events;
 
+use Doctrine\ODM\MongoDB\Event;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 
@@ -268,57 +269,57 @@ abstract class BaseDocument
     public $preFlush = false;
 
     /** @ODM\PrePersist */
-    public function prePersist()
+    public function prePersist(Event\LifecycleEventArgs $e)
     {
         $this->prePersist = true;
         $this->createdAt = new \DateTime();
     }
 
     /** @ODM\PostPersist */
-    public function postPersist()
+    public function postPersist(Event\LifecycleEventArgs $e)
     {
         $this->postPersist = true;
     }
 
     /** @ODM\PreUpdate */
-    public function preUpdate()
+    public function preUpdate(Event\PreUpdateEventArgs $e)
     {
         $this->preUpdate = true;
         $this->updatedAt = new \DateTime();
     }
 
     /** @ODM\PostUpdate */
-    public function postUpdate()
+    public function postUpdate(Event\LifecycleEventArgs $e)
     {
         $this->postUpdate = true;
     }
 
     /** @ODM\PreRemove */
-    public function preRemove()
+    public function preRemove(Event\LifecycleEventArgs $e)
     {
         $this->preRemove = true;
     }
 
     /** @ODM\PostRemove */
-    public function postRemove()
+    public function postRemove(Event\LifecycleEventArgs $e)
     {
         $this->postRemove = true;
     }
 
     /** @ODM\PreLoad */
-    public function preLoad()
+    public function preLoad(Event\PreLoadEventArgs $e)
     {
         $this->preLoad = true;
     }
 
     /** @ODM\PostLoad */
-    public function postLoad()
+    public function postLoad(Event\LifecycleEventArgs $e)
     {
         $this->postLoad = true;
     }
     
     /** @ODM\PreFlush */
-    public function preFlush()
+    public function preFlush(Event\PreFlushEventArgs $e)
     {
         $this->preFlush = true;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM43Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM43Test.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
+use Doctrine\ODM\MongoDB\Event\PreLoadEventArgs;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 class MODM43Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
@@ -31,8 +32,9 @@ class Person
     public $lastName;
 
     /** @ODM\PreLoad */
-    public function preLoad(array &$data)
+    public function preLoad(PreLoadEventArgs $e)
     {
+        $data =& $e->getData();
         if (isset($data['name'])) {
             $e = explode(' ', $data['name']);
             $data['firstName'] = $e[0];


### PR DESCRIPTION
Closes #902 

This PR contains a tiny BC break - before `preLoad` lifecycle callback received `$data` by reference directly, now it receives a `PreLoadEventArgs` as it should BUT I wouldn't count it as BC break though - that event wasn't even documented.