### PR TITLE
Allow reusing embedded documents and collections

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -745,7 +745,7 @@ class UnitOfWork implements PropertyChangedListener
                 // created one. This can only mean it was cloned and replaced
                 // on another document.
                 if ($actualValue instanceof PersistentCollection && $actualValue->getOwner() !== $document) {
-                    $this->fixPersistentCollectionOwnership($actualValue, $document, $class, $propName);
+                    $actualValue = $this->fixPersistentCollectionOwnership($actualValue, $document, $class, $propName);
                 }
 
                 // if embed-many or reference-many relationship
@@ -2512,6 +2512,8 @@ class UnitOfWork implements PropertyChangedListener
             $newValue = clone $coll;
             $newValue->setOwner($document, $class->fieldMappings[$propName]);
             $class->reflFields[$propName]->setValue($document, $newValue);
+            // @todo following line should be superfluous once collections are stored in change sets
+            $this->setOriginalDocumentProperty(spl_object_hash($document), $propName, $newValue);
             return $newValue;
         }
         return $coll;

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -948,6 +948,12 @@ class UnitOfWork implements PropertyChangedListener
                         list(, $knownParent, ) = $this->getParentAssociation($entry);
                         if ($knownParent && $knownParent !== $parentDocument) {
                             $entry = clone $entry;
+                            if ($assoc['type'] === ClassMetadata::ONE) {
+                                $class->setFieldValue($parentDocument, $assoc['name'], $entry);
+                            } else {
+                                // must use unwrapped value to not trigger orphan removal
+                                $unwrappedValue[$key] = $entry;
+                            }
                             $this->persistNew($targetClass, $entry);
                         }
                         $this->setParentAssociation($entry, $assoc, $parentDocument, $path);

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -950,6 +950,7 @@ class UnitOfWork implements PropertyChangedListener
                             $entry = clone $entry;
                             if ($assoc['type'] === ClassMetadata::ONE) {
                                 $class->setFieldValue($parentDocument, $assoc['name'], $entry);
+                                $this->setOriginalDocumentProperty(spl_object_hash($parentDocument), $assoc['name'], $entry);
                             } else {
                                 // must use unwrapped value to not trigger orphan removal
                                 $unwrappedValue[$key] = $entry;

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -945,6 +945,11 @@ class UnitOfWork implements PropertyChangedListener
 
                 case self::STATE_MANAGED:
                     if ($targetClass->isEmbeddedDocument) {
+                        list(, $knownParent, ) = $this->getParentAssociation($entry);
+                        if ($knownParent && $knownParent !== $parentDocument) {
+                            $entry = clone $entry;
+                            $this->persistNew($targetClass, $entry);
+                        }
                         $this->setParentAssociation($entry, $assoc, $parentDocument, $path);
                         $this->computeChangeSet($targetClass, $entry);
                     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
@@ -567,6 +567,11 @@ class EmbeddedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
 
         $this->assertNotSame($test1->embed, $test2->embed);
+
+        $originalTest1 = $this->uow->getOriginalDocumentData($test1);
+        $this->assertSame($originalTest1['embed'], $test1->embed);
+        $originalTest2 = $this->uow->getOriginalDocumentData($test2);
+        $this->assertSame($originalTest2['embed'], $test2->embed);
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
@@ -524,6 +524,32 @@ class EmbeddedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertNotSame($test->embed, $test->embedMany[0]);
         $this->assertNotSame($test->embed, $test->embedMany[1]);
     }
+
+    public function testWhenCopyingManyEmbedSubDocumentsFromOneDocumentToAnotherWillNotAffectTheSourceDocument()
+    {
+        $test1 = new ChangeEmbeddedIdTest();
+
+        $embedded = new EmbeddedDocumentWithId();
+        $embedded->id = (string) new \MongoId();;
+        $test1->embedMany = array($embedded);
+
+        $this->dm->persist($test1);
+        $this->dm->flush();
+
+        $test2 = new ChangeEmbeddedIdTest();
+        $test2->embedMany = $test1->embedMany; //using clone will work
+        $this->dm->persist($test2);
+        $this->dm->flush();
+
+        //do some operations on test1
+        $this->dm->persist($test1);
+        $this->dm->flush();
+
+        $this->dm->clear(); //get clean results from mongo
+        $test1 = $this->dm->find(get_class($test1), $test1->id);
+
+        $this->assertEquals(1, count($test1->embedMany));
+    }
 }
 
 /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
