### PR TITLE
Changed XML mapping examples

### DIFF
--- a/docs/en/reference/embedded-mapping.rst
+++ b/docs/en/reference/embedded-mapping.rst
@@ -170,7 +170,7 @@ the embedded document. The field name can be customized with the
 
     .. code-block:: xml
 
-        <embed-many fieldName="tasks">
+        <embed-many field="tasks">
             <discriminator-field name="type" />
         </embed-many>
 
@@ -209,7 +209,7 @@ class name in each embedded document:
 
     .. code-block:: xml
 
-        <embed-many fieldName="tasks">
+        <embed-many field="tasks">
             <discriminator-map>
                 <discriminator-mapping value="download" class="DownloadTask" />
                 <discriminator-mapping value="build" class="BuildTask" />
@@ -255,7 +255,7 @@ discriminator:
 
     .. code-block:: xml
 
-        <embed-many fieldName="tasks">
+        <embed-many field="tasks">
             <discriminator-map>
                 <discriminator-mapping value="download" class="DownloadTask" />
                 <discriminator-mapping value="build" class="BuildTask" />


### PR DESCRIPTION
The XML examples of the embedded mapping are using the attribute 'fieldName'. It should be the attribute 'field' so the example is the same for PHP and YAML. Also the attribute 'field' is required for the embedded elements.