### PR TITLE
Fix regression with increment strategy

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -1258,6 +1258,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
         switch (true) {
             case $mapping['type'] == 'int':
             case $mapping['type'] == 'float':
+            case $mapping['type'] == 'increment':
                 $defaultStrategy = self::STORAGE_STRATEGY_SET;
                 $allowedStrategies = [self::STORAGE_STRATEGY_SET, self::STORAGE_STRATEGY_INCREMENT];
                 break;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataInfoTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataInfoTest.php
@@ -328,6 +328,18 @@ class ClassMetadataInfoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             'sort' => array('foo' => 1)
         ));
     }
+
+    public function testIncrementTypeAutomaticallyAssumesIncrementStrategy()
+    {
+        $cm = new ClassMetadataInfo('stdClass');
+        $cm->mapField([
+            'fieldName' => 'incrementField',
+            'type' => 'increment',
+        ]);
+
+        $mapping = $cm->fieldMappings['incrementField'];
+        $this->assertSame(ClassMetadataInfo::STORAGE_STRATEGY_INCREMENT, $mapping['strategy']);
+    }
 }
 
 class TestCustomRepositoryClass extends DocumentRepository


### PR DESCRIPTION
This fixes a regression introduced in #1352 where using the now deprecated `Increment` type would cause a `MappingException`.