### PR TITLE
Fix bug when priming references nested in embedded documents

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
@@ -190,7 +190,7 @@ class ReferencePrimer
         }
 
         $mapping = $class->fieldMappings[$e[0]];
-        $e[0] = $mapping['name'];
+        $e[0] = $mapping['fieldName'];
 
         // Case of embedded document(s) to recurse through:
         if ( ! isset($mapping['reference'])) {


### PR DESCRIPTION
This PR backports patch from #1414 into `1.0.x` branch. Tests are not carried over because they're built on stuff that is not available in `1.0.x` branch, they will be merged with original PR into `dev-master`