### PR TITLE
[Docs] Fix wrong text about DocumentManager

### DIFF
--- a/docs/en/reference/architecture.rst
+++ b/docs/en/reference/architecture.rst
@@ -95,8 +95,8 @@ did not find a way yet, if you did, please contact us).
 The DocumentManager
 -------------------
 
-The ``DocumentManager`` class is a central access point to the ORM
-functionality provided by Doctrine 2. The ``DocumentManager`` API is
+The ``DocumentManager`` class is a central access point to the ODM
+functionality provided by Doctrine. The ``DocumentManager`` API is
 used to manage the persistence of your objects and to query for
 persistent objects.
 


### PR DESCRIPTION
- Replaces "ORM" by "ODM"
- Also removes the "2" from "Doctrine 2" because Doctrine Mongo ODM is currently in 1.X

PS: Github added EOL EOF automatically.