### PR TITLE
Write concern per document

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -401,8 +401,8 @@ Optional attributes:
 -
    writeConcern - Specifies the write concern for this document that overwrites
    the default write concern specified in the configuration. It does not overwrite
-   a write concern given as option to the ``flush`` method when committing your
-   documents.
+   a write concern given as :ref:`option <flush_options>` to the ``flush``
+   method when committing your documents.
 
 .. code-block:: php
 

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -398,6 +398,9 @@ Optional attributes:
 -
    requireIndexes - Specifies whether or not queries for this document should
    require indexes by default. This may also be specified per query.
+-
+   writeConcern - Specifies the write concern for this document that overwrites
+   the default write concern specified in the configuration.
 
 .. code-block:: php
 

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -400,7 +400,9 @@ Optional attributes:
    require indexes by default. This may also be specified per query.
 -
    writeConcern - Specifies the write concern for this document that overwrites
-   the default write concern specified in the configuration.
+   the default write concern specified in the configuration. It does not overwrite
+   a write concern given as option to the ``flush`` method when committing your
+   documents.
 
 .. code-block:: php
 

--- a/docs/en/reference/working-with-objects.rst
+++ b/docs/en/reference/working-with-objects.rst
@@ -145,6 +145,7 @@ Example:
     $user->setPassword('changeme');
     $dm->flush($user);
 
+.. _flush_options:
 
 Flush Options
 -------------

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -47,6 +47,7 @@
     </xs:sequence>
     <xs:attribute name="db" type="xs:NMTOKEN" />
     <xs:attribute name="name" type="xs:string" />
