### PR TITLE
Fix bug when priming references nested in embedded documents

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
@@ -192,7 +192,7 @@ class ReferencePrimer
         }
 
         $mapping = $class->fieldMappings[$e[0]];
-        $e[0] = $mapping['name'];
+        $e[0] = $mapping['fieldName'];
 
         // Case of embedded document(s) to recurse through:
         if ( ! isset($mapping['reference'])) {

--- a/tests/Documents/Functional/EmbedNamed.php
+++ b/tests/Documents/Functional/EmbedNamed.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Documents\Functional;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/** @ODM\Document */
+class EmbedNamed
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedOne(targetDocument="EmbeddedWhichReferences", name="embedded_doc") */
+    public $embeddedDoc;
+
+    /** @ODM\EmbedMany(targetDocument="EmbeddedWhichReferences", name="embedded_docs") */
+    public $embeddedDocs = [];
+}

--- a/tests/Documents/Functional/EmbeddedWhichReferences.php
+++ b/tests/Documents/Functional/EmbeddedWhichReferences.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Documents\Functional;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/** @ODM\EmbeddedDocument */
+class EmbeddedWhichReferences
+{
+    /** @ODM\ReferenceOne(targetDocument="Reference", name="reference_doc") */
+    public $referencedDoc;
+
+    /** @ODM\ReferenceMany(targetDocument="Reference", name="reference_docs") */
+    public $referencedDocs = [];
+}


### PR DESCRIPTION
Fix bug that occur when you have a schema like this :
```php
/** @ODM\Document */
class Document
{
    /** @ODM\Id */
    public $id;

    /** @ODM\EmbedOne(targetDocument="Embedded") */
    public $embeddedDocument;
}

/** @ODM\EmbeddedDocument */
class Embedded
{
    /** @ODM\ReferenceMany(targetDocument="Referenced", name="referenced_documents") */
    public $referencedDocuments;
}

/** @ODM\Document */
class Referenced
{
    /** @ODM\Id */
    public $id;
}
```

And you execute a query like this :
```php
$qb = $dm->createQueryBuilder('Document')
    ->field('embeddedDocument.referencedDocuments')->prim(true)
;
$documents = $qb->getQuery()->execute();
```

I think it also occur if you change `@ODM\EmbedOne` to `@ODM\EmbedMany` and/or `@ODM\ReferenceMany` to `@ODM\ReferenceOne`.
To be sure, I test it all in [ReferencePrimerTest.php](1414/files#diff-cc9044aa79f40c245e290f9eb2c471c6R175)