### PR TITLE
Removed composer.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@ tools/sandbox/Hydrators/*
 tests/Proxies/*
 tests/Hydrators/*
 phpunit.xml
-composer.lock
 vendor/


### PR DESCRIPTION
It is a well established best practice to commit the `composer.lock` file to the repository.