### PR TITLE
Expr::references should go through discriminator map

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -58,6 +58,16 @@ class MappingException extends BaseMappingException
     }
 
     /**
+     * @param string $className
+     * @param string $fieldName
+     * @return MappingException
+     */
+    public static function mappingNotFoundInClassNorDescendants($className, $fieldName)
+    {
+        return new self("No mapping found for field '$fieldName' in class '$className' nor its descendants.");
+    }
+
+    /**
      * @param string $document
      * @param string $fieldName
      * @return MappingException

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -68,6 +68,17 @@ class MappingException extends BaseMappingException
     }
 
     /**
+     * @param $fieldName
+     * @param $className
+     * @param $className2
+     * @return MappingException
+     */
+    public static function referenceFieldConflict($fieldName, $className, $className2)
+    {
+        return new self("Reference mapping for field '$fieldName' in class '$className' conflicts with one mapped in class '$className2'.");
+    }
+
+    /**
      * @param string $document
      * @param string $fieldName
      * @return MappingException

--- a/lib/Doctrine/ODM/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Expr.php
@@ -75,7 +75,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
                     }
                 }
                 if ( ! isset($mapping) || $mapping === null) {
-                    throw $e;
+                    throw MappingException::mappingNotFoundInClassNorDescendants($this->class->name, $this->currentField);
                 }
             }
             $dbRef = $this->dm->createDBRef($document, $mapping);

--- a/lib/Doctrine/ODM/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Expr.php
@@ -61,28 +61,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
     public function references($document)
     {
         if ($this->currentField) {
-            $mapping = null;
-            try {
-                $mapping = $this->class->getFieldMapping($this->currentField);
-            } catch (MappingException $e) {
-                if (empty($this->class->discriminatorMap)) {
-                    throw $e;
-                }
-                $foundIn = null;
-                foreach ($this->class->discriminatorMap as $child) {
-                    $childClass = $this->dm->getClassMetadata($child);
-                    if ($childClass->hasAssociation($this->currentField)) {
-                        if ($mapping !== null && $mapping !== $childClass->getFieldMapping($this->currentField)) {
-                            throw MappingException::referenceFieldConflict($this->currentField, $foundIn->name, $childClass->name);
-                        }
-                        $mapping = $childClass->getFieldMapping($this->currentField);
-                        $foundIn = $childClass;
-                    }
-                }
-                if ($mapping === null) {
-                    throw MappingException::mappingNotFoundInClassNorDescendants($this->class->name, $this->currentField);
-                }
-            }
+            $mapping = $this->getReferenceMapping();
             $dbRef = $this->dm->createDBRef($document, $mapping);
 
             if (isset($mapping['simple']) && $mapping['simple']) {
@@ -112,7 +91,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
     public function includesReferenceTo($document)
     {
         if ($this->currentField) {
-            $mapping = $this->class->getFieldMapping($this->currentField);
+            $mapping = $this->getReferenceMapping();
             $dbRef = $this->dm->createDBRef($document, $mapping);
 
             if (isset($mapping['simple']) && $mapping['simple']) {
@@ -148,5 +127,38 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
         return $this->dm->getUnitOfWork()
             ->getDocumentPersister($this->class->name)
             ->prepareQueryOrNewObj($this->newObj);
+    }
+
+    /**
+     * Gets reference mapping for current field from current class or its descendants.
+     *
+     * @return array
+     * @throws MappingException
+     */
+    private function getReferenceMapping()
+    {
+        $mapping = null;
+        try {
+            $mapping = $this->class->getFieldMapping($this->currentField);
+        } catch (MappingException $e) {
+            if (empty($this->class->discriminatorMap)) {
+                throw $e;
+            }
+            $foundIn = null;
+            foreach ($this->class->discriminatorMap as $child) {
+                $childClass = $this->dm->getClassMetadata($child);
+                if ($childClass->hasAssociation($this->currentField)) {
+                    if ($mapping !== null && $mapping !== $childClass->getFieldMapping($this->currentField)) {
+                        throw MappingException::referenceFieldConflict($this->currentField, $foundIn->name, $childClass->name);
+                    }
+                    $mapping = $childClass->getFieldMapping($this->currentField);
+                    $foundIn = $childClass;
+                }
+            }
+            if ($mapping === null) {
+                throw MappingException::mappingNotFoundInClassNorDescendants($this->class->name, $this->currentField);
+            }
+        }
+        return $mapping;
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -2,16 +2,65 @@
 
 namespace Doctrine\ODM\MongoDB\Tests\Query;
 
-use Doctrine\ODM\MongoDB\Query\Builder;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Documents\Feature;
 
 class BuilderTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testPrimeRequiresBooleanOrCallable()
     {
         $this->dm->createQueryBuilder('Documents\User')
             ->field('groups')->prime(1);
     }
+
+    public function testReferencesGoesThroughDiscriminatorMap()
+    {
+        $f = new Feature('Smarter references');
+        $this->dm->persist($f);
+
+        $q1 = $this->dm->createQueryBuilder(ParentClass::class)
+            ->field('featureFull')->references($f)
+            ->getQuery()->debug();
+
+        $this->assertEquals([ 'featureFull.$id' => new \MongoId($f->id) ], $q1['query']);
+
+        $q2 = $this->dm->createQueryBuilder(ParentClass::class)
+            ->field('featureSimple')->references($f)
+            ->getQuery()->debug();
+
+        $this->assertEquals([ 'featureSimple' => new \MongoId($f->id) ], $q2['query']);
+    }
+}
+
+/**
+ * @ODM\Document
+ * @ODM\InheritanceType("SINGLE_COLLECTION")
+ * @ODM\DiscriminatorField(fieldName="type")
+ * @ODM\DiscriminatorMap({"ca"="ChildA", "cb"="ChildB"})
+ */
+class ParentClass
+{
+    /** @ODM\Id */
+    public $id;
+}
+
+/**
+ * @ODM\Document
+ */
+class ChildA extends ParentClass
+{
+    /** @ODM\ReferenceOne(targetDocument="Documents\Feature") */
+    public $featureFull;
+}
+
+/**
+ * @ODM\Document
+ */
+class ChildB extends ParentClass
+{
+    /** @ODM\ReferenceOne(targetDocument="Documents\Feature", simple=true) */
+    public $featureSimple;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -33,6 +33,20 @@ class BuilderTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->assertEquals([ 'featureSimple' => new \MongoId($f->id) ], $q2['query']);
     }
