### PR TITLE
Avoid null embedded documents.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -612,6 +612,9 @@ class DocumentPersister
         $owner = $collection->getOwner();
         if ($embeddedDocuments) {
             foreach ($embeddedDocuments as $key => $embeddedDocument) {
+                if (!is_array($embeddedDocument)) {
+                    continue;
+                }
                 $className = $this->uow->getClassNameForAssociation($mapping, $embeddedDocument);
                 $embeddedMetadata = $this->dm->getClassMetadata($className);
                 $embeddedDocumentObject = $embeddedMetadata->newInstance();


### PR DESCRIPTION
We recently uncovered some null embedded documents in our mongodb. Though it is not clear how they were introduced, their existence causes loadEmbedManyCollection to die with:

```
Symfony\Component\Debug\Exception\ContextErrorException occured doing REDACTED, message: Catchable Fatal Error: Argument 2 passed to Doctrine\ODM\MongoDB\UnitOfWork::getClassNameForAssociation() must be of the type array, null given, called in /REDACTED/vendor/doctrine/mongodb-odm/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php on line 615 and defined in /REDACTED/vendor/doctrine/mongodb-odm/lib/Doctrine/ODM/MongoDB/UnitOfWork.php line 2702
```

Adding some defensive coding to avoid type hint fatal.
