### PR TITLE
Do not duplicate properties and methods on children classes

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
@@ -438,20 +438,21 @@ public function <methodName>()
 
     private function hasProperty($property, ClassMetadataInfo $metadata)
     {
-        if ($this->extendsClass()) {
+        if ($this->extendsClass() || class_exists($metadata->name)) {
             // don't generate property if its already on the base class.
-            $reflClass = new \ReflectionClass($this->getClassToExtend());
+            $reflClass = new \ReflectionClass($this->getClassToExtend() ?: $metadata->name);
+
             if ($reflClass->hasProperty($property)) {
                 return true;
             }
         }
-        
+
         foreach ($this->getTraits($metadata) as $trait) {
             if ($trait->hasProperty($property)) {
                 return true;
             }
         }
-        
+
         return (
             isset($this->staticReflection[$metadata->name]) &&
             in_array($property, $this->staticReflection[$metadata->name]['properties'])
@@ -460,20 +461,21 @@ public function <methodName>()
 
     private function hasMethod($method, ClassMetadataInfo $metadata)
     {
-        if ($this->extendsClass()) {
+        if ($this->extendsClass() || class_exists($metadata->name)) {
             // don't generate method if its already on the base class.
-            $reflClass = new \ReflectionClass($this->getClassToExtend());
+            $reflClass = new \ReflectionClass($this->getClassToExtend() ?: $metadata->name);
+
             if ($reflClass->hasMethod($method)) {
                 return true;
             }
         }
-        
+
         foreach ($this->getTraits($metadata) as $trait) {
             if ($trait->hasMethod($method)) {
                 return true;
             }
         }
-        
+
         return (
             isset($this->staticReflection[$metadata->name]) &&
             in_array($method, $this->staticReflection[$metadata->name]['methods'])
@@ -512,13 +514,13 @@ public function <methodName>()
     {
         return substr($metadata->name, 0, strrpos($metadata->name, '\\'));
     }
-    
+
     /**
      * @param ClassMetadataInfo $metadata
      *
      * @return array
      */
-    protected function getTraits(ClassMetadataInfo $metadata) 
+    protected function getTraits(ClassMetadataInfo $metadata)
     {
         if (PHP_VERSION_ID >= 50400 && ($metadata->reflClass !== null || class_exists($metadata->name))) {
             $reflClass = $metadata->reflClass === null ? new \ReflectionClass($metadata->name) : $metadata->reflClass;
@@ -698,7 +700,7 @@ public function <methodName>()
 
         return implode("\n\n", $methods);
     }
-    
+
     /**
      * @param array $fieldMapping
      *
@@ -999,13 +1001,13 @@ public function <methodName>()
 
             case ClassMetadataInfo::GENERATOR_TYPE_UUID:
                 return 'UUID';
-                
+
             case ClassMetadataInfo::GENERATOR_TYPE_ALNUM:
                 return 'ALNUM';
 
             case ClassMetadataInfo::GENERATOR_TYPE_CUSTOM:
                 return 'CUSTOM';
-                
+
             case ClassMetadataInfo::GENERATOR_TYPE_NONE:
                 return 'NONE';
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/DocumentGeneratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/DocumentGeneratorTest.php
@@ -192,7 +192,7 @@ class DocumentGeneratorTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals($cm->idGenerator, $metadata->idGenerator);
         $this->assertEquals($cm->customRepositoryClassName, $metadata->customRepositoryClassName);
     }
-    
+
     public function testTraitPropertiesAndMethodsAreNotDuplicated()
     {
         if (PHP_VERSION_ID < 50400) {
@@ -212,7 +212,7 @@ class DocumentGeneratorTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertSame($reflClass->hasMethod('getAddress'), false);
     }
 
-    public function testTraitPropertiesAndMethodsAreNotDuplicatedInChildClasses() 
+    public function testTraitPropertiesAndMethodsAreNotDuplicatedInChildClasses()
     {
         if (PHP_VERSION_ID < 50400) {
             $this->markTestSkipped('Traits are not available before php 5.4.');
@@ -231,6 +231,74 @@ class DocumentGeneratorTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertSame($reflClass->hasMethod('getAddress'), false);
     }
 
+    /**
+     * Tests that properties, getters and setters are not duplicated on children classes
+     *
+     * @see https://github.com/doctrine/mongodb-odm/issues/1299
+     */
+    public function testMethodsAndPropertiesAreNotDuplicatedInChildClasses()
+    {
+        $cmf = $this->dm->getMetadataFactory();
+        $nsDir = $this->tmpDir.'/'.$this->namespace;
+
+        // Copy GH1299User class to temp dir
+        $content = str_replace(
+            'namespace Doctrine\ODM\MongoDB\Tests\Tools\GH1299',
+            'namespace '.$this->namespace,
+            file_get_contents(__DIR__.'/GH1299/GH1299User.php')
+        );
+        $fname = $nsDir.'/GH1299User.php';
+        file_put_contents($fname, $content);
+        require $fname;
+
+        // Generate document class
+        $metadata = $cmf->getMetadataFor($this->namespace.'\GH1299User');
+        $this->generator->writeDocumentClass($metadata, $this->tmpDir);
+
+        // Make a copy of the generated class that does not extend the BaseUser class
+        $source = file_get_contents($fname);
+
+        // class _DDC1590User extends DDC1590Entity { ... }
+        $source2 = str_replace('class GH1299User', 'class _GH1299User', $source);
+        $fname2  = $nsDir.'/_DDC1590User.php';
+        file_put_contents($fname2, $source2);
+        require $fname2;
+
+        $source3 = str_replace('class GH1299User extends BaseUser', 'class __GH1299User', $source);
+        $fname3  = $nsDir.'/_GH1299User.php';
+        file_put_contents($fname3, $source3);
+        require $fname3;
+
+        // The GH1299User class that extends BaseUser should have all properties, getters and setters
+        // (some of them are inherited from BaseUser)
+        $reflClass2 = new \ReflectionClass($this->namespace.'\_GH1299User');
+
+        $this->assertTrue($reflClass2->hasProperty('id'));
+        $this->assertTrue($reflClass2->hasProperty('name'));
+        $this->assertTrue($reflClass2->hasProperty('lastname'));
+
+        $this->assertTrue($reflClass2->hasMethod('getId'));
+        $this->assertFalse($reflClass2->hasMethod('setId'));
+        $this->assertTrue($reflClass2->hasMethod('getName'));
+        $this->assertTrue($reflClass2->hasMethod('setName'));
+        $this->assertTrue($reflClass2->hasMethod('getLastname'));
+        $this->assertTrue($reflClass2->hasMethod('setLastname'));
+
+        // The class that does not extend BaseUser should not have the properties and methods / setters
+        // from the BaseUser class, but only its own specific ones
+        $reflClass3 = new \ReflectionClass($this->namespace.'\__GH1299User');
+
+        $this->assertFalse($reflClass3->hasProperty('id'));
+        $this->assertFalse($reflClass3->hasProperty('name'));
+        $this->assertTrue($reflClass3->hasProperty('lastname'));
+
+        $this->assertFalse($reflClass3->hasMethod('getId'));
+        $this->assertFalse($reflClass3->hasMethod('setId'));
+        $this->assertFalse($reflClass3->hasMethod('getName'));
+        $this->assertFalse($reflClass3->hasMethod('setName'));
+        $this->assertTrue($reflClass3->hasMethod('getLastname'));
+        $this->assertTrue($reflClass3->hasMethod('setLastname'));
+    }
 }
 
 class DocumentGeneratorAuthor {}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH1299/BaseUser.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH1299/BaseUser.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Tools\GH1299;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/** @ODM\Document */
+class BaseUser
+{
+    /** @ODM\Id */
+    protected $id;
+
+    /** @ODM\Field(type="string") */
+    protected $name;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH1299/GH1299User.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH1299/GH1299User.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Tools\GH1299;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\Tools\GH1299\BaseUser;
+
+/** @ODM\Document */
+class GH1299User extends BaseUser
+{
+    /** @ODM\String */
+    protected $lastname;
+}


### PR DESCRIPTION
Fixes #1299 .

This is inspired by the PR made on the ORM: https://github.com/doctrine/doctrine2/pull/1098

Please note that some extra whitespaces have been removed for code style as well. This can been done in an other PR if needed, but I think that's alright as there are not many.