### PR TITLE
Fix for fatal exception if persisted collection was unserialized

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -103,11 +103,6 @@ trait PersistentCollectionTrait
      */
     private $hints = array();
 
-    /**
-     * @var ClassMetadata
-     */
-    private $typeClass;
-
     /** {@inheritdoc} */
     public function setDocumentManager(DocumentManager $dm)
     {
@@ -219,10 +214,6 @@ trait PersistentCollectionTrait
     {
         $this->owner = $document;
         $this->mapping = $mapping;
-
-        if ( ! empty($this->mapping['targetDocument']) && $this->dm) {
-            $this->typeClass = $this->dm->getClassMetadata($this->mapping['targetDocument']);
-        }
     }
 
     /** {@inheritdoc} */
@@ -317,14 +308,16 @@ trait PersistentCollectionTrait
     /** {@inheritdoc} */
     public function getTypeClass()
     {
-        if (empty($this->typeClass)) {
-            if (!$this->dm) {
-                throw new MongoDBException('No DocumentManager is associated with this PersistentCollection, please set one using setDocumentManager');
-            }
-            throw new MongoDBException('Specifying targetDocument is required for the ClassMetadata to be obtained.');
+        switch (true) {
+            case ($this->dm === null):
+                throw new MongoDBException('No DocumentManager is associated with this PersistentCollection, please set one using setDocumentManager method.');
+            case (empty($this->mapping)):
+                throw new MongoDBException('No mapping is associated with this PersistentCollection, please set one using setOwner method.');
+            case (empty($this->mapping['targetDocument'])):
+                throw new MongoDBException('Specifying targetDocument is required for the ClassMetadata to be obtained.');
+            default:
+                return $this->dm->getClassMetadata($this->mapping['targetDocument']);
         }
-
-        return $this->typeClass;
     }
 
     /** {@inheritdoc} */

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -220,7 +220,7 @@ trait PersistentCollectionTrait
         $this->owner = $document;
         $this->mapping = $mapping;
 
-        if ( ! empty($this->mapping['targetDocument'])) {
+        if ( ! empty($this->mapping['targetDocument']) && $this->dm) {
             $this->typeClass = $this->dm->getClassMetadata($this->mapping['targetDocument']);
         }
     }
@@ -318,6 +318,9 @@ trait PersistentCollectionTrait
     public function getTypeClass()
     {
         if (empty($this->typeClass)) {
+            if (!$this->dm) {
+                throw new MongoDBException('No DocumentManager is associated with this PersistentCollection, please set one using setDocumentManager');
+            }
             throw new MongoDBException('Specifying targetDocument is required for the ClassMetadata to be obtained.');
         }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
@@ -22,6 +22,22 @@ class PersistentCollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException \Doctrine\ODM\MongoDB\MongoDBException
+     */
+    public function testSetOwnerWithSerializedCollection()
+    {
+        $collection = new PersistentCollection(new ArrayCollection(), $this->getMockDocumentManager(), $this->getMockUnitOfWork());
+        $owner = new \stdClass();
+
+        $serialized = serialize($collection);
+        /** @var PersistentCollection $unserialized */
+        $unserialized = unserialize($serialized);
+
+        $unserialized->setOwner($owner, array('targetDocument' => '\stdClass'));
+        $unserialized->getTypeClass();
+    }
+
+    /**
      * @param array $expected
      * @param array $snapshot
      * @param \Closure $callback


### PR DESCRIPTION
This builds up on @notrix PR #1390 and changes way `typeClass` is obtained to prevent duplicating code