### PR TITLE
Allow PHP 7 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         { "name": "Andreas Braun", "email": "alcaeus@alcaeus.org" }
     ],
     "require": {
-        "php": "^5.5",
+        "php": "^5.5 || ^7.0",
         "ext-mongo": "^1.5",
         "symfony/console": "~2.3|~3.0",
         "doctrine/annotations": "~1.0",


### PR DESCRIPTION
While ODM does not officially support PHP 7 (due to the legacy MongoDB driver not being available), there are alternatives the people may use. This PR aims to allow those developers to use ODM with a polyfill for ext-mongo (e.g. mongofill, mongo-php-adapter) in PHP 7.