### PR TITLE
Add support for partial indexes

### DIFF
--- a/docs/en/reference/indexes.rst
+++ b/docs/en/reference/indexes.rst
@@ -72,6 +72,13 @@ You can customize the index with some additional options:
    **sparse** - Create a sparse index. If a unique index is being created
    the sparse option will allow duplicate null entries, but the field must be
    unique otherwise.
+-
+   **partialFilterExpression** - Create a partial index. Partial indexes only
+   index the documents in a collection that meet a specified filter expression.
+   By indexing a subset of the documents in a collection, partial indexes have
+   lower storage requirements and reduced performance costs for index creation
+   and maintenance. This feature was introduced with MongoDB 3.2 and is not
+   available on older versions.
 
 Unique Index
 ------------

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -256,10 +256,29 @@
     <xs:attribute name="value" type="xs:NMTOKEN" use="required" />
   </xs:complexType>
 
+  <xs:simpleType name="partial-filter-expression-comparison">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="eq"/>
+      <xs:enumeration value="exists"/>
+      <xs:enumeration value="gt"/>
+      <xs:enumeration value="gte"/>
+      <xs:enumeration value="lt"/>
+      <xs:enumeration value="lte"/>
+      <xs:enumeration value="type"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="partial-filter-expression">
+    <xs:attribute name="field" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="comparison" type="odm:partial-filter-expression-comparison" use="optional" default="eq"/>
+    <xs:attribute name="value" type="xs:string" use="required" />
+  </xs:complexType>
+
   <xs:complexType name="index">
     <xs:sequence>
       <xs:element name="key" type="odm:index-key" minOccurs="1" maxOccurs="unbounded"/>
       <xs:element name="option" type="odm:index-option" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="partialFilterExpression" type="odm:partial-filter-expression" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN"/>
     <xs:attribute name="drop-dups" type="xs:boolean"/>

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -256,7 +256,7 @@
     <xs:attribute name="value" type="xs:NMTOKEN" use="required" />
   </xs:complexType>
 
-  <xs:simpleType name="partial-filter-expression-comparison">
+  <xs:simpleType name="partial-filter-expression-operator">
     <xs:restriction base="xs:token">
       <xs:enumeration value="eq"/>
       <xs:enumeration value="exists"/>
@@ -268,17 +268,33 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:complexType name="partial-filter-expression-field">
+    <xs:sequence>
+      <xs:element name="field" type="odm:partial-filter-expression-field" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="operator" type="odm:partial-filter-expression-operator" use="optional" />
+    <xs:attribute name="value" type="xs:string" use="optional" />
+  </xs:complexType>
+
+  <xs:complexType name="partial-filter-expression-and">
+    <xs:sequence>
+      <xs:element name="field" type="odm:partial-filter-expression-field" minOccurs="1" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+
   <xs:complexType name="partial-filter-expression">
-    <xs:attribute name="field" type="xs:NMTOKEN" use="required"/>
-    <xs:attribute name="comparison" type="odm:partial-filter-expression-comparison" use="optional" default="eq"/>
-    <xs:attribute name="value" type="xs:string" use="required" />
+    <xs:choice>
+      <xs:element name="and" type="odm:partial-filter-expression-and" minOccurs="1" maxOccurs="unbounded" />
+      <xs:element name="field" type="odm:partial-filter-expression-field" minOccurs="1" maxOccurs="unbounded" />
+    </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="index">
     <xs:sequence>
       <xs:element name="key" type="odm:index-key" minOccurs="1" maxOccurs="unbounded"/>
       <xs:element name="option" type="odm:index-option" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="partialFilterExpression" type="odm:partial-filter-expression" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="partial-filter-expression" type="odm:partial-filter-expression" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN"/>
     <xs:attribute name="drop-dups" type="xs:boolean"/>

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractIndex.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractIndex.php
@@ -33,4 +33,5 @@ abstract class AbstractIndex extends Annotation
     public $unique = false;
     public $sparse = false;
     public $options = array();
+    public $partialFilterExpression = array();
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -235,6 +235,9 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 $options[$name] = $index->$name;
             }
         }
+        if (! empty($index->partialFilterExpression)) {
+            $options['partialFilterExpression'] = $index->partialFilterExpression;
+        }
         $options = array_merge($options, $index->options);
         $class->addIndex($keys, $options);
     }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -373,6 +373,21 @@ class XmlDriver extends FileDriver
             }
         }
 
