### PR TITLE
Add tests on IdGenerator and upsert with IdGenerator

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomIdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomIdTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Documents\Account;
 use Documents\CustomUser;
 use Documents\User;
+use Documents\UserIdGenerator;
 
 class CustomIdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
@@ -144,5 +145,58 @@ class CustomIdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->assertNull($this->dm->find('Documents\User', 'userId'));
         $this->assertNull($this->dm->find('Documents\CustomUser', 'asd'));
+    }
+    
+    public function testCustomIdGenerator()
+    {
+        $username = uniqid();
+
+        $user1 = new UserIdGenerator();
+        $user1->setUsername($username);
+        
+        $this->dm->persist($user1);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        unset($user1);
+
+        $users = $this->dm->getRepository("Documents\UserIdGenerator")->findAll();
+
+        $this->assertCount(1, $users);
+        
+        foreach($users as $user){
+            $this->assertEquals(md5($username), $user->getId());
+        }
+    }
+    
+    public function testUpsertCustomIdGenerator()
+    {
+        $username = uniqid();
+
+        $user1 = new UserIdGenerator();
+        $user1->setUsername($username);
+        
+        $this->dm->persist($user1);
+        $this->dm->flush();
+        $this->dm->clear();
+        
+        unset($user1);
+
+        $user2 = new UserIdGenerator();
+        $user2->setUsername($username);
+
+        $this->dm->persist($user2);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        unset($user2);
+
+        $users = $this->dm->getRepository("Documents\UserIdGenerator")->findAll();
+
+        $this->assertCount(1, $users);
+        
+        foreach($users as $user){
+            $this->assertEquals(md5($username), $user->getId());
+        }
     }
 }

--- a/tests/Documents/IdGenerator/UserIdGenerator.php
+++ b/tests/Documents/IdGenerator/UserIdGenerator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Documents\IdGenerator;
+
+class UserIdGenerator extends \Doctrine\ODM\MongoDB\Id\AbstractIdGenerator
+{
+    
+    /* (non-PHPdoc)
+     * @see \Doctrine\ODM\MongoDB\Id\AbstractIdGenerator::generate()
+     */
+    public function generate(\Doctrine\ODM\MongoDB\DocumentManager $dm, $document)
+    {
+        if(!$document->getUsername()){
+            throw new \Exception('username is required to make an id');
+        }
+        return md5($document->getUsername());
+    }
+    
+}

--- a/tests/Documents/UserIdGenerator.php
+++ b/tests/Documents/UserIdGenerator.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Documents;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document(collection="users")
+ */
+class UserIdGenerator extends BaseDocument
+{
+    /** @ODM\Id(strategy="CUSTOM", type="string", options={"class"="\Documents\IdGenerator\UserIdGenerator"}) */
+    protected $id;
+
+    /** @ODM\Field(type="string") */
+    protected $username;
+    
+    /**
+     * @return the $id
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return the $username
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * @param string $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @param string $username
+     */
+    public function setUsername($username)
+    {
+        $this->username = $username;
+    }
+
+}


### PR DESCRIPTION
Doctrine don't UPSERT document with _id auto-generated by custom id generator (class extends \Doctrine\ODM\MongoDB\Id\AbstractIdGenerator),

Write 2 tests on Custom Id 
```
@ODM\Id(strategy="CUSTOM", type="string", options={"class"="\Documents\IdGenerator\UserIdGenerator"})
```

- testCustomIdGenerator : OK
- testUpsertCustomIdGenerator : FAILED (duplicate error, need to upsert)

related issue : https://github.com/doctrine/mongodb-odm/issues/1408

edit (@alcaeus): Fence code block.