### PR TITLE
Adding test for persisting embedded documents from manually hydrated …

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1350Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1350Test.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Query\Query;
+
+class GH1350Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testManualHydrateAndMerge()
+    {
+        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\GH1350Document');
+        $document = $class->newInstance();
+        $this->dm->getHydratorFactory()->hydrate($document, array(
+          '_id' => 1,
+          'name' => 'maciej',
+          'embedOne' => ['name' => 'maciej'],
+          'embedMany' => [
+              ['name' => 'maciej']
+          ],
+        ), [ Query::HINT_READ_ONLY => true ]);
+        $this->dm->merge($document);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $document = $this->dm->getRepository(__NAMESPACE__.'\GH1350Document')->findOneById(1);
+        $this->assertEquals(1, $document->id);
+        $this->assertEquals('maciej', $document->embedOne->name);
+        $this->assertEquals(1, $document->embedMany->count());
+    }
+}
+
+/** @ODM\Document */
+class GH1350Document
+{
+    /** @ODM\Id(strategy="none") */
+    public $id;
+
+    /** @ODM\EmbedOne(targetDocument="GH1350Embedded", strategy="set") */
+    public $embedOne;
+
+    /** @ODM\EmbedMany(targetDocument="GH1350Embedded", strategy="set") */
+    public $embedMany;
+}
+
+/** @ODM\EmbeddedDocument */
+class GH1350Embedded
+{
+    /** @ODM\Field(type="string") */
+    public $name;
+
+    public function __construct($name) {
+      $this->name = $name;
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
@@ -54,63 +54,6 @@ class GH1418Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals(1, $document->embedMany->count());
         $this->assertEquals('maciej', $document->embedMany->first()->name);
     }
-
-    public function testManualHydrateAndMergeWorkaround()
-    {
-        $document = new GH1418Document;
-        $class = $this->dm->getClassMetadata(get_class($document));
-        $this->dm->getHydratorFactory()->hydrate($document, array(
-          '_id' => 1,
-          'name' => 'maciej',
-          'embedOne' => ['name' => 'maciej'],
-          'embedMany' => [
-              ['name' => 'maciej']
-          ],
-        ), [ Query::HINT_READ_ONLY => true ]);
-
-        foreach ($document->embedMany AS $val) {
-          $this->dm->getUnitOfWork()->getDocumentState($val);
-        }
-
-        $this->dm->merge($document);
-        $this->dm->flush();
-        $this->dm->clear();
-
-        $document = $this->dm->getRepository(__NAMESPACE__.'\GH1418Document')->find(1);
-        $this->assertEquals(1, $document->id);
-        $this->assertEquals('maciej', $document->embedOne->name);
-        $this->assertEquals(1, $document->embedMany->count());
-        $this->assertEquals('maciej', $document->embedMany->first()->name);
-    }
-
-    public function testManualHydrateAndPersistWorkaround()
-    {
-        $document = new GH1418Document;
-        $class = $this->dm->getClassMetadata(get_class($document));
-        $this->dm->getHydratorFactory()->hydrate($document, array(
-          '_id' => 1,
-          'name' => 'maciej',
-          'embedOne' => ['name' => 'maciej'],
-          'embedMany' => [
-              ['name' => 'maciej']
-          ],
-        ), [ Query::HINT_READ_ONLY => true ]);
-
-        foreach ($document->embedMany AS $val) {
-          $this->dm->getUnitOfWork()->getDocumentState($val);
-        }
-
-        $this->dm->persist($document);
-        $this->dm->flush();
-        $this->dm->clear();
-
-        $document = $this->dm->getRepository(__NAMESPACE__.'\GH1418Document')->find(1);
-        $this->assertEquals(1, $document->id);
-        $this->assertEquals('maciej', $document->embedOne->name);
-        $this->assertEquals(1, $document->embedMany->count());
-        $this->assertEquals('maciej', $document->embedMany->first()->name);
-    }
-
 }
 
 /** @ODM\Document */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
@@ -60,10 +60,10 @@ class GH1418Document
     /** @ODM\Id(strategy="none") */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="GH1418Embedded", strategy="set") */
+    /** @ODM\EmbedOne(targetDocument="GH1418Embedded") */
     public $embedOne;
 
-    /** @ODM\EmbedMany(targetDocument="GH1418Embedded", strategy="set") */
+    /** @ODM\EmbedMany(targetDocument="GH1418Embedded") */
     public $embedMany;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
@@ -24,7 +24,7 @@ class GH1418Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $document = $this->dm->getRepository(__NAMESPACE__.'\GH1418Document')->findOneById(1);
+        $document = $this->dm->getRepository(__NAMESPACE__.'\GH1418Document')->find(1);
         $this->assertEquals(1, $document->id);
         $this->assertEquals('maciej', $document->embedOne->name);
         $this->assertEquals(1, $document->embedMany->count());
