### PR TITLE
Use fieldName in mapping instead of name when persisting

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2348,7 +2348,7 @@ class UnitOfWork implements PropertyChangedListener
             if ($relatedDocuments instanceof Collection || is_array($relatedDocuments)) {
                 if ($relatedDocuments instanceof PersistentCollection) {
                     if ($relatedDocuments->getOwner() !== $document) {
-                        $relatedDocuments = $this->fixPersistentCollectionOwnership($relatedDocuments, $document, $class, $mapping['name']);
+                        $relatedDocuments = $this->fixPersistentCollectionOwnership($relatedDocuments, $document, $class, $mapping['fieldName']);
                     }
                     // Unwrap so that foreach() does not initialize
                     $relatedDocuments = $relatedDocuments->unwrap();
@@ -2363,7 +2363,7 @@ class UnitOfWork implements PropertyChangedListener
                             $relatedDocuments[$relatedKey] = $relatedDocument;
                         }
                         $pathKey = ! isset($mapping['strategy']) || CollectionHelper::isList($mapping['strategy']) ? $count++ : $relatedKey;
-                        $this->setParentAssociation($relatedDocument, $mapping, $document, $mapping['name'] . '.' . $pathKey);
+                        $this->setParentAssociation($relatedDocument, $mapping, $document, $mapping['fieldName'] . '.' . $pathKey);
                     }
                     $this->doPersist($relatedDocument, $visited);
                 }
@@ -2372,9 +2372,9 @@ class UnitOfWork implements PropertyChangedListener
                     list(, $knownParent, ) = $this->getParentAssociation($relatedDocuments);
                     if ($knownParent && $knownParent !== $document) {
                         $relatedDocuments = clone $relatedDocuments;
-                        $class->setFieldValue($document, $mapping['name'], $relatedDocuments);
+                        $class->setFieldValue($document, $mapping['fieldName'], $relatedDocuments);
                     }
-                    $this->setParentAssociation($relatedDocuments, $mapping, $document, $mapping['name']);
+                    $this->setParentAssociation($relatedDocuments, $mapping, $document, $mapping['fieldName']);
                 }
                 $this->doPersist($relatedDocuments, $visited);
             }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
@@ -581,6 +581,24 @@ class EmbeddedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $originalTest2 = $this->uow->getOriginalDocumentData($test2);
         $this->assertSame($originalTest2['embed'], $test2->embed);
     }
+
+    public function testEmbeddedDocumentWithDifferentFieldNameAnnotation()
+    {
+        $test1 = new ChangeEmbeddedWithNameAnnotationTest();
+
+        $embedded = new EmbeddedDocumentWithId();
+        $embedded->id = (string) new \MongoId();
+
+        $firstEmbedded = new EmbedDocumentWithAnotherEmbed();
+        $firstEmbedded->embed = $embedded;
+
+        $secondEmbedded = clone $firstEmbedded;
+
+        $test1->embedOne = $firstEmbedded;
+        $test1->embedTwo = $secondEmbedded;
+
+        $this->dm->persist($test1);
+    }
 }
 
 /**
@@ -616,4 +634,36 @@ class EmbeddedDocumentWithId
 {
     /** @ODM\Id */
     public $id;
+}
+
+/**
+ * @ODM\Document
+ */
+class ChangeEmbeddedWithNameAnnotationTest
+{
+    /**
+     * @ODM\Id
+     */
+    public $id;
+
+    /**
+     * @ODM\EmbedOne(targetDocument="EmbeddedDocumentWithAnotherEmbedded")
+     */
+    public $embedOne;
+
+    /**
+     * @ODM\EmbedOne(targetDocument="EmbeddedDocumentWithAnotherEmbedded")
+     */
+    public $embedTwo;
+}
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class EmbedDocumentWithAnotherEmbed
+{
+    /**
+     * @ODM\EmbedOne(targetDocument="EmbeddedDocumentWithId", name="m_id")
+     */
+    public $embed;
 }


### PR DESCRIPTION
This is a bug that happens when the name annotation of an embed document is different of the field name itself.

Related: https://github.com/doctrine/mongodb-odm/commit/85d91b74b64057d9f812d030d6d15d51e9fa278d

