### PR TITLE
NOTIFY change tracking policy fixes

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -690,7 +690,7 @@ class UnitOfWork implements PropertyChangedListener
             // and we have a copy of the original data
             $originalData = $this->originalDocumentData[$oid];
             $isChangeTrackingNotify = $class->isChangeTrackingNotify();
-            if ($isChangeTrackingNotify && ! $recompute) {
+            if ($isChangeTrackingNotify && ! $recompute && isset($this->documentChangeSets[$oid])) {
                 $changeSet = $this->documentChangeSets[$oid];
             } else {
                 $changeSet = array();

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -240,6 +240,24 @@ class UnitOfWorkTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue($updates[0] === $item);
     }
 
+    public function testDoubleCommitWithChangeTrackingNotify()
+    {
+        $pb = $this->getMockPersistenceBuilder();
+
+        $class = $this->dm->getClassMetadata('Doctrine\ODM\MongoDB\Tests\NotifyChangedDocument');
+        $persister = $this->getMockDocumentPersister($pb, $class);
+        $this->uow->setDocumentPersister($class->name, $persister);
+
+        $entity = new NotifyChangedDocument();
+        $entity->setId(2);
+        $this->uow->persist($entity);
+
+        $this->uow->commit($entity);
+        @$this->uow->commit($entity);
+
+        $this->assertNull(error_get_last(), 'Expected not to get an error after committing an entity multiple times using the NOTIFY change tracking policy.');
+    }
+
     public function testGetDocumentStateWithAssignedIdentity()
     {
         $pb = $this->getMockPersistenceBuilder();

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -686,7 +686,10 @@ class ParentAssociationTest
     }
 }
 
-/** @ODM\Document */
+/**
+ * @ODM\Document
+ * @ODM\ChangeTrackingPolicy("NOTIFY")
+ */
 class NotifyChangedDocument implements \Doctrine\Common\NotifyPropertyChanged
 {
     private $_listeners = array();


### PR DESCRIPTION
This PR fixes some issues with documents using the NOTIFY change tracking policy, namely:
* Committing a document of this kind multiple times raised an `Undefined index` notice as reported in #740. Fixed the error and created a test case for it.
* Committing only a single document made the UnitOfWork lose changes of all other managed documents with NOTIFY change tracking policy. Fixed this too and also created a test case for it.
* Additionally I found that the current test case for the this change tracking policy (namely: `UnitOfWorkTest::testChangeTrackingNotify`) used a document without the required `@ODM\ChangeTrackingPolicy("NOTIFY")` annotation as its test subject, so the test didn't test what it supposed to test. I added the missing annotation to this dummy document.