### PR TITLE
Fix parameter checking in BsonFilter

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Filter/BsonFilter.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Filter/BsonFilter.php
@@ -80,7 +80,7 @@ abstract class BsonFilter
      */
     final public function getParameter($name)
     {
-        if ( ! isset($this->parameters[$name])) {
+        if ( ! array_key_exists($name, $this->parameters)) {
             throw new \InvalidArgumentException("Filter parameter '" . $name . "' is not set.");
         }
         return $this->parameters[$name];

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/BsonFilterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/BsonFilterTest.php
@@ -19,6 +19,13 @@ class BsonFilterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $filter->setParameter('username', 'Tim');
         $this->assertEquals('Tim', $filter->getParameter('username'));
     }
+
+    public function testGetNullParameter()
+    {
+        $filter = new Filter($this->dm);
+        $filter->setParameter('foo', null);
+        $this->assertNull($filter->getParameter('foo'));
+    }
  
     public function testCreateMockOfFilter()
     {


### PR DESCRIPTION
Replace `isset` to `array_key_exists` because using the former throws exception if the parameter's value is null.