+
+    /**
+     * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
+     * @expectedExceptionMessage No mapping found for field 'nope' in class 'Doctrine\ODM\MongoDB\Tests\Query\ParentClass' nor its descendants.
+     */
+    public function testReferencesThrowsSpecializedExceptionForDiscriminatedDocuments()
+    {
+        $f = new Feature('Smarter references');
+        $this->dm->persist($f);
+
+        $this->dm->createQueryBuilder(ParentClass::class)
+            ->field('nope')->references($f)
+            ->getQuery();
+    }
 }
 
 /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -47,6 +47,20 @@ class BuilderTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->field('nope')->references($f)
             ->getQuery();
     }
+
+    /**
+     * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
+     * @expectedExceptionMessage Reference mapping for field 'conflict' in class 'Doctrine\ODM\MongoDB\Tests\Query\ChildA' conflicts with one mapped in class 'Doctrine\ODM\MongoDB\Tests\Query\ChildB'.
+     */
+    public function testReferencesThrowsSpecializedExceptionForConflictingMappings()
+    {
+        $f = new Feature('Smarter references');
+        $this->dm->persist($f);
+
+        $this->dm->createQueryBuilder(ParentClass::class)
+            ->field('conflict')->references($f)
+            ->getQuery();
+    }
 }
 
 /**
@@ -68,6 +82,9 @@ class ChildA extends ParentClass
 {
     /** @ODM\ReferenceOne(targetDocument="Documents\Feature") */
     public $featureFull;
+
+    /** @ODM\ReferenceOne(targetDocument="Documents\Feature") */
+    public $conflict;
 }
 
 /**
@@ -77,4 +94,7 @@ class ChildB extends ParentClass
 {
     /** @ODM\ReferenceOne(targetDocument="Documents\Feature", simple=true) */
     public $featureSimple;
+
+    /** @ODM\ReferenceOne(targetDocument="Documents\Feature", simple=true) */
+    public $conflict;
 }


### PR DESCRIPTION
Before it was throwing an exception that field was not found. Test case is written like this only for the sake of testing, normally we use same type of references everywhere, only fields are named differently in child classes for the sake of making sense :)