### PR TITLE
No backup option

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateDocumentsCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateDocumentsCommand.php
@@ -76,6 +76,10 @@ class GenerateDocumentsCommand extends Console\Command\Command
             new InputOption(
                 'num-spaces', null, InputOption::VALUE_OPTIONAL,
                 'Defines the number of indentation spaces.', 4
+            ),
+            new InputOption(
+                'no-backup', null, InputOption::VALUE_NONE,
+                'Flag to define if the generator should provide a backup file of exisiting code.'
             )
         ))
         ->setHelp(<<<EOT
@@ -135,6 +139,7 @@ EOT
             $documentGenerator->setGenerateStubMethods($input->getOption('generate-methods'));
             $documentGenerator->setRegenerateDocumentIfExists($input->getOption('regenerate-documents'));
             $documentGenerator->setUpdateDocumentIfExists($input->getOption('update-documents'));
+            $documentGenerator->setBackupExisting(!$input->getOption('no-backup'));
             $documentGenerator->setNumSpaces($input->getOption('num-spaces'));
 
             if (($extend = $input->getOption('extend')) !== null) {


### PR DESCRIPTION
add no-backup option. default is false. if you want to have backups, need to specify --generate-backup=true on command line.

For future consideration: Update documentation to specific that options where false is an option must be specified as <option>=0, since false is recognized as a string and thus resolves to TRUE in php.

Thanks!