### PR TITLE
Deprecate field type annotation classes in favor of Field

### DIFF
--- a/docs/en/cookbook/blending-orm-and-mongodb-odm.rst
+++ b/docs/en/cookbook/blending-orm-and-mongodb-odm.rst
@@ -22,7 +22,7 @@ First lets define our `Product` document:
         /** @Id */
         private $id;
 
-        /** @String */
+        /** @Field(type="string") */
         private $title;
 
         public function getId()

--- a/docs/en/cookbook/simple-search-engine.rst
+++ b/docs/en/cookbook/simple-search-engine.rst
@@ -10,7 +10,7 @@ Sample Model: Product
 ---------------------
 
 Imagine you had a ``Product`` document and you want to search the products by keywords. You can
-setup a document like the following with a ``$keywords`` property that is mapped as a ``@Collection``:
+setup a document like the following with a ``$keywords`` property that is mapped as a collection:
 
 .. code-block:: php
 
@@ -24,10 +24,10 @@ setup a document like the following with a ``$keywords`` property that is mapped
         /** @Id */
         private $id;
 
-        /** @String */
+        /** @Field(type="string") */
         private $title;
 
-        /** @Collection @Index */
+        /** @Field(type="collection") @Index */
         private $keywords = array();
 
         // ...
@@ -120,10 +120,10 @@ You can setup a ``Keyword`` document like the following:
     /** @EmbeddedDocument */
     class Keyword
     {
-        /** @String @Index */
+        /** @Field(type="string") @Index */
         private $keyword;
 
-        /** @Int */
+        /** @Field(type="int") */
         private $weight;
 
         public function __construct($keyword, $weight)

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -14,7 +14,7 @@ does not exist.
 
     <?php
 
-    /** @String @AlsoLoad("name") */
+    /** @Field(type="string") @AlsoLoad("name") */
     public $fullName;
 
 The ``$fullName`` property will be loaded from ``fullName`` if it exists, but
@@ -51,6 +51,11 @@ Alias of `@Field`_, with "type" attribute set to "bin". Converts value to
     /** @Bin */
     private $data;
 
+.. note::
+
+    This annotation is deprecated and will be removed in ODM 2.0. Please use the
+    `@Field`_ annotation with type "bin".
+
 @BinCustom
 ----------
 
@@ -63,6 +68,11 @@ value to `MongoBinData`_ with ``MongoBinData::CUSTOM`` sub-type.
 
     /** @BinCustom */
     private $data;
+
+.. note::
+
+    This annotation is deprecated and will be removed in ODM 2.0. Please use the
+    `@Field`_ annotation with type "bin\_custom".
 
 @BinFunc
 --------
@@ -77,6 +87,11 @@ Alias of `@Field`_, with "type" attribute set to "bin\_func". Converts value to
     /** @BinFunc */
     private $data;
 
+.. note::
+
+    This annotation is deprecated and will be removed in ODM 2.0. Please use the
+    `@Field`_ annotation with type "bin\_func".
+
 @BinMD5
 -------
 
@@ -89,6 +104,11 @@ Alias of `@Field`_, with "type" attribute set to "bin\_md5". Converts value to
 
     /** @BinMD5 */
     private $password;
+
+.. note::
+
+    This annotation is deprecated and will be removed in ODM 2.0. Please use the
+    `@Field`_ annotation with type "bin\_md5".
 
 @BinUUID
 --------
@@ -126,8 +146,13 @@ value to `MongoBinData`_ with ``MongoBinData::UUID_RFC4122`` sub-type.
     RFC 4122 UUIDs must be 16 bytes. The PHP driver will throw an exception if
     the binary data's size is invalid.
 
+.. note::
+
+    This annotation is deprecated and will be removed in ODM 2.0. Please use the
+    `@Field`_ annotation with type "bin\_uuid\_rfc4122".
+
 @Bool
---------
+-----
 
 Alias of `@Field`_, with "type" attribute set to "bool". Internally it uses
 exactly same logic as `@Boolean`_ annotation and "boolean" type.
@@ -138,6 +163,13 @@ exactly same logic as `@Boolean`_ annotation and "boolean" type.
 
     /** @Bool */
     private $active;
+
+.. note::
+
+    This annotation is deprecated because it uses a keyword that was reserved in
+    PHP 7. It will be removed in ODM 2.0. Please use the `@Field`_ annotation
+    with type "bool".
+
 
 @Boolean
 --------
@@ -150,6 +182,11 @@ Alias of `@Field`_, with "type" attribute set to "boolean".
 
     /** @Boolean */
     private $active;
+
+.. note::
+
+    This annotation is deprecated and will be removed in ODM 2.0. Please use the
+    `@Field`_ annotation with type "bool".
 
 @Collection
 -----------
@@ -164,6 +201,11 @@ retrieves the value as a numerically indexed array.
     /** @Collection */
     private $tags = array();
 
+.. note::
+
+    This annotation is deprecated and will be removed in ODM 2.0. Please use the
+    `@Field`_ annotation with type "collection".
+
 @Date
 -----
 
@@ -177,6 +219,11 @@ in MongoDB. The property will be a DateTime when loaded from the database.
 
     /** @Date */
     private $createdAt;
+
+.. note::
+
+    This annotation is deprecated and will be removed in ODM 2.0. Please use the
+    `@Field`_ annotation with type "date".
 
 @DefaultDiscriminatorValue
 --------------------------
@@ -286,10 +333,10 @@ calculated distance value.
     /** @EmbeddedDocument */
     class Coordinates
     {
-        /** @Float */
+        /** @Field(type="float") */
         public $latitude;
     
-        /** @Float */
+        /** @Field(type="float") */
         public $longitude;
     }
 
@@ -459,7 +506,7 @@ to be stored within an `@EmbedOne`_ or `@EmbedMany`_ relationship.
     /** @EmbeddedDocument */
     class Money
     {
-        /** @Float */
+        /** @Field(type="float") */
         private $amount;
     
         public function __construct($amount)
@@ -569,7 +616,7 @@ that created the file.
 
     <?php
 
-    /** @String */
+    /** @Field(type="string") */
     private $filename;
 
     /** @NotSaved(type="int") */
@@ -588,6 +635,13 @@ that created the file.
 ------
 
 Alias of `@Field`_, with "type" attribute set to "float".
+
+.. note::
+
+    This annotation is deprecated because it uses a keyword that was reserved in
+    PHP 7. It will be removed in ODM 2.0. Please use the `@Field`_ annotation
+    with type "float".
+
 
 .. _haslifecyclecallbacks:
 
@@ -616,6 +670,11 @@ annotation will cause Doctrine to ignore the callbacks.
 
 Alias of `@Field`_, with "type" attribute set to "hash". Stores and retrieves
 the value as an associative array.
+
+.. note::
+
+    This annotation is deprecated and will be removed in ODM 2.0. Please use the
+    `@Field`_ annotation with type "hash".
 
 @Id
 ---
@@ -676,6 +735,11 @@ The query sent to Mongo would resemble the following:
 The field will be incremented by the difference between the new and old values.
 This is useful if many requests are attempting to update the field concurrently.
 
+.. note::
+
+    This annotation is deprecated and will be removed in ODM 2.0. Please use the
+    `@Field`_ annotation with type "increment".
+
 @Index
 ------
 
@@ -723,7 +787,7 @@ If you are creating a single-field index, you can simply specify an `@Index`_ or
 
     <?php
 
-    /** @String @UniqueIndex */
+    /** @Field(type="string") @UniqueIndex */
     private $username;
 
 @Indexes
@@ -793,6 +857,12 @@ Alias of `@Field`_, with "type" attribute set to "int".
     /** @Int */
     private $columns;
 
+.. note::
+
+    This annotation is deprecated because it uses a keyword that was reserved in
+    PHP 7. It will be removed in ODM 2.0. Please use the `@Field`_ annotation
+    with type "int".
+
 @Integer
 --------
 
@@ -806,6 +876,11 @@ exactly same logic as `@Int`_ annotation and "int" type.
     /** @Integer */
     private $columns;
 
+.. note::
+
+    This annotation is deprecated and will be removed in ODM 2.0. Please use the
+    `@Field`_ annotation with type "int".
+
 @Key
 ----
 
@@ -817,6 +892,11 @@ respectively.
 
     The BSON MaxKey and MinKey types are internally used by MongoDB for indexing
     and sharding. There is generally no reason to use these in an application.
+
+.. note::
+
+    This annotation is deprecated and will be removed in ODM 2.0. Please use the
+    `@Field`_ annotation with type "key".
 
 @MappedSuperclass
 -----------------
@@ -1208,6 +1288,13 @@ Alias of `@Field`_, with "type" attribute set to "string".
     /** @String */
     private $username;
 
+.. note::
+
+    This annotation is deprecated because it uses a keyword that was reserved in
+    PHP 7. It will be removed in ODM 2.0. Please use the `@Field`_ annotation
+    with type "string".
+
+
 @Timestamp
 ----------
 
@@ -1218,7 +1305,12 @@ converted to `MongoTimestamp`_ for storage in MongoDB.
 
     The BSON timestamp type is an internal type used for MongoDB's replication
     and sharding. If you need to store dates in your application, you should use
-    the `@Date`_ annotation instead.
+    the "date" type instead.
+
+.. note::
+
+    This annotation is deprecated and will be removed in ODM 2.0. Please use the
+    `@Field`_ annotation with type "timestamp".
 
 @UniqueIndex
 ------------
@@ -1229,7 +1321,7 @@ Alias of `@Index`_, with the ``unique`` option set by default.
 
     <?php
 
-    /** @String @UniqueIndex */
+    /** @Field(type="string") @UniqueIndex */
     private $email;
 
 .. _annotations_reference_version:
@@ -1239,13 +1331,13 @@ Alias of `@Index`_, with the ``unique`` option set by default.
 
 The annotated instance variable will be used to store version information, which
 is used for pessimistic and optimistic locking. This is only compatible with
-`@Int`_ and `@Date`_ field types, and cannot be combined with `@Id`_.
+integer and date field types, and cannot be combined with `@Id`_.
 
 .. code-block:: php
 
     <?php
 
-    /** @Int @Version */
+    /** @Field(type="int") @Version */
     private $version;
 
 By default, Doctrine ODM processes updates :ref:`embed-many <embed_many>` and

--- a/docs/en/reference/capped-collections.rst
+++ b/docs/en/reference/capped-collections.rst
@@ -35,7 +35,7 @@ the ``@Document`` annotation:
             /** @Id */
             public $id;
 
-            /** @String */
+            /** @Field(type="string") */
             public $name;
         }
 

--- a/docs/en/reference/geospatial-queries.rst
+++ b/docs/en/reference/geospatial-queries.rst
@@ -24,7 +24,7 @@ First, setup some documents like the following:
             /** @Id */
             public $id;
 
-            /** @String */
+            /** @Field(type="string") */
             public $name;
 
             /** @EmbedOne(targetDocument="Coordinates") */
@@ -37,10 +37,10 @@ First, setup some documents like the following:
         /** @EmbeddedDocument */
         class Coordinates
         {
-            /** @Float */
+            /** @Field(type="float") */
             public $x;
     
-            /** @Float */
+            /** @Field(type="float") */
             public $y;
         }
 

--- a/docs/en/reference/indexes.rst
+++ b/docs/en/reference/indexes.rst
@@ -23,7 +23,7 @@ property:
             /** @Id */
             public $id;
     
-            /** @String @Index */
+            /** @Field(type="string") @Index */
             public $username;
         }
 