@@ -550,6 +550,24 @@ class EmbeddedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->assertEquals(1, count($test1->embedMany));
     }
+
+    public function testReusedEmbeddedDocumentsAreClonedInFact()
+    {
+        $test1 = new ChangeEmbeddedIdTest();
+        $test2 = new ChangeEmbeddedIdTest();
+
+        $embedded = new EmbeddedDocumentWithId();
+        $embedded->id = (string) new \MongoId();
+
+        $test1->embed = $embedded;
+        $test2->embed = $embedded;
+
+        $this->dm->persist($test1);
+        $this->dm->persist($test2);
+        $this->dm->flush();
+
+        $this->assertNotSame($test1->embed, $test2->embed);
+    }
 }
 
 /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
@@ -62,6 +62,12 @@ class GH1229Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             $secondParent->addChild($child);
 
             $this->dm->flush();
+            $actualChildren = $secondParent->getChildren();
+
+            $this->assertNotSame($actualChildren, $child);
+
+            list(, $parent, ) = $this->uow->getParentAssociation(end($actualChildren));
+            $this->assertSame($this->secondParentId, $parent->id);
         }
 
         $this->dm->clear();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class GH1229Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    /**
+     * @var string
+     */
+    protected $firstParentId;
+
+    /**
+     * @var string
+     */
+    protected $secondParentId;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $firstParent = new GH1229Parent();
+        $this->dm->persist($firstParent);
+
+        $secondParent = new GH1229Parent();
+        $this->dm->persist($secondParent);
+
+        $firstParent->addChild(new GH1229Child('type a'));
+        $firstParent->addChild(new GH1229ChildTypeB('type b'));
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $this->firstParentId = $firstParent->id;
+        $this->secondParentId = $secondParent->id;
+    }
+
+    /**
+     * @group m
+     */
+    public function testMethodAWithoutClone()
+    {
+        /** @var GH1229Parent $firstParent */
+        $firstParent = $this->dm->find(GH1229Parent::CLASSNAME, $this->firstParentId);
+        $this->assertNotNull($firstParent);
+
+        /** @var GH1229Parent $secondParent */
+        $secondParent = $this->dm->find(GH1229Parent::CLASSNAME, $this->secondParentId);
+        $this->assertNotNull($secondParent);
+
+        foreach ($firstParent->getChildren() as $child) {
+            if ($child->getOrder() !== 0) {
+                continue;
+            }
+
+            $firstParent->removeChild($child);
+            $secondParent->addChild($child);
+
+            $this->dm->flush();
+        }
+
+        $this->dm->clear();
+
+        /** @var GH1229Parent $firstParent */
+        $firstParent = $this->dm->find(GH1229Parent::CLASSNAME, $this->firstParentId);
+        $this->assertNotNull($firstParent);
+        $this->assertCount(0, $firstParent->getChildren());
+
+        /** @var GH1229Parent $secondParent */
+        $secondParent = $this->dm->find(GH1229Parent::CLASSNAME, $this->secondParentId);
+        $this->assertNotNull($secondParent);
+        $this->assertCount(2, $secondParent->getChildren());
+
+        $children = $secondParent->getChildren();
+
+        $this->assertInstanceOf(GH1229Child::CLASSNAME, $children[0]);
+        $this->assertInstanceOf(GH1229ChildTypeB::CLASSNAME, $children[1]);
+    }
+
+    /**
+     * @group m
+     */
+    public function testMethodAWithClone()
+    {
+        /** @var GH1229Parent $firstParent */
+        $firstParent = $this->dm->find(GH1229Parent::CLASSNAME, $this->firstParentId);
+        $this->assertNotNull($firstParent);
+
+        /** @var GH1229Parent $secondParent */
+        $secondParent = $this->dm->find(GH1229Parent::CLASSNAME, $this->secondParentId);
+        $this->assertNotNull($secondParent);
+
+        foreach ($firstParent->getChildren() as $child) {
+            if ($child->getOrder() !== 0) {
+                continue;
+            }
+
+            $firstParent->removeChild($child);
+            $secondParent->addChild(clone $child);
+
+            $this->dm->flush();
+        }
+
+        $this->dm->clear();
+
+        /** @var GH1229Parent $firstParent */
+        $firstParent = $this->dm->find(GH1229Parent::CLASSNAME, $this->firstParentId);
+        $this->assertNotNull($firstParent);
+        $this->assertCount(0, $firstParent->getChildren());
+
+        /** @var GH1229Parent $secondParent */
+        $secondParent = $this->dm->find(GH1229Parent::CLASSNAME, $this->secondParentId);
+        $this->assertNotNull($secondParent);
+        $this->assertCount(2, $secondParent->getChildren());
+
+        $children = $secondParent->getChildren();
+
+        $this->assertInstanceOf(GH1229Child::CLASSNAME, $children[0]);
+        $this->assertInstanceOf(GH1229ChildTypeB::CLASSNAME, $children[1]);
+    }
+}
+
+/** @ODM\Document */
+class GH1229Parent
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedMany(discriminatorField="_class") */
+    protected $children;
+
+    public function __construct()
+    {
+        $this->children = new ArrayCollection();
+    }
+
+    /**
+     * @return GH1229Child[]
+     */
+    public function getChildren()
+    {
+        return $this->children->toArray();
+    }
+
+    /**
+     * @param GH1229Child $child
+     */
+    public function addChild(GH1229Child $child)
+    {
+        $child->setOrder(count($this->children));
+        $this->children->add($child);
+    }
+
+    /**
+     * @param GH1229Child $child
+     */
+    public function removeChild(GH1229Child $child)
+    {
+        $this->children->removeElement($child);
+        $this->reorderChildren($child->getOrder(), -1);
+    }
+
+    /**
+     * @param int $starting
+     * @param int $change
+     */
+    public function reorderChildren($starting, $change)
+    {
+        foreach ($this->children as $child) {
+            if ($child->getOrder() >= $starting) {
+                $child->setOrder($child->getOrder() + $change);
+            }
+        }
+    }
+}
+
+/** @ODM\EmbeddedDocument */
+class GH1229Child
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @ODM\String */
+    public $name;
+
+    /** @ODM\Int */
+    public $order = 0;
+
+    /**
+     * @param string $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOrder()
+    {
+        return $this->order;
+    }
+
+    /**
+     * @param int $order
+     *
+     * @return $this
+     */
+    public function setOrder($order)
+    {
+        $this->order = $order;
+
+        return $this;
+    }
+}
+
+/** @ODM\EmbeddedDocument */
+class GH1229ChildTypeB extends GH1229Child
+{
+    const CLASSNAME = __CLASS__;
+}


### PR DESCRIPTION
So this is the thing that was popping out lately a lot. I must admit that first direction I took was throwing exception when such embedded document was found BUT since we allowed reusing/cloning persistent collection loong long time ago I couldn't. ~~So I'd say make reusing embedded documents easier for now and forbid both things in 2.0?~~

Thoughts? If we'd get around to merge this I'll write test ~~(and hopefully create a ticket scheduled for 2.0)~~ EDIT: actually I'm leaning towards keeping this, indeed it might be better for the developer to not care

/cc @alcaeus @jmikola @jwage 