### PR TITLE
Fixing ClassMetadata to work on case sensitive filesystems

### DIFF
--- a/docs/en/reference/filters.rst
+++ b/docs/en/reference/filters.rst
@@ -29,7 +29,7 @@ should be accessed via ``BsonFilter::getParameter()``.
 
     namespace Vendor\Filter;
 
-    use Doctrine\ODM\MongoDB\Mapping\ClassMetaData;
+    use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
     use Doctrine\ODM\MongoDB\Query\Filter\BsonFilter;
 
     class MyLocaleFilter extends BsonFilter

--- a/lib/Doctrine/ODM/MongoDB/Query/Filter/BsonFilter.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Filter/BsonFilter.php
@@ -20,7 +20,7 @@
 namespace Doctrine\ODM\MongoDB\Query\Filter;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Mapping\ClassMetaData;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 
 /**
  * The base class that user defined filters should extend.

--- a/lib/Doctrine/ODM/MongoDB/Query/FilterCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/FilterCollection.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Query;
 
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Mapping\ClassMetaData;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 
 /**
  * Collection class for all the query filters.

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/BsonFilterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/BsonFilterTest.php
@@ -19,4 +19,11 @@ class BsonFilterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $filter->setParameter('username', 'Tim');
         $this->assertEquals('Tim', $filter->getParameter('username'));
     }
+ 
+    public function testCreateMockOfFilter()
+    {
+        $this->getMockBuilder('\Doctrine\ODM\MongoDB\Query\Filter\BsonFilter')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/Filter.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/Filter.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\ODM\MongoDB\Tests\Query\Filter;
 
-use Doctrine\ODM\MongoDB\Mapping\ClassMetaData;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Query\Filter\BsonFilter;
 
 class Filter extends BsonFilter


### PR DESCRIPTION
When BsonFilter class gets to mock, it shows case sensitive problem. If any class inherits from it, the problem does not exists - the inherited class can change typed argument (ClassMetaData to ClassMetadata). The only way I know how to test it,  is to creating a mock.