### PR TITLE
Removed redundant parens and incorrect double-quote usage.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -302,8 +302,8 @@ class DocumentManager implements ObjectManager
 
         $metadata = $this->metadataFactory->getMetadataFor($className);
         $db = $metadata->getDatabase();
-        $db = $db ? $db : $this->config->getDefaultDB();
-        $db = $db ? $db : 'doctrine';
+        $db = $db ?: $this->config->getDefaultDB();
+        $db = $db ?: 'doctrine';
         $this->documentDatabases[$className] = $this->connection->selectDatabase($db);
 
         return $this->documentDatabases[$className];

--- a/lib/Doctrine/ODM/MongoDB/Id/AlnumGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Id/AlnumGenerator.php
@@ -84,14 +84,14 @@ class AlnumGenerator extends IncrementGenerator
         $index = $this->awkwardSafeMode ? $this->awkwardSafeChars : $this->chars;
         $base  = strlen($index);
 
-        $out = "";
+        $out = '';
         do {
             $out = $index[bcmod($id, $base)] . $out;
             $id = bcdiv($id, $base);
         } while (bccomp($id, 0) == 1);
 
         if (is_numeric($this->pad)) {
-            $out = str_pad($out, $this->pad, "0", STR_PAD_LEFT);
+            $out = str_pad($out, $this->pad, '0', STR_PAD_LEFT);
         }
 
         return $out;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -268,7 +268,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             case ClassMetadata::GENERATOR_TYPE_NONE;
                 break;
             default:
-                throw new MappingException("Unknown generator type: " . $class->generatorType);
+                throw new MappingException('Unknown generator type: ' . $class->generatorType);
         }
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -109,7 +109,7 @@ class MappingException extends BaseMappingException
     {
         return new self(
             "Document class '$className' used in the discriminator map of class '$owningClass' " .
-            "does not exist."
+            'does not exist.'
         );
     }
 
@@ -164,7 +164,7 @@ class MappingException extends BaseMappingException
     public static function identifierRequired($documentName)
     {
         return new self("No identifier/primary key specified for Document '$documentName'."
-            . " Every Document must have an identifier/primary key.");
+            . ' Every Document must have an identifier/primary key.');
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/MongoDBException.php
+++ b/lib/Doctrine/ODM/MongoDB/MongoDBException.php
@@ -129,7 +129,7 @@ class MongoDBException extends \Exception
     public static function invalidValueForType($type, $expected, $got)
     {
         if (is_array($expected)) {
-            $expected = sprintf("%s or %s",
+            $expected = sprintf('%s or %s',
                 join(', ', array_slice($expected, 0, -1)),
                 end($expected)
             );

--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -108,7 +108,7 @@ class CollectionPersister
             case ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET:
             case ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET_ARRAY:
                 throw new \UnexpectedValueException($mapping['strategy'] . ' update collection strategy should have been handled by DocumentPersister. Please report a bug in issue tracker');
-            
+
             case ClassMetadataInfo::STORAGE_STRATEGY_SET:
             case ClassMetadataInfo::STORAGE_STRATEGY_SET_ARRAY:
                 $this->setCollection($coll, $options);
@@ -273,7 +273,7 @@ class CollectionPersister
         }
         $collection = $this->dm->getDocumentCollection($className);
         $result = $collection->update($query, $newObj, $options);
-        if (($class->isVersioned) && ! $result['n']) {
+        if ($class->isVersioned && ! $result['n']) {
             throw LockException::lockFailed($document);
         }
     }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -290,7 +290,7 @@ class DocumentPersister
                 }
                 $data['$set'][$versionMapping['name']] = $nextVersion;
             }
-            
+
             try {
                 $this->executeUpsert($data, $options);
                 $this->handleCollections($document, $options);
@@ -319,7 +319,7 @@ class DocumentPersister
             unset($data['$set']);
         }
 
