### PR TITLE
Fix the ' needs an Object' exception for simple references

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Expr.php
@@ -94,7 +94,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
             $dbRef = $this->dm->createDBRef($document, $mapping);
 
             if (isset($mapping['simple']) && $mapping['simple']) {
-                $this->query[$mapping['name']]['$elemMatch'] = $dbRef;
+                $this->query[$mapping['name']] = $dbRef;
             } else {
                 $keys = array('ref' => true, 'id' => true, 'db' => true);
 


### PR DESCRIPTION
Bug discovered in #1349 and planned to be solved in #1405, but created this fix for the 1.0.x branch first.