+        if (isset($xmlIndex->{'partialFilterExpression'})) {
+            foreach ($xmlIndex->{'partialFilterExpression'} as $partialFilterExpression) {
+                $operator = (string) $partialFilterExpression['comparison'] ?: 'eq';
+                $value = (string) $partialFilterExpression['value'];
+                if ($value === 'true') {
+                    $value = true;
+                } elseif ($value === 'false') {
+                    $value = false;
+                } elseif (is_numeric($value)) {
+                    $value = preg_match('/^[-]?\d+$/', $value) ? (integer) $value : (float) $value;
+                }
+                $options['partialFilterExpression'][(string) $partialFilterExpression['field']] = array('$' . $operator => $value);
+            }
+        }
+
         $class->addIndex($keys, $options);
     }
 

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -439,6 +439,7 @@ class SchemaManager
      *   (c) Mongo index is unique without dropDups and mapped index is unique
      *       with dropDups
      *   (d) Geospatial options differ (bits, max, min)
+     *   (e) The partialFilterExpression differs
      *
      * Regarding (c), the inverse case is not a reason to delete and
      * recreate the index, since dropDups only affects creation of
@@ -467,7 +468,7 @@ class SchemaManager
             return false;
         }
 
-        foreach (array('bits', 'max', 'min') as $option) {
+        foreach (array('bits', 'max', 'min', 'partialFilterExpression') as $option) {
             if (isset($mongoIndex[$option]) xor isset($documentIndexOptions[$option])) {
                 return false;
             }

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -468,7 +468,7 @@ class SchemaManager
             return false;
         }
 
-        foreach (array('bits', 'max', 'min', 'partialFilterExpression') as $option) {
+        foreach (array('bits', 'max', 'min') as $option) {
             if (isset($mongoIndex[$option]) xor isset($documentIndexOptions[$option])) {
                 return false;
             }
@@ -478,6 +478,16 @@ class SchemaManager
 
                 return false;
             }
+        }
+
+        if (empty($mongoIndex['partialFilterExpression']) xor empty($documentIndexOptions['partialFilterExpression'])) {
+            return false;
+        }
+
+        if (isset($mongoIndex['partialFilterExpression']) && isset($documentIndexOptions['partialFilterExpression']) &&
+            $mongoIndex['partialFilterExpression'] !== $documentIndexOptions['partialFilterExpression']) {
+
+            return false;
         }
 
         return true;

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -67,4 +67,11 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
 
         return DocumentManager::create($conn, $config);
     }
+
+    protected function getServerVersion()
+    {
+        $result = $this->dm->getConnection()->selectDatabase(DOCTRINE_MONGODB_DATABASE)->command(array('buildInfo' => 1));
+
+        return $result['version'];
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -303,20 +303,26 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
         $this->assertTrue(isset($indexes[1]['options']['dropDups']));
         $this->assertEquals(true, $indexes[1]['options']['dropDups']);
 
-        $this->assertTrue(isset($indexes[2]['keys']['mysqlProfileId']));
-        $this->assertEquals(-1, $indexes[2]['keys']['mysqlProfileId']);
+        $this->assertTrue(isset($indexes[2]['keys']['lock']));
+        $this->assertEquals(1, $indexes[2]['keys']['lock']);
         $this->assertTrue( ! empty($indexes[2]['options']));
-        $this->assertTrue(isset($indexes[2]['options']['unique']));
-        $this->assertEquals(true, $indexes[2]['options']['unique']);
-        $this->assertTrue(isset($indexes[2]['options']['dropDups']));
-        $this->assertEquals(true, $indexes[2]['options']['dropDups']);
+        $this->assertTrue(isset($indexes[2]['options']['partialFilterExpression']));
+        $this->assertSame(array('version' => array('$gt' => 1), 'discr' => array('$eq' => 'default')), $indexes[2]['options']['partialFilterExpression']);
 
-        $this->assertTrue(isset($indexes[3]['keys']['username']));
-        $this->assertEquals(-1, $indexes[3]['keys']['username']);
+        $this->assertTrue(isset($indexes[3]['keys']['mysqlProfileId']));
+        $this->assertEquals(-1, $indexes[3]['keys']['mysqlProfileId']);
+        $this->assertTrue( ! empty($indexes[3]['options']));
         $this->assertTrue(isset($indexes[3]['options']['unique']));
         $this->assertEquals(true, $indexes[3]['options']['unique']);
         $this->assertTrue(isset($indexes[3]['options']['dropDups']));
-        $this->assertEquals(false, $indexes[3]['options']['dropDups']);
+        $this->assertEquals(true, $indexes[3]['options']['dropDups']);
+
+        $this->assertTrue(isset($indexes[4]['keys']['username']));
+        $this->assertEquals(-1, $indexes[4]['keys']['username']);
+        $this->assertTrue(isset($indexes[4]['options']['unique']));
+        $this->assertEquals(true, $indexes[4]['options']['unique']);
+        $this->assertTrue(isset($indexes[4]['options']['dropDups']));
+        $this->assertEquals(false, $indexes[4]['options']['dropDups']);
 
         return $class;
     }
