### PR TITLE
Fix PHP 7 compatibility errors

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -795,11 +795,12 @@ class DocumentPersister
     {
         $hints = $collection->getHints();
         $mapping = $collection->getMapping();
+        $repositoryMethod = $mapping['repositoryMethod'];
         $cursor = $this->dm->getRepository($mapping['targetDocument'])
-            ->$mapping['repositoryMethod']($collection->getOwner());
+            ->$repositoryMethod($collection->getOwner());
 
         if ( ! $cursor instanceof CursorInterface) {
-            throw new \BadMethodCallException("Expected repository method {$mapping['repositoryMethod']} to return a CursorInterface");
+            throw new \BadMethodCallException("Expected repository method {$repositoryMethod} to return a CursorInterface");
         }
 
         if (isset($mapping['sort'])) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
@@ -270,13 +270,13 @@ class PartialIndexOnDocumentTest
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $username;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $email;
 
-    /** @ODM\Integer */
+    /** @ODM\Field(type="integer") */
     public $counter;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
@@ -77,7 +77,7 @@ class Vehicle
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\String */
+    /** @ODM\Field(type="string") */
     public $name;
 
     /** @ODM\EmbedMany */


### PR DESCRIPTION
This PR doesn't bring full PHP 7 compatibility but it removes a couple of issues that will arise should one manage to get ODM running on PHP 7:
- As mentioned in the [PHP 7 Upgrade log](https://secure.php.net/manual/de/migration70.incompatible.php), changes to variable handling cause an array to string conversion in DocumentPersister
- There were a couple of deprecated annotations still being used in tests. Due to string and integer being reserved keywords in PHP 7, these annotations are not loaded and cause errors.