### PR TITLE
Add option to fetch documents as Read-Only

### DIFF
--- a/docs/en/reference/query-builder-api.rst
+++ b/docs/en/reference/query-builder-api.rst
@@ -216,6 +216,32 @@ changeset will be reset in the process.
 
 Refreshing is not applicable if hydration is disabled.
 
+Fetching Documents as Read-Only
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Similar to ``refresh()``, ``readOnly()`` instructs ODM to not only hydrate the
+latest data but also to create new document's instance (i.e. if found document
+would be already managed by Doctrine, new instance will be returned) and not
+register it in ``UnitOfWork``.
+
+This technique can prove especially useful when using ``select()`` with no intent
+to update fetched documents.
+
+.. code-block:: php
+
+    <?php
+
+    $user = $dm->createQueryBuilder('User')
+        ->field('username')->equals('malarzm')
+        ->readOnly()
+        ->getQuery()
+        ->getSingleResult();
+
+    // Maciej's user will have the latest data, and will not be the same object
+    // as the one that was already managed (if it was)
+
+Read-Only is not applicable if hydration is disabled.
+
 Disabling Hydration
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/en/reference/query-builder-api.rst
+++ b/docs/en/reference/query-builder-api.rst
@@ -242,6 +242,13 @@ to update fetched documents.
 
 Read-Only is not applicable if hydration is disabled.
 
+.. note::
+
+    Read-only mode is not deep, i.e. any references (be it owning or inverse) of
+    fetched WILL be managed by Doctrine. This is a shortcoming of current
+    implementation, may change in future and will not be considered a BC break
+    (will be treated as a feature instead).
+
 Disabling Hydration
 ~~~~~~~~~~~~~~~~~~~
 

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -342,7 +342,9 @@ EOF
             \$embeddedData = \$this->dm->getHydratorFactory()->hydrate(\$return, \$embeddedDocument, \$hints);
             \$embeddedId = \$embeddedMetadata->identifier && isset(\$embeddedData[\$embeddedMetadata->identifier]) ? \$embeddedData[\$embeddedMetadata->identifier] : null;
 
-            \$this->unitOfWork->registerManaged(\$return, \$embeddedId, \$embeddedData);
+            if (empty(\$hints[Query::HINT_READ_ONLY])) {
+                \$this->unitOfWork->registerManaged(\$return, \$embeddedId, \$embeddedData);
+            }
 
             \$this->class->reflFields['%2\$s']->setValue(\$document, \$return);
             \$hydratedData['%2\$s'] = \$return;
@@ -365,6 +367,7 @@ namespace $namespace;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Hydrator\HydratorInterface;
+use Doctrine\ODM\MongoDB\Query\Query;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -643,12 +643,14 @@ class DocumentPersister
 
                 $this->uow->setParentAssociation($embeddedDocumentObject, $mapping, $owner, $mapping['name'] . '.' . $key);
 
-                $data = $this->hydratorFactory->hydrate($embeddedDocumentObject, $embeddedDocument);
+                $data = $this->hydratorFactory->hydrate($embeddedDocumentObject, $embeddedDocument, $collection->getHints());
                 $id = $embeddedMetadata->identifier && isset($data[$embeddedMetadata->identifier])
                     ? $data[$embeddedMetadata->identifier]
                     : null;
-
-                $this->uow->registerManaged($embeddedDocumentObject, $id, $data);
+                
+                if (empty($collection->getHints()[Query::HINT_READ_ONLY])) {
+                    $this->uow->registerManaged($embeddedDocumentObject, $id, $data);
+                }
                 if (CollectionHelper::isHash($mapping['strategy'])) {
                     $collection->set($key, $embeddedDocumentObject);
                 } else {

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -81,6 +81,13 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     private $requireIndexes;
 
     /**
+     * Whether or not to register documents in UnitOfWork.
+     *
+     * @var bool
+     */
+    private $readOnly;
+
+    /**
      * Construct a Builder
      *
      * @param DocumentManager $dm
@@ -179,6 +186,16 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function hydrate($bool = true)
     {
         $this->hydrate = $bool;
+        return $this;
+    }
+
+    /**
+     * @param bool $bool
+     * @return $this
+     */
+    public function readOnly($bool = true)
+    {
+        $this->readOnly = $bool;
         return $this;
     }
 
@@ -358,7 +375,8 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
             $this->hydrate,
             $this->refresh,
             $this->primers,
-            $this->requireIndexes
+            $this->requireIndexes,
+            $this->readOnly
         );
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -40,6 +40,7 @@ class Query extends \Doctrine\MongoDB\Query\Query
     const HINT_SLAVE_OKAY = 2;
     const HINT_READ_PREFERENCE = 3;
     const HINT_READ_PREFERENCE_TAGS = 4;
