### PR TITLE
Prepare field's value for references

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -975,8 +975,7 @@ class DocumentPersister
                 return array($fieldName, $this->pb->prepareEmbeddedDocumentValue($mapping, $value));
             }
 
-            if (! empty($mapping['reference']) && $mapping['type'] === ClassMetadata::ONE
-                && is_object($value) && ! ($value instanceof \MongoId)) {
+            if (! empty($mapping['reference']) && is_object($value) && ! ($value instanceof \MongoId)) {
                 try {
                     return array($fieldName, $this->dm->createDBRef($value, $mapping));
                 } catch (MappingException $e) {

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -20,6 +20,7 @@
 namespace Doctrine\ODM\MongoDB\Persisters;
 
 use Doctrine\Common\EventManager;
+use Doctrine\Common\Persistence\Mapping\MappingException;
 use Doctrine\MongoDB\CursorInterface;
 use Doctrine\ODM\MongoDB\Cursor;
 use Doctrine\ODM\MongoDB\DocumentManager;
@@ -972,6 +973,15 @@ class DocumentPersister
             if ( ! empty($mapping['embedded']) && is_object($value) &&
                 ! $this->dm->getMetadataFactory()->isTransient(get_class($value))) {
                 return array($fieldName, $this->pb->prepareEmbeddedDocumentValue($mapping, $value));
+            }
+
+            if (! empty($mapping['reference']) && $mapping['type'] === ClassMetadata::ONE
+                && is_object($value) && ! ($value instanceof \MongoId)) {
+                try {
+                    return array($fieldName, $this->dm->createDBRef($value, $mapping));
+                } catch (MappingException $e) {
+                    // do nothing in case passed object is not mapped document
+                }
             }
 
             // No further preparation unless we're dealing with a simple reference

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
@@ -4,6 +4,10 @@ namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ODM\MongoDB\LockMode;
+use Documents\Account;
+use Documents\Address;
+use Documents\Group;
+use Documents\User;
 
 class DocumentRepositoryTest extends BaseTest
 {
@@ -24,5 +28,38 @@ class DocumentRepositoryTest extends BaseTest
 
         $document = $repository->find($invalidId, LockMode::OPTIMISTIC);
         $this->assertNull($document);
+    }
+
+    public function testFindByRefOneFull()
+    {
+        $user = new User();
+        $account = new Account('name');
+        $user->setAccount($account);
+        $this->dm->persist($user);
+        $this->dm->persist($account);
+        $this->dm->flush();
+        $this->assertSame($user, $this->dm->getRepository(User::class)->findOneBy(['account' => $account]));
+    }
+
+    public function testFindByRefOneSimple()
+    {
+        $user = new User();
+        $account = new Account('name');
+        $user->setAccountSimple($account);
+        $this->dm->persist($user);
+        $this->dm->persist($account);
+        $this->dm->flush();
+        $this->assertSame($user, $this->dm->getRepository(User::class)->findOneBy(['accountSimple' => $account]));
+    }
+
+    public function testFindByEmbedOne()
+    {
+        $user = new User();
+        $address = new Address();
+        $address->setCity('Cracow');
+        $user->setAddress($address);
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $this->assertSame($user, $this->dm->getRepository(User::class)->findOneBy(['address' => $address]));
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
@@ -7,6 +7,7 @@ use Doctrine\ODM\MongoDB\LockMode;
 use Documents\Account;
 use Documents\Address;
 use Documents\Group;
+use Documents\Phonenumber;
 use Documents\User;
 
 class DocumentRepositoryTest extends BaseTest
@@ -61,5 +62,37 @@ class DocumentRepositoryTest extends BaseTest
         $this->dm->persist($user);
         $this->dm->flush();
         $this->assertSame($user, $this->dm->getRepository(User::class)->findOneBy(['address' => $address]));
+    }
+
+    public function testFindByRefManyFull()
+    {
+        $user = new User();
+        $group = new Group('group');
+        $user->addGroup($group);
+        $this->dm->persist($user);
+        $this->dm->persist($group);
+        $this->dm->flush();
+        $this->assertSame($user, $this->dm->getRepository(User::class)->findOneBy(['groups' => $group]));
+    }
+
+    public function testFindByRefManySimple()
+    {
+        $user = new User();
+        $group = new Group('group');
+        $user->addGroupSimple($group);
+        $this->dm->persist($user);
+        $this->dm->persist($group);
+        $this->dm->flush();
+        $this->assertSame($user, $this->dm->getRepository(User::class)->findOneBy(['groupsSimple' => $group]));
+    }
+
+    public function testFindByEmbedMany()
+    {
+        $user = new User();
+        $phonenumber = new Phonenumber('12345678');
+        $user->addPhonenumber($phonenumber);
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $this->assertSame($user, $this->dm->getRepository(User::class)->findOneBy(['phonenumbers' => $phonenumber]));
     }
 }

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -53,6 +53,9 @@ class User extends BaseDocument
     /** @ODM\ReferenceOne(targetDocument="Account", cascade={"all"}) */
     protected $account;
 
+    /** @ODM\ReferenceOne(targetDocument="Account", simple=true, cascade={"all"}) */
+    protected $accountSimple;
+
     /** @ODM\Field(type="int") */
     protected $hits = 0;
 
@@ -184,6 +187,17 @@ class User extends BaseDocument
     public function getAccount()
     {
         return $this->account;
+    }
+
+    public function setAccountSimple(Account $account)
+    {
+        $this->accountSimple = $account;
+        $this->accountSimple->setUser($this);
+    }
+
+    public function getAccountSimple()
+    {
+        return $this->accountSimple;
     }
 
     public function getPhonenumbers()

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -41,6 +41,9 @@ class User extends BaseDocument
     /** @ODM\ReferenceMany(targetDocument="Group", cascade={"all"}) */
     protected $groups;
 
+    /** @ODM\ReferenceMany(targetDocument="Group", simple=true, cascade={"all"}) */
+    protected $groupsSimple;
+
     /** @ODM\ReferenceMany(targetDocument="Group", cascade={"all"}, strategy="addToSet") */
     protected $uniqueGroups;
 
@@ -82,6 +85,7 @@ class User extends BaseDocument
         $this->phonebooks = new ArrayCollection();
         $this->phonenumbers = new ArrayCollection();
         $this->groups = new ArrayCollection();
+        $this->groupsSimple = new ArrayCollection();
         $this->sortedGroups = new ArrayCollection();
         $this->sortedGroupsAsc = new ArrayCollection();
         $this->posts = new ArrayCollection();
@@ -244,6 +248,11 @@ class User extends BaseDocument
             }
         }
         return false;
+    }
+
+    public function addGroupSimple(Group $group)
+    {
+        $this->groupsSimple[] = $group;
     }
 
     public function getUniqueGroups()


### PR DESCRIPTION
This is a subset of ODM preparing query according to field's mapping, but as it's bigger thing here's small part that is cool enough to make its way to 1.1 already - now one can query for references without using query builder! It even doesn't matter if reference is one or many, simple or not:

```
$dm->getRepository(User::class)->findOneBy(['account' => $account]);
$dm->getRepository(User::class)->findBy(['groups' => $group]);
```

Additionally to being nice it should fix https://github.com/doctrine/DoctrineMongoDBBundle/issues/208 and close #292 :)