### PR TITLE
Fixed targetDocument types to match property names and annotations

### DIFF
--- a/tests/Documents/Functional/SimpleEmbedAndReference.php
+++ b/tests/Documents/Functional/SimpleEmbedAndReference.php
@@ -10,15 +10,15 @@ class SimpleEmbedAndReference
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedMany(targetDocument="Reference") */
+    /** @ODM\EmbedMany(targetDocument="Embedded") */
     public $embedMany = array();
 
-    /** @ODM\ReferenceMany(targetDocument="Embedded") */
+    /** @ODM\ReferenceMany(targetDocument="Reference") */
     public $referenceMany = array();
 
-    /** @ODM\EmbedOne(targetDocument="Reference") */
+    /** @ODM\EmbedOne(targetDocument="Embedded") */
     public $embedOne;
 
-    /** @ODM\ReferenceOne(targetDocument="Embedded") */
+    /** @ODM\ReferenceOne(targetDocument="Reference") */
     public $referenceOne;
 }


### PR DESCRIPTION
A test document class ``SimpleEmbedAndReference`` contained ``targetDocument`` settings that did not match property and annotations, this PR fixes them. The only test method that actually uses the document is ``FunctionalTest::testSimplerEmbedAndReference`` that only checks the association type, not actually whether it's embedded or referenced.