### PR TITLE
Check for duplicates before scheduling orphanRemoval

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -441,7 +441,7 @@ class PersistentCollection implements BaseCollection
 
         $this->changed();
 
-        if ($this->isOrphanRemovalEnabled()) {
+        if ($this->isOrphanRemovalEnabled() && ! $this->contains($element)) {
             $this->uow->scheduleOrphanRemoval($element);
         }
 
@@ -539,7 +539,7 @@ class PersistentCollection implements BaseCollection
 
         // Handle orphanRemoval
         if ($this->uow !== null && $this->isOrphanRemovalEnabled() && $oldValue !== $value) {
-            if ($oldValue !== null) {
+            if ($oldValue !== null && ! $this->contains($oldValue)) {
                 $this->uow->scheduleOrphanRemoval($oldValue);
             }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
@@ -5,7 +5,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-class GH41275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
     public function testResortAtomicCollectionsFlipItems()
     {
@@ -166,10 +166,11 @@ class GH41275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $two = $container->$strategy->get(1);
         $three = $container->$strategy->get(2);
-        $container->items->set(1, $three);
-        $container->items->set(2, $two);
+        $container->$strategy->set(1, $three);
+        $container->$strategy->set(2, $two);
 
         $this->dm->flush();
+
         $this->dm->refresh($container);
 
         $this->assertSame(


### PR DESCRIPTION
Fixes #1275 and closes #1277 BUT increases complexity of `set` and `removeElement` when `orphanRemoval` is enabled