### PR TITLE
Fix broken conversion of microseconds less than 100000.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/DateType.php
@@ -42,14 +42,15 @@ class DateType extends Type
         if ($value instanceof \DateTime || $value instanceof \DateTimeInterface) {
             return $value;
         } elseif ($value instanceof \MongoDate) {
-            $datetime = static::craftDateTime($value->sec, $value->usec);
+            $microseconds = str_pad($value->usec, 6, '0', STR_PAD_LEFT); // ensure microseconds
+            $datetime = static::craftDateTime($value->sec, $microseconds);
         } elseif (is_numeric($value)) {
             $seconds = $value;
             $microseconds = 0;
 
             if (false !== strpos($value, '.')) {
                 list($seconds, $microseconds) = explode('.', $value);
-                $microseconds = (int) str_pad((int) $microseconds, 6, '0'); // ensure microseconds
+                $microseconds = str_pad($microseconds, 6, '0'); // ensure microseconds
             }
 
             $datetime = static::craftDateTime($seconds, $microseconds);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
@@ -6,6 +6,19 @@ use Doctrine\ODM\MongoDB\Types\Type;
 
 class DateTypeTest extends \PHPUnit_Framework_TestCase
 {
+    public function testGetDateTime()
+    {
+        $type = Type::getType(Type::DATE);
+
+        $timestamp = 100000000.001;
+        $dateTime = $type->getDateTime($timestamp);
+        $this->assertEquals($timestamp, $dateTime->format('U.u'));
+
+        $mongoDate = new \MongoDate(100000000, 1000);
+        $dateTime = $type->getDateTime($mongoDate);
+        $this->assertEquals($timestamp, $dateTime->format('U.u'));
+    }
+
     public function testConvertToDatabaseValue()
     {
         $type = Type::getType(Type::DATE);


### PR DESCRIPTION
Dates with microsecond values less than 100000 are not correctly converted to PHP objects.

When converting from MongoDate objects, the `usec` field returns an integer that is concatenated directly to a string formated date in `craftDateTime`. For example, the value 1.0001 gets split into 1 second and 100 microseconds, which then gets concatenated as "1.100".

When converting numeric values, the sub-seconds are broken into a string which is then padded to six values; however, it is casted to an int first. For example, 1.0001 gets split into a string "0001" which is cast to the integer 1 and padded to "100000", resulting in "1.100000".

In order to properly convert microseconds, they are string padded without converting to an integer.