@@ -47,7 +47,7 @@ class GH1418Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $document = $this->dm->getRepository(__NAMESPACE__.'\GH1418Document')->findOneById(1);
+        $document = $this->dm->getRepository(__NAMESPACE__.'\GH1418Document')->find(1);
         $this->assertEquals(1, $document->id);
         $this->assertEquals('maciej', $document->embedOne->name);
         $this->assertEquals(1, $document->embedMany->count());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
@@ -2,15 +2,14 @@
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Query\Query;
 
-class GH1350Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1418Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
     public function testManualHydrateAndMerge()
     {
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\GH1350Document');
+        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\GH1418Document');
         $document = $class->newInstance();
         $this->dm->getHydratorFactory()->hydrate($document, array(
           '_id' => 1,
@@ -24,7 +23,7 @@ class GH1350Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $document = $this->dm->getRepository(__NAMESPACE__.'\GH1350Document')->findOneById(1);
+        $document = $this->dm->getRepository(__NAMESPACE__.'\GH1418Document')->findOneById(1);
         $this->assertEquals(1, $document->id);
         $this->assertEquals('maciej', $document->embedOne->name);
         $this->assertEquals(1, $document->embedMany->count());
@@ -32,25 +31,21 @@ class GH1350Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 }
 
 /** @ODM\Document */
-class GH1350Document
+class GH1418Document
 {
     /** @ODM\Id(strategy="none") */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="GH1350Embedded", strategy="set") */
+    /** @ODM\EmbedOne(targetDocument="GH1418Embedded", strategy="set") */
     public $embedOne;
 
-    /** @ODM\EmbedMany(targetDocument="GH1350Embedded", strategy="set") */
+    /** @ODM\EmbedMany(targetDocument="GH1418Embedded", strategy="set") */
     public $embedMany;
 }
 
 /** @ODM\EmbeddedDocument */
-class GH1350Embedded
+class GH1418Embedded
 {
     /** @ODM\Field(type="string") */
     public $name;
-
-    public function __construct($name) {
-      $this->name = $name;
-    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
@@ -9,8 +9,8 @@ class GH1418Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
     public function testManualHydrateAndPersist()
     {
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\GH1418Document');
-        $document = $class->newInstance();
+        $document = new GH1418Document;
+        $class = $this->dm->getClassMetadata(get_class($document));
         $this->dm->getHydratorFactory()->hydrate($document, array(
           '_id' => 1,
           'name' => 'maciej',
@@ -32,8 +32,8 @@ class GH1418Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testManualHydrateAndMerge()
     {
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\GH1418Document');
-        $document = $class->newInstance();
+        $document = new GH1418Document;
+        $class = $this->dm->getClassMetadata(get_class($document));
         $this->dm->getHydratorFactory()->hydrate($document, array(
           '_id' => 1,
           'name' => 'maciej',

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
@@ -28,6 +28,7 @@ class GH1418Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals(1, $document->id);
         $this->assertEquals('maciej', $document->embedOne->name);
         $this->assertEquals(1, $document->embedMany->count());
+        $this->assertEquals('maciej', $document->embedMany->first()->name);
     }
 
     public function testManualHydrateAndMerge()
@@ -51,6 +52,7 @@ class GH1418Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals(1, $document->id);
         $this->assertEquals('maciej', $document->embedOne->name);
         $this->assertEquals(1, $document->embedMany->count());
+        $this->assertEquals('maciej', $document->embedMany->first()->name);
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
@@ -54,6 +54,25 @@ class GH1418Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals(1, $document->embedMany->count());
         $this->assertEquals('maciej', $document->embedMany->first()->name);
     }
+
+    public function testManualHydrateAndPersistEmbedEmpty()
+    {
+        $document = new GH1418Document;
+        $class = $this->dm->getClassMetadata(get_class($document));
+        $this->dm->getHydratorFactory()->hydrate($document, array(
+          '_id' => 1,
+          'name' => 'maciej',
+        ), [ Query::HINT_READ_ONLY => true ]);
+        // This is a work around to trigger persisting the embedded documents
+        // until a solution is implemented
+        $this->dm->getUnitOfWork()->getDocumentState($document->embedOne);
+        $this->dm->getUnitOfWork()->getDocumentState($document->embedMany);
+
+        $this->dm->persist($document);
+        $this->dm->flush();
+        $this->dm->clear();
+        // If no error is thrown, the test has passed
+    }
 }
 
 /** @ODM\Document */


### PR DESCRIPTION
…documents

In regards to #1350, this PR adds a (failed) test that hydrates a document from raw data, merges the document to the db, and then tests that the embedded documents were actually persisted.

The embedOne field is properly persisted, but the embedMany field is not.