### PR TITLE
Preserve \MongoRegex on string typed identifier

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Types/StringType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/StringType.php
@@ -30,7 +30,7 @@ class StringType extends Type
 {
     public function convertToDatabaseValue($value)
     {
-        return $value !== null ? (string) $value : null;
+        return ($value === null || $value instanceof \MongoRegex) ? $value : (string) $value;
     }
 
     public function convertToPHPValue($value)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1294Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1294Test.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class GH1294Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testMongoRegexSearchOnIdentifierWithUuidStrategy()
+    {
+        $userClass = __NAMESPACE__ . '\GH1294User';
+
+        $user1 = new GH1294User();
+        $user1->id = 'aaa111aaa';
+        $user1->name = 'Steven';
+
+        $user2 = new GH1294User();
+        $user2->id = 'bbb111bbb';
+        $user2->name = 'Jeff';
+
+        $this->dm->persist($user1);
+        $this->dm->persist($user2);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $qb = $this->dm->createQueryBuilder($userClass);
+
+        $res = $qb->field('id')
+            ->equals(new \MongoRegex("/^bbb.*$/i"))
+            ->getQueryArray();
+
+        $this->assertTrue(($res['_id'] instanceof \MongoRegex));
+        $this->assertEquals('^bbb.*$', $res['_id']->regex);
+        $this->assertEquals('i', $res['_id']->flags);
+    }
+}
+
+/** @ODM\Document */
+class GH1294User
+{
+    /** @ODM\Id(strategy="UUID", type="string") */
+    public $id;
+
+    /** @ODM\String */
+    public $name = false;
+
+    // Return the identifier without triggering Proxy initialization
+    public function getId()
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
This is a possible fix for #1294 and a unit test to avoid regression.

I'm not sure if this should be handled in the `Type` class. It makes kinda sense as it's the culprit. But maybe it's a too much narrow check (topic wise) in the `Type`. But I'm not sure where it could be handled elsewhere as `convertToDatabaseValue()` will be called anyway and the `\MongoRegex` instance would be lost(?)