-        /* If there are no modifiers remaining, we're upserting a document with 
+        /* If there are no modifiers remaining, we're upserting a document with
          * an identifier as its only field. Since a document with the identifier
          * may already exist, the desired behavior is "insert if not exists" and
          * NOOP otherwise. MongoDB 2.6+ does not allow empty modifiers, so $set
@@ -776,7 +776,7 @@ class DocumentPersister
     private function loadReferenceManyWithRepositoryMethod(PersistentCollection $collection)
     {
         $cursor = $this->createReferenceManyWithRepositoryMethodCursor($collection);
-        $mapping = $collection->getMapping();        
+        $mapping = $collection->getMapping();
         $documents = $cursor->toArray(false);
         foreach ($documents as $key => $obj) {
             if (CollectionHelper::isHash($mapping['strategy'])) {
@@ -871,7 +871,7 @@ class DocumentPersister
          */
         if ($this->class->hasDiscriminator() && ! isset($preparedQuery[$this->class->discriminatorField])) {
             $discriminatorValues = $this->getClassDiscriminatorValues($this->class);
-            if ((count($discriminatorValues) === 1)) {
+            if (count($discriminatorValues) === 1) {
                 $preparedQuery[$this->class->discriminatorField] = $discriminatorValues[0];
             } else {
                 $preparedQuery[$this->class->discriminatorField] = array('$in' => $discriminatorValues);
@@ -1244,7 +1244,7 @@ class DocumentPersister
         }
 
         // If a defaultDiscriminatorValue is set and it is among the discriminators being queries, add NULL to the list
-        if ($metadata->defaultDiscriminatorValue && (array_search($metadata->defaultDiscriminatorValue, $discriminatorValues)) !== false) {
+        if ($metadata->defaultDiscriminatorValue && array_search($metadata->defaultDiscriminatorValue, $discriminatorValues) !== false) {
             $discriminatorValues[] = null;
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -391,7 +391,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
             $discriminatorValues = $this->getDiscriminatorValues($documentNames);
 
             // If a defaultDiscriminatorValue is set and it is among the discriminators being queries, add NULL to the list
-            if ($metadata->defaultDiscriminatorValue && (array_search($metadata->defaultDiscriminatorValue, $discriminatorValues)) !== false) {
+            if ($metadata->defaultDiscriminatorValue && array_search($metadata->defaultDiscriminatorValue, $discriminatorValues) !== false) {
                 $discriminatorValues[] = null;
             }
 

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -425,7 +425,7 @@ class SchemaManager
         if ($class->isMappedSuperclass || $class->isEmbeddedDocument) {
             throw new \InvalidArgumentException('Cannot delete document indexes for mapped super classes or embedded documents.');
         }
-        $this->dm->getDocumentDatabase($documentName)->execute("function() { return true; }");
+        $this->dm->getDocumentDatabase($documentName)->execute('function() { return true; }');
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -59,7 +59,7 @@ EOT
         }
 
         if ($cacheDriver instanceof \Doctrine\Common\Cache\ApcCache) {
-            throw new \LogicException("Cannot clear APC Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
+            throw new \LogicException('Cannot clear APC Cache from Console, its shared in the Webserver memory and not accessible from the CLI.');
         }
 
         $output->write('Clearing ALL Metadata cache entries' . PHP_EOL);

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
@@ -81,7 +81,7 @@ class CreateCommand extends AbstractCommand
             }
         }
 
-        return ($isErrored) ? 255 : 0;
+        return $isErrored ? 255 : 0;
     }
 
     protected function processDocumentCollection(SchemaManager $sm, $document)

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
@@ -74,7 +74,7 @@ class DropCommand extends AbstractCommand
             }
         }
 
-        return ($isErrored) ? 255 : 0;
+        return $isErrored ? 255 : 0;
     }
 
     protected function processDocumentCollection(SchemaManager $sm, $document)

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
@@ -66,7 +66,7 @@ class UpdateCommand extends AbstractCommand
             $isErrored = true;
         }
 