+    <xs:attribute name="writeConcern" type="xs:string" />
     <xs:attribute name="collection" type="xs:NMTOKEN" />
     <xs:attribute name="capped-collection" type="xs:boolean" />
     <xs:attribute name="capped-collection-size" type="xs:integer" />

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -447,7 +447,7 @@ class Configuration extends \Doctrine\MongoDB\Configuration
     /**
      * Sets array of default commit options.
      *
-     * @param boolean $defaultCommitOptions
+     * @param array $defaultCommitOptions
      */
     public function setDefaultCommitOptions($defaultCommitOptions)
     {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Document.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Document.php
@@ -33,4 +33,5 @@ final class Document extends AbstractDocument
     public $requireIndexes = false;
     public $shardKey;
     public $slaveOkay;
+    public $writeConcern;
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -105,6 +105,7 @@ class ClassMetadata extends ClassMetadataInfo
             'namespace', // TODO: REMOVE
             'db',
             'collection',
+            'writeConcern',
             'rootDocumentName',
             'generatorType',
             'generatorOptions',

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -147,6 +147,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             $class->setLifecycleCallbacks($parent->lifecycleCallbacks);
             $class->setAlsoLoadMethods($parent->alsoLoadMethods);
             $class->setChangeTrackingPolicy($parent->changeTrackingPolicy);
+            $class->setWriteConcern($parent->writeConcern);
             $class->setFile($parent->getFile());
             if ($parent->isMappedSuperclass) {
                 $class->setCustomRepositoryClass($parent->customRepositoryClassName);
@@ -179,10 +180,6 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         if ($parent && $parent->isInheritanceTypeSingleCollection()) {
             $class->setDatabase($parent->getDatabase());
             $class->setCollection($parent->getCollection());
-        }
-
-        if ($parent && $class->writeConcern === null) {
-            $class->setWriteConcern($parent->writeConcern);
         }
 
         $class->setParentClasses($nonSuperclassParents);

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -180,10 +180,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             $class->setDatabase($parent->getDatabase());
             $class->setCollection($parent->getCollection());
 
-            if (! $class->writeConcern) {
+            if ($class->writeConcern === null) {
                 $class->setWriteConcern($parent->writeConcern);
             }
-
         }
 
         $class->setParentClasses($nonSuperclassParents);

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -179,10 +179,10 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         if ($parent && $parent->isInheritanceTypeSingleCollection()) {
             $class->setDatabase($parent->getDatabase());
             $class->setCollection($parent->getCollection());
+        }
 
-            if ($class->writeConcern === null) {
-                $class->setWriteConcern($parent->writeConcern);
-            }
+        if ($parent && $class->writeConcern === null) {
+            $class->setWriteConcern($parent->writeConcern);
         }
 
         $class->setParentClasses($nonSuperclassParents);

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -179,6 +179,11 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         if ($parent && $parent->isInheritanceTypeSingleCollection()) {
             $class->setDatabase($parent->getDatabase());
             $class->setCollection($parent->getCollection());
+
+            if (! $class->writeConcern) {
+                $class->setWriteConcern($parent->writeConcern);
+            }
+
         }
 
         $class->setParentClasses($nonSuperclassParents);

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -189,6 +189,11 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
     public $collectionMax;
 
     /**
+     * READ-ONLY: Describes the level of acknowledgement requested from MongoDB for write operations.
+     */
+    public $writeConcern;
+
+    /**
      * READ-ONLY: The field name of the document identifier.
      */
     public $identifier;
@@ -895,6 +900,34 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
     public function isSharded()
     {
         return $this->shardKey ? true : false;
+    }
+
+    /**
+     * Sets the write concern used by this class.
+     *
+     * @param string $writeConcern
+     */
+    public function setWriteConcern($writeConcern)
+    {
+        $this->writeConcern = $writeConcern;
+    }
+
+    /**
+     * @return string
+     */
+    public function getWriteConcern()
+    {
+        return $this->writeConcern;
+    }
+
+    /**
+     * Whether there is a write concern configured for this class.
+     *
+     * @return bool
+     */
+    public function hasWriteConcern()
+    {
+        return $this->writeConcern !== null;
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -127,6 +127,9 @@ class AnnotationDriver extends AbstractAnnotationDriver
         if (isset($documentAnnot->repositoryClass) && !$class->isEmbeddedDocument) {
             $class->setCustomRepositoryClass($documentAnnot->repositoryClass);
         }
+        if (isset($documentAnnot->writeConcern)) {
+            $class->setWriteConcern($documentAnnot->writeConcern);
+        }
         if (isset($documentAnnot->indexes)) {
             foreach ($documentAnnot->indexes as $index) {
                 $this->addIndex($class, $index);

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -84,6 +84,9 @@ class XmlDriver extends FileDriver
                 $class->setCollection((string) $xmlRoot['collection']);
             }
         }
+        if (isset($xmlRoot['writeConcern'])) {
+            $class->setWriteConcern((string) $xmlRoot['writeConcern']);
+        }
         if (isset($xmlRoot['inheritance-type'])) {
             $inheritanceType = (string) $xmlRoot['inheritance-type'];
             $class->setInheritanceType(constant(MappingClassMetadata::class . '::INHERITANCE_TYPE_' . $inheritanceType));

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
@@ -61,6 +61,9 @@ class YamlDriver extends FileDriver
         if (isset($element['collection'])) {
             $class->setCollection($element['collection']);
         }
+        if (isset($element['writeConcern'])) {
+            $class->setWriteConcern($element['writeConcern']);
+        }
         if ($element['type'] == 'document') {
             if (isset($element['repositoryClass'])) {
                 $class->setCustomRepositoryClass($element['repositoryClass']);

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -376,12 +376,6 @@ class UnitOfWork implements PropertyChangedListener
             $this->evm->dispatchEvent(Events::preFlush, new Event\PreFlushEventArgs($this->dm));
         }
 
-        $defaultOptions = $this->dm->getConfiguration()->getDefaultCommitOptions();
-        if ($options) {
-            $options = array_merge($defaultOptions, $options);
-        } else {
-            $options = $defaultOptions;
-        }
         // Compute changes done since last commit.
         if ($document === null) {
             $this->computeChangeSets();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -13,7 +13,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         parent::setUp();
 
-        $this->class = __NAMESPACE__ . '\DocumentPersisterTestDocument';
+        $this->class = DocumentPersisterTestDocument::class;
 
         $collection = $this->dm->getDocumentCollection($this->class);
         $collection->drop();
@@ -139,7 +139,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
      */
     public function testPrepareQueryOrNewObjWithHashId($hashId)
     {
-        $class = __NAMESPACE__ . '\DocumentPersisterTestHashIdDocument';
+        $class = DocumentPersisterTestHashIdDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
         $value = array('_id' => $hashId);
@@ -153,7 +153,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
      */
     public function testPrepareQueryOrNewObjWithHashIdAndInOperators($hashId)
     {
-        $class = __NAMESPACE__ . '\DocumentPersisterTestHashIdDocument';
+        $class = DocumentPersisterTestHashIdDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
         $value = array('_id' => array('$exists' => true));
@@ -193,7 +193,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testPrepareQueryOrNewObjWithSimpleReferenceToTargetDocumentWithNormalIdType()
     {
-        $class = __NAMESPACE__ . '\DocumentPersisterTestHashIdDocument';
+        $class = DocumentPersisterTestHashIdDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
         $id = new \MongoId();
@@ -234,7 +234,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
      */
     public function testPrepareQueryOrNewObjWithSimpleReferenceToTargetDocumentWithHashIdType($hashId)
     {
-        $class = __NAMESPACE__ . '\DocumentPersisterTestDocument';
+        $class = DocumentPersisterTestDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
         $value = array('simpleRef' => $hashId);
@@ -270,7 +270,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testPrepareQueryOrNewObjWithDBRefReferenceToTargetDocumentWithNormalIdType()
     {
-        $class = __NAMESPACE__ . '\DocumentPersisterTestHashIdDocument';
+        $class = DocumentPersisterTestHashIdDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
         $id = new \MongoId();
@@ -311,7 +311,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
      */
     public function testPrepareQueryOrNewObjWithDBRefReferenceToTargetDocumentWithHashIdType($hashId)
     {
-        $class = __NAMESPACE__ . '\DocumentPersisterTestDocument';
+        $class = DocumentPersisterTestDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
         $value = array('complexRef.id' => $hashId);
@@ -352,19 +352,19 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         return array(
             'default' => array(
-                'className' => __NAMESPACE__ . '\DocumentPersisterTestDocument',
+                'className' => DocumentPersisterTestDocument::class,
                 'writeConcern' => 1,
             ),
             'acknowledged' => array(
-                'className' => __NAMESPACE__ . '\DocumentPersisterWriteConcernAcknowledged',
+                'className' => DocumentPersisterWriteConcernAcknowledged::class,
                 'writeConcern' => 1,
             ),
             'unacknowledged' => array(
-                'className' => __NAMESPACE__ . '\DocumentPersisterWriteConcernUnacknowledged',
+                'className' => DocumentPersisterWriteConcernUnacknowledged::class,
                 'writeConcern' => 0,
             ),
             'majority' => array(
-                'className' => __NAMESPACE__ . '\DocumentPersisterWriteConcernMajority',
+                'className' => DocumentPersisterWriteConcernMajority::class,
                 'writeConcern' => 'majority',
             ),
         );
@@ -448,7 +448,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testDefaultWriteConcernIsRespected()
     {
-        $class = __NAMESPACE__ . '\DocumentPersisterTestDocument';
+        $class = DocumentPersisterTestDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
         $collection = $this->getMock('\MongoCollection', ['batchInsert'], [], '', false);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -38,7 +38,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
      */
     public function testDocumentLevelWriteConcern($class)
     {
-        $this->assertEquals(0, $class->getWriteConcern());
+        $this->assertEquals(1, $class->getWriteConcern());
 
         return $class;
     }
@@ -354,7 +354,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
 }
 
 /**
- * @ODM\Document(collection="cms_users", writeConcern=0)
+ * @ODM\Document(collection="cms_users", writeConcern=1)
  * @ODM\DiscriminatorField(fieldName="discr")
  * @ODM\DiscriminatorMap({"default"="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser"})
  * @ODM\DefaultDiscriminatorValue("default")

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -36,6 +36,17 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
      * @depends testDocumentCollectionNameAndInheritance
      * @param ClassMetadata $class
      */
+    public function testDocumentLevelWriteConcern($class)
+    {
+        $this->assertEquals(0, $class->getWriteConcern());
+
+        return $class;
+    }
+
+    /**
+     * @depends testDocumentLevelWriteConcern
+     * @param ClassMetadata $class
+     */
     public function testFieldMappings($class)
     {
         $this->assertEquals(14, count($class->fieldMappings));
@@ -343,7 +354,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
 }
 
 /**
- * @ODM\Document(collection="cms_users")
+ * @ODM\Document(collection="cms_users", writeConcern=0)
  * @ODM\DiscriminatorField(fieldName="discr")
  * @ODM\DiscriminatorMap({"default"="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser"})
  * @ODM\DefaultDiscriminatorValue("default")

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
@@ -150,8 +150,11 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
 
     public function testDocumentAnnotationCanSpecifyWriteConcern()
     {
-        $cm = $this->dm->getClassMetadata(__NAMESPACE__ . '\AnnotationDriverTestWriteConcern');
+        $cm = $this->dm->getClassMetadata(__NAMESPACE__ . '\AnnotationDriverTestWriteConcernMajority');
         $this->assertEquals('majority', $cm->writeConcern);
+
+        $cm = $this->dm->getClassMetadata(__NAMESPACE__ . '\AnnotationDriverTestWriteConcernUnacknowledged');
+        $this->assertSame(0, $cm->writeConcern);
 
         $cm = $this->dm->getClassMetadata(__NAMESPACE__ . '\ColumnWithoutType');
         $this->assertNull($cm->writeConcern);
@@ -218,7 +221,16 @@ class AnnotationDriverEmbeddedWithShardKey
 /**
  * @ODM\Document(writeConcern="majority")
  */
-class AnnotationDriverTestWriteConcern
+class AnnotationDriverTestWriteConcernMajority
+{
+    /** @ODM\Id */
+    public $id;
+}
+
+/**
+ * @ODM\Document(writeConcern=0)
+ */
+class AnnotationDriverTestWriteConcernUnacknowledged
 {
     /** @ODM\Id */
     public $id;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
@@ -10,9 +10,9 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
     // @TODO: This can be a generic test for all drivers
     public function testFieldInheritance()
     {
-        $super = $this->dm->getClassMetadata(__NAMESPACE__ . '\AnnotationDriverTestSuper');
-        $parent = $this->dm->getClassMetadata(__NAMESPACE__ . '\AnnotationDriverTestParent');
-        $child = $this->dm->getClassMetadata(__NAMESPACE__ . '\AnnotationDriverTestChild');
+        $super = $this->dm->getClassMetadata(AnnotationDriverTestSuper::class);
+        $parent = $this->dm->getClassMetadata(AnnotationDriverTestParent::class);
+        $child = $this->dm->getClassMetadata(AnnotationDriverTestChild::class);
 
         $this->assertFalse($super->hasField('id'), 'MappedSuperclass does not register its own public field');
         $this->assertFalse($super->hasField('protected'), 'MappedSuperclass does not register its own protected field');
@@ -39,7 +39,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
 
         $this->assertArrayNotHasKey('declared', $parent->fieldMappings['id'], 'Document does not track "declared" for non-inherited public field from MappedSuperclass parent');
         $this->assertArrayNotHasKey('declared', $parent->fieldMappings['protected'], 'Document does not track "declared" for non-inherited protected field from MappedSuperclass parent');
-        $this->assertEquals(__NAMESPACE__ . '\AnnotationDriverTestSuper', $parent->fieldMappings['private']['declared'], 'Non-inherited private field from MappedSuperclass parent is declared in MappedSuperclass parent');
+        $this->assertEquals(AnnotationDriverTestSuper::class, $parent->fieldMappings['private']['declared'], 'Non-inherited private field from MappedSuperclass parent is declared in MappedSuperclass parent');
         $this->assertArrayNotHasKey('declared', $parent->fieldMappings['foo'], 'Document does not track "declared" for its own public field');
 
         $this->assertTrue($child->hasField('id'), 'Document does have public field from MappedSuperclass grandparent');
@@ -53,10 +53,10 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $this->assertTrue($child->hasField('bar'), 'Document does register its own public field');
         $this->assertFalse($child->isInheritedField('bar'), 'Document does not inherit its own field');
 
-        $this->assertEquals(__NAMESPACE__ . '\AnnotationDriverTestParent', $child->fieldMappings['id']['declared'], 'Inherited public field from MappedSuperclass grandparent is declared in Document parent');
-        $this->assertEquals(__NAMESPACE__ . '\AnnotationDriverTestParent', $child->fieldMappings['protected']['declared'], 'Inherited protected field from MappedSuperclass grandparent is declared in Document parent');
-        $this->assertEquals(__NAMESPACE__ . '\AnnotationDriverTestSuper', $child->fieldMappings['private']['declared'], 'Inherited private field from MappedSuperclass grandparent is declared in MappedSuperclass grandparent');
-        $this->assertEquals(__NAMESPACE__ . '\AnnotationDriverTestParent', $child->fieldMappings['foo']['declared'], 'Inherited public field from Document parent is declared in Document parent');
+        $this->assertEquals(AnnotationDriverTestParent::class, $child->fieldMappings['id']['declared'], 'Inherited public field from MappedSuperclass grandparent is declared in Document parent');
+        $this->assertEquals(AnnotationDriverTestParent::class, $child->fieldMappings['protected']['declared'], 'Inherited protected field from MappedSuperclass grandparent is declared in Document parent');
+        $this->assertEquals(AnnotationDriverTestSuper::class, $child->fieldMappings['private']['declared'], 'Inherited private field from MappedSuperclass grandparent is declared in MappedSuperclass grandparent');
+        $this->assertEquals(AnnotationDriverTestParent::class, $child->fieldMappings['foo']['declared'], 'Inherited public field from Document parent is declared in Document parent');
     }
 
     /**
@@ -131,7 +131,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
      */
     public function testGetClassNamesReturnsOnlyTheAppropriateClasses()
     {
-        $extraneousClassName = __NAMESPACE__.'\ColumnWithoutType';
+        $extraneousClassName = ColumnWithoutType::class;
 
         $annotationDriver = $this->_loadDriverForCMSDocuments();
         $classes = $annotationDriver->getAllClassNames();
@@ -145,18 +145,18 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
      */
     public function testEmbeddedClassCantHaveShardKey()
     {
-        $this->dm->getClassMetadata(__NAMESPACE__ . '\AnnotationDriverEmbeddedWithShardKey');
+        $this->dm->getClassMetadata(AnnotationDriverEmbeddedWithShardKey::class);
     }
 
     public function testDocumentAnnotationCanSpecifyWriteConcern()
     {
-        $cm = $this->dm->getClassMetadata(__NAMESPACE__ . '\AnnotationDriverTestWriteConcernMajority');
+        $cm = $this->dm->getClassMetadata(AnnotationDriverTestWriteConcernMajority::class);
         $this->assertEquals('majority', $cm->writeConcern);
 
-        $cm = $this->dm->getClassMetadata(__NAMESPACE__ . '\AnnotationDriverTestWriteConcernUnacknowledged');
+        $cm = $this->dm->getClassMetadata(AnnotationDriverTestWriteConcernUnacknowledged::class);
         $this->assertSame(0, $cm->writeConcern);
 
-        $cm = $this->dm->getClassMetadata(__NAMESPACE__ . '\ColumnWithoutType');
+        $cm = $this->dm->getClassMetadata(ColumnWithoutType::class);
         $this->assertNull($cm->writeConcern);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
@@ -148,6 +148,15 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $this->dm->getClassMetadata(__NAMESPACE__ . '\AnnotationDriverEmbeddedWithShardKey');
     }
 
+    public function testDocumentAnnotationCanSpecifyWriteConcern()
+    {
+        $cm = $this->dm->getClassMetadata(__NAMESPACE__ . '\AnnotationDriverTestWriteConcern');
+        $this->assertEquals('majority', $cm->writeConcern);
+
+        $cm = $this->dm->getClassMetadata(__NAMESPACE__ . '\ColumnWithoutType');
+        $this->assertNull($cm->writeConcern);
+    }
+
     protected function _loadDriverForCMSDocuments()
     {
         $annotationDriver = $this->_loadDriver();
@@ -204,4 +213,13 @@ class AnnotationDriverEmbeddedWithShardKey
 {
     /** @ODM\Field(type="string") */
     public $foo;
+}
+
+/**
+ * @ODM\Document(writeConcern="majority")
+ */
+class AnnotationDriverTestWriteConcern
+{
+    /** @ODM\Id */
+    public $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
@@ -5,7 +5,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-    <document name="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser" collection="cms_users" writeConcern="0">
+    <document name="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser" collection="cms_users" writeConcern="1">
         <discriminator-field name="discr" />
         <discriminator-map>
             <discriminator-mapping value="default" class="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser" />

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
@@ -5,7 +5,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-    <document name="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser" collection="cms_users">
+    <document name="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser" collection="cms_users" writeConcern="0">
         <discriminator-field name="discr" />
         <discriminator-map>
             <discriminator-mapping value="default" class="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser" />

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.yml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.yml
@@ -1,7 +1,7 @@
 Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser:
   type: document
   collection: cms_users
-  writeConcern: 0
+  writeConcern: 1
   discriminatorField:
     fieldName: discr
   discriminatorMap:

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.yml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.yml
@@ -1,6 +1,7 @@
 Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser:
   type: document
   collection: cms_users
+  writeConcern: 0
   discriminatorField:
     fieldName: discr
   discriminatorMap:


### PR DESCRIPTION
This PR aims to fix #1409. Please let me know if there is something missing that I can improve or there should be more tests.

I had to move the default options from the `UnitOfWork` to the `DocumentPersister` to ensure it can be determined if the given options are passed through `flush()` or are the system wide defaults.