### PR TITLE
Add PHP 7 to the build matrix using polyfill

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,22 @@ env:
     - MONGO_VERSION=1.5.8
     - MONGO_VERSION=stable
 
+matrix:
+  include:
+    - php: 7.0
+      env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable
+
+
 services: mongodb
 
 before_script:
-  - yes '' | pecl -q install -f mongo-${MONGO_VERSION} && echo "extension=mongo.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
+  - if [ "x${MONGO_VERSION}" != "x" ]; then yes '' | pecl -q install -f mongo-${MONGO_VERSION} && echo "extension=mongo.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi
   - sudo pip install mongo-orchestration
   - sudo mongo-orchestration start
   - curl -XPUT http://localhost:8889/v1/sharded_clusters/myCluster --data @tests/sharded.json | python -m json.tool
   - composer self-update
+  - if [ "x${MONGODB_VERSION}" != "x" ]; then pecl install -f mongodb-${MONGODB_VERSION}; fi
+  - if [ "x${ADAPTER_VERSION}" != "x" ]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
   - composer install --dev
 
 script:


### PR DESCRIPTION
While composer.json has allowed installing on PHP 7 for a while (given that the `ext-mongo` requirement is fulfilled), there were no tests for that platform. This PR adds alcaeus/mongo-php-adapter as polyfill to the PHP 7 version of the build matrix.

Note: due to a [bug with composer](https://github.com/composer/composer/issues/5030) the build step installing the polyfill is running with the `ignore-platform-reqs` flag. Once this bug is fixed the flag should be removed.