-        return ($isErrored) ? 255 : 0;
+        return $isErrored ? 255 : 0;
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Tools/DisconnectedClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/DisconnectedClassMetadataFactory.php
@@ -41,7 +41,7 @@ class DisconnectedClassMetadataFactory extends ClassMetadataFactory
         if (strpos($className, "\\") !== false) {
             $metadata->namespace = strrev(substr( strrev($className), strpos(strrev($className), "\\")+1 ));
         } else {
-            $metadata->namespace = "";
+            $metadata->namespace = '';
         }
         return $metadata;
     }

--- a/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
@@ -187,7 +187,7 @@ public function <methodName>()
         if ($this->backupExisting && file_exists($path)) {
             $backupPath = dirname($path) . DIRECTORY_SEPARATOR . basename($path) . '~';
             if ( ! copy($path, $backupPath)) {
-                throw new \RuntimeException("Attempt to backup overwritten document file but copy operation failed.");
+                throw new \RuntimeException('Attempt to backup overwritten document file but copy operation failed.');
             }
         }
 
@@ -220,7 +220,7 @@ public function <methodName>()
 
         $replacements = array(
             $this->generateDocumentNamespace($metadata),
-            $this->generateDocumentImports($metadata),
+            $this->generateDocumentImports(),
             $this->generateDocumentDocBlock($metadata),
             $this->generateDocumentClassName($metadata),
             $this->generateDocumentBody($metadata)
@@ -389,7 +389,7 @@ public function <methodName>()
             }
         }
         if ($collections) {
-            return $this->prefixCodeWithSpaces(str_replace("<collections>", $this->spaces . implode("\n" . $this->spaces, $collections), self::$constructorMethodTemplate));
+            return $this->prefixCodeWithSpaces(str_replace('<collections>', $this->spaces . implode("\n" . $this->spaces, $collections), self::$constructorMethodTemplate));
         }
         return '';
     }
@@ -566,7 +566,7 @@ public function <methodName>()
             if ($metadata->indexes) {
                 $indexes = array();
                 $indexLines = array();
-                $indexLines[] = " *     indexes={";
+                $indexLines[] = ' *     indexes={';
                 foreach ($metadata->indexes as $index) {
                     $keys = array();
                     foreach ($index['keys'] as $key => $value) {
@@ -739,7 +739,7 @@ public function <methodName>()
                 continue;
             }
 
-            $lines[] = $this->generateAssociationMappingPropertyDocBlock($fieldMapping, $metadata);
+            $lines[] = $this->generateAssociationMappingPropertyDocBlock($fieldMapping);
             $lines[] = $this->spaces . 'protected $' . $fieldMapping['fieldName']
                 . ($fieldMapping['type'] === ClassMetadataInfo::MANY ? ' = array()' : null) . ";\n";
         }
@@ -926,7 +926,7 @@ public function <methodName>()
                     foreach ($fieldMapping['options'] as $key => $value) {
                         $options[] = '"' . $key . '" = "' . $value . '"';
                     }
-                    $field[] = "options={" . implode(', ', $options) . "}";
+                    $field[] = 'options={' . implode(', ', $options) . '}';
                 }
                 $lines[] = $this->spaces . ' * @ODM\\Field(' . implode(', ', $field) . ')';
             }

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -174,10 +174,10 @@ class UnitOfWork implements PropertyChangedListener
      * @var array
      */
     private $collectionUpdates = array();
-    
+
     /**
      * A list of documents related to collections scheduled for update or deletion
-     * 
+     *
      * @var array
      */
     private $hasScheduledCollections = array();
@@ -451,7 +451,7 @@ class UnitOfWork implements PropertyChangedListener
         $this->collectionDeletions =
         $this->visitedCollections =
         $this->scheduledForDirtyCheck =
-        $this->orphanRemovals = 
+        $this->orphanRemovals =
         $this->hasScheduledCollections = array();
     }
 
