### PR TITLE
Using repositoryMethod should imply inverseSide

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -1206,6 +1206,10 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
                 $mapping['isInverseSide'] = true;
                 $mapping['isOwningSide'] = false;
             }
+            if (isset($mapping['repositoryMethod'])) {
+                $mapping['isInverseSide'] = true;
+                $mapping['isOwningSide'] = false;
+            }
             if (!isset($mapping['orphanRemoval'])) {
                 $mapping['orphanRemoval'] = false;
             }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -1155,11 +1155,6 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
                 (isset($mapping['mappedBy']) || isset($mapping['inversedBy']))) {
             throw MappingException::owningAndInverseReferencesRequireTargetDocument($this->name, $mapping['fieldName']);
         }
-
-        if (isset($mapping['reference']) && $mapping['type'] === 'many' && ! isset($mapping['mappedBy'])
-            && ! empty($mapping['sort']) && ! CollectionHelper::usesSet($mapping['strategy'])) {
-            throw MappingException::referenceManySortMustNotBeUsedWithNonSetCollectionStrategy($this->name, $mapping['fieldName'], $mapping['strategy']);
-        }
         
         if ($this->isEmbeddedDocument && $mapping['type'] === 'many' && CollectionHelper::isAtomic($mapping['strategy'])) {
             throw MappingException::atomicCollectionStrategyNotAllowed($mapping['strategy'], $this->name, $mapping['fieldName']);
@@ -1213,6 +1208,11 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
             if (!isset($mapping['orphanRemoval'])) {
                 $mapping['orphanRemoval'] = false;
             }
+        }
+
+        if (isset($mapping['reference']) && $mapping['type'] === 'many' && $mapping['isOwningSide']
+            && ! empty($mapping['sort']) && ! CollectionHelper::usesSet($mapping['strategy'])) {
+            throw MappingException::referenceManySortMustNotBeUsedWithNonSetCollectionStrategy($this->name, $mapping['fieldName'], $mapping['strategy']);
         }
 
         $this->fieldMappings[$mapping['fieldName']] = $mapping;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceRepositoryMethodTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceRepositoryMethodTest.php
@@ -84,4 +84,20 @@ class ReferenceRepositoryMethodTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                   ->getSingleResult();
         $this->assertEquals('Comment', $blogPost->repoCommentsSet[0]->getText());
     }
+
+    public function testRepositoryMethodWithoutMappedBy()
+    {
+        $blogPost = new \Documents\BlogPost('Test');
+
+        $blogPost->addComment(new \Documents\Comment('Comment', new \DateTime()));
+        $this->dm->persist($blogPost);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $blogPost = $this->dm->createQueryBuilder('Documents\BlogPost')
+            ->getQuery()
+            ->getSingleResult();
+        $this->assertCount(1, $blogPost->repoCommentsWithoutMappedBy);
+        $this->assertEquals('Comment', $blogPost->repoCommentsWithoutMappedBy[0]->getText());
+    }
 }

--- a/tests/Documents/BlogPost.php
+++ b/tests/Documents/BlogPost.php
@@ -41,6 +41,9 @@ class BlogPost
     /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", strategy="set", repositoryMethod="findManyComments") */
     public $repoCommentsSet;
 
+    /** @ODM\ReferenceMany(targetDocument="Comment", repositoryMethod="findManyComments") */
+    public $repoCommentsWithoutMappedBy;
+
     /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", repositoryMethod="findManyCommentsEager") */
     public $repoCommentsEager;
 


### PR DESCRIPTION
Lately I omitted on purpose `mappedBy` on `ReferenceMany` using `repositoryMethod` since there was no owning side and using `count()` on such uninitialized `PersistentCollection` was stubbornly returning `0`.