@@ -90,7 +90,7 @@ Unique Index
             /** @Id */
             public $id;
     
-            /** @String @Index(unique=true, order="asc") */
+            /** @Field(type="string") @Index(unique=true, order="asc") */
             public $username;
         }
 
@@ -123,7 +123,7 @@ For your convenience you can quickly specify a unique index with
             /** @Id */
             public $id;
     
-            /** @String @UniqueIndex(order="asc") */
+            /** @Field(type="string") @UniqueIndex(order="asc") */
             public $username;
         }
 
@@ -158,10 +158,10 @@ you can specify them on the class doc block:
             /** @Id */
             public $id;
     
-            /** @Integer */
+            /** @Field(type="int") */
             public $accountId;
     
-            /** @String */
+            /** @Field(type="string") */
             public $username;
         }
 
@@ -217,10 +217,10 @@ annotation:
             /** @Id */
             public $id;
     
-            /** @Integer */
+            /** @Field(type="int") */
             public $accountId;
     
-            /** @String */
+            /** @Field(type="string") */
             public $username;
         }
 
@@ -272,7 +272,7 @@ documents.
     /** @EmbeddedDocument */
     class Comment
     {
-        /** @Date @Index */
+        /** @Field(type="date") @Index */
         private $date;
 
         // ...
@@ -356,10 +356,10 @@ options structures manually:
         /** @EmbeddedDocument */
         class Coordinates
         {
-            /** @Float */
+            /** @Field(type="float") */
             public $latitude;
     
-            /** @Float */
+            /** @Field(type="float") */
             public $longitude;
         }
 
@@ -399,7 +399,7 @@ make it to the database and cause performance problems.
             /** @Id */
             public $id;
     
-            /** @String @Index */
+            /** @Field(type="string") @Index */
             public $city;
         }
 

--- a/docs/en/reference/introduction.rst
+++ b/docs/en/reference/introduction.rst
@@ -34,22 +34,22 @@ Here is a quick example of some PHP object documents that demonstrates a few of 
         /** @ODM\Id */
         private $id;
     
-        /** @ODM\Increment */
+        /** @ODM\Field(type="increment") */
         private $changes = 0;
     
-        /** @ODM\Collection */
+        /** @ODM\Field(type="collection") */
         private $notes = array();
     
-        /** @ODM\String */
+        /** @ODM\Field(type="string") */
         private $name;
     
-        /** @ODM\Int */
+        /** @ODM\Field(type="int") */
         private $salary;
     
-        /** @ODM\Date */
+        /** @ODM\Field(type="date") */
         private $started;
     
-        /** @ODM\Date */
+        /** @ODM\Field(type="date") */
         private $left;
     
         /** @ODM\EmbedOne(targetDocument="Address") */
@@ -104,16 +104,16 @@ Here is a quick example of some PHP object documents that demonstrates a few of 
     /** @ODM\EmbeddedDocument */
     class Address
     {
-        /** @ODM\String */
+        /** @ODM\Field(type="string") */
         private $address;
     
-        /** @ODM\String */
+        /** @ODM\Field(type="string") */
         private $city;
     
-        /** @ODM\String */
+        /** @ODM\Field(type="string") */
         private $state;
     
-        /** @ODM\String */
+        /** @ODM\Field(type="string") */
         private $zipcode;
 
         public function getAddress() { return $this->address; }
@@ -135,7 +135,7 @@ Here is a quick example of some PHP object documents that demonstrates a few of 
         /** @ODM\Id */
         private $id;
     
-        /** @ODM\String */
+        /** @ODM\Field(type="string") */
         private $name;
     
         public function __construct($name) { $this->name = $name; }

--- a/docs/en/reference/map-reduce.rst
+++ b/docs/en/reference/map-reduce.rst
@@ -32,13 +32,13 @@ named ``Event`` and it was related to a ``User`` document:
         /** @ReferenceOne(targetDocument="Documents\User") */
         private $user;
     
-        /** @String */
+        /** @Field(type="string") */
         private $type;
     
-        /** @Date */
+        /** @Field(type="date") */
         private $date;
     
-        /** @String */
+        /** @Field(type="string") */
         private $description;
     
         // getters and setters

--- a/docs/en/reference/migrating-schemas.rst
+++ b/docs/en/reference/migrating-schemas.rst
@@ -30,7 +30,7 @@ Let's say you have a simple document that starts off with the following fields:
         /** @Id */
         public $id;
 
-        /** @String */
+        /** @Field(type="string") */
         public $name;
     }
 
@@ -47,7 +47,7 @@ hydrate ``fullName`` from ``name`` if the new field doesn't exist.
         /** @Id */
         public $id;
 
-        /** @String @AlsoLoad("name") */
+        /** @Field(type="string") @AlsoLoad("name") */
         public $fullName;
     }
 
@@ -80,10 +80,10 @@ before normal hydration.
         /** @Id */
         public $id;
 
-        /** @String */
+        /** @Field(type="string") */
         public $firstName;
 
-        /** @String */
+        /** @Field(type="string") */
         public $lastName;
 
         /** @AlsoLoad({"name", "fullName"}) */
@@ -125,13 +125,13 @@ Imagine you have some address-related fields on a Person document:
         /** @Id */
         public $id;
 
-        /** @String */
+        /** @Field(type="string") */
         public $name;
 
-        /** @String */
+        /** @Field(type="string") */
         public $street;
 
-        /** @String */
+        /** @Field(type="string") */
         public $city;
     }
 
