### PR TITLE
Dispatch an event when proxy initialization fails

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -179,6 +179,9 @@ the life-time of their registered documents.
 -
    onClear - The onClear event occurs after the UnitOfWork has had
    its state cleared.
+-
+   documentNotFound - The documentNotFound event occurs when a proxy object
+   could not be initialized. This event is not a lifecycle callback.
 
 You can access the Event constants from the ``Events`` class in the
 ODM package.
@@ -556,6 +559,36 @@ Define the ``EventTest`` class with a ``onClear()`` method:
             // do something
         }
     }
+
+documentNotFound
+~~~~~~~~~~~~~~~~
+
+.. code-block:: php
+
+    <?php
+
+    $test = new EventTest();
+    $evm = $dm->getEventManager();
+    $evm->addEventListener(Events::documentNotFound, $test);
+
+Define the ``EventTest`` class with a ``documentNotFound()`` method:
+
+.. code-block:: php
+
+    <?php
+
+    class EventTest
+    {
+        public function documentNotFound(\Doctrine\ODM\MongoDB\Event\DocumentNotFoundEventArgs $eventArgs)
+        {
+            $proxy = $eventArgs->getObject();
+            $identifier = $eventArgs->getIdentifier();
+            // do something
+            // To prevent the documentNotFound exception from being thrown, call the disableException() method:
+            $eventArgs->disableException();
+        }
+    }
+
 
 postUpdate, postRemove, postPersist
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/Doctrine/ODM/MongoDB/Event/DocumentNotFoundEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/DocumentNotFoundEventArgs.php
@@ -1,0 +1,88 @@
+<?php
+/*
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ODM\MongoDB\Event;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+
+/**
+ * Provides event arguments for the documentNotFound event.
+ *
+ * @since 1.1
+ */
+class DocumentNotFoundEventArgs extends LifecycleEventArgs
+{
+    /**
+     * @var string
+     */
+    private $identifier;
+
+    /**
+     * @var bool
+     */
+    private $disableException = false;
+
+    /**
+     * Constructor.
+     *
+     * @param object $document
+     * @param DocumentManager $dm
+     * @param string $identifier
+     */
+    public function __construct($document, DocumentManager $dm, $identifier)
+    {
+        parent::__construct($document, $dm);
+        $this->identifier = $identifier;
+    }
+
+    /**
+     * Retrieve associated identifier.
+     *
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Indicates whether the proxy initialization exception is disabled.
+     *
+     * @return bool
+     */
+    public function isExceptionDisabled()
+    {
+        return $this->disableException;
+    }
+
+    /**
+     * Disable the throwing of an exception
+     *
+     * This method indicates to the proxy initializer that the missing document
+     * has been handled and no exception should be thrown. This can't be reset.
+     *
+     * @param bool $disableException
+     */
+    public function disableException($disableException = true)
+    {
+        $this->disableException = $disableException;
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Events.php
+++ b/lib/Doctrine/ODM/MongoDB/Events.php
@@ -161,4 +161,12 @@ final class Events
      * @var string
      */
     const onClear = 'onClear';
+
+    /**
+     * The documentNotFound event occurs if a proxy object could not be found in
+     * the database.
+     *
+     * @var string
+     */
+    const documentNotFound = 'documentNotFound';
 }

--- a/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
+++ b/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
@@ -21,6 +21,7 @@ namespace Doctrine\ODM\MongoDB\Utility;
 
 use Doctrine\Common\EventManager;
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Event\DocumentNotFoundEventArgs;
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Event\PreUpdateEventArgs;
 use Doctrine\ODM\MongoDB\Events;
@@ -58,6 +59,19 @@ class LifecycleEventManager
         $this->dm = $dm;
         $this->evm = $evm;
         $this->uow = $uow;
+    }
+
+    /**
+     * @param object $proxy
+     * @param mixed $id
+     * @return bool Returns whether the exceptionDisabled flag was set
+     */
+    public function documentNotFound($proxy, $id)
+    {
+        $eventArgs = new DocumentNotFoundEventArgs($proxy, $this->dm, $id);
+        $this->evm->dispatchEvent(Events::documentNotFound, $eventArgs);
+
+        return $eventArgs->isExceptionDisabled();
     }
 
     /**


### PR DESCRIPTION
Supersedes #532, Closes #1258.

This builds on top of the code added in #532. The new `DocumentNotFoundEventArgs` class contains the proxy object and its identifier. Event subscribers can choose to handle the missing document and call `disableException()` on the $eventArgs object to prevent the `DocumentNotFound` exception from being thrown.

As mentioned in the ticket, this event is not available as a lifecycle callback because we don't have a valid object on which to call a lifecycle callback.