+    const HINT_READ_ONLY = 5;
 
     /**
      * The DocumentManager instance.

--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -96,8 +96,9 @@ class Query extends \Doctrine\MongoDB\Query\Query
      * @param boolean $refresh
      * @param array $primers
      * @param null $requireIndexes
+     * @param boolean $readOnly
      */
-    public function __construct(DocumentManager $dm, ClassMetadata $class, Collection $collection, array $query = array(), array $options = array(), $hydrate = true, $refresh = false, array $primers = array(), $requireIndexes = null)
+    public function __construct(DocumentManager $dm, ClassMetadata $class, Collection $collection, array $query = array(), array $options = array(), $hydrate = true, $refresh = false, array $primers = array(), $requireIndexes = null, $readOnly = false)
     {
         $primers = array_filter($primers);
 
@@ -116,6 +117,7 @@ class Query extends \Doctrine\MongoDB\Query\Query
         $this->primers = $primers;
         $this->requireIndexes = $requireIndexes;
 
+        $this->setReadOnly($readOnly);
         $this->setRefresh($refresh);
 
         if (isset($query['slaveOkay'])) {
@@ -156,6 +158,19 @@ class Query extends \Doctrine\MongoDB\Query\Query
     public function setHydrate($hydrate)
     {
         $this->hydrate = (boolean) $hydrate;
+    }
+
+    /**
+     * Set whether documents should be registered in UnitOfWork. If document would
+     * already be managed it will be left intact and new instance returned.
+     * 
+     * This option has no effect if hydration is disabled.
+     * 
+     * @param boolean $readOnly
+     */
+    public function setReadOnly($readOnly)
+    {
+        $this->unitOfWorkHints[Query::HINT_READ_ONLY] = (boolean) $readOnly;
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2653,6 +2653,12 @@ class UnitOfWork implements PropertyChangedListener
 
             unset($data[$class->discriminatorField]);
         }
+        
+        if (! empty($hints[Query::HINT_READ_ONLY])) {
+            $document = $class->newInstance();
+            $this->hydratorFactory->hydrate($document, $data, $hints);
+            return $document;
+        }
 
         $id = $class->getDatabaseIdentifierValue($data['_id']);
         $serializedId = serialize($id);

--- a/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Query\Query;
 
 class HydratorTest extends BaseTest
 {
@@ -40,6 +41,26 @@ class HydratorTest extends BaseTest
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\PersistentCollection', $user->embedMany);
         $this->assertEquals('jon', $user->embedOne->name);
         $this->assertEquals('jon', $user->embedMany[0]->name);
+    }
+    
+    public function testReadOnly()
+    {
+        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\HydrationClosureUser');
+
+        $user = new HydrationClosureUser();
+        $this->dm->getHydratorFactory()->hydrate($user, [
+            '_id' => 1,
+            'name' => 'maciej',
+            'birthdate' => new \DateTime('1961-01-01'),
+            'embedOne' => ['name' => 'maciej'],
+            'embedMany' => [
+                ['name' => 'maciej']
+            ],
+        ], [ Query::HINT_READ_ONLY => true ]);
+        
+        $this->assertFalse($this->uow->isInIdentityMap($user));
+        $this->assertFalse($this->uow->isInIdentityMap($user->embedOne));
+        $this->assertFalse($this->uow->isInIdentityMap($user->embedMany[0]));
     }
 }
 


### PR DESCRIPTION
This not only fixes #1377 but also exposes `readOnly` as an option for query builder. 

Read-only takes precedence over `refresh` when combined. Document fetched in read-only manner can be `merge`d back into `DocumentManager` at developer's discretion, forbiding such action is out of scope of this PR (IMHO :)