@@ -144,10 +144,10 @@ Later on, you may want to migrate this data into an embedded Address document:
     /** @EmbeddedDocument */
     class Address
     {
-        /** @String */
+        /** @Field(type="string") */
         public $street;
 
-        /** @String */
+        /** @Field(type="string") */
         public $city;
     
         public function __construct($street, $city)
@@ -163,7 +163,7 @@ Later on, you may want to migrate this data into an embedded Address document:
         /** @Id */
         public $id;
 
-        /** @String */
+        /** @Field(type="string") */
         public $name;
     
         /** @NotSaved */

--- a/docs/en/reference/trees.rst
+++ b/docs/en/reference/trees.rst
@@ -17,10 +17,10 @@ Full Tree in Single Document
         /** @Id */
         private $id;
     
-        /** @String */
+        /** @Field(type="string") */
         private $title;
     
-        /** @String */
+        /** @Field(type="string") */
         private $body;
     
         /** @EmbedMany(targetDocument="Comment") */
@@ -32,10 +32,10 @@ Full Tree in Single Document
     /** @EmbeddedDocument */
     class Comment
     {
-        /** @String */
+        /** @Field(type="string") */
         private $by;
     
-        /** @String */
+        /** @Field(type="string") */
         private $text;
     
         /** @EmbedMany(targetDocument="Comment") */
@@ -73,7 +73,7 @@ Parent Reference
         /** @Id */
         private $id;
     
-        /** @String */
+        /** @Field(type="string") */
         private $name;
     
         /**
@@ -112,7 +112,7 @@ Child Reference
         /** @Id */
         private $id;
     
-        /** @String */
+        /** @Field(type="string") */
         private $name;
     
         /**
@@ -161,7 +161,7 @@ Array of Ancestors
     /** @MappedSuperclass */
     class BaseCategory
     {
-        /** @String */
+        /** @Field(type="string") */
         private $name;
     
         // ...
@@ -233,10 +233,10 @@ Materialized Paths
         /** @Id */
         private $id;
     
-        /** @String */
+        /** @Field(type="string") */
         private $name;
     
-        /** @String */
+        /** @Field(type="string") */
         private $path;
     
         // ...

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -76,10 +76,10 @@ You can provide your mapping information in Annotations, XML, or YAML:
             /** @ODM\Id */
             private $id;
 
-            /** @ODM\String */
+            /** @ODM\Field(type="string") */
             private $name;
 
-            /** @ODM\String */
+            /** @ODM\Field(type="string") */
             private $email;
 
             /** @ODM\ReferenceMany(targetDocument="BlogPost", cascade="all") */
@@ -94,13 +94,13 @@ You can provide your mapping information in Annotations, XML, or YAML:
             /** @ODM\Id */
             private $id;
 
-            /** @ODM\String */
+            /** @ODM\Field(type="string") */
             private $title;
 
-            /** @ODM\String */
+            /** @ODM\Field(type="string") */
             private $body;
 
-            /** @ODM\Date */
+            /** @ODM\Field(type="date") */
             private $createdAt;
 
             // ...

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AlsoLoad.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AlsoLoad.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Loads data from a different field if the original field is not set
+ *
+ * @Annotation
+ */
 final class AlsoLoad extends Annotation
 {
     public $name;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Bin.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Bin.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class Bin extends AbstractField
 {
     public $type = 'bin';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinCustom.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinCustom.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class BinCustom extends AbstractField
 {
     public $type = 'bin_custom';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinFunc.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinFunc.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class BinFunc extends AbstractField
 {
     public $type = 'bin_func';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinMD5.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinMD5.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class BinMD5 extends AbstractField
 {
     public $type = 'bin_md5';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinUUID.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinUUID.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class BinUUID extends AbstractField
 {
     public $type = 'bin_uuid';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinUUIDRFC4122.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinUUIDRFC4122.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class BinUUIDRFC4122 extends AbstractField
 {
     public $type = 'bin_uuid_rfc4122';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Bool.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Bool.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class Bool extends AbstractField
 {
     public $type = 'bool';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Boolean.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Boolean.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class Boolean extends AbstractField
 {
     public $type = 'boolean';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ChangeTrackingPolicy.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ChangeTrackingPolicy.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Specifies the change tracking policy for a document
+ *
+ * @Annotation
+ */
 final class ChangeTrackingPolicy extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Collection.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Collection.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class Collection extends AbstractField
 {
     public $type = 'collection';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Date.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Date.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class Date extends AbstractField
 {
     public $type = 'date';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DefaultDiscriminatorValue.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DefaultDiscriminatorValue.php
@@ -21,7 +21,12 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Specifies a default discriminator value to be used when the discriminator
+ * field is not set in a document
+ *
+ * @Annotation
+ */
 final class DefaultDiscriminatorValue extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DiscriminatorField.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DiscriminatorField.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Specify a field name to store a discriminator value
+ *
+ * @Annotation
+ */
 final class DiscriminatorField extends Annotation
 {
     /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DiscriminatorMap.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DiscriminatorMap.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Specify a map of discriminator values and classes
+ *
+ * @Annotation
+ */
 final class DiscriminatorMap extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DiscriminatorValue.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DiscriminatorValue.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Use the specified discriminator for this class
+ *
+ * @Annotation
+ */
 final class DiscriminatorValue extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Distance.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Distance.php
@@ -19,7 +19,11 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * Use this field to store distance information for geoNear queries
+ *
+ * @Annotation
+ */
 final class Distance extends AbstractField
 {
     public $distance = true;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Document.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Document.php
@@ -19,7 +19,11 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * Identifies a class as a document that can be stored in the database
+ *
+ * @Annotation
+ */
 final class Document extends AbstractDocument
 {
     public $db;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/EmbedMany.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/EmbedMany.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 
-/** @Annotation */
+/**
+ * Embeds multiple documents
+ *
+ * @Annotation
+ */
 final class EmbedMany extends AbstractField
 {
     public $type = 'many';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/EmbedOne.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/EmbedOne.php
@@ -19,7 +19,11 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * Embeds a single document
+ *
+ * @Annotation
+ */
 final class EmbedOne extends AbstractField
 {
     public $type = 'one';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/EmbeddedDocument.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/EmbeddedDocument.php
@@ -19,7 +19,11 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * Identifies a class as a document that can be embedded but not stored by itself
+ *
+ * @Annotation
+ */
 final class EmbeddedDocument extends AbstractDocument
 {
     public $indexes = array();

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Field.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Field.php
@@ -19,7 +19,11 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * Specifies a generic field mapping
+ *
+ * @Annotation
+ */
 final class Field extends AbstractField
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/File.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/File.php
@@ -19,7 +19,12 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * Maps a field as GridFS file and instructs ODM to store the entire document in
+ * a GridFS collection.
+ *
+ * @Annotation
+ */
 final class File extends AbstractField
 {
     public $type = 'file';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Float.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Float.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class Float extends AbstractField
 {
     public $type = 'float';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/HasLifecycleCallbacks.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/HasLifecycleCallbacks.php
@@ -21,7 +21,12 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Must be set on a document class to instruct Doctrine to check for lifecycle
+ * callback annotations on public methods.
+ *
+ * @Annotation
+ */
 final class HasLifecycleCallbacks extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Hash.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Hash.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class Hash extends AbstractField
 {
     public $type = 'hash';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Id.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Id.php
@@ -19,7 +19,11 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * Special field mapping to map document identifiers
+ *
+ * @Annotation
+ */
 final class Id extends AbstractField
 {
     public $id = true;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Increment.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Increment.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class Increment extends AbstractField
 {
     public $type = 'increment';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Index.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Index.php
@@ -19,7 +19,11 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * Defines an index on a field
+ *
+ * @Annotation
+ */
 final class Index extends AbstractIndex
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Indexes.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Indexes.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Specifies a list of indexes for a document
+ *
+ * @Annotation
+ */
 final class Indexes extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Inheritance.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Inheritance.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Specifies inheritance mapping for a document
+ *
+ * @Annotation
+ */
 final class Inheritance extends Annotation
 {
     public $type = 'NONE';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/InheritanceType.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/InheritanceType.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Specifies which inheritance type to use for a document
+ *
+ * @Annotation
+ */
 final class InheritanceType extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Int.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Int.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class Int extends AbstractField
 {
     public $type = 'int';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Integer.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Integer.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class Integer extends AbstractField
 {
     public $type = 'integer';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Key.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Key.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class Key extends AbstractField
 {
     public $type = 'key';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Lock.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Lock.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Specifies a field to use for pessimistic locking
+ *
+ * @Annotation
+ */
 final class Lock extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/MappedSuperclass.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/MappedSuperclass.php
@@ -19,7 +19,12 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * Specifies a parent class that other documents may extend to inherit mapping
+ * information
+ *
+ * @Annotation
+ */
 final class MappedSuperclass extends AbstractDocument
 {
     /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/NotSaved.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/NotSaved.php
@@ -19,7 +19,11 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * Specifies that a field will not be written to the database
+ *
+ * @Annotation
+ */
 final class NotSaved extends AbstractField
 {
     public $notSaved = true;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ObjectId.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ObjectId.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class ObjectId extends AbstractField
 {
     public $type = 'object_id';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PostLoad.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PostLoad.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Marks a method as a postLoad lifecycle callback
+ *
+ * @Annotation
+ */
 final class PostLoad extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PostPersist.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PostPersist.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Marks a method as a postPersist lifecycle callback
+ *
+ * @Annotation
+ */
 final class PostPersist extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PostRemove.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PostRemove.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Marks a method as a postRemove lifecycle callback
+ *
+ * @Annotation
+ */
 final class PostRemove extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PostUpdate.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PostUpdate.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Marks a method as a postUpdate lifecycle callback
+ *
+ * @Annotation
+ */
 final class PostUpdate extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PreFlush.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PreFlush.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Marks a method as a preFlush lifecycle callback
+ *
+ * @Annotation
+ */
 final class PreFlush extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PreLoad.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PreLoad.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Marks a method as a preLoad lifecycle callback
+ *
+ * @Annotation
+ */
 final class PreLoad extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PrePersist.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PrePersist.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Marks a method as a prePersist lifecycle callback
+ *
+ * @Annotation
+ */
 final class PrePersist extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PreRemove.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PreRemove.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Marks a method as a preRemove lifecycle callback
+ *
+ * @Annotation
+ */
 final class PreRemove extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PreUpdate.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PreUpdate.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Marks a method as a preUpdate lifecycle callback
+ *
+ * @Annotation
+ */
 final class PreUpdate extends Annotation
 {
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Raw.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Raw.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class Raw extends AbstractField
 {
     public $type = 'raw';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceMany.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceMany.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 
-/** @Annotation */
+/**
+ * Specifies a one-to-many relationship to a different document
+ *
+ * @Annotation
+ */
 final class ReferenceMany extends AbstractField
 {
     public $type = 'many';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceOne.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceOne.php
@@ -19,7 +19,11 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * Specifies a one-to-one relationship to a different document
+ *
+ * @Annotation
+ */
 final class ReferenceOne extends AbstractField
 {
     public $type = 'one';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/String.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/String.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class String extends AbstractField
 {
     public $type = 'string';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Timestamp.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Timestamp.php
@@ -19,7 +19,10 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * @Annotation
+ * @deprecated This class will be removed in ODM 2.0
+ */
 final class Timestamp extends AbstractField
 {
     public $type = 'timestamp';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/UniqueIndex.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/UniqueIndex.php
@@ -19,7 +19,11 @@
 
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
-/** @Annotation */
+/**
+ * Specifies a unique index on a field
+ *
+ * @Annotation
+ */
 final class UniqueIndex extends AbstractIndex
 {
     public $unique = true;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Version.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Version.php
@@ -21,7 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
-/** @Annotation */
+/**
+ * Specifies a field to use for optimistic locking
+ *
+ * @Annotation
+ */
 final class Version extends Annotation
 {
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleCallbacksTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleCallbacksTest.php
@@ -290,13 +290,13 @@ class Profile extends BaseDocument
 /** @ODM\MappedSuperclass @ODM\HasLifecycleCallbacks */
 abstract class BaseDocument
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\Date */
+    /** @ODM\Field(type="date") */
     public $createdAt;
 
-    /** @ODM\Date */
+    /** @ODM\Field(type="date") */
     public $updatedAt;
 
     public $prePersist = false;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleListenersTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleListenersTest.php
@@ -196,7 +196,7 @@ class TestDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\EmbedMany(targetDocument="TestEmbeddedDocument") */
@@ -215,7 +215,7 @@ class TestDocument
 /** @ODM\EmbeddedDocument */
 class TestEmbeddedDocument
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }
 
@@ -226,7 +226,7 @@ class TestProfile
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\EmbedOne(targetDocument="Image") */
@@ -238,7 +238,7 @@ class TestProfile
  */
 class Image
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\EmbedMany(targetDocument="Thumbnail") */
@@ -255,7 +255,7 @@ class Image
  */
 class Thumbnail
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public function __construct($name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AlsoLoadTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AlsoLoadTest.php
@@ -214,7 +214,7 @@ class AlsoLoadDocument
     public $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @ODM\AlsoLoad({"bar", "zip"})
      */
     public $foo;
@@ -232,7 +232,7 @@ class AlsoLoadDocument
     public $zip;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @ODM\AlsoLoad("zip")
      */
     public $zap = 'zap';
@@ -243,14 +243,14 @@ class AlsoLoadDocument
     /** @ODM\NotSaved */
     public $fullName;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $firstName;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $lastName;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @ODM\AlsoLoad("testNew")
      */
     public $test = 'test';
@@ -280,7 +280,7 @@ class AlsoLoadDocument
 /** @ODM\Document */
 class AlsoLoadChild extends AlsoLoadDocument
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $fizz;
 
     /** @ODM\AlsoLoad("buzz") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
@@ -546,13 +546,13 @@ class AtomicSetUser
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\Int @ODM\Version */
+    /** @ODM\Field(type="int") @ODM\Version */
     public $version = 1;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $surname;
 
     /** @ODM\EmbedMany(strategy="atomicSet", targetDocument="Documents\Phonenumber") */
@@ -585,7 +585,7 @@ class AtomicSetUser
  */
 class AtomicSetInception
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $value;
 
     /** @ODM\EmbedOne(targetDocument="AtomicSetInception") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
@@ -26,11 +26,11 @@ class BinDataTest extends BaseTest
     public function provideData()
     {
         return array(
-            array('bin', 'test', 0), // MongoBinData::GENERIC is only defined in driver 1.5+
+            array('bin', 'test', \MongoBinData::GENERIC),
             array('binFunc', 'test', \MongoBinData::FUNC),
             array('binByteArray', 'test', \MongoBinData::BYTE_ARRAY),
             array('binUUID', 'test', \MongoBinData::UUID),
-            array('binUUIDRFC4122', '1234567890ABCDEF', 4), // MongoBinData::UUID_RFC4122 is only defined in driver 1.5+
+            array('binUUIDRFC4122', '1234567890ABCDEF', \MongoBinData::UUID_RFC4122),
             array('binMD5', 'test', \MongoBinData::MD5),
             array('binCustom', 'test', \MongoBinData::CUSTOM),
         );
@@ -43,24 +43,24 @@ class BinDataTestUser
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\Bin */
+    /** @ODM\Field(type="bin") */
     public $bin;
 
-    /** @ODM\Bin(type="bin_func") */
+    /** @ODM\Field(type="bin_func") */
     public $binFunc;
 
-    /** @ODM\Bin(type="bin_bytearray") */
+    /** @ODM\Field(type="bin_bytearray") */
     public $binByteArray;
 
-    /** @ODM\Bin(type="bin_uuid") */
+    /** @ODM\Field(type="bin_uuid") */
     public $binUUID;
 
-    /** @ODM\Bin(type="bin_uuid_rfc4122") */
+    /** @ODM\Field(type="bin_uuid_rfc4122") */
     public $binUUIDRFC4122;
 
-    /** @ODM\Bin(type="bin_md5") */
+    /** @ODM\Field(type="bin_md5") */
     public $binMD5;
 
-    /** @ODM\Bin(type="bin_custom") */
+    /** @ODM\Field(type="bin_custom") */
     public $binCustom;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -259,7 +259,7 @@ class CollectionPersisterUser
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $username;
 
     /** @ODM\EmbedMany(targetDocument="CollectionPersisterCategory") */
@@ -272,7 +272,7 @@ class CollectionPersisterUser
 /** @ODM\EmbeddedDocument */
 class CollectionPersisterCategory
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\EmbedMany(targetDocument="CollectionPersisterCategory") */
@@ -290,7 +290,7 @@ class CollectionPersisterPhonenumber
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $phonenumber;
 
     public function __construct($phonenumber)
@@ -305,7 +305,7 @@ class CollectionPersisterPost
   /** @ODM\Id */
   public $id;
 
-  /** @ODM\String */
+  /** @ODM\Field(type="string") */
   public $post;
 
   /** @ODM\EmbedMany(targetDocument="CollectionPersisterComment", strategy="set") */
@@ -326,10 +326,10 @@ class CollectionPersisterComment
   /** @ODM\Id */
   public $id;
 
-  /** @ODM\String */
+  /** @ODM\Field(type="string") */
   public $comment;
 
-  /** @ODM\String */
+  /** @ODM\Field(type="string") */
   public $by;
 
   /** @ODM\EmbedMany(targetDocument="CollectionPersisterComment", strategy="set") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionsTest.php
@@ -95,7 +95,7 @@ class CollectionTest
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $username;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomFieldNameTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomFieldNameTest.php
@@ -103,6 +103,6 @@ class CustomFieldName
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String(name="login") */
+    /** @ODM\Field(name="login", type="string") */
     public $username;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
@@ -136,7 +136,7 @@ abstract class ChildDocument
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $type;
 
     public function __construct($type)
@@ -214,7 +214,7 @@ class ChildDocumentWithDiscriminatorSimple extends ChildDocumentWithDiscriminato
 /** @ODM\Document(collection="discriminator_child") */
 class ChildDocumentWithDiscriminatorComplex extends ChildDocumentWithDiscriminatorSimple
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $value;
 
     public function __construct($type, $value)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -352,7 +352,7 @@ class DocumentPersisterTestDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String(name="dbName") */
+    /** @ODM\Field(name="dbName", type="string") */
     public $name;
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedReferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedReferenceTest.php
@@ -61,7 +61,7 @@ class Offer
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\EmbedMany(targetDocument="Link") */
@@ -80,7 +80,7 @@ class Link
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $url;
 
     /** @ODM\ReferenceMany(targetDocument="ReferencedDocument") */
@@ -99,7 +99,7 @@ class ReferencedDocument
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public function __construct($name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilesTest.php
@@ -175,7 +175,7 @@ class TestFile
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\File */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -889,7 +889,7 @@ class ParentAssociationTestA
 {
     /** @ODM\Id */
     public $id;
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
     /** @ODM\EmbedOne */
     public $child;
@@ -902,7 +902,7 @@ class ParentAssociationTestA
 /** @ODM\EmbeddedDocument */
 class ParentAssociationTestB
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
     /** @ODM\EmbedMany */
     public $children = array();
@@ -915,7 +915,7 @@ class ParentAssociationTestB
 /** @ODM\EmbeddedDocument */
 class ParentAssociationTestC
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
     public function __construct($name)
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/GeoSpatialTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/GeoSpatialTest.php
@@ -181,7 +181,7 @@ class City
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\EmbedOne(targetDocument="Coordinates") */
@@ -194,9 +194,9 @@ class City
 /** @ODM\EmbeddedDocument */
 class Coordinates
 {
-    /** @ODM\Float */
+    /** @ODM\Field(type="float") */
     public $latitude;
 
-    /** @ODM\Float */
+    /** @ODM\Field(type="float") */
     public $longitude;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
@@ -343,7 +343,7 @@ class %s
     /** @Doctrine\ODM\MongoDB\Mapping\Annotations\Id(strategy="%s", options={"type"="%s"}) **/
     public $id;
 
-    /** @Doctrine\ODM\MongoDB\Mapping\Annotations\String **/
+    /** @Doctrine\ODM\MongoDB\Mapping\Annotations\Field("type=string") **/
     public $test = "test";
 }', $shortClassName, $strategy, $type);
 
@@ -360,7 +360,7 @@ class UuidUser
     /** @ODM\Id(strategy="uuid", options={"salt"="test"}) */
     public $id;
 
-    /** @ODM\String(name="t") */
+    /** @ODM\Field(name="t", type="string") */
     public $name;
 
     public function __construct($name)
@@ -375,7 +375,7 @@ class CollectionIdUser
     /** @ODM\Id(strategy="increment") */
     public $id;
 
-    /** @ODM\String(name="t") */
+    /** @ODM\Field(name="t", type="string") */
     public $name;
 
     /** @ODM\ReferenceOne(targetDocument="ReferencedCollectionId", cascade={"persist"}) */
@@ -396,7 +396,7 @@ class ReferencedCollectionId
     /** @ODM\Id(strategy="increment") */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public function __construct($name)
@@ -416,7 +416,7 @@ class EmbeddedCollectionId
     /** @ODM\Id(strategy="increment") */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public function __construct($name)
@@ -436,7 +436,7 @@ class AlnumCharsUser
     /** @ODM\Id(strategy="alnum", options={"chars"="zyxwvutsrqponmlkjihgfedcba"}) */
     public $id;
 
-    /** @ODM\String(name="t") */
+    /** @ODM\Field(name="t", type="string") */
     public $name;
 
     public function __construct($name)
@@ -451,7 +451,7 @@ class CustomIdUser
     /** @ODM\Id(strategy="none",nullable=true) */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public function __construct($name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
@@ -209,10 +209,10 @@ class UniqueOnFieldTest
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String @ODM\UniqueIndex(safe=true) */
+    /** @ODM\Field(type="string") @ODM\UniqueIndex(safe=true) */
     public $username;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $email;
 }
 
@@ -222,10 +222,10 @@ class UniqueOnDocumentTest
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $username;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $email;
 }
 
@@ -235,10 +235,10 @@ class IndexesOnDocumentTest
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $username;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $email;
 }
 
@@ -248,10 +248,10 @@ class MultipleFieldsUniqueIndexTest
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $username;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $email;
 }
 
@@ -261,10 +261,10 @@ class UniqueSparseOnFieldTest
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String @ODM\UniqueIndex(safe=true, sparse=true) */
+    /** @ODM\Field(type="string") @ODM\UniqueIndex(safe=true, sparse=true) */
     public $username;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $email;
 }
 
@@ -274,10 +274,10 @@ class UniqueSparseOnDocumentTest
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $username;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $email;
 }
 
@@ -287,10 +287,10 @@ class SparseIndexesOnDocumentTest
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $username;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $email;
 }
 
@@ -300,10 +300,10 @@ class MultipleFieldsUniqueSparseIndexTest
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $username;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $email;
 }
 
@@ -313,10 +313,10 @@ class MultipleFieldIndexes
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String @ODM\UniqueIndex(name="test") */
+    /** @ODM\Field(type="string") @ODM\UniqueIndex(name="test") */
     public $username;
 
-    /** @ODM\String @ODM\Index(unique=true) */
+    /** @ODM\Field(type="string") @ODM\Index(unique=true) */
     public $email;
 }
 
@@ -326,7 +326,7 @@ class DocumentWithEmbeddedIndexes
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\EmbedOne(targetDocument="EmbeddedDocumentWithIndexes") */
@@ -350,7 +350,7 @@ class DocumentWithDiscriminatorIndex
 /** @ODM\EmbeddedDocument */
 class EmbeddedDocumentWithIndexes
 {
-    /** @ODM\String @ODM\Index */
+    /** @ODM\Field(type="string") @ODM\Index */
     public $name;
 
     /** @ODM\EmbedMany(targetDocument="EmbeddedManyDocumentWithIndexes") */
@@ -360,14 +360,14 @@ class EmbeddedDocumentWithIndexes
 /** @ODM\EmbeddedDocument */
 class EmbeddedManyDocumentWithIndexes
 {
-    /** @ODM\String @ODM\Index */
+    /** @ODM\Field(type="string") @ODM\Index */
     public $name;
 }
 
 /** @ODM\EmbeddedDocument */
 class YetAnotherEmbeddedDocumentWithIndex
 {
-    /** @ODM\String @ODM\Index */
+    /** @ODM\Field(type="string") @ODM\Index */
     public $value;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LifecycleTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LifecycleTest.php
@@ -58,7 +58,7 @@ class ParentObject
     /** @ODM\ReferenceMany(targetDocument="ChildObject", cascade="all") */
     private $children;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     /** @ODM\EmbedOne(targetDocument="ChildEmbeddedObject") */
@@ -117,7 +117,7 @@ class ChildObject
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     public function __construct($name)
@@ -139,7 +139,7 @@ class ChildObject
 /** @ODM\EmbeddedDocument */
 class ChildEmbeddedObject
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     public function __construct($name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
@@ -415,10 +415,10 @@ abstract class AbstractVersionBase
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $title;
 
-    /** @ODM\Lock @ODM\Int */
+    /** @ODM\Lock @ODM\Field(type="int") */
     public $locked;
 
     /**
@@ -451,14 +451,14 @@ abstract class AbstractVersionBase
 /** @ODM\Document */
 class LockInt extends AbstractVersionBase
 {
-    /** @ODM\Version @ODM\Int */
+    /** @ODM\Version @ODM\Field(type="int") */
     public $version;
 }
 
 /** @ODM\Document */
 class LockTimestamp extends AbstractVersionBase
 {
-    /** @ODM\Version @ODM\Date */
+    /** @ODM\Version @ODM\Field(type="date") */
     public $version;
 }
 
@@ -468,7 +468,7 @@ class InvalidLockDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\Lock @ODM\String */
+    /** @ODM\Lock @ODM\Field(type="string") */
     public $lock;
 }
 
@@ -478,6 +478,6 @@ class InvalidVersionDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\Version @ODM\String */
+    /** @ODM\Version @ODM\Field(type="string") */
     public $version;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/MappedSuperclassTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/MappedSuperclassTest.php
@@ -38,10 +38,10 @@ class MappedSuperclassTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 /** @ODM\MappedSuperclass */
 class MappedSuperclassBase
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $mapped1;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $mapped2;
 
     /**
@@ -88,7 +88,7 @@ class MappedSuperclassRelated1
     /** @ODM\Id(strategy="none") */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     public function setName($name)
@@ -118,7 +118,7 @@ class DocumentSubClass extends MappedSuperclassBase
     /** @ODM\Id(strategy="none") */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
     
     public function setName($name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
@@ -138,7 +138,7 @@ class Hierarchy
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     /** @ODM\ReferenceMany(targetDocument="Hierarchy") */
@@ -195,7 +195,7 @@ class Hierarchy
 /** @ODM\MappedSuperclass */
 class BaseCategory
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $name;
 
     /** @ODM\EmbedMany(targetDocument="ChildCategory") */
@@ -268,7 +268,7 @@ class Order
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $title;
 
     /** @ODM\EmbedOne(targetDocument="ProductBackup") */
@@ -281,7 +281,7 @@ class Product
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $title;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalEmbedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalEmbedTest.php
@@ -172,7 +172,7 @@ class OrphanRemovalCascadeProfile
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\ReferenceOne(targetDocument="OrphanRemovalCascadeAddress", orphanRemoval=true, cascade={"all"}) */
@@ -188,6 +188,6 @@ class OrphanRemovalCascadeAddress
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
@@ -257,6 +257,6 @@ class OrphanRemovalProfile
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PrePersistTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PrePersistTest.php
@@ -34,7 +34,7 @@ class PrePersistTestDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $field;
 
     /** @ODM\PrePersist */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RawTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RawTypeTest.php
@@ -42,6 +42,6 @@ class RawType
 	/** @ODM\Id */
 	public $id;
 
-	/** @ODM\Raw */
+	/** @ODM\Field(type="raw") */
 	public $raw;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
@@ -98,7 +98,7 @@ class Action
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $type;
 
     public function __construct($type)
@@ -121,7 +121,7 @@ class Action
 class CommentableAction extends Action
 {
     /**
-     * @ODM\Collection
+     * @ODM\Field(type="collection")
      **/
     protected $comments = array();
 
@@ -168,7 +168,7 @@ abstract class ActivityStreamItem
  */
 abstract class GroupActivityStreamItem extends ActivityStreamItem
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $groupId;
 
     public function __construct(Action $action, $groupId)
@@ -199,7 +199,7 @@ class GroupMembersActivityStreamItem extends GroupActivityStreamItem
  */
 abstract class UserActivityStreamItem extends ActivityStreamItem
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $userId;
 
     public function __construct(Action $action, $userId)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RequireIndexesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RequireIndexesTest.php
@@ -276,10 +276,10 @@ class RequireIndexesDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String @ODM\Index */
+    /** @ODM\Field(type="string") @ODM\Index */
     public $indexed;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $notIndexed;
 
     /** @ODM\EmbedOne(targetDocument="Doctrine\ODM\MongoDB\Tests\Functional\RequireIndexesEmbeddedDocument") */
@@ -303,19 +303,19 @@ class DoesNotRequireIndexesDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String @ODM\Index */
+    /** @ODM\Field(type="string") @ODM\Index */
     public $indexed;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $notIndexed;
 }
 
 /** @ODM\EmbeddedDocument */
 class RequireIndexesEmbeddedDocument
 {
-    /** @ODM\String @ODM\Index */
+    /** @ODM\Field(type="string") @ODM\Index */
     public $indexed;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $notIndexed;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php
@@ -53,7 +53,7 @@ class GH1011Document
 /** @ODM\EmbeddedDocument */
 class GH1011Embedded
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public function __construct($name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
@@ -44,7 +44,7 @@ class GH1058PersistDocument
 {
     /** @ODM\Id */
     private $id;
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $value;
     public function getId()
     {
@@ -60,7 +60,7 @@ class GH1058UpsertDocument
 {
     /** @ODM\Id */
     private $id;
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $value;
     public function getId()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1107Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1107Test.php
@@ -26,7 +26,7 @@ class GH1107ParentClass
     /** @ODM\Id(strategy="NONE") */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php
@@ -49,7 +49,7 @@ class GH1117Document
  */
 class GH1117EmbeddedDocument
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $value;
 
     public function __construct($value)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1138Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1138Test.php
@@ -52,7 +52,7 @@ class GH1138Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
@@ -57,7 +57,7 @@ class GH1225Document
  */
 class GH1225EmbeddedDocument
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $value;
 
     public function __construct($value)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
@@ -192,10 +192,10 @@ class GH1229Child
 {
     const CLASSNAME = __CLASS__;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\Int */
+    /** @ODM\Field(type="int") */
     public $order = 0;
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
@@ -187,7 +187,7 @@ class Item {
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /**
@@ -209,7 +209,7 @@ class Element {
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public function __construct($name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1294Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1294Test.php
@@ -41,7 +41,7 @@ class GH1294User
     /** @ODM\Id(strategy="UUID", type="string") */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name = false;
 
     // Return the identifier without triggering Proxy initialization

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH232Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH232Test.php
@@ -44,7 +44,7 @@ class Product
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\EmbedMany(targetDocument="Price") */
@@ -75,6 +75,6 @@ class SubProduct
 /** @ODM\EmbeddedDocument */
 class Price
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $price;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
@@ -60,7 +60,7 @@ class User
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $name;
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH301Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH301Test.php
@@ -35,7 +35,7 @@ class GH301Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH435Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH435Test.php
@@ -27,13 +27,13 @@ class GH435Parent
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\Int */
+    /** @ODM\Field(type="int") */
     protected $test;
 }
 
 /** @ODM\Document */
 class GH435Child extends GH435Parent
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $test;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH453Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH453Test.php
@@ -268,13 +268,13 @@ class GH453Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\Hash */
+    /** @ODM\Field(type="hash") */
     public $hash;
 
-    /** @ODM\Collection() */
+    /** @ODM\Field(type="collection") */
     public $colPush;
 
-    /** @ODM\Collection() */
+    /** @ODM\Field(type="collection") */
     public $colSet;
 
     /** @ODM\EmbedMany(strategy="pushAll")) */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH467Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH467Test.php
@@ -30,7 +30,7 @@ class GH467Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\Collection */
+    /** @ODM\Field(type="collection") */
     public $col;
 
     /** @ODM\EmbedMany(targetDocument="GH467EmbeddedDocument") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
@@ -113,7 +113,7 @@ class GH560Document
     /** @ODM\Id(strategy="NONE") */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public function __construct($id, $name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH561Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH561Test.php
@@ -63,7 +63,7 @@ class GH561EmbeddedDocument
 /** @ODM\EmbeddedDocument */
 class GH561AnotherEmbeddedDocument
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public function __construct($name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
@@ -64,6 +64,6 @@ class GH580Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String @ODM\Index(unique=true) */
+    /** @ODM\Field(type="string") @ODM\Index(unique=true) */
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH593Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH593Test.php
@@ -102,7 +102,7 @@ class GH593User
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\Boolean(name="d") */
+    /** @ODM\Field(name="d", type="bool") */
     public $deleted = false;
 
     /** @ODM\ReferenceMany(targetDocument="GH593User", inversedBy="followedBy", simple=true) */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH596Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH596Test.php
@@ -47,9 +47,9 @@ class GH596Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\Boolean */
+    /** @ODM\Field(type="bool") */
     public $deleted = false;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH597Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH597Test.php
@@ -157,7 +157,7 @@ class GH597Post
 /** @ODM\EmbeddedDocument */
 class GH597Comment
 {
-    /** @ODM\String() */
+    /** @ODM\Field(type="string") */
     public $comment;
 
     public function __construct($comment)
@@ -173,7 +173,7 @@ class GH597ReferenceMany
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String() */
+    /** @ODM\Field(type="string") */
     public $field;
 
     public function __construct($field)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
@@ -104,7 +104,7 @@ class GH602User
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\Boolean(name="user_deleted") */
+    /** @ODM\Field(name="user_deleted", type="bool") */
     public $deleted = false;
 
     /** @ODM\ReferenceMany(targetDocument="GH602Thing", inversedBy="likedBy", simple=true) */
@@ -128,7 +128,7 @@ class GH602Thing
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\Boolean(name="thing_deleted") */
+    /** @ODM\Field(name="thing_deleted", type="bool") */
     public $deleted = false;
 
     /** @ODM\ReferenceMany(targetDocument="GH602User", mappedBy="likes") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH611Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH611Test.php
@@ -128,10 +128,10 @@ class GH611Document
 /** @ODM\EmbeddedDocument */
 class GH611EmbeddedDocument
 {
-    /** @ODM\Integer */
+    /** @ODM\Field(type="int") */
     public $id;
 
-    /** @ODM\String(name="n") */
+    /** @ODM\Field(name="n", type="string") */
     public $name;
 
     public function __construct($id, $name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH628Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH628Test.php
@@ -25,6 +25,6 @@ class GH628Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\Raw(name="f") */
+    /** @ODM\Field(name="f", type="raw") */
     public $foo;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH665Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH665Test.php
@@ -65,7 +65,7 @@ class GH665Document
 /** @ODM\EmbeddedDocument */
 class GH665Embedded
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public function __construct($name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH788Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH788Test.php
@@ -405,7 +405,7 @@ class GH788DocumentListed extends GH788Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }
 
@@ -417,7 +417,7 @@ class GH788DocumentUnlisted extends GH788DocumentListed
 /** @ODM\EmbeddedDocument */
 class GH788InlineEmbedListed
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }
 
@@ -432,7 +432,7 @@ class GH788InlineRefListed
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }
 
@@ -451,7 +451,7 @@ class GH788ExternEmbedListed
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }
 
@@ -471,7 +471,7 @@ class GH788ExternRefListed
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH816Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH816Test.php
@@ -37,6 +37,6 @@ class GH816Document
     /** @ODM\Id */
     public $_id;
     
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $title;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH832Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH832Test.php
@@ -45,7 +45,7 @@ class GH832Document
     public $file;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @ODM\UniqueIndex
      */
     public $unique;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
@@ -102,7 +102,7 @@ class GH852Document
     /** @ODM\Id(strategy="NONE", type="custom_id") */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH878Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH878Test.php
@@ -66,7 +66,7 @@ class GH878Document
 /** @ODM\EmbeddedDocument */
 class GH878SubDocument
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $some = '2';
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH880Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH880Test.php
@@ -42,10 +42,10 @@ class GH880Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $status;
 
-    /** @ODM\Int */
+    /** @ODM\Field(type="int") */
     public $category;
 
     public function __construct($status = "", $category = 0)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH897Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH897Test.php
@@ -42,7 +42,7 @@ class GH897A
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }
 
@@ -52,7 +52,7 @@ class GH897B
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\ReferenceOne(targetDocument="GH897A") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH921Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH921Test.php
@@ -61,7 +61,7 @@ class GH921User
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     /** @ODM\ReferenceMany(targetDocument="GH921Post") */
@@ -81,7 +81,7 @@ class GH921Post
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     public function getId() { return $this->id; }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH942Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH942Test.php
@@ -61,7 +61,7 @@ class GH942Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }
 
@@ -78,7 +78,7 @@ class GH942DocumentParent
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH944Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH944Test.php
@@ -65,7 +65,7 @@ class GH944Document
  */
 class GH944Embedded
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $text;
 
     public function __construct($text)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH977Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH977Test.php
@@ -56,10 +56,10 @@ class GH977TestDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $value1;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $value2;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH999Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH999Test.php
@@ -38,7 +38,7 @@ class GH999Document
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     public function __construct($name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
@@ -39,7 +39,7 @@ class MODM116Parent
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     /** @ODM\ReferenceOne(targetDocument="MODM116Child") **/

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM140Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM140Test.php
@@ -127,7 +127,7 @@ class Category
 	/** @ODM\Id */
 	protected $id;
 	
-	/** @ODM\String */
+	/** @ODM\Field(type="string") */
 	public $name;
 	
 	/** @ODM\EmbedMany(targetDocument="Post") */
@@ -160,7 +160,7 @@ class Post
 /** @ODM\EmbeddedDocument */
 class PostVersion
 {
-	/** @ODM\String */
+	/** @ODM\Field(type="string") */
 	public $name;
 	
 	public function __construct($name)
@@ -176,6 +176,6 @@ class Comment
 	/** @ODM\Id */
 	protected $id;
 
-	/** @ODM\String */
+	/** @ODM\Field(type="string") */
 	public $content;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM29Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM29Test.php
@@ -63,7 +63,7 @@ class MODM29Doc
 /** @ODM\EmbeddedDocument */
 class MODM29Embedded
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $val;
 
     function __construct($val) {$this->set($val);}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM42Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM42Test.php
@@ -38,7 +38,7 @@ class Directory
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $test = 'test';
 
     /** @ODM\ReferenceMany(targetDocument="File") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM43Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM43Test.php
@@ -25,10 +25,10 @@ class Person
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $firstName;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $lastName;
 
     /** @ODM\PreLoad */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM45Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM45Test.php
@@ -38,7 +38,7 @@ class MODM45A
 /** @ODM\EmbeddedDocument */
 class MODM45B
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $val;
     function setVal($val) {$this->val = $val;}
     function getVal() {return $this->val;}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM46Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM46Test.php
@@ -36,6 +36,6 @@ class MODM46A
 /** @ODM\EmbeddedDocument */
 class MODM46AB
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $value;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM47Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM47Test.php
@@ -24,7 +24,7 @@ class MODM47A
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $b = 'tmp';
 
     /** @ODM\AlsoLoad("c") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM48Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM48Test.php
@@ -44,7 +44,7 @@ class MODM48A
 /** @ODM\EmbeddedDocument */
 class MODM48B
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $val;
 
     function setVal($val) {$this->val = $val;}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM52Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM52Test.php
@@ -35,7 +35,7 @@ class MODM52Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
  */
 class MODM52Container
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $value;
 
     /** @ODM\EmbedMany(targetDocument="MODM52Embedded", strategy="set") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM56Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM56Test.php
@@ -35,10 +35,10 @@ class MODM56Parent
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\Date */
+    /** @ODM\Field(type="date") */
     public $updatedAt;
 
     /** @ODM\EmbedMany(targetDocument="MODM56Child") */
@@ -62,7 +62,7 @@ class MODM56Child
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public function __construct($name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM62Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM62Test.php
@@ -28,7 +28,7 @@ class MODM62Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\Collection */
+    /** @ODM\Field(type="collection") */
     public $b = array('ok');
 
     public function setB($b) {$this->b = $b;}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM65Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM65Test.php
@@ -53,12 +53,12 @@ class MODM65User
 class MODM65SocialNetworkUser
 {
 	/**
-	 * @ODM\String(name="fN")
+	 * @ODM\Field(name="fN", type="string")
 	 * @var string
 	 */
 	public $firstName;
 	/**
-	 * @ODM\String(name="lN")
+	 * @ODM\Field(name="lN", type="string")
 	 * @var string
 	 */
 	public $lastName;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM66Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM66Test.php
@@ -83,7 +83,7 @@ class MODM52B
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $value;
 
     function __construct($v)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM67Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM67Test.php
@@ -110,18 +110,18 @@ class MODM67DerivedClass
  */
 class MODM67EmbeddedObject
 {
-    /** @ODM\Int */
+    /** @ODM\Field(type="int") */
     public $numAccesses = 0;
 
-    /** @ODM\Bool */
+    /** @ODM\Field(type="bool") */
     public $prePersist = false;
 
-    /** @ODM\Bool */
+    /** @ODM\Field(type="bool") */
     public $postPersist = false;
 
-    /** @ODM\Bool */
+    /** @ODM\Field(type="bool") */
     public $preUpdate = false;
 
-    /** @ODM\Bool */
+    /** @ODM\Field(type="bool") */
     public $postUpdate = false;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
@@ -38,13 +38,13 @@ class Avatar
 	protected $id;
 
 	/**
-	 * @ODM\String(name="na")
+	 * @ODM\Field(name="na", type="string")
 	 * @var string
 	 */
 	protected $name;
 
 	/**
-	 * @ODM\Int(name="sex")
+	 * @ODM\Field(name="sex", type="int")
 	 * @var int
 	 */
 	protected $sex;
@@ -120,7 +120,7 @@ class Avatar
 class AvatarPart
 {
 	/**
-	 * @ODM\String(name="col")
+	 * @ODM\Field(name="col", type="string")
 	 * @var string
 	 */
 	protected $color;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM72Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM72Test.php
@@ -19,6 +19,6 @@ class MODM72User
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String(options={"test"="test"}) */
+    /** @ODM\Field(type="string", options={"test"="test"}) */
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM76Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM76Test.php
@@ -31,7 +31,7 @@ class MODM76A
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $test = 'test';
 
     /** @ODM\EmbedMany(targetDocument="MODM76B") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
@@ -65,7 +65,7 @@ class MODM81TestDocument
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $name;
 
     /** @ODM\EmbedMany(targetDocument="MODM81TestEmbeddedDocument") */
@@ -116,7 +116,7 @@ class MODM81TestDocument
 /** @ODM\EmbeddedDocument */
 class MODM81TestEmbeddedDocument
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $message;
 
     /** @ODM\ReferenceOne(targetDocument="MODM81TestDocument") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM83Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM83Test.php
@@ -65,7 +65,7 @@ class MODM83TestDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\EmbedOne(targetDocument="MODM83TestEmbeddedDocument") */
@@ -75,7 +75,7 @@ class MODM83TestDocument
 /** @ODM\EmbeddedDocument */
 class MODM83TestEmbeddedDocument
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }
 
@@ -85,6 +85,6 @@ class MODM83OtherDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM90Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM90Test.php
@@ -81,7 +81,7 @@ class MODM90TestDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /**
@@ -100,16 +100,16 @@ class MODM90TestDocument
 /** @ODM\EmbeddedDocument */
 class MODM90TestEmbeddedDocument
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }
 
 /** @ODM\EmbeddedDocument */
 class MODM90Test2EmbeddedDocument
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\String The discriminator field is a real property */
+    /** @ODM\Field(type="string") The discriminator field is a real property */
     public $type;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM91Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM91Test.php
@@ -57,7 +57,7 @@ class MODM91TestDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\EmbedOne(targetDocument="MODM91TestEmbeddedDocument") */
@@ -67,6 +67,6 @@ class MODM91TestDocument
 /** @ODM\EmbeddedDocument */
 class MODM91TestEmbeddedDocument
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM92Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM92Test.php
@@ -74,7 +74,7 @@ class MODM92TestDocument
 /** @ODM\EmbeddedDocument */
 class MODM92TestEmbeddedDocument
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public function __construct($name) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM95Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM95Test.php
@@ -80,7 +80,7 @@ class MODM95TestDocument
 /** @ODM\EmbeddedDocument */
 class MODM95TestEmbeddedDocument
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public function __construct($name) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/UpsertTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/UpsertTest.php
@@ -57,6 +57,6 @@ class UpsertTestUserEmbedded
      */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $test;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
@@ -47,10 +47,10 @@ class VersionedDocument
     /** @ODM\Id */
     public $id;
     
-    /** @ODM\Int @ODM\Version */
+    /** @ODM\Field(type="int") @ODM\Version */
     public $version = 1;
     
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
     
     /** @ODM\EmbedMany(targetDocument="VersionedEmbeddedDocument") */
@@ -67,7 +67,7 @@ class VersionedDocument
  */
 class VersionedEmbeddedDocument
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $value;
     
     /** @ODM\EmbedMany(targetDocument="VersionedEmbeddedDocument") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
@@ -49,10 +49,10 @@ class HydrationClosureUser
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
     
-    /** @ODM\Date */
+    /** @ODM\Field(type="date") */
     public $birthdate;
 
     /** @ODM\ReferenceOne(targetDocument="HydrationClosureReferenceOne") */
@@ -74,7 +74,7 @@ class HydrationClosureReferenceOne
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }
 
@@ -84,20 +84,20 @@ class HydrationClosureReferenceMany
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }
 
 /** @ODM\EmbeddedDocument */
 class HydrationClosureEmbedMany
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }
 
 /** @ODM\EmbeddedDocument */
 class HydrationClosureEmbedOne
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -339,30 +339,30 @@ class AbstractMappingDriverUser
 
     /**
      * @ODM\Version
-     * @ODM\Int
+     * @ODM\Field(type="int")
      */
     public $version;
 
     /**
      * @ODM\Lock
-     * @ODM\Int
+     * @ODM\Field(type="int")
      */
     public $lock;
 
     /**
-     * @ODM\String(name="username")
+     * @ODM\Field(name="username", type="string")
      * @ODM\UniqueIndex(order="desc", dropDups=false)
      */
     public $name;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @ODM\UniqueIndex(order="desc", dropDups=true)
      */
     public $email;
 
     /**
-     * @ODM\Int
+     * @ODM\Field(type="int")
      * @ODM\UniqueIndex(order="desc", dropDups=true)
      */
     public $mysqlProfileId;
@@ -398,12 +398,12 @@ class AbstractMappingDriverUser
     public $otherPhonenumbers;
 
     /**
-     * @ODM\Date
+     * @ODM\Field(type="date")
      */
     public $createdAt;
 
     /**
-     * @ODM\Collection
+     * @ODM\Field(type="collection")
      */
     public $roles = array();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
@@ -167,23 +167,23 @@ class AnnotationDriverTestSuper
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $protected;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $private;
 }
 
 /** @ODM\Document */
 class AnnotationDriverTestParent extends AnnotationDriverTestSuper
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $foo;
 }
 
 /** @ODM\Document */
 class AnnotationDriverTestChild extends AnnotationDriverTestParent
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $bar;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
@@ -81,16 +81,16 @@ class DocumentSubClass extends TransientBaseClass
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 }
 
 /** @ODM\MappedSuperclass */
 class MappedSuperclassBase
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $mapped1;
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $mapped2;
 
     /**
@@ -107,6 +107,6 @@ class DocumentSubClass2 extends MappedSuperclassBase
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
@@ -36,7 +36,7 @@ class LoadEventTestDocument
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     private $about;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Documents/GlobalNamespaceDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Documents/GlobalNamespaceDocument.php
@@ -13,12 +13,12 @@ class DoctrineGlobal_Article
     protected $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     protected $headline;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     protected $text;
 
@@ -44,13 +44,13 @@ class DoctrineGlobal_User
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @var string
      */
     private $username;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @var string
      */
     private $email;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DereferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DereferenceTest.php
@@ -48,7 +48,7 @@ class Post
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $title;
 
     /** @ODM\EmbedMany(targetDocument="Comment", strategy="set") */
@@ -61,6 +61,6 @@ class Comment
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $subject;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -245,7 +245,7 @@ class Person
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $firstName;
 
     /** @ODM\ReferenceOne */
@@ -276,7 +276,7 @@ class EmbedTest
     /** @ODM\EmbedMany(name="e1", targetDocument="Doctrine\ODM\MongoDB\Tests\EmbedTest") */
     public $embeddedMany;
 
-    /** @ODM\String(name="n") */
+    /** @ODM\Field(name="n", type="string") */
     public $name;
 
     /** @ODM\ReferenceOne(name="p", targetDocument="Doctrine\ODM\MongoDB\Tests\Person") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH1299/GH1299User.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH1299/GH1299User.php
@@ -8,6 +8,6 @@ use Doctrine\ODM\MongoDB\Tests\Tools\GH1299\BaseUser;
 /** @ODM\Document */
 class GH1299User extends BaseUser
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $lastname;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/Address.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/Address.php
@@ -7,7 +7,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\EmbeddedDocument */
 class Address
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $street;
     
     public function getStreet()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/User.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/User.php
@@ -12,7 +12,7 @@ class User
     /** @ODM\Id */
     private $id;
     
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
     
     public function getId()

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -724,7 +724,7 @@ class NotifyChangedDocument implements \Doctrine\Common\NotifyPropertyChanged
     /** @ODM\Id(type="int_id", strategy="none") */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $data;
 
     /** @ODM\ReferenceMany(targetDocument="NotifyChangedRelatedItem") */
@@ -822,7 +822,7 @@ class ArrayTest
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\Hash */
+    /** @ODM\Field(type="hash") */
     public $data;
 
     public function __construct($data)

--- a/tests/Documents/Address.php
+++ b/tests/Documents/Address.php
@@ -7,25 +7,25 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\EmbeddedDocument */
 class Address
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $address;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $city;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $state;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $zipcode;
 
-    /** @ODM\Increment */
+    /** @ODM\Field(type="increment") */
     public $count = 0;
 
     /** @ODM\EmbedOne(targetDocument="Address") */
     private $subAddress;
 
-    /** @ODM\String(name="testFieldName") */
+    /** @ODM\Field(name="testFieldName", type="string") */
     private $test;
 
     public function setSubAddress(Address $subAddress)

--- a/tests/Documents/Album.php
+++ b/tests/Documents/Album.php
@@ -10,7 +10,7 @@ class Album
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     /** @ODM\EmbedMany(targetDocument="Song") */

--- a/tests/Documents/Article.php
+++ b/tests/Documents/Article.php
@@ -13,13 +13,13 @@ class Article
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $title;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $body;
 
-    /** @ODM\Date */
+    /** @ODM\Field(type="date") */
     private $createdAt;
 
     /** @ODM\Field(type="collection") */

--- a/tests/Documents/Bars/Bar.php
+++ b/tests/Documents/Bars/Bar.php
@@ -10,7 +10,7 @@ class Bar
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     /** @ODM\EmbedMany(targetDocument="Documents\Bars\Location") */

--- a/tests/Documents/Bars/Location.php
+++ b/tests/Documents/Bars/Location.php
@@ -7,7 +7,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\EmbeddedDocument */
 class Location
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     public function __construct($name = null)

--- a/tests/Documents/BaseCategory.php
+++ b/tests/Documents/BaseCategory.php
@@ -7,7 +7,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\MappedSuperclass(repositoryClass="Documents\BaseCategoryRepository") */
 abstract class BaseCategory
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
      protected $name;
 
      /** @ODM\EmbedMany(targetDocument="SubCategory") */

--- a/tests/Documents/BaseDocument.php
+++ b/tests/Documents/BaseDocument.php
@@ -9,7 +9,7 @@ abstract class BaseDocument
 {
     public $persisted = false;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $inheritedProperty;
 
     public function setInheritedProperty($value)

--- a/tests/Documents/BaseEmployee.php
+++ b/tests/Documents/BaseEmployee.php
@@ -10,22 +10,22 @@ abstract class BaseEmployee
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\Increment */
+    /** @ODM\Field(type="increment") */
     protected $changes = 0;
 
-    /** @ODM\Collection */
+    /** @ODM\Field(type="collection") */
     protected $notes = array();
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $name;
 
-    /** @ODM\Float */
+    /** @ODM\Field(type="float") */
     protected $salary;
 
-    /** @ODM\Date */
+    /** @ODM\Field(type="date") */
     protected $started;
 
-    /** @ODM\Date */
+    /** @ODM\Field(type="date") */
     protected $left;
 
     /** @ODM\EmbedOne(targetDocument="Address") */

--- a/tests/Documents/BlogPost.php
+++ b/tests/Documents/BlogPost.php
@@ -11,7 +11,7 @@ class BlogPost
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\ReferenceMany(targetDocument="Tag", inversedBy="blogPosts", cascade={"all"}) */

--- a/tests/Documents/Book.php
+++ b/tests/Documents/Book.php
@@ -13,7 +13,7 @@ class Book
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\Int @ODM\Version */
+    /** @ODM\Field(type="int") @ODM\Version */
     public $version = 1;
 
     /** @ODM\EmbedMany(targetDocument="Chapter", strategy="atomicSet") */

--- a/tests/Documents/BrowseNode.php
+++ b/tests/Documents/BrowseNode.php
@@ -10,7 +10,7 @@ class BrowseNode
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /**

--- a/tests/Documents/Cart.php
+++ b/tests/Documents/Cart.php
@@ -10,7 +10,7 @@ class Cart
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\Int */
+    /** @ODM\Field(type="int") */
     public $numItems = 0;
 
     /**

--- a/tests/Documents/Chapter.php
+++ b/tests/Documents/Chapter.php
@@ -11,13 +11,13 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  */
 class Chapter
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\EmbedMany(targetDocument="Page") */
     public $pages;
 
-    /** @ODM\Int */
+    /** @ODM\Field(type="int") */
     public $nbPages = 0;
 
     public function __construct($name = null)

--- a/tests/Documents/CmsAddress.php
+++ b/tests/Documents/CmsAddress.php
@@ -18,17 +18,17 @@ class CmsAddress
     public $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     public $country;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     public $zip;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     public $city;
 

--- a/tests/Documents/CmsArticle.php
+++ b/tests/Documents/CmsArticle.php
@@ -17,11 +17,11 @@ class CmsArticle
      */
     public $id;
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     public $topic;
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     public $text;
     /**

--- a/tests/Documents/CmsComment.php
+++ b/tests/Documents/CmsComment.php
@@ -29,7 +29,7 @@ class CmsComment
      */
     public $article;
 
-    /** @ODM\String(name="ip") */
+    /** @ODM\Field(name="ip", type="string") */
     public $authorIp;
 
     public function setArticle(CmsArticle $article) {

--- a/tests/Documents/CmsContent.php
+++ b/tests/Documents/CmsContent.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 abstract class CmsContent extends CmsPage
 {
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     public $title;
 }

--- a/tests/Documents/CmsGroup.php
+++ b/tests/Documents/CmsGroup.php
@@ -14,7 +14,7 @@ class CmsGroup
      */
     public $id;
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     public $name;
     /**

--- a/tests/Documents/CmsPage.php
+++ b/tests/Documents/CmsPage.php
@@ -18,7 +18,7 @@ abstract class CmsPage
     public $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     public $slug;
 }

--- a/tests/Documents/CmsProduct.php
+++ b/tests/Documents/CmsProduct.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 class CmsProduct extends CmsContent
 {
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     public $name;
 }

--- a/tests/Documents/CmsUser.php
+++ b/tests/Documents/CmsUser.php
@@ -16,17 +16,17 @@ class CmsUser
     public $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     public $status;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     public $username;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     public $name;
 

--- a/tests/Documents/Comment.php
+++ b/tests/Documents/Comment.php
@@ -11,16 +11,16 @@ class Comment
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $text;
 
     /** @ODM\ReferenceOne(targetDocument="BlogPost", inversedBy="comments", cascade={"all"}) */
     public $parent;
 
-    /** @ODM\Date @ODM\Index(order="1") */
+    /** @ODM\Field(type="date") @ODM\Index(order="1") */
     public $date;
 
-    /** @ODM\Boolean */
+    /** @ODM\Field(type="bool") */
     public $isByAdmin = false;
 
     public function __construct($text, DateTime $date, $isByAdmin = false)

--- a/tests/Documents/CustomUser.php
+++ b/tests/Documents/CustomUser.php
@@ -10,10 +10,10 @@ class CustomUser
     /** @ODM\Id(strategy="none") */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $username;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $password;
 
     /** @ODM\ReferenceOne(targetDocument="Account", cascade={"all"}) */

--- a/tests/Documents/Customer.php
+++ b/tests/Documents/Customer.php
@@ -10,10 +10,10 @@ class Customer
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\String(name="cart") */
+    /** @ODM\Field(name="cart", type="string") */
     public $cartTest;
 
     /**

--- a/tests/Documents/Developer.php
+++ b/tests/Documents/Developer.php
@@ -17,7 +17,7 @@ class Developer
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $name;
 

--- a/tests/Documents/Ecommerce/ConfigurableProduct.php
+++ b/tests/Documents/Ecommerce/ConfigurableProduct.php
@@ -15,7 +15,7 @@ class ConfigurableProduct
     protected $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     protected $name;
 

--- a/tests/Documents/Ecommerce/Currency.php
+++ b/tests/Documents/Ecommerce/Currency.php
@@ -20,12 +20,12 @@ class Currency
     protected $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     protected $name;
 
     /**
-     * @ODM\Float
+     * @ODM\Field(type="float")
      */
     protected $multiplier;
 

--- a/tests/Documents/Ecommerce/Money.php
+++ b/tests/Documents/Ecommerce/Money.php
@@ -8,7 +8,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 class Money
 {
     /**
-     * @ODM\Float
+     * @ODM\Field(type="float")
      */
     protected $amount;
 

--- a/tests/Documents/Ecommerce/Option.php
+++ b/tests/Documents/Ecommerce/Option.php
@@ -13,7 +13,7 @@ class Option
     protected $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @var string
      */
     protected $name;

--- a/tests/Documents/Ecommerce/StockItem.php
+++ b/tests/Documents/Ecommerce/StockItem.php
@@ -15,12 +15,12 @@ class StockItem
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $name;
 
     /**
-     * @ODM\Int
+     * @ODM\Field(type="int")
      */
     private $inventory;
 

--- a/tests/Documents/Event.php
+++ b/tests/Documents/Event.php
@@ -13,10 +13,10 @@ class Event
     /** @ODM\ReferenceOne(targetDocument="Documents\User") */
     private $user;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $title;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $type;
 
     public function getId()

--- a/tests/Documents/Feature.php
+++ b/tests/Documents/Feature.php
@@ -10,7 +10,7 @@ class Feature
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /**

--- a/tests/Documents/File.php
+++ b/tests/Documents/File.php
@@ -11,13 +11,13 @@ class File
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     /** @ODM\File */
     private $file;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $filename;
 
     /** @ODM\NotSaved(type="int") */

--- a/tests/Documents/ForumUser.php
+++ b/tests/Documents/ForumUser.php
@@ -10,7 +10,7 @@ class ForumUser
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $username;
 
     /** @ODM\ReferenceOne(targetDocument="ForumAvatar", cascade={"persist"}) */

--- a/tests/Documents/FriendUser.php
+++ b/tests/Documents/FriendUser.php
@@ -10,7 +10,7 @@ class FriendUser
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /**

--- a/tests/Documents/Functional/Embedded.php
+++ b/tests/Documents/Functional/Embedded.php
@@ -7,6 +7,6 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\EmbeddedDocument */
 class Embedded
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }

--- a/tests/Documents/Functional/EmbeddedTestLevel0.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel0.php
@@ -9,7 +9,7 @@ class EmbeddedTestLevel0
 {
     /** @ODM\Id */
     public $id;
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
     /** @ODM\EmbedMany(targetDocument="EmbeddedTestLevel1") */
     public $level1 = array();

--- a/tests/Documents/Functional/EmbeddedTestLevel0b.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel0b.php
@@ -9,7 +9,7 @@ class EmbeddedTestLevel0b
 {
     /** @ODM\Id */
     public $id;
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
     /** @ODM\EmbedOne(targetDocument="EmbeddedTestLevel1") */
     public $oneLevel1;

--- a/tests/Documents/Functional/EmbeddedTestLevel1.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel1.php
@@ -7,7 +7,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\EmbeddedDocument @ODM\HasLifecycleCallbacks */
 class EmbeddedTestLevel1
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
     /** @ODM\EmbedMany(targetDocument="EmbeddedTestLevel2") */
     public $level2 = array();

--- a/tests/Documents/Functional/EmbeddedTestLevel2.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel2.php
@@ -7,7 +7,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\EmbeddedDocument @ODM\HasLifecycleCallbacks */
 class EmbeddedTestLevel2
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public $preRemove = false;

--- a/tests/Documents/Functional/FavoritesUser.php
+++ b/tests/Documents/Functional/FavoritesUser.php
@@ -10,7 +10,7 @@ class FavoritesUser
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     /**

--- a/tests/Documents/Functional/NotSaved.php
+++ b/tests/Documents/Functional/NotSaved.php
@@ -10,7 +10,7 @@ class NotSaved
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\NotSaved */

--- a/tests/Documents/Functional/NotSavedEmbedded.php
+++ b/tests/Documents/Functional/NotSavedEmbedded.php
@@ -7,7 +7,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\EmbeddedDocument */
 class NotSavedEmbedded
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\NotSaved */

--- a/tests/Documents/Functional/PreUpdateTestProduct.php
+++ b/tests/Documents/Functional/PreUpdateTestProduct.php
@@ -12,7 +12,7 @@ class PreUpdateTestProduct
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\EmbedOne(targetDocument="PreUpdateTestSellable") */

--- a/tests/Documents/Functional/PreUpdateTestSeller.php
+++ b/tests/Documents/Functional/PreUpdateTestSeller.php
@@ -10,7 +10,7 @@ class PreUpdateTestSeller
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public function getName()

--- a/tests/Documents/Functional/Reference.php
+++ b/tests/Documents/Functional/Reference.php
@@ -10,6 +10,6 @@ class Reference
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }

--- a/tests/Documents/Functional/SameCollection1.php
+++ b/tests/Documents/Functional/SameCollection1.php
@@ -15,9 +15,9 @@ class SameCollection1
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $test;
 }

--- a/tests/Documents/Functional/SameCollection2.php
+++ b/tests/Documents/Functional/SameCollection2.php
@@ -15,12 +15,12 @@ class SameCollection2
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $ok;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $w00t;
 }

--- a/tests/Documents/Functional/SameCollection3.php
+++ b/tests/Documents/Functional/SameCollection3.php
@@ -13,9 +13,9 @@ class SameCollection3
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $test;
 }

--- a/tests/Documents/Functional/Ticket/GH683/AbstractEmbedded.php
+++ b/tests/Documents/Functional/Ticket/GH683/AbstractEmbedded.php
@@ -11,6 +11,6 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  */
 class AbstractEmbedded
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }

--- a/tests/Documents/Functional/Ticket/GH683/EmbeddedSubDocument1.php
+++ b/tests/Documents/Functional/Ticket/GH683/EmbeddedSubDocument1.php
@@ -9,6 +9,6 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  */
 class EmbeddedSubDocument1 extends AbstractEmbedded
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }

--- a/tests/Documents/Functional/Ticket/GH683/EmbeddedSubDocument2.php
+++ b/tests/Documents/Functional/Ticket/GH683/EmbeddedSubDocument2.php
@@ -9,6 +9,6 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  */
 class EmbeddedSubDocument2 extends AbstractEmbedded
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }

--- a/tests/Documents/Functional/Ticket/GH683/ParentDocument.php
+++ b/tests/Documents/Functional/Ticket/GH683/ParentDocument.php
@@ -9,7 +9,7 @@ class ParentDocument
 {
     /** @ODM\Id */
     public $id;
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
     /** @ODM\EmbedOne(targetDocument="AbstractEmbedded") */
     public $embedOne;

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayCollectionLevel0.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayCollectionLevel0.php
@@ -11,7 +11,7 @@ class EmbedManyInArrayCollectionLevel0
 {
     /** @ODM\Id */
     public $id;
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
     /** @ODM\EmbedMany(targetDocument="EmbedManyInArrayCollectionLevel1") */
     public $level1;

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayCollectionLevel1.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayCollectionLevel1.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 /** @ODM\EmbeddedDocument */
 class EmbedManyInArrayCollectionLevel1
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
     /** @ODM\EmbedMany(targetDocument="MODM160Level2") */
     public $level2;

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayLevel0.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayLevel0.php
@@ -11,7 +11,7 @@ class EmbedManyInArrayLevel0
 {
     /** @ODM\Id */
     public $id;
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
     /** @ODM\EmbedMany(targetDocument="EmbedManyInArrayLevel1") */
     public $level1 = array();

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayLevel1.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayLevel1.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 /** @ODM\EmbeddedDocument */
 class EmbedManyInArrayLevel1
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
     /** @ODM\EmbedMany(targetDocument="MODM160Level2") */
     public $level2 = array();

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedOneLevel0.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedOneLevel0.php
@@ -11,7 +11,7 @@ class EmbedOneLevel0
 {
     /** @ODM\Id */
     public $id;
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
     /** @ODM\EmbedOne(targetDocument="EmbedOneLevel1") */
     public $level1;

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedOneLevel1.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedOneLevel1.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 /** @ODM\EmbeddedDocument */
 class EmbedOneLevel1
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
     /** @ODM\EmbedOne(targetDocument="MODM160Level2") */
     public $level2;

--- a/tests/Documents/Functional/Ticket/MODM160/MODM160Level2.php
+++ b/tests/Documents/Functional/Ticket/MODM160/MODM160Level2.php
@@ -7,7 +7,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\EmbeddedDocument */
 class MODM160Level2
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
 

--- a/tests/Documents/Functional/VirtualHostDirective.php
+++ b/tests/Documents/Functional/VirtualHostDirective.php
@@ -7,11 +7,11 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\EmbeddedDocument */
 class VirtualHostDirective
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $recId;
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $name;
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $value;
     /**
      * @ODM\EmbedMany(targetDocument="Documents\Functional\VirtualHostDirective")

--- a/tests/Documents/IdentifiedChapter.php
+++ b/tests/Documents/IdentifiedChapter.php
@@ -11,7 +11,7 @@ class IdentifiedChapter
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\EmbedMany(targetDocument="Page") */

--- a/tests/Documents/Issue.php
+++ b/tests/Documents/Issue.php
@@ -10,12 +10,12 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 class Issue
 {
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $name;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     private $description;
 

--- a/tests/Documents/Message.php
+++ b/tests/Documents/Message.php
@@ -10,7 +10,7 @@ class Message
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     public function __construct($name)

--- a/tests/Documents/Page.php
+++ b/tests/Documents/Page.php
@@ -10,7 +10,7 @@ class Page
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\Integer */
+    /** @ODM\Field(type="int") */
     public $number;
 
     public function __construct($number)

--- a/tests/Documents/Phonebook.php
+++ b/tests/Documents/Phonebook.php
@@ -8,7 +8,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\EmbeddedDocument */
 class Phonebook
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $title;
 
     /** @ODM\EmbedMany(targetDocument="Phonenumber") */

--- a/tests/Documents/Phonenumber.php
+++ b/tests/Documents/Phonenumber.php
@@ -8,7 +8,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\EmbeddedDocument */
 class Phonenumber
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $phonenumber;
 
     /** @ODM\ReferenceOne(targetDocument="User", cascade={"persist"}) */

--- a/tests/Documents/Product.php
+++ b/tests/Documents/Product.php
@@ -10,7 +10,7 @@ class Product
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /**

--- a/tests/Documents/Project.php
+++ b/tests/Documents/Project.php
@@ -17,7 +17,7 @@ class Project
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     /** @ODM\EmbedOne(targetDocument="Address") */

--- a/tests/Documents/Server.php
+++ b/tests/Documents/Server.php
@@ -18,6 +18,6 @@ class Server
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 }

--- a/tests/Documents/SimpleReferenceUser.php
+++ b/tests/Documents/SimpleReferenceUser.php
@@ -19,7 +19,7 @@ class SimpleReferenceUser
     /** @ODM\ReferenceMany(targetDocument="Documents\User", simple=true) */
     public $users = array();
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     public function setUser($user)

--- a/tests/Documents/Song.php
+++ b/tests/Documents/Song.php
@@ -7,7 +7,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\EmbeddedDocument */
 class Song
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     public function __construct($name)

--- a/tests/Documents/Strategy.php
+++ b/tests/Documents/Strategy.php
@@ -10,7 +10,7 @@ class Strategy
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\Collection() */
+    /** @ODM\Field(type="collection") */
     public $logs = array();
 
     /** @ODM\EmbedMany(targetDocument="Message", strategy="set") */

--- a/tests/Documents/Tag.php
+++ b/tests/Documents/Tag.php
@@ -10,7 +10,7 @@ class Tag
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\ReferenceMany(targetDocument="BlogPost", mappedBy="tags") */

--- a/tests/Documents/Task.php
+++ b/tests/Documents/Task.php
@@ -10,7 +10,7 @@ class Task
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $name;
 
     public function __construct($name)

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -17,10 +17,10 @@ class User extends BaseDocument
     /** @ODM\Field(type="string") */
     protected $username;
 
-    /** @ODM\Bin(type="bin_md5") */
+    /** @ODM\Field(type="bin_md5") */
     protected $password;
 
-    /** @ODM\Date */
+    /** @ODM\Field(type="date") */
     protected $createdAt;
 
     /** @ODM\EmbedOne(targetDocument="Address", nullable=true) */
@@ -53,13 +53,13 @@ class User extends BaseDocument
     /** @ODM\ReferenceOne(targetDocument="Account", cascade={"all"}) */
     protected $account;
 
-    /** @ODM\Int */
+    /** @ODM\Field(type="int") */
     protected $hits = 0;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $nullTest;
 
-    /** @ODM\Increment */
+    /** @ODM\Field(type="increment") */
     protected $count = 0;
 
     /** @ODM\ReferenceMany(targetDocument="BlogPost", mappedBy="user", nullable=true) */
@@ -71,7 +71,7 @@ class User extends BaseDocument
     /** @ODM\ReferenceMany(targetDocument="Documents\SimpleReferenceUser", mappedBy="users") */
     protected $simpleReferenceManyInverse;
 
-    /** @ODM\Collection */
+    /** @ODM\Field(type="collection") */
     private $logs = array();
 
     public function __construct()

--- a/tests/Documents/UserUpsert.php
+++ b/tests/Documents/UserUpsert.php
@@ -19,13 +19,13 @@ class UserUpsert
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $username;
 
-    /** @ODM\Int */
+    /** @ODM\Field(type="int") */
     public $hits;
 
-    /** @ODM\Increment */
+    /** @ODM\Field(type="increment") */
     public $count;
 
     /** @ODM\ReferenceMany(targetDocument="Group", cascade={"all"}) */

--- a/tests/Documents/UserUpsertIdStrategyNone.php
+++ b/tests/Documents/UserUpsertIdStrategyNone.php
@@ -18,13 +18,13 @@ class UserUpsertIdStrategyNone
     /** @ODM\Id(strategy="none") */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $username;
 
-    /** @ODM\Int */
+    /** @ODM\Field(type="int") */
     public $hits;
 
-    /** @ODM\Increment */
+    /** @ODM\Field(type="increment") */
     public $count;
 
     /** @ODM\ReferenceMany(targetDocument="Group", cascade={"all"}) */

--- a/tests/Documents/VersionedDocument.php
+++ b/tests/Documents/VersionedDocument.php
@@ -14,6 +14,6 @@ class VersionedDocument extends BaseDocument
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\Version @ODM\Int */
+    /** @ODM\Version @ODM\Field(type="int") */
     public $version;
 }

--- a/tests/Documents/VersionedUser.php
+++ b/tests/Documents/VersionedUser.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  */
 class VersionedUser extends User
 {
-    /** @ODM\Int @ODM\Version */
+    /** @ODM\Field(type="int") @ODM\Version */
     protected $version;
 
     public function getVersion()

--- a/tools/sandbox/Documents/Account.php
+++ b/tools/sandbox/Documents/Account.php
@@ -10,7 +10,7 @@ class Account
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $name;
 
     public function __construct($name)

--- a/tools/sandbox/Documents/Address.php
+++ b/tools/sandbox/Documents/Address.php
@@ -7,16 +7,16 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\EmbeddedDocument */
 class Address
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $street;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $city;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $state;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $postalCode;
 
     public function getStreet()

--- a/tools/sandbox/Documents/Phonenumber.php
+++ b/tools/sandbox/Documents/Phonenumber.php
@@ -7,7 +7,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\EmbeddedDocument */
 class Phonenumber
 {
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $phonenumber;
 
     public function __construct($phonenumber = null)

--- a/tools/sandbox/Documents/User.php
+++ b/tools/sandbox/Documents/User.php
@@ -11,10 +11,10 @@ class User
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     private $username;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     protected $password;
 
     /** @ODM\EmbedOne(targetDocument="Address") */


### PR DESCRIPTION
Closes #1207.

Starting with PHP 7, some of the type annotation ODM uses are reserved keywords:
* int
* string
* bool
* float

To avoid having large inconsistencies we decided to deprecate all type annotations (e.g. those extending `AbstractField` and only overwriting the `type` property) to be removed in ODM 2.0. This affects the following annotation classes:
* Bin
* BinCustom
* BinFunc
* BinMD5
* BinUUID
* BinUUIDRFC4122
* Bool
* Boolean
* Collection
* Date
* Float
* Hash
* Increment
* Int
* Integer
* Key
* ObjectId
* Raw
* String
* Timestamp

Instead, users should switch to using `@Field(type="...")` to map fields.