### PR TITLE
Unschedule orphan removal if an element is re-added

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -187,9 +187,13 @@ class PersistentCollection implements BaseCollection
             $newObjects = $this->coll->toArray();
         }
 
+        $this->initialized = true;
+
         $this->coll->clear();
         $this->uow->loadCollection($this);
         $this->takeSnapshot();
+
+        $this->mongoData = array();
 
         // Reattach any NEW objects added through add()
         if ($newObjects) {
@@ -203,9 +207,6 @@ class PersistentCollection implements BaseCollection
 
             $this->isDirty = true;
         }
-
-        $this->mongoData = array();
-        $this->initialized = true;
     }
 
     /**
@@ -533,7 +534,18 @@ class PersistentCollection implements BaseCollection
      */
     public function set($key, $value)
     {
+        $oldValue = $this->get($key);
         $this->coll->set($key, $value);
+
+        // Handle orphanRemoval
+        if ($this->uow !== null && $this->isOrphanRemovalEnabled()) {
+            if ($oldValue !== null) {
+                $this->uow->scheduleOrphanRemoval($oldValue);
+            }
+
+            $this->uow->unscheduleOrphanRemoval($value);
+        }
+
         $this->changed();
     }
 

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -551,6 +551,11 @@ class PersistentCollection implements BaseCollection
         }
         $this->coll->add($value);
         $this->changed();
+
+        if ($this->uow !== null && $this->isOrphanRemovalEnabled()) {
+            $this->uow->unscheduleOrphanRemoval($value);
+        }
+
         return true;
     }
 

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2480,6 +2480,21 @@ class UnitOfWork implements PropertyChangedListener
         $this->orphanRemovals[spl_object_hash($document)] = $document;
     }
 
+    /**
+     * INTERNAL:
+     * Unschedules an embedded or referenced object for removal.
+     *
+     * @ignore
+     * @param object $document
+     */
+    public function unscheduleOrphanRemoval($document)
+    {
+        $oid = spl_object_hash($document);
+        if (isset($this->orphanRemovals[$oid])) {
+            unset($this->orphanRemovals[$oid]);
+        }
+    }
+
     private function fixPersistentCollectionOwnership(PersistentCollection $coll, $document, $class, $propName)
     {
         $owner = $coll->getOwner();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
@@ -171,6 +171,31 @@ class OrphanRemovalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertNotNull($this->getProfileRepository()->find($profile3->id), 'Profile 3 should have been created');
     }
 
+    public function testOrphanRemovalOnReferenceManyUsingSet()
+    {
+        $profile1 = new OrphanRemovalProfile();
+        $profile2 = new OrphanRemovalProfile();
+        $profile3 = new OrphanRemovalProfile();
+
+        $user = new OrphanRemovalUser();
+        $user->profileMany[] = $profile1;
+        $user->profileMany[] = $profile2;
+        $this->dm->persist($user);
+        $this->dm->persist($profile1);
+        $this->dm->persist($profile2);
+        $this->dm->persist($profile3);
+        $this->dm->flush();
+
+        $user->profileMany->set(0, $profile3);
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $this->assertNull($this->getProfileRepository()->find($profile1->id), 'Profile 1 should have been removed');
+        $this->assertNotNull($this->getProfileRepository()->find($profile2->id), 'Profile 2 should have been left as-is');
+        $this->assertNotNull($this->getProfileRepository()->find($profile3->id), 'Profile 3 should have been created');
+    }
+
     public function testOrphanRemovalWhenRemovingAndAddingSameElement()
     {
         $profile = new OrphanRemovalProfile();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
@@ -171,6 +171,25 @@ class OrphanRemovalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertNotNull($this->getProfileRepository()->find($profile3->id), 'Profile 3 should have been created');
     }
 
+    public function testOrphanRemovalWhenRemovingAndAddingSameElement()
+    {
+        $profile = new OrphanRemovalProfile();
+
+        $user = new OrphanRemovalUser();
+        $user->profileMany[] = $profile;
+        $this->dm->persist($user);
+        $this->dm->persist($profile);
+        $this->dm->flush();
+
+        $user->profileMany->removeElement($profile);
+        $user->profileMany->add($profile);
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $this->assertNotNull($this->getProfileRepository()->find($profile->id), 'Profile 1 should not have been removed');
+    }
+
     /**
      * @return \Doctrine\ODM\MongoDB\DocumentRepository
      */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class GH1225Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testRemoveAddEmbeddedDocToExistingDocumentWithPreUpdateHook()
+    {
+        $doc = new GH1225Document();
+        $doc->embeds->add(new GH1225EmbeddedDocument('foo'));
+        $this->dm->persist($doc);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $doc = $this->dm->getRepository(get_class($doc))->find($doc->id);
+        $embeddedDoc = $doc->embeds->first();
+        $doc->embeds->clear();
+        $doc->embeds->add($embeddedDoc);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $doc = $this->dm->getRepository(get_class($doc))->find($doc->id);
+        $this->assertCount(1, $doc->embeds);
+    }
+}
+
+/**
+ * @ODM\Document
+ * @ODM\HasLifecycleCallbacks
+ */
+class GH1225Document
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedMany(strategy="atomicSet", targetDocument="GH1225EmbeddedDocument") */
+    public $embeds;
+
+    public function __construct()
+    {
+        $this->embeds = new ArrayCollection();
+    }
+
+    /**
+     * @ODM\PreUpdate
+     */
+    public function exampleHook()
+    {
+    }
+}
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class GH1225EmbeddedDocument
+{
+    /** @ODM\String */
+    public $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+}


### PR DESCRIPTION
This fixes a minor issue where removing an element from a PersistentCollection with orphanRemoval enabled and then re-adding it to the same collection leaves it scheduled for removal. This can produce invalid references.
This PR also fixes an issue where using ```set()``` in a PersistentCollection with orphanRemoval enabled would not remove an element that was overwritten and is no longer part of the collection.