### PR TITLE
Introduce postCollectionLoad event

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -182,6 +182,10 @@ the life-time of their registered documents.
 -
    documentNotFound - The documentNotFound event occurs when a proxy object
    could not be initialized. This event is not a lifecycle callback.
+-
+   postCollectionLoad - The postCollectionLoad event occurs just after
+   collection has been initialized (loaded) and before new elements
+   are re-added to it.
 
 You can access the Event constants from the ``Events`` class in the
 ODM package.
@@ -623,6 +627,38 @@ Define the ``EventTest`` class with a ``postUpdate()``, ``postRemove()`` and ``p
         {
         }
     }
+
+postCollectionLoad
+~~~~~~~~~~~~~~~~~~
+
+.. note::
+    This event was introduced in version 1.1
+
+.. code-block:: php
+
+    <?php
+
+    $test = new EventTest();
+    $evm = $dm->getEventManager();
+    $evm->addEventListener(Events::postCollectionLoad, $test);
+
+Define the ``EventTest`` class with a ``postCollectionLoad()`` method:
+
+.. code-block:: php
+
+    <?php
+
+    class EventTest
+    {
+        public function postCollectionLoad(\Doctrine\ODM\MongoDB\Event\PostCollectionLoadEventArgs $eventArgs)
+        {
+            $collection = $eventArgs->getCollection();
+            if ($collection instanceof \Malarzm\Collections\DiffableCollection) {
+                $collection->snapshot();
+            }
+        }
+    }
+
 
 Load ClassMetadata Event
 ------------------------

--- a/lib/Doctrine/ODM/MongoDB/Event/PostCollectionLoadEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PostCollectionLoadEventArgs.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Event;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
+
+/**
+ * Class that holds arguments for postCollectionLoad event.
+ * 
+ * @since 1.1
+ */
+class PostCollectionLoadEventArgs extends ManagerEventArgs
+{
+    /**
+     * @var PersistentCollectionInterface
+     */
+    private $collection;
+
+    /**
+     * @param PersistentCollectionInterface $collection
+     * @param DocumentManager $dm
+     */
+    public function __construct(PersistentCollectionInterface $collection, DocumentManager $dm)
+    {
+        parent::__construct($dm);
+        $this->collection = $collection;
+    }
+
+    /**
+     * Gets collection that was just initialized (loaded).
+     *
+     * @return PersistentCollectionInterface
+     */
+    public function getCollection()
+    {
+        return $this->collection;
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Events.php
+++ b/lib/Doctrine/ODM/MongoDB/Events.php
@@ -169,4 +169,11 @@ final class Events
      * @var string
      */
     const documentNotFound = 'documentNotFound';
+
+    /**
+     * The postCollectionLoad event occurs after collection is initialized (loaded).
+     *
+     * @var string
+     */
+    const postCollectionLoad = 'postCollectionLoad';
 }

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -455,7 +455,7 @@ trait PersistentCollectionTrait
                 : $documentPersister->createReferenceManyWithRepositoryMethodCursor($this)->count();
         }
 
-        return count($this->mongoData) + $count;
+        return $count + ($this->initialized ? 0 : count($this->mongoData));
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2710,6 +2710,7 @@ class UnitOfWork implements PropertyChangedListener
     public function loadCollection(PersistentCollectionInterface $collection)
     {
         $this->getDocumentPersister(get_class($collection->getOwner()))->loadCollection($collection);
+        $this->lifecycleEventManager->postCollectionLoad($collection);
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
+++ b/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
@@ -23,9 +23,11 @@ use Doctrine\Common\EventManager;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Event\DocumentNotFoundEventArgs;
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
+use Doctrine\ODM\MongoDB\Event\PostCollectionLoadEventArgs;
 use Doctrine\ODM\MongoDB\Event\PreUpdateEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 
 /**
@@ -72,6 +74,12 @@ class LifecycleEventManager
         $this->evm->dispatchEvent(Events::documentNotFound, $eventArgs);
 
         return $eventArgs->isExceptionDisabled();
+    }
+
+    public function postCollectionLoad(PersistentCollectionInterface $coll)
+    {
+        $eventArgs = new PostCollectionLoadEventArgs($coll, $this->dm);
+        $this->evm->dispatchEvent(Events::postCollectionLoad, $eventArgs);
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
+++ b/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
@@ -76,6 +76,11 @@ class LifecycleEventManager
         return $eventArgs->isExceptionDisabled();
     }
 
+    /**
+     * Dispatches postCollectionLoad event.
+     *
+     * @param PersistentCollectionInterface $coll
+     */
     public function postCollectionLoad(PersistentCollectionInterface $coll)
     {
         $eventArgs = new PostCollectionLoadEventArgs($coll, $this->dm);


### PR DESCRIPTION
This event will effectively allow developer to implement own change tracking in collections as event is dispatched after UoW loads collection but before re-adding new elements (same time as `PersistentCollection` takes its snapshot).

- [x] dispatch event
- [x] ~~annotated callback~~ it's too hacky to introduce with current `ClassMetadata` :(
- [x] docs