### PR TITLE
Functional test to demonstrate incorrect value in PreUpdate changeset with embedded document

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1230Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1230Test.php
@@ -5,19 +5,19 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GHXXXXTest extends BaseTest
+class GH1230Test extends BaseTest
 {
     public function testEmbeddedDocChangesetInPreUpdateHook()
     {
-        $doc = new GHXXXXDocument();
-        $doc->embeddedDoc = new GHXXXXEmbeddedDocument('embedded doc value');
+        $doc = new GH1230Document();
+        $doc->embeddedDoc = new GH1230EmbeddedDocument('embedded doc value');
         $doc->stringProperty = 'string property';
 
         $this->dm->persist($doc);
         $this->dm->flush();
         $this->dm->clear();
 
-        /** @var GHXXXXDocument $doc */
+        /** @var GH1230Document $doc */
         $doc = $this->dm->getRepository(get_class($doc))->find($doc->id);
         $doc->embeddedDoc->value = 'updated embedded doc value';
         $doc->stringProperty = 'updated string property';
@@ -39,16 +39,16 @@ class GHXXXXTest extends BaseTest
  * @ODM\Document
  * @ODM\HasLifecycleCallbacks
  */
-class GHXXXXDocument
+class GH1230Document
 {
     /** @ODM\Id */
     public $id;
-    /** @ODM\EmbedOne(targetDocument="GHXXXXEmbeddedDocument") */
+    /** @ODM\EmbedOne(targetDocument="GH1230EmbeddedDocument") */
     public $embeddedDoc;
     /** @ODM\String */
     public $stringProperty;
 
-    /** @var GHXXXXTest */
+    /** @var GH1230Test */
     public $test;
 
     /**
@@ -63,8 +63,8 @@ class GHXXXXDocument
                     'updated string property',
                 ),
                 'embeddedDoc'    => array(
-                    new GHXXXXEmbeddedDocument('embedded doc value'),
-                    new GHXXXXEmbeddedDocument('updated embedded doc value'),
+                    new GH1230EmbeddedDocument('embedded doc value'),
+                    new GH1230EmbeddedDocument('updated embedded doc value'),
                 ),
             ),
             $this->test->getDm()->getUnitOfWork()->getDocumentChangeSet($this)
@@ -75,7 +75,7 @@ class GHXXXXDocument
 /**
  * @ODM\EmbeddedDocument
  */
-class GHXXXXEmbeddedDocument
+class GH1230EmbeddedDocument
 {
     /** @ODM\String */
     public $value;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GHXXXXTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GHXXXXTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class GHXXXXTest extends BaseTest
+{
+    public function testEmbeddedDocChangesetInPreUpdateHook()
+    {
+        $doc = new GHXXXXDocument();
+        $doc->embeddedDoc = new GHXXXXEmbeddedDocument('embedded doc value');
+        $doc->stringProperty = 'string property';
+
+        $this->dm->persist($doc);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        /** @var GHXXXXDocument $doc */
+        $doc = $this->dm->getRepository(get_class($doc))->find($doc->id);
+        $doc->embeddedDoc->value = 'updated embedded doc value';
+        $doc->stringProperty = 'updated string property';
+
+        $doc->test = $this;
+
+        $this->dm->persist($doc);
+        $this->dm->flush();
+        $this->dm->clear();
+    }
+
+    public function getDm()
+    {
+        return $this->dm;
+    }
+}
+
+/**
+ * @ODM\Document
+ * @ODM\HasLifecycleCallbacks
+ */
+class GHXXXXDocument
+{
+    /** @ODM\Id */
+    public $id;
+    /** @ODM\EmbedOne(targetDocument="GHXXXXEmbeddedDocument") */
+    public $embeddedDoc;
+    /** @ODM\String */
+    public $stringProperty;
+
+    /** @var GHXXXXTest */
+    public $test;
+
+    /**
+     * @ODM\PreUpdate
+     */
+    public function preUpdateHook()
+    {
+        $this->test->assertEquals(
+            array(
+                'stringProperty' => array(
+                    'string property',
+                    'updated string property',
+                ),
+                'embeddedDoc'    => array(
+                    new GHXXXXEmbeddedDocument('embedded doc value'),
+                    new GHXXXXEmbeddedDocument('updated embedded doc value'),
+                ),
+            ),
+            $this->test->getDm()->getUnitOfWork()->getDocumentChangeSet($this)
+        );
+    }
+}
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class GHXXXXEmbeddedDocument
+{
+    /** @ODM\String */
+    public $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+}


### PR DESCRIPTION
In an `@ODM\PreUpdate` hook, the DM changeset's 'original value' for an embedded document is actually the changed value. The attached test fails with the following output:

```
$ vendor/bin/phpunit /Users/maxr/src/mongodb-odm/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1230Test.php
PHPUnit 4.8.7 by Sebastian Bergmann and contributors.

F

Time: 127 ms, Memory: 7.50Mb

There was 1 failure:

1) Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH1230Test::testEmbeddedDocChangesetInPreUpdateHook
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'stringProperty' => Array (...)
     'embeddedDoc' => Array (
         0 => Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH1230EmbeddedDocument Object (
-            'value' => 'embedded doc value'
+            'value' => 'updated embedded doc value'
         )
         1 => Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH1230EmbeddedDocument Object (...)
     )
 )

/Users/maxr/src/mongodb-odm/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1230Test.php:71
/Users/maxr/src/mongodb-odm/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php:549
/Users/maxr/src/mongodb-odm/lib/Doctrine/ODM/MongoDB/UnitOfWork.php:1194
/Users/maxr/src/mongodb-odm/lib/Doctrine/ODM/MongoDB/UnitOfWork.php:426
/Users/maxr/src/mongodb-odm/lib/Doctrine/ODM/MongoDB/DocumentManager.php:528
/Users/maxr/src/mongodb-odm/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1230Test.php:28

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```