### PR TITLE
Functional test to demonstrate that modifications to embedManys do not work as expected if @preUpdate hooks are used

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
@@ -10,16 +10,15 @@ class GH1225Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testAddOnUninitializedCollection()
     {
         $doc = new GH1225Document();
-        $mySubDoc = new GH1225EmbeddedDocument('foo');
-        $doc->embeds->add($mySubDoc);
+        $doc->embeds->add(new GH1225EmbeddedDocument('foo'));
         $this->dm->persist($doc);
         $this->dm->flush();
         $this->dm->clear();
 
         $doc = $this->dm->getRepository(get_class($doc))->find($doc->id);
-        $removedEmbeddedDocumentOne = $doc->embeds->first();
+        $embeddedDoc = $doc->embeds->first();
         $doc->embeds->clear();
-        $doc->embeds->add($removedEmbeddedDocumentOne);
+        $doc->embeds->add($embeddedDoc);
         $this->dm->flush();
         $this->dm->clear();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
@@ -5,12 +5,12 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1225Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
     public function testAddOnUninitializedCollection()
     {
-        $doc = new GHXXXXDocument();
-        $mySubDoc = new GHXXXXEmbeddedDocument('foo');
+        $doc = new GH1225Document();
+        $mySubDoc = new GH1225EmbeddedDocument('foo');
         $doc->embeds->add($mySubDoc);
         $this->dm->persist($doc);
         $this->dm->flush();
@@ -32,12 +32,12 @@ class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
  * @ODM\Document
  * @ODM\HasLifecycleCallbacks
  */
-class GHXXXXDocument
+class GH1225Document
 {
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedMany(strategy="atomicSet", targetDocument="GHXXXXEmbeddedDocument") */
+    /** @ODM\EmbedMany(strategy="atomicSet", targetDocument="GH1225EmbeddedDocument") */
     public $embeds;
 
     public function __construct()
@@ -56,7 +56,7 @@ class GHXXXXDocument
 /**
  * @ODM\EmbeddedDocument
  */
-class GHXXXXEmbeddedDocument
+class GH1225EmbeddedDocument
 {
     /** @ODM\String */
     public $value;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
@@ -7,7 +7,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 class GH1225Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
-    public function testAddOnUninitializedCollection()
+    public function testRemoveAddEmbeddedDocToExistingDocumentWithPreUpdateHook()
     {
         $doc = new GH1225Document();
         $doc->embeds->add(new GH1225EmbeddedDocument('foo'));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GHXXXXTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GHXXXXTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class GHXXXXTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testAddOnUninitializedCollection()
+    {
+        $doc = new GHXXXXDocument();
+        $mySubDoc = new GHXXXXEmbeddedDocument('foo');
+        $doc->embeds->add($mySubDoc);
+        $this->dm->persist($doc);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $doc = $this->dm->getRepository(get_class($doc))->find($doc->id);
+        $removedEmbeddedDocumentOne = $doc->embeds->first();
+        $doc->embeds->clear();
+        $doc->embeds->add($removedEmbeddedDocumentOne);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $doc = $this->dm->getRepository(get_class($doc))->find($doc->id);
+        $this->assertCount(1, $doc->embeds);
+    }
+}
+
+/**
+ * @ODM\Document
+ * @ODM\HasLifecycleCallbacks
+ */
+class GHXXXXDocument
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedMany(strategy="atomicSet", targetDocument="GHXXXXEmbeddedDocument") */
+    public $embeds;
+
+    public function __construct()
+    {
+        $this->embeds = new ArrayCollection();
+    }
+
+    /**
+     * @ODM\PreUpdate
+     */
+    public function exampleHook()
+    {
+    }
+}
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class GHXXXXEmbeddedDocument
+{
+    /** @ODM\String */
+    public $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+}


### PR DESCRIPTION
When preUpdate hooks are used, Doctrine ODM does not handle changes to embedMany elements correctly.

The attached functional test only passes when the preUpdate hook is removed.