@@ -538,7 +538,7 @@ class UnitOfWork implements PropertyChangedListener
         $state = $this->getDocumentState($document);
 
         if ($state !== self::STATE_MANAGED && $state !== self::STATE_REMOVED) {
-            throw new \InvalidArgumentException("Document has to be managed or scheduled for removal for single computation " . $this->objToStr($document));
+            throw new \InvalidArgumentException('Document has to be managed or scheduled for removal for single computation ' . $this->objToStr($document));
         }
 
         $class = $this->dm->getClassMetadata(get_class($document));
@@ -804,7 +804,7 @@ class UnitOfWork implements PropertyChangedListener
                 $changeSet[$propName] = array($orgValue, $actualValue);
             }
             if ($changeSet) {
-                $this->documentChangeSets[$oid] = (isset($this->documentChangeSets[$oid]))
+                $this->documentChangeSets[$oid] = isset($this->documentChangeSets[$oid])
                     ? $changeSet + $this->documentChangeSets[$oid]
                     : $changeSet;
 
@@ -964,10 +964,10 @@ class UnitOfWork implements PropertyChangedListener
             switch ($state) {
                 case self::STATE_NEW:
                     if ( ! $assoc['isCascadePersist']) {
-                        throw new \InvalidArgumentException("A new document was found through a relationship that was not"
-                            . " configured to cascade persist operations: " . $this->objToStr($entry) . "."
-                            . " Explicitly persist the new document or configure cascading persist operations"
-                            . " on the relationship.");
+                        throw new \InvalidArgumentException('A new document was found through a relationship that was not'
+                            . ' configured to cascade persist operations: ' . $this->objToStr($entry) . '.'
+                            . ' Explicitly persist the new document or configure cascading persist operations'
+                            . ' on the relationship.');
                     }
 
                     $this->persistNew($targetClass, $entry);
@@ -1005,8 +1005,8 @@ class UnitOfWork implements PropertyChangedListener
                 case self::STATE_DETACHED:
                     // Can actually not happen right now as we assume STATE_NEW,
                     // so the exception will be raised from the DBAL layer (constraint violation).
-                    throw new \InvalidArgumentException("A detached document was found through a "
-                        . "relationship during cascading a persist operation.");
+                    throw new \InvalidArgumentException('A detached document was found through a '
+                        . 'relationship during cascading a persist operation.');
 
                 default:
                     // MANAGED associated documents are already taken into account
@@ -1066,14 +1066,14 @@ class UnitOfWork implements PropertyChangedListener
 
             if ($class->generatorType === ClassMetadata::GENERATOR_TYPE_NONE && $idValue === null) {
                 throw new \InvalidArgumentException(sprintf(
-                    "%s uses NONE identifier generation strategy but no identifier was provided when persisting.",
+                    '%s uses NONE identifier generation strategy but no identifier was provided when persisting.',
                     get_class($document)
                 ));
             }
 
             if ($class->generatorType === ClassMetadata::GENERATOR_TYPE_AUTO && $idValue !== null && ! \MongoId::isValid($idValue)) {
                 throw new \InvalidArgumentException(sprintf(
-                    "%s uses AUTO identifier generation strategy but provided identifier is not valid MongoId.",
+                    '%s uses AUTO identifier generation strategy but provided identifier is not valid MongoId.',
                     get_class($document)
                 ));
             }
@@ -1225,13 +1225,13 @@ class UnitOfWork implements PropertyChangedListener
         $oid = spl_object_hash($document);
 
         if (isset($this->documentUpdates[$oid])) {
-            throw new \InvalidArgumentException("Dirty document can not be scheduled for insertion.");
+            throw new \InvalidArgumentException('Dirty document can not be scheduled for insertion.');
         }
         if (isset($this->documentDeletions[$oid])) {
-            throw new \InvalidArgumentException("Removed document can not be scheduled for insertion.");
+            throw new \InvalidArgumentException('Removed document can not be scheduled for insertion.');
         }
         if (isset($this->documentInsertions[$oid])) {
-            throw new \InvalidArgumentException("Document can not be scheduled for insertion twice.");
+            throw new \InvalidArgumentException('Document can not be scheduled for insertion twice.');
         }
 
         $this->documentInsertions[$oid] = $document;
@@ -1254,16 +1254,16 @@ class UnitOfWork implements PropertyChangedListener
         $oid = spl_object_hash($document);
 
         if ($class->isEmbeddedDocument) {
-            throw new \InvalidArgumentException("Embedded document can not be scheduled for upsert.");
+            throw new \InvalidArgumentException('Embedded document can not be scheduled for upsert.');
         }
         if (isset($this->documentUpdates[$oid])) {
-            throw new \InvalidArgumentException("Dirty document can not be scheduled for upsert.");
+            throw new \InvalidArgumentException('Dirty document can not be scheduled for upsert.');
         }
         if (isset($this->documentDeletions[$oid])) {
-            throw new \InvalidArgumentException("Removed document can not be scheduled for upsert.");
+            throw new \InvalidArgumentException('Removed document can not be scheduled for upsert.');
         }
         if (isset($this->documentUpserts[$oid])) {
-            throw new \InvalidArgumentException("Document can not be scheduled for upsert twice.");
+            throw new \InvalidArgumentException('Document can not be scheduled for upsert twice.');
         }
 
         $this->documentUpserts[$oid] = $document;
@@ -1303,11 +1303,11 @@ class UnitOfWork implements PropertyChangedListener
     {
         $oid = spl_object_hash($document);
         if ( ! isset($this->documentIdentifiers[$oid])) {
-            throw new \InvalidArgumentException("Document has no identity.");
+            throw new \InvalidArgumentException('Document has no identity.');
         }
 
         if (isset($this->documentDeletions[$oid])) {
-            throw new \InvalidArgumentException("Document is removed.");
+            throw new \InvalidArgumentException('Document is removed.');
         }
 
         if ( ! isset($this->documentUpdates[$oid])
@@ -1471,7 +1471,7 @@ class UnitOfWork implements PropertyChangedListener
 
         // Check for a version field, if available, to avoid a DB lookup.
         if ($class->isVersioned) {
-            return ($class->getFieldValue($document, $class->versionField))
+            return $class->getFieldValue($document, $class->versionField)
                 ? self::STATE_DETACHED
                 : self::STATE_NEW;
         }
@@ -1690,7 +1690,7 @@ class UnitOfWork implements PropertyChangedListener
 
             case self::STATE_DETACHED:
                 throw new \InvalidArgumentException(
-                    "Behavior of persist() for a detached document is not yet defined.");
+                    'Behavior of persist() for a detached document is not yet defined.');
 
             default:
                 throw MongoDBException::invalidDocumentState($documentState);
@@ -2041,7 +2041,7 @@ class UnitOfWork implements PropertyChangedListener
                 $id = $class->getDatabaseIdentifierValue($this->documentIdentifiers[$oid]);
                 $this->getDocumentPersister($class->name)->refresh($id, $document);
             } else {
-                throw new \InvalidArgumentException("Document is not MANAGED.");
+                throw new \InvalidArgumentException('Document is not MANAGED.');
             }
         }
 
@@ -2093,7 +2093,7 @@ class UnitOfWork implements PropertyChangedListener
                 continue;
             }
             $relatedDocuments = $class->reflFields[$mapping['fieldName']]->getValue($document);
-            if (($relatedDocuments instanceof Collection || is_array($relatedDocuments))) {
+            if ($relatedDocuments instanceof Collection || is_array($relatedDocuments)) {
                 if ($relatedDocuments instanceof PersistentCollection) {
                     // Unwrap so that foreach() does not initialize
                     $relatedDocuments = $relatedDocuments->unwrap();
@@ -2217,7 +2217,7 @@ class UnitOfWork implements PropertyChangedListener
             }
 
             $relatedDocuments = $class->reflFields[$mapping['fieldName']]->getValue($document);
-            if (($relatedDocuments instanceof Collection || is_array($relatedDocuments))) {
+            if ($relatedDocuments instanceof Collection || is_array($relatedDocuments)) {
                 // If its a PersistentCollection initialization is intended! No unwrap!
                 foreach ($relatedDocuments as $relatedDocument) {
                     $this->doRemove($relatedDocument, $visited);
@@ -2240,7 +2240,7 @@ class UnitOfWork implements PropertyChangedListener
     public function lock($document, $lockMode, $lockVersion = null)
     {
         if ($this->getDocumentState($document) != self::STATE_MANAGED) {
-            throw new \InvalidArgumentException("Document is not MANAGED.");
+            throw new \InvalidArgumentException('Document is not MANAGED.');
         }
 
         $documentName = get_class($document);
@@ -2298,7 +2298,7 @@ class UnitOfWork implements PropertyChangedListener
             $this->collectionUpdates =
             $this->collectionDeletions =
             $this->parentAssociations =
-            $this->orphanRemovals = 
+            $this->orphanRemovals =
             $this->hasScheduledCollections = array();
         } else {
             $visited = array();
@@ -2405,11 +2405,11 @@ class UnitOfWork implements PropertyChangedListener
     {
         return isset($this->collectionDeletions[spl_object_hash($coll)]);
     }
-    
+
     /**
      * INTERNAL:
      * Unschedules a collection from being deleted when this UnitOfWork commits.
-     * 
+     *
      * @param \Doctrine\ODM\MongoDB\PersistentCollection $coll
      */
     public function unscheduleCollectionDeletion(PersistentCollection $coll)
@@ -2443,11 +2443,11 @@ class UnitOfWork implements PropertyChangedListener
             $this->scheduleCollectionOwner($coll);
         }
     }
-    
+
     /**
      * INTERNAL:
      * Unschedules a collection from being updated when this UnitOfWork commits.
-     * 
+     *
      * @param \Doctrine\ODM\MongoDB\PersistentCollection $coll
      */
     public function unscheduleCollectionUpdate(PersistentCollection $coll)
@@ -2459,7 +2459,7 @@ class UnitOfWork implements PropertyChangedListener
             unset($this->hasScheduledCollections[spl_object_hash($topmostOwner)][$oid]);
         }
     }
-    
+
     /**
      * Checks whether a PersistentCollection is scheduled for update.
      *
@@ -2486,22 +2486,22 @@ class UnitOfWork implements PropertyChangedListener
                 ? $this->visitedCollections[$oid]
                 : array();
     }
-    
+
     /**
      * INTERNAL:
      * Gets PersistentCollections that are scheduled to update and related to $document
-     * 
+     *
      * @param object $document
      * @return array
      */
     public function getScheduledCollections($document)
     {
         $oid = spl_object_hash($document);
-        return isset($this->hasScheduledCollections[$oid]) 
+        return isset($this->hasScheduledCollections[$oid])
                 ? $this->hasScheduledCollections[$oid]
                 : array();
     }
-    
+
     /**
      * Checks whether the document is related to a PersistentCollection
      * scheduled for update or deletion.
@@ -2513,7 +2513,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         return isset($this->hasScheduledCollections[spl_object_hash($document)]);
     }
-    
+
     /**
      * Marks the PersistentCollection's top-level owner as having a relation to
      * a collection scheduled for update or deletion.
@@ -2524,7 +2524,7 @@ class UnitOfWork implements PropertyChangedListener
      * If the collection is nested within atomic collection, it is immediately
      * unscheduled and atomic one is scheduled for update instead. This makes
      * calculating update data way easier.
-     * 
+     *
      * @param PersistentCollection $coll
      */
     private function scheduleCollectionOwner(PersistentCollection $coll)
@@ -2569,7 +2569,7 @@ class UnitOfWork implements PropertyChangedListener
             $parentAssociation = $this->getParentAssociation($document);
 
             if ( ! $parentAssociation) {
-                throw new \UnexpectedValueException("Could not determine parent association for " . get_class($document));
+                throw new \UnexpectedValueException('Could not determine parent association for ' . get_class($document));
             }
 
             list(, $document, ) = $parentAssociation;


### PR DESCRIPTION
Threw in ternary shorthand as a bonus. This feature was introduced in PHP 5.3 so no reason not to use it.