@@ -328,7 +334,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
  * @ODM\DiscriminatorMap({"default"="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser"})
  * @ODM\DefaultDiscriminatorValue("default")
  * @ODM\HasLifecycleCallbacks
- * @ODM\Indexes(@ODM\Index(keys={"createdAt"="asc"},expireAfterSeconds=3600))
+ * @ODM\Indexes(@ODM\Index(keys={"createdAt"="asc"},expireAfterSeconds=3600),@ODM\Index(keys={"lock"="asc"},partialFilterExpression={"version"={"$gt"=1},"discr"={"$eq"="default"}}))
  */
 class AbstractMappingDriverUser
 {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -4,6 +4,8 @@ namespace Doctrine\ODM\MongoDB\Tests\Mapping\Driver;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 
+require_once 'fixtures/InvalidPartialFilterDocument.php';
+require_once 'fixtures/PartialFilterDocument.php';
 require_once 'fixtures/User.php';
 require_once 'fixtures/EmbeddedDocument.php';
 
@@ -240,4 +242,40 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
         ), $classMetadata->fieldMappings['name']);
     }
 
+    public function testPartialFilterExpressions()
+    {
+        $classMetadata = new ClassMetadata('TestDocuments\PartialFilterDocument');
+        $this->driver->loadMetadataForClass('TestDocuments\PartialFilterDocument', $classMetadata);
+
+        $this->assertEquals([
+            [
+                'keys' => ['fieldA' => 1],
+                'options' => [
+                    'partialFilterExpression' => [
+                        'version' => ['$gt' => 1],
+                        'discr' => ['$eq' => 'default'],
+                    ],
+                ],
+            ],
+            [
+                'keys' => ['fieldB' => 1],
+                'options' => [
+                    'partialFilterExpression' => [
+                        '$and' => [
+                            ['version' => ['$gt' => 1]],
+                            ['discr' => ['$eq' => 'default']],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'keys' => ['fieldC' => 1],
+                'options' => [
+                    'partialFilterExpression' => [
+                        'embedded' => ['foo' => 'bar'],
+                    ],
+                ],
+            ],
+        ], $classMetadata->getIndexes());
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
@@ -55,6 +55,27 @@ class XmlDriverTest extends AbstractDriverTest
         $this->assertSame(0, $profileMapping['limit']);
         $this->assertSame(2, $profileMapping['skip']);
     }
+
+    public function testInvalidPartialFilterExpressions()
+    {
+        $classMetadata = new ClassMetadata('TestDocuments\InvalidPartialFilterDocument');
+        $this->driver->loadMetadataForClass('TestDocuments\InvalidPartialFilterDocument', $classMetadata);
+
+        $this->assertEquals([
+            [
+                'keys' => ['fieldA' => 1],
+                'options' => [
+                    'partialFilterExpression' => [
+                        '$and' => [['discr' => ['$eq' => 'default']]],
+                    ],
+                ],
+            ],
+            [
+                'keys' => ['fieldB' => 1],
+                'options' => [],
+            ],
+        ], $classMetadata->getIndexes());
+    }
 }
 
 namespace TestDocuments;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/InvalidPartialFilterDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/InvalidPartialFilterDocument.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace TestDocuments;
+
+class InvalidPartialFilterDocument
+{
+    protected $id;
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/PartialFilterDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/PartialFilterDocument.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace TestDocuments;
+
+class PartialFilterDocument
+{
+    protected $id;
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.InvalidPartialFilterDocument.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.InvalidPartialFilterDocument.dcm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="TestDocuments\InvalidPartialFilterDocument" db="documents" collection="partialFilterDocument">
+        <field name="id" id="true" />
+        <indexes>
+            <index>
+                <key name="fieldA" order="asc" />
+                <partial-filter-expression>
+                    <field name="version" value="1" operator="gt" />
+                    <and>
+                        <field name="discr" operator="eq" value="default" />
+                    </and>
+                </partial-filter-expression>
+            </index>
+            <index>
+                <key name="fieldB" order="asc" />
+                <partial-filter-expression>
+                    <and>
+                        <and>
+                            <field name="discr" operator="eq" value="default" />
+                        </and>
+                    </and>
+                </partial-filter-expression>
+            </index>
+        </indexes>
+    </document>
+</doctrine-mongo-mapping>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.PartialFilterDocument.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.PartialFilterDocument.dcm.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="TestDocuments\PartialFilterDocument" db="documents" collection="partialFilterDocument">
+        <field name="id" id="true" />
+        <indexes>
+            <index>
+                <key name="fieldA" order="asc" />
+                <partial-filter-expression>
+                    <field name="version" value="1" operator="gt" />
+                    <field name="discr" operator="eq" value="default" />
+                </partial-filter-expression>
+            </index>
+            <index>
+                <key name="fieldB" order="asc" />
+                <partial-filter-expression>
+                    <and>
+                        <field name="version" value="1" operator="gt" />
+                    </and>
+                    <and>
+                        <field name="discr" operator="eq" value="default" />
+                    </and>
+                </partial-filter-expression>
+            </index>
+            <index>
+                <key name="fieldC" order="asc" />
+                <partial-filter-expression>
+                    <field name="embedded">
+                        <field name="foo" value="bar" />
+                    </field>
+                </partial-filter-expression>
+            </index>
+        </indexes>
+    </document>
+</doctrine-mongo-mapping>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/yaml/TestDocuments.PartialFilterDocument.dcm.yml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/yaml/TestDocuments.PartialFilterDocument.dcm.yml
@@ -1,0 +1,30 @@
+TestDocuments\PartialFilterDocument:
+  db: documents
+  collection: partialFilterDocument
+  fields:
+    id:
+      fieldName: id
+      id: true
+  indexes:
+    index1:
+      keys:
+        fieldA: asc
+      options:
+        partialFilterExpression:
+          version: { $gt: 1 }
+          discr: { $eq: 'default' }
+    index2:
+      keys:
+        fieldB: asc
+      options:
+        partialFilterExpression:
+          $and:
+            - version: { $gt: 1 }
+            - discr: { $eq: 'default' }
+    index3:
+      keys:
+        fieldC: asc
+      options:
+        partialFilterExpression:
+          embedded:
+            foo: bar

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
@@ -30,8 +30,10 @@
             </index>
             <index>
                 <key name="lock" order="asc" />
-                <partialFilterExpression field="version" comparison="gt" value="1" />
-                <partialFilterExpression field="discr" value="default" />
+                <partial-filter-expression>
+                    <field name="version" value="1" operator="gt" />
+                    <field name="discr" operator="eq" value="default" />
+                </partial-filter-expression>
             </index>
         </indexes>
         <reference-one target-document="Address" field="address">

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
@@ -28,6 +28,11 @@
                 <key name="createdAt" order="asc" />
                 <option name="expireAfterSeconds" value="3600" />
             </index>
+            <index>
+                <key name="lock" order="asc" />
+                <partialFilterExpression field="version" comparison="gt" value="1" />
+                <partialFilterExpression field="discr" value="default" />
+            </index>
         </indexes>
         <reference-one target-document="Address" field="address">
             <cascade>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.yml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.yml
@@ -46,6 +46,13 @@ Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser:
       options:
         unique: true
         dropDups: true
+    index3:
+      keys:
+        lock: asc
+      options:
+        partialFilterExpression:
+          version: { $gt: 1 }
+          discr: { $eq: 'default' }
   referenceOne:
     address:
       targetDocument: Address


### PR DESCRIPTION
MongoDB 3.2 adds support for [partial indexes](https://docs.mongodb.org/manual/core/index-partial/). This PR adds support for adding partialIndexExpression options to the index specification.

Examples:
- YAML:
```
  indexes:
    index1:
      keys:
        username: desc
      options:
        unique: true
        dropDups: false
        partialFilterExpression:
          version: { $gt: 1 }
          discr: { $eq: 'default' }
```
- XML:
```
<indexes>
    <index unique="true">
        <key name="username" order="desc" />
        <option name="dropDups" value="false" />
        <partialFilterExpression>
            <field name="version" value="1" operator="gt" />
            <field name="discr" operator="eq" value="default" />
        </partialFilterExpression>
    </index>
</indexes>
```
- Annotations:
```
/**
 * @ODM\Indexes(
 *     @ODM\Index(keys={"username"="asc"},dropDups=true,partialFilterExpression={"counter"={"$gt"=5}})
 * )
 */
```

List of TODOs:
- [x] Figure out how to properly map $and in XML
- [x] Ensure SchemaManager::isMongoIndexEquivalentToDocumentIndex() works properly
- [x] You can always add more tests