### PR TITLE
Replace increment type with a storage strategy

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -67,9 +67,9 @@ Working with Objects
 Advanced Topics
 ---------------
 
-* **Collections**
+* **Collections**:
   :doc:`Capped Collections <reference/capped-collections>` |
-  :doc:`Collection Strategies <reference/collection-strategies>`
+  :doc:`Storage Strategies <reference/storage-strategies>`
 
 * **Best Practices**:
   :doc:`Best Practices <reference/best-practices>`

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -419,7 +419,7 @@ Optional attributes:
 -
     strategy - The strategy used to persist changes to the collection. Possible
     values are ``addToSet``, ``pushAll``, ``set``, and ``setArray``. ``pushAll``
-    is the default. See :ref:`collection_strategies` for more information.
+    is the default. See :ref:`storage_strategies` for more information.
 
 .. code-block:: php
 
@@ -738,7 +738,8 @@ This is useful if many requests are attempting to update the field concurrently.
 .. note::
 
     This annotation is deprecated and will be removed in ODM 2.0. Please use the
-    `@Field`_ annotation with type "increment".
+    `@Field`_ annotation with type "int" or "float" and use the "increment"
+    strategy.
 
 @Index
 ------
@@ -1196,7 +1197,7 @@ Optional attributes:
 -
     strategy - The strategy used to persist changes to the collection. Possible
     values are ``addToSet``, ``pushAll``, ``set``, and ``setArray``. ``pushAll``
-    is the default. See :ref:`collection_strategies` for more information.
+    is the default. See :ref:`storage_strategies` for more information.
 
 .. code-block:: php
 

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -166,7 +166,6 @@ Here is a quick overview of the built-in mapping types:
 -  ``float``
 -  ``hash``
 -  ``id``
--  ``increment``
 -  ``int``
 -  ``key``
 -  ``object_id``
@@ -197,7 +196,6 @@ This list explains some of the less obvious mapping types:
 -  ``hash``: associative array to MongoDB object
 -  ``id``: string to MongoId by default, but other formats are possible
 -  ``timestamp``: string to MongoTimestamp
--  ``increment``: integer in both PHP and MongoDB
 -  ``raw``: any type
 
 .. note::

--- a/docs/en/reference/introduction.rst
+++ b/docs/en/reference/introduction.rst
@@ -34,7 +34,7 @@ Here is a quick example of some PHP object documents that demonstrates a few of 
         /** @ODM\Id */
         private $id;
     
-        /** @ODM\Field(type="increment") */
+        /** @ODM\Field(type="int", strategy="increment") */
         private $changes = 0;
     
         /** @ODM\Field(type="collection") */

--- a/docs/en/reference/storage-strategies.rst
+++ b/docs/en/reference/storage-strategies.rst
@@ -1,29 +1,37 @@
-.. _collection_strategies:
+.. _storage_strategies:
 
-Collection Strategies
-=====================
+Storage Strategies
+==================
 
-Doctrine MongoDB ODM implements four different strategies for persisting changes
-to collections of embedded documents or references. These strategies apply to
-the following mapping types:
+Doctrine MongoDB ODM implements several different strategies for persisting changes
+to mapped fields. These strategies apply to the following mapping types:
 
+- :ref:`int`
+- :ref:`float`
 - :ref:`embed_many`
 - :ref:`reference_many`
 
-Internally, Doctrine tracks changes via the PersistentCollection class. The
+For collections, Doctrine tracks changes via the PersistentCollection class. The
 strategies described on this page are implemented by the CollectionPersister
-class.
+class. The ``increment`` strategy cannot be used for collections.
 
-``addToSet``
-------------
+increment
+---------
+
+The ``increment`` strategy does not apply to collections but can be used for
+``int`` and ``float`` fields. When using the ``increment`` strategy, the field
+value will be updated using the `$inc`_ operator.
+
+addToSet
+--------
 
 The ``addToSet`` strategy uses MongoDB's `$addToSet`_ operator to insert
 elements into the array. This strategy is useful for ensuring that duplicate
 values will not be inserted into the collection. Like the `pushAll`_ strategy,
 elements are inserted in a separate query after removing deleted elements.
 
-``set``
--------
+set
+---
 
 The ``set`` strategy uses MongoDB's `$set`_ operator to update the entire
 collection with a single update query.
@@ -37,15 +45,15 @@ collection with a single update query.
     `setArray`_ strategy if you want to ensure that the collection is always
     stored as a BSON array.
 
-``setArray``
-------------
+setArray
+--------
 
 The ``setArray`` strategy uses MongoDB's `$set`_ operator, just like the ``set``
 strategy, but will first numerically reindex the collection to ensure that it is
 stored as a BSON array.
 
-``pushAll``
------------
+pushAll
+-------
 
 The ``pushAll`` strategy uses MongoDB's `$pushAll`_ operator to insert
 elements into the array. MongoDB does not allow elements to be added and removed
@@ -54,8 +62,8 @@ queries to remove and insert elements (in that order).
 
 .. _atomic_set:
 
-``atomicSet``
--------------
+atomicSet
+---------
 
 The ``atomicSet`` strategy uses MongoDB's `$set`_ operator to update the entire
 collection with a single update query. Unlike with ``set`` strategy there will
@@ -70,8 +78,8 @@ strategy can be especially useful when dealing with high concurrency and
 
 .. _atomic_set_array:
 
-``atomicSetArray``
-------------------
+atomicSetArray
+--------------
 
 The ``atomicSetArray`` strategy works exactly like ``atomicSet`` strategy,  but 
 will first numerically reindex the collection to ensure that it is stored as a 
@@ -83,6 +91,7 @@ BSON array.
     collections mapped directly in a top-level document.
 
 .. _`$addToSet`: http://docs.mongodb.org/manual/reference/operator/addToSet/
+.. _`$inc`: http://docs.mongodb.org/manual/reference/operator/inc/
 .. _`$pushAll`: http://docs.mongodb.org/manual/reference/operator/pushAll/
 .. _`$set`: http://docs.mongodb.org/manual/reference/operator/set/
 .. _`$unset`: http://docs.mongodb.org/manual/reference/operator/unset/

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -64,7 +64,7 @@
     <xs:attribute name="id" type="xs:boolean" default="false" />
     <xs:attribute name="name" type="xs:NMTOKEN" />
     <xs:attribute name="type" type="xs:NMTOKEN" default="string" />
-    <xs:attribute name="strategy" type="xs:NMTOKEN" default="pushAll" />
+    <xs:attribute name="strategy" type="xs:NMTOKEN" default="set" />
     <xs:attribute name="fieldName" type="xs:NMTOKEN" />
     <xs:attribute name="embed" type="xs:boolean" />
     <xs:attribute name="file" type="xs:boolean" />

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractField.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractField.php
@@ -27,4 +27,5 @@ abstract class AbstractField extends Annotation
     public $type = 'string';
     public $nullable = false;
     public $options = array();
+    public $strategy;
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Increment.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Increment.php
@@ -21,9 +21,11 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use regular field mapping
+ * with the increment strategy instead
  */
 final class Increment extends AbstractField
 {
     public $type = 'increment';
+    public $strategy = 'increment';
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -152,6 +152,12 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
      */
     const STORAGE_STRATEGY_INCREMENT = 'increment';
 
+    const STORAGE_STRATEGY_PUSH_ALL = 'pushAll';
+    const STORAGE_STRATEGY_ADD_TO_SET = 'addToSet';
+    const STORAGE_STRATEGY_ATOMIC_SET = 'atomicSet';
+    const STORAGE_STRATEGY_ATOMIC_SET_ARRAY = 'atomicSetArray';
+    const STORAGE_STRATEGY_SET_ARRAY = 'setArray';
+
     /**
      * READ-ONLY: The name of the mongo database the document is mapped to.
      */

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -236,12 +236,13 @@ class XmlDriver extends FileDriver
     private function addEmbedMapping(ClassMetadataInfo $class, $embed, $type)
     {
         $attributes = $embed->attributes();
+        $defaultStrategy = $type == 'one' ? ClassMetadataInfo::STORAGE_STRATEGY_SET : CollectionHelper::DEFAULT_STRATEGY;
         $mapping = array(
             'type'           => $type,
             'embedded'       => true,
             'targetDocument' => isset($attributes['target-document']) ? (string) $attributes['target-document'] : null,
             'name'           => (string) $attributes['field'],
-            'strategy'       => isset($attributes['strategy']) ? (string) $attributes['strategy'] : CollectionHelper::DEFAULT_STRATEGY,
+            'strategy'       => isset($attributes['strategy']) ? (string) $attributes['strategy'] : $defaultStrategy,
         );
         if (isset($attributes['fieldName'])) {
             $mapping['fieldName'] = (string) $attributes['fieldName'];
@@ -275,6 +276,7 @@ class XmlDriver extends FileDriver
             $cascade = current($cascade) ?: next($cascade);
         }
         $attributes = $reference->attributes();
+        $defaultStrategy = $type == 'one' ? ClassMetadataInfo::STORAGE_STRATEGY_SET : CollectionHelper::DEFAULT_STRATEGY;
         $mapping = array(
             'cascade'          => $cascade,
             'orphanRemoval'    => isset($attributes['orphan-removal']) ? ('true' === (string) $attributes['orphan-removal']) : false,
@@ -283,7 +285,7 @@ class XmlDriver extends FileDriver
             'simple'           => isset($attributes['simple']) ? ('true' === (string) $attributes['simple']) : false,
             'targetDocument'   => isset($attributes['target-document']) ? (string) $attributes['target-document'] : null,
             'name'             => (string) $attributes['field'],
-            'strategy'         => isset($attributes['strategy']) ? (string) $attributes['strategy'] : CollectionHelper::DEFAULT_STRATEGY,
+            'strategy'         => isset($attributes['strategy']) ? (string) $attributes['strategy'] : $defaultStrategy,
             'inversedBy'       => isset($attributes['inversed-by']) ? (string) $attributes['inversed-by'] : null,
             'mappedBy'         => isset($attributes['mapped-by']) ? (string) $attributes['mapped-by'] : null,
             'repositoryMethod' => isset($attributes['repository-method']) ? (string) $attributes['repository-method'] : null,

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
@@ -233,12 +233,13 @@ class YamlDriver extends FileDriver
 
     private function addMappingFromEmbed(ClassMetadataInfo $class, $fieldName, $embed, $type)
     {
+        $defaultStrategy = $type == 'one' ? ClassMetadataInfo::STORAGE_STRATEGY_SET : CollectionHelper::DEFAULT_STRATEGY;
         $mapping = array(
             'type'           => $type,
             'embedded'       => true,
             'targetDocument' => isset($embed['targetDocument']) ? $embed['targetDocument'] : null,
             'fieldName'      => $fieldName,
-            'strategy'       => isset($embed['strategy']) ? (string) $embed['strategy'] : CollectionHelper::DEFAULT_STRATEGY,
+            'strategy'       => isset($embed['strategy']) ? (string) $embed['strategy'] : $defaultStrategy,
         );
         if (isset($embed['name'])) {
             $mapping['name'] = $embed['name'];
@@ -257,6 +258,7 @@ class YamlDriver extends FileDriver
 
     private function addMappingFromReference(ClassMetadataInfo $class, $fieldName, $reference, $type)
     {
+        $defaultStrategy = $type == 'one' ? ClassMetadataInfo::STORAGE_STRATEGY_SET : CollectionHelper::DEFAULT_STRATEGY;
         $mapping = array(
             'cascade'          => isset($reference['cascade']) ? $reference['cascade'] : null,
             'orphanRemoval'    => isset($reference['orphanRemoval']) ? $reference['orphanRemoval'] : false,
@@ -265,7 +267,7 @@ class YamlDriver extends FileDriver
             'simple'           => isset($reference['simple']) ? (boolean) $reference['simple'] : false,
             'targetDocument'   => isset($reference['targetDocument']) ? $reference['targetDocument'] : null,
             'fieldName'        => $fieldName,
-            'strategy'         => isset($reference['strategy']) ? (string) $reference['strategy'] : CollectionHelper::DEFAULT_STRATEGY,
+            'strategy'         => isset($reference['strategy']) ? (string) $reference['strategy'] : $defaultStrategy,
             'inversedBy'       => isset($reference['inversedBy']) ? (string) $reference['inversedBy'] : null,
             'mappedBy'         => isset($reference['mappedBy']) ? (string) $reference['mappedBy'] : null,
             'repositoryMethod' => isset($reference['repositoryMethod']) ? (string) $reference['repositoryMethod'] : null,

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -275,4 +275,16 @@ class MappingException extends BaseMappingException
     {
         return new self("ReferenceMany's sort can not be used with addToSet and pushAll strategies, $strategy used in $className::$fieldName");
     }
+
+    /**
+     * @param string $className
+     * @param string $fieldName
+     * @param string $type
+     * @param string $strategy
+     * @return MappingException
+     */
+    public static function invalidStorageStrategy($className, $fieldName, $type, $strategy)
+    {
+        return new self("Invalid strategy $strategy used in $className::$fieldName with type $type");
+    }
 }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -21,6 +21,7 @@ namespace Doctrine\ODM\MongoDB\Persisters;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\LockException;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 use Doctrine\ODM\MongoDB\PersistentCollection;
 use Doctrine\ODM\MongoDB\Persisters\PersistenceBuilder;
 use Doctrine\ODM\MongoDB\UnitOfWork;
@@ -104,17 +105,17 @@ class CollectionPersister
         }
 
         switch ($mapping['strategy']) {
-            case 'atomicSet':
-            case 'atomicSetArray':
+            case ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET:
+            case ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET_ARRAY:
                 throw new \UnexpectedValueException($mapping['strategy'] . ' update collection strategy should have been handled by DocumentPersister. Please report a bug in issue tracker');
             
-            case 'set':
-            case 'setArray':
+            case ClassMetadataInfo::STORAGE_STRATEGY_SET:
+            case ClassMetadataInfo::STORAGE_STRATEGY_SET_ARRAY:
                 $this->setCollection($coll, $options);
                 break;
 
-            case 'addToSet':
-            case 'pushAll':
+            case ClassMetadataInfo::STORAGE_STRATEGY_ADD_TO_SET:
+            case ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL:
                 $coll->initialize();
                 $this->deleteElements($coll, $options);
                 $this->insertElements($coll, $options);
@@ -210,7 +211,7 @@ class CollectionPersister
 
         $value = array_values(array_map($callback, $insertDiff));
 
-        if ($mapping['strategy'] === 'addToSet') {
+        if ($mapping['strategy'] === ClassMetadataInfo::STORAGE_STRATEGY_ADD_TO_SET) {
             $value = array('$each' => $value);
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1043,7 +1043,7 @@ class DocumentPersister
             return array($fieldName, $value);
         }
 
-        if (isset($mapping['strategy']) && CollectionHelper::isHash($mapping['strategy'])
+        if ($mapping['type'] == 'many' && CollectionHelper::isHash($mapping['strategy'])
                 && isset($e[2])) {
             $objectProperty = $e[2];
             $objectPropertyPrefix = $e[1] . '.';

--- a/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
@@ -20,6 +20,7 @@ namespace Doctrine\ODM\MongoDB\Persisters;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 use Doctrine\ODM\MongoDB\PersistentCollection;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Doctrine\ODM\MongoDB\UnitOfWork;
@@ -140,26 +141,20 @@ class PersistenceBuilder
 
             list($old, $new) = $change;
 
-            // @Inc
-            if ($mapping['type'] === 'increment') {
-                if ($new === null) {
-                    if ($mapping['nullable'] === true) {
-                        $updateData['$set'][$mapping['name']] = null;
-                    } else {
-                        $updateData['$unset'][$mapping['name']] = true;
-                    }
-                } elseif ($new >= $old) {
-                    $updateData['$inc'][$mapping['name']] = $new - $old;
-                } else {
-                    $updateData['$inc'][$mapping['name']] = ($old - $new) * -1;
-                }
-
-            // @Field, @String, @Date, etc.
-            } elseif ( ! isset($mapping['association'])) {
-                if (isset($new) || $mapping['nullable'] === true) {
-                    $updateData['$set'][$mapping['name']] = (is_null($new) ? null : Type::getType($mapping['type'])->convertToDatabaseValue($new));
-                } else {
+            // Scalar fields
+            if ( ! isset($mapping['association'])) {
+                if ($new === null && $mapping['nullable'] !== true) {
                     $updateData['$unset'][$mapping['name']] = true;
+                } else {
+                    if ($new !== null && $mapping['strategy'] === ClassMetadataInfo::STORAGE_STRATEGY_INCREMENT) {
+                        $operator = '$inc';
+                        $value = Type::getType($mapping['type'])->convertToDatabaseValue($new - $old);
+                    } else {
+                        $operator = '$set';
+                        $value = $new === null ? null : Type::getType($mapping['type'])->convertToDatabaseValue($new);
+                    }
+
+                    $updateData[$operator][$mapping['name']] = $value;
                 }
 
             // @EmbedOne
@@ -246,31 +241,28 @@ class PersistenceBuilder
 
             list($old, $new) = $change;
 
-            // @Inc
-            if ($mapping['type'] === 'increment') {
-                if ($new >= $old) {
-                    $updateData['$inc'][$mapping['name']] = $new - $old;
-                } else {
-                    $updateData['$inc'][$mapping['name']] = ($old - $new) * -1;
-                }
+            // Scalar fields
+            if ( ! isset($mapping['association'])) {
+                if ($new !== null || $mapping['nullable'] === true) {
+                    if ($new !== null && $mapping['strategy'] === ClassMetadataInfo::STORAGE_STRATEGY_INCREMENT) {
+                        $operator = '$inc';
+                        $value = Type::getType($mapping['type'])->convertToDatabaseValue($new - $old);
+                    } else {
+                        $operator = '$set';
+                        $value = $new === null ? null : Type::getType($mapping['type'])->convertToDatabaseValue($new);
+                    }
 
-            // @Field, @String, @Date, etc.
-            } elseif ( ! isset($mapping['association'])) {
-                if (isset($new) || $mapping['nullable'] === true) {
-                    $updateData['$set'][$mapping['name']] = (is_null($new) ? null : Type::getType($mapping['type'])->convertToDatabaseValue($new));
+                    $updateData[$operator][$mapping['name']] = $value;
                 }
 
             // @EmbedOne
             } elseif (isset($mapping['association']) && $mapping['association'] === ClassMetadata::EMBED_ONE) {
+                // If we don't have a new value then do nothing on upsert
                 // If we have a new embedded document then lets set the whole thing
                 if ($new && $this->uow->isScheduledForInsert($new)) {
                     $updateData['$set'][$mapping['name']] = $this->prepareEmbeddedDocumentValue($mapping, $new);
-
-                // If we don't have a new value then do nothing on upsert
-                } elseif ( ! $new) {
-
-                // Update existing embedded document
-                } else {
+                } elseif ($new) {
+                    // Update existing embedded document
                     $update = $this->prepareUpsertData($new);
                     foreach ($update as $cmd => $values) {
                         foreach ($values as $key => $value) {

--- a/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
@@ -104,7 +104,7 @@ class PersistenceBuilder
             // We're excluding collections using addToSet since there is a risk
             // of duplicated entries stored in the collection
             } elseif ($mapping['type'] === ClassMetadata::MANY && ! $mapping['isInverseSide']
-                    && $mapping['strategy'] !== 'addToSet' && ! $new->isEmpty()) {
+                    && $mapping['strategy'] !== ClassMetadataInfo::STORAGE_STRATEGY_ADD_TO_SET && ! $new->isEmpty()) {
                 $insertData[$mapping['name']] = $this->prepareAssociatedCollectionValue($new, true);
             }
         }

--- a/lib/Doctrine/ODM/MongoDB/Types/IncrementType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/IncrementType.php
@@ -23,6 +23,7 @@ namespace Doctrine\ODM\MongoDB\Types;
  * The Increment type.
  *
  * @since       1.0
+ * @deprecated This type will be removed in ODM 2.0. Please use int or float instead
  */
 class IncrementType extends Type
 {

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2180,7 +2180,7 @@ class UnitOfWork implements PropertyChangedListener
                             $relatedDocument = clone $relatedDocument;
                             $relatedDocuments[$relatedKey] = $relatedDocument;
                         }
-                        $pathKey = ! isset($mapping['strategy']) || CollectionHelper::isList($mapping['strategy']) ? $count++ : $relatedKey;
+                        $pathKey = CollectionHelper::isList($mapping['strategy']) ? $count++ : $relatedKey;
                         $this->setParentAssociation($relatedDocument, $mapping, $document, $mapping['fieldName'] . '.' . $pathKey);
                     }
                     $this->doPersist($relatedDocument, $visited);
@@ -2537,7 +2537,7 @@ class UnitOfWork implements PropertyChangedListener
             while (null !== ($parentAssoc = $this->getParentAssociation($parent))) {
                 list($mapping, $parent, ) = $parentAssoc;
             }
-            if (isset($mapping['strategy']) && CollectionHelper::isAtomic($mapping['strategy'])) {
+            if (CollectionHelper::isAtomic($mapping['strategy'])) {
                 $class = $this->dm->getClassMetadata(get_class($document));
                 $atomicCollection = $class->getFieldValue($document, $mapping['fieldName']);
                 $this->scheduleCollectionUpdate($atomicCollection);

--- a/lib/Doctrine/ODM/MongoDB/Utility/CollectionHelper.php
+++ b/lib/Doctrine/ODM/MongoDB/Utility/CollectionHelper.php
@@ -18,6 +18,7 @@
  */
 
 namespace Doctrine\ODM\MongoDB\Utility;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 
 /**
  * Utility class used to unify checks on how collection strategies should behave.
@@ -27,7 +28,7 @@ namespace Doctrine\ODM\MongoDB\Utility;
  */
 class CollectionHelper
 {
-    const DEFAULT_STRATEGY = 'pushAll';
+    const DEFAULT_STRATEGY = ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL;
 
     /**
      * Returns whether update query must be included in query updating owning document.
@@ -37,7 +38,7 @@ class CollectionHelper
      */
     public static function isAtomic($strategy)
     {
-        return $strategy === 'atomicSet' || $strategy === 'atomicSetArray';
+        return $strategy === ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET || $strategy === ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET_ARRAY;
     }
 
     /**
@@ -48,7 +49,7 @@ class CollectionHelper
      */
     public static function isHash($strategy)
     {
-        return $strategy === 'set' || $strategy === 'atomicSet';
+        return $strategy === ClassMetadataInfo::STORAGE_STRATEGY_SET || $strategy === ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET;
     }
     
     /**
@@ -59,7 +60,7 @@ class CollectionHelper
      */
     public static function isList($strategy)
     {
-        return $strategy !== 'set' && $strategy !== 'atomicSet';
+        return $strategy !== ClassMetadataInfo::STORAGE_STRATEGY_SET && $strategy !== ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET;
     }
     
     /**
@@ -70,6 +71,14 @@ class CollectionHelper
      */
     public static function usesSet($strategy)
     {
-        return in_array($strategy, array('set', 'setArray', 'atomicSet', 'atomicSetArray'));
+        return in_array(
+            $strategy,
+            [
+                ClassMetadataInfo::STORAGE_STRATEGY_SET,
+                ClassMetadataInfo::STORAGE_STRATEGY_SET_ARRAY,
+                ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET,
+                ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET_ARRAY
+            ]
+        );
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -295,6 +295,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user = new User();
         $user->setUsername('jon');
         $user->setCount(100);
+        $user->setFloatCount(100);
 
         $this->dm->persist($user);
         $this->dm->flush();
@@ -303,18 +304,22 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user = $this->dm->getRepository('Documents\User')->findOneBy(array('username' => 'jon'));
 
         $user->incrementCount(5);
+        $user->incrementFloatCount(5);
         $this->dm->flush();
         $this->dm->clear();
 
         $user = $this->dm->getRepository('Documents\User')->findOneBy(array('username' => 'jon'));
-        $this->assertEquals(105, $user->getCount());
+        $this->assertSame(105, $user->getCount());
+        $this->assertSame(105.0, $user->getFloatCount());
 
         $user->setCount(50);
+        $user->setFloatCount(50);
 
         $this->dm->flush();
         $this->dm->clear();
         $user = $this->dm->getRepository('Documents\User')->findOneBy(array('username' => 'jon'));
-        $this->assertEquals(50, $user->getCount());
+        $this->assertSame(50, $user->getCount());
+        $this->assertSame(50.0, $user->getFloatCount());
     }
 
     public function testIncrementWithFloat()
@@ -322,6 +327,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user = new User();
         $user->setUsername('jon');
         $user->setCount(100);
+        $user->setFloatCount(100);
 
         $this->dm->persist($user);
         $this->dm->flush();
@@ -330,18 +336,22 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user = $this->dm->getRepository('Documents\User')->findOneBy(array('username' => 'jon'));
 
         $user->incrementCount(1.337);
+        $user->incrementFloatCount(1.337);
         $this->dm->flush();
         $this->dm->clear();
 
         $user = $this->dm->getRepository('Documents\User')->findOneBy(array('username' => 'jon'));
-        $this->assertEquals(101.337, $user->getCount());
+        $this->assertSame(101, $user->getCount());
+        $this->assertSame(101.337, $user->getFloatCount());
 
         $user->incrementCount(9.163);
+        $user->incrementFloatCount(9.163);
         $this->dm->flush();
         $this->dm->clear();
 
         $user = $this->dm->getRepository('Documents\User')->findOneBy(array('username' => 'jon'));
-        $this->assertEquals(110.5, $user->getCount());
+        $this->assertSame(110, $user->getCount());
+        $this->assertSame(110.5, $user->getFloatCount());
     }
 
     public function testIncrementSetsNull()
@@ -349,27 +359,33 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user = new User();
         $user->setUsername('jon');
         $user->setCount(10);
+        $user->setFloatCount(10);
 
         $this->dm->persist($user);
         $this->dm->flush();
         $this->dm->clear();
 
         $user = $this->dm->getRepository('Documents\User')->findOneBy(array('username' => 'jon'));
-        $this->assertEquals(10, $user->getCount());
+        $this->assertSame(10, $user->getCount());
+        $this->assertSame(10.0, $user->getFloatCount());
 
         $user->incrementCount(1);
+        $user->incrementFloatCount(1);
         $this->dm->flush();
         $this->dm->clear();
 
         $user = $this->dm->getRepository('Documents\User')->findOneBy(array('username' => 'jon'));
-        $this->assertEquals(11, $user->getCount());
+        $this->assertSame(11, $user->getCount());
+        $this->assertSame(11.0, $user->getFloatCount());
 
         $user->setCount(null);
+        $user->setFloatCount(null);
         $this->dm->flush();
         $this->dm->clear();
 
         $user = $this->dm->getRepository('Documents\User')->findOneBy(array('username' => 'jon'));
-        $this->assertEquals(null, $user->getCount());
+        $this->assertSame(null, $user->getCount());
+        $this->assertSame(null, $user->getFloatCount());
     }
 
     public function testTest()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedCollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedCollectionsTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 use Documents\Phonebook;
 use Documents\Phonenumber;
 
@@ -64,12 +65,12 @@ class NestedCollectionsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function provideStrategy()
     {
         return array(
-            array('atomicSet'),
-            array('atomicSetArray'),
-            array('set'),
-            array('setArray'),
-            array('pushAll'),
-            array('addToSet'),
+            array(ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET),
+            array(ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET_ARRAY),
+            array(ClassMetadataInfo::STORAGE_STRATEGY_SET),
+            array(ClassMetadataInfo::STORAGE_STRATEGY_SET_ARRAY),
+            array(ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL),
+            array(ClassMetadataInfo::STORAGE_STRATEGY_ADD_TO_SET),
         );
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
@@ -4,6 +4,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 
 class GH1275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
@@ -132,12 +133,12 @@ class GH1275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public static function getCollectionStrategies()
     {
         return array(
-            'testResortWithStrategyAddToSet' => array('addToSet'),
-            'testResortWithStrategySet' => array('set'),
-            'testResortWithStrategySetArray' => array('setArray'),
-            'testResortWithStrategyPushAll' => array('pushAll'),
-            'testResortWithStrategyAtomicSet' => array('atomicSet'),
-            'testResortWithStrategyAtomicSetArray' => array('atomicSetArray'),
+            'testResortWithStrategyAddToSet' => array(ClassMetadataInfo::STORAGE_STRATEGY_ADD_TO_SET),
+            'testResortWithStrategySet' => array(ClassMetadataInfo::STORAGE_STRATEGY_SET),
+            'testResortWithStrategySetArray' => array(ClassMetadataInfo::STORAGE_STRATEGY_SET_ARRAY),
+            'testResortWithStrategyPushAll' => array(ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL),
+            'testResortWithStrategyAtomicSet' => array(ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET),
+            'testResortWithStrategyAtomicSetArray' => array(ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET_ARRAY),
         );
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
 use Doctrine\ODM\MongoDB\Mapping\Driver\YamlDriver;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -47,7 +48,6 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
         $this->assertTrue(isset($class->fieldMappings['name']));
         $this->assertTrue(isset($class->fieldMappings['email']));
         $this->assertTrue(isset($class->fieldMappings['roles']));
-        $this->assertFalse(isset($class->fieldMappings['roles']['strategy']));
 
         return $class;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataInfoTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataInfoTest.php
@@ -248,7 +248,7 @@ class ClassMetadataInfoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             'fieldName' => 'many',
             'reference' => true,
             'type' => 'many',
-            'strategy' => 'atomicSet',
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET,
         ));
     }
 
@@ -261,7 +261,7 @@ class ClassMetadataInfoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $config = array_merge($config, array(
             'fieldName' => 'many',
             'reference' => true,
-            'strategy' => 'atomicSet',
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET,
         ));
 
         $cm = new ClassMetadataInfo('stdClass');
@@ -323,7 +323,7 @@ class ClassMetadataInfoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $cm->mapField(array(
             'fieldName' => 'ref',
             'reference' => true,
-            'strategy' => 'pushAll',
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL,
             'type' => 'many',
             'sort' => array('foo' => 1)
         ));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -57,7 +57,8 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'isOwningSide' => true,
             'nullable' => false,
             'unique' => true,
-            'sparse' => true
+            'sparse' => true,
+            'strategy' => 'set',
         ), $classMetadata->fieldMappings['username']);
         
         $this->assertEquals(array(
@@ -78,7 +79,8 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'isCascadeRemove' => false,
             'isInverseSide' => false,
             'isOwningSide' => true,
-            'nullable' => false
+            'nullable' => false,
+            'strategy' => 'set',
         ), $classMetadata->fieldMappings['createdAt']);
 
         $this->assertEquals(array(
@@ -93,6 +95,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'isInverseSide' => false,
             'isOwningSide' => true,
             'nullable' => false,
+            'strategy' => 'set',
         ), $classMetadata->fieldMappings['tags']);
 
         $this->assertEquals(array(
@@ -239,6 +242,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'isInverseSide' => false,
             'isOwningSide' => true,
             'nullable' => false,
+            'strategy' => 'set',
         ), $classMetadata->fieldMappings['name']);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -114,7 +114,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'isInverseSide' => false,
             'isOwningSide' => true,
             'nullable' => false,
-            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL,
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_SET,
         ), $classMetadata->fieldMappings['address']);
 
         $this->assertEquals(array(
@@ -152,7 +152,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'isInverseSide' => false,
             'isOwningSide' => true,
             'nullable' => false,
-            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL,
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_SET,
             'inversedBy' => null,
             'mappedBy' => null,
             'repositoryMethod' => null,
@@ -178,7 +178,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'isInverseSide' => false,
             'isOwningSide' => true,
             'nullable' => false,
-            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL,
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_SET,
             'inversedBy' => null,
             'mappedBy' => null,
             'repositoryMethod' => null,

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\ODM\MongoDB\Tests\Mapping\Driver;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 
 require_once 'fixtures/InvalidPartialFilterDocument.php';
 require_once 'fixtures/PartialFilterDocument.php';
@@ -58,7 +59,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'nullable' => false,
             'unique' => true,
             'sparse' => true,
-            'strategy' => 'set',
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_SET,
         ), $classMetadata->fieldMappings['username']);
         
         $this->assertEquals(array(
@@ -80,7 +81,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'isInverseSide' => false,
             'isOwningSide' => true,
             'nullable' => false,
-            'strategy' => 'set',
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_SET,
         ), $classMetadata->fieldMappings['createdAt']);
 
         $this->assertEquals(array(
@@ -95,7 +96,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'isInverseSide' => false,
             'isOwningSide' => true,
             'nullable' => false,
-            'strategy' => 'set',
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_SET,
         ), $classMetadata->fieldMappings['tags']);
 
         $this->assertEquals(array(
@@ -113,7 +114,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'isInverseSide' => false,
             'isOwningSide' => true,
             'nullable' => false,
-            'strategy' => 'pushAll',
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL,
         ), $classMetadata->fieldMappings['address']);
 
         $this->assertEquals(array(
@@ -131,7 +132,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'isInverseSide' => false,
             'isOwningSide' => true,
             'nullable' => false,
-            'strategy' => 'pushAll',
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL,
         ), $classMetadata->fieldMappings['phonenumbers']);
 
         $this->assertEquals(array(
@@ -151,7 +152,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'isInverseSide' => false,
             'isOwningSide' => true,
             'nullable' => false,
-            'strategy' => 'pushAll',
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL,
             'inversedBy' => null,
             'mappedBy' => null,
             'repositoryMethod' => null,
@@ -177,7 +178,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'isInverseSide' => false,
             'isOwningSide' => true,
             'nullable' => false,
-            'strategy' => 'pushAll',
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL,
             'inversedBy' => null,
             'mappedBy' => null,
             'repositoryMethod' => null,
@@ -203,7 +204,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'isInverseSide' => false,
             'isOwningSide' => true,
             'nullable' => false,
-            'strategy' => 'pushAll',
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL,
             'inversedBy' => null,
             'mappedBy' => null,
             'repositoryMethod' => null,
@@ -242,7 +243,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'isInverseSide' => false,
             'isOwningSide' => true,
             'nullable' => false,
-            'strategy' => 'set',
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_SET,
         ), $classMetadata->fieldMappings['name']);
     }
 

--- a/tests/Documents/Address.php
+++ b/tests/Documents/Address.php
@@ -19,7 +19,7 @@ class Address
     /** @ODM\Field(type="string") */
     private $zipcode;
 
-    /** @ODM\Field(type="increment") */
+    /** @ODM\Field(type="int", strategy="increment") */
     public $count = 0;
 
     /** @ODM\EmbedOne(targetDocument="Address") */

--- a/tests/Documents/BaseEmployee.php
+++ b/tests/Documents/BaseEmployee.php
@@ -10,7 +10,7 @@ abstract class BaseEmployee
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\Field(type="increment") */
+    /** @ODM\Field(type="int", strategy="increment") */
     protected $changes = 0;
 
     /** @ODM\Field(type="collection") */

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -59,8 +59,11 @@ class User extends BaseDocument
     /** @ODM\Field(type="string") */
     protected $nullTest;
 
-    /** @ODM\Field(type="increment") */
-    protected $count = 0;
+    /** @ODM\Field(type="int", strategy="increment") */
+    protected $count;
+
+    /** @ODM\Field(type="float", strategy="increment") */
+    protected $floatCount;
 
     /** @ODM\ReferenceMany(targetDocument="BlogPost", mappedBy="user", nullable=true) */
     protected $posts;
@@ -267,6 +270,16 @@ class User extends BaseDocument
         $this->count = $count;
     }
 
+    public function getFloatCount()
+    {
+        return $this->floatCount;
+    }
+
+    public function setFloatCount($floatCount)
+    {
+        $this->floatCount = $floatCount;
+    }
+
     public function getSimpleReferenceOneInverse()
     {
         return $this->simpleReferenceOneInverse;
@@ -282,7 +295,16 @@ class User extends BaseDocument
         if ($num === null) {
             $this->count++;
         } else {
-            $this->count = $this->count + $num;
+            $this->count += $num;
+        }
+    }
+
+    public function incrementFloatCount($num = null)
+    {
+        if ($num === null) {
+            $this->floatCount++;
+        } else {
+            $this->floatCount += $num;
         }
     }
 

--- a/tests/Documents/UserUpsert.php
+++ b/tests/Documents/UserUpsert.php
@@ -25,7 +25,7 @@ class UserUpsert
     /** @ODM\Field(type="int") */
     public $hits;
 
-    /** @ODM\Field(type="increment") */
+    /** @ODM\Field(type="int", strategy="increment") */
     public $count;
 
     /** @ODM\ReferenceMany(targetDocument="Group", cascade={"all"}) */

--- a/tests/Documents/UserUpsertIdStrategyNone.php
+++ b/tests/Documents/UserUpsertIdStrategyNone.php
@@ -24,7 +24,7 @@ class UserUpsertIdStrategyNone
     /** @ODM\Field(type="int") */
     public $hits;
 
-    /** @ODM\Field(type="increment") */
+    /** @ODM\Field(type="int", strategy="increment") */
     public $count;
 
     /** @ODM\ReferenceMany(targetDocument="Group", cascade={"all"}) */


### PR DESCRIPTION
This PR deprecates the `increment` type that can be used in ODM, replacing it instead with a more flexible `strategy` option for fields.

First of all, the `increment` type was supposed to handle int and float values at the same time. There was no option to ensure a value read from the database was cast to an int (which could lead to unexpected floats appearing in the application if one wasn't careful).
Furthermore, for collections there is a `strategy` option which controls how the elements in a collection are written to the database. This kind of write control is exactly what should be used for increment fields as well.

At first glance, there are no BC breaks to this. When the `ClassMetadataInfo` class encounters a mapping with type `increment`, it will automatically set the strategy to `increment`, regardless of any other strategy being set. The type is left unchanged to keep the current type cast behavior. Users are encouraged to switch their increment mappings to the new strategy field.

Open tasks:
- [x] Write proper documentation about the new strategy, add deprecation notes for the `increment` type
- [x] Collection strategies still use magic strings, these should be converted to class constants for good measure
- [x] The validation which strategy is acceptable for which mapping should probably be generalized and put in one place to ensure consistency.

@malarzm: I'd appreciate your guidance on the last two tasks since you've spent quite some time with collections ;)