### PR TITLE
Require latest stable version of doctrine/mongodb

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "^5.5 || ^7.0",
-        "ext-mongo": "^1.5",
         "symfony/console": "~2.3|~3.0",
         "doctrine/annotations": "~1.0",
         "doctrine/collections": "~1.1",
@@ -23,7 +22,7 @@
         "doctrine/cache": "~1.0",
         "doctrine/inflector": "~1.0",
         "doctrine/instantiator": "~1.0.1",
-        "doctrine/mongodb": "~1.2"
+        "doctrine/mongodb": "~1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8|~5.0",


### PR DESCRIPTION
This removes the need for the extra driver requirement in composer.json and brings driver and PHP versions for both packages to the same requirement.