### PR TITLE
Fix merging read-only documents with persistent collections

### DIFF
--- a/docs/en/reference/query-builder-api.rst
+++ b/docs/en/reference/query-builder-api.rst
@@ -249,6 +249,12 @@ Read-Only is not applicable if hydration is disabled.
     implementation, may change in future and will not be considered a BC break
     (will be treated as a feature instead).
 
+.. note::
+
+    To manage a document previously fetched in read-only mode, always use the
+    `merge` method of the DocumentManager. Using `persist` in these cases can
+    have unwanted side effects.
+
 Disabling Hydration
 ~~~~~~~~~~~~~~~~~~~
 

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1798,36 +1798,32 @@ class UnitOfWork implements PropertyChangedListener
                 $document->__load();
             }
 
-            // Try to look the document up in the identity map.
-            $id = $class->isEmbeddedDocument ? null : $class->getIdentifierObject($document);
+            $identifier = $class->getIdentifier();
+            // We always have one element in the identifier array but it might be null
+            $id = $identifier[0] !== null ? $class->getIdentifierObject($document) : null;
+            $managedCopy = null;
 
-            if ($id === null) {
-                // If there is no identifier, it is actually NEW.
+            // Try to fetch document from the database
+            if (! $class->isEmbeddedDocument && $id !== null) {
+                $managedCopy = $this->dm->find($class->name, $id);
+
+                // Managed copy may be removed in which case we can't merge
+                if ($managedCopy && $this->getDocumentState($managedCopy) === self::STATE_REMOVED) {
+                    throw new \InvalidArgumentException('Removed entity detected during merge. Cannot merge with a removed entity.');
+                }
+
+                if ($managedCopy instanceof Proxy && ! $managedCopy->__isInitialized__) {
+                    $managedCopy->__load();
+                }
+            }
+
+            if ($managedCopy === null) {
+                // Create a new managed instance
                 $managedCopy = $class->newInstance();
-                $this->persistNew($class, $managedCopy);
-            } else {
-                $managedCopy = $this->tryGetById($id, $class);
-
-                if ($managedCopy) {
-                    // We have the document in memory already, just make sure it is not removed.
-                    if ($this->getDocumentState($managedCopy) === self::STATE_REMOVED) {
-                        throw new \InvalidArgumentException('Removed entity detected during merge. Cannot merge with a removed entity.');
-                    }
-                } else {
-                    // We need to fetch the managed copy in order to merge.
-                    $managedCopy = $this->dm->find($class->name, $id);
-                }
-
-                if ($managedCopy === null) {
-                    // If the identifier is ASSIGNED, it is NEW
-                    $managedCopy = $class->newInstance();
+                if ($id !== null) {
                     $class->setIdentifierValue($managedCopy, $id);
-                    $this->persistNew($class, $managedCopy);
-                } else {
-                    if ($managedCopy instanceof Proxy && ! $managedCopy->__isInitialized__) {
-                        $managedCopy->__load();
-                    }
                 }
+                $this->persistNew($class, $managedCopy);
             }
 
             if ($class->isVersioned) {

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1882,7 +1882,7 @@ class UnitOfWork implements PropertyChangedListener
                     } else {
                         $mergeCol = $prop->getValue($document);
 
-                        if ($mergeCol instanceof PersistentCollectionInterface && ! $mergeCol->isInitialized()) {
+                        if ($mergeCol instanceof PersistentCollectionInterface && ! $mergeCol->isInitialized() && ! $assoc2['isCascadeMerge']) {
                             /* Do not merge fields marked lazy that have not
                              * been fetched. Keep the lazy persistent collection
                              * of the managed copy.
@@ -2122,11 +2122,6 @@ class UnitOfWork implements PropertyChangedListener
                 if ($relatedDocuments === $class->reflFields[$assoc['fieldName']]->getValue($managedCopy)) {
                     // Collections are the same, so there is nothing to do
                     continue;
-                }
-
-                if ($relatedDocuments instanceof PersistentCollectionInterface) {
-                    // Unwrap so that foreach() does not initialize
-                    $relatedDocuments = $relatedDocuments->unwrap();
                 }
 
                 foreach ($relatedDocuments as $relatedDocument) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Query\Query;
+
+class GH1418Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testManualHydrateAndPersist()
+    {
+        $document = new GH1418Document;
+        $this->dm->getHydratorFactory()->hydrate($document, array(
+          '_id' => 1,
+          'name' => 'maciej',
+          'embedOne' => ['name' => 'maciej'],
+          'embedMany' => [
+              ['name' => 'maciej']
+          ],
+        ), [ Query::HINT_READ_ONLY => true ]);
+
+        $this->dm->persist($document);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $document = $this->dm->getRepository(GH1418Document::class)->find(1);
+        $this->assertEquals(1, $document->id);
+        $this->assertEquals('maciej', $document->embedOne->name);
+        $this->assertEquals(1, $document->embedMany->count());
+        $this->assertEquals('maciej', $document->embedMany->first()->name);
+    }
+
+    public function testManualHydrateAndMerge()
+    {
+        $document = new GH1418Document;
+        $this->dm->getHydratorFactory()->hydrate($document, array(
+          '_id' => 1,
+          'name' => 'maciej',
+          'embedOne' => ['name' => 'maciej'],
+          'embedMany' => [
+              ['name' => 'maciej']
+          ],
+        ), [ Query::HINT_READ_ONLY => true ]);
+
+        $this->dm->merge($document);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $document = $this->dm->getRepository(GH1418Document::class)->find(1);
+        $this->assertEquals(1, $document->id);
+        $this->assertEquals('maciej', $document->embedOne->name);
+        $this->assertEquals(1, $document->embedMany->count());
+        $this->assertEquals('maciej', $document->embedMany->first()->name);
+    }
+}
+
+/** @ODM\Document */
+class GH1418Document
+{
+    /** @ODM\Id(strategy="none") */
+    public $id;
+
+    /** @ODM\EmbedOne(targetDocument="GH1418Embedded") */
+    public $embedOne;
+
+    /** @ODM\EmbedMany(targetDocument="GH1418Embedded") */
+    public $embedMany;
+}
+
+/** @ODM\EmbeddedDocument */
+class GH1418Embedded
+{
+    /** @ODM\Field(type="string") */
+    public $name;
+}


### PR DESCRIPTION
This builds on top of the tests written in #1418.

When merging previously unmanaged documents, we need to initialize `PersistentCollection` instances if the association is configured to cascade merges. This way, ODM picks up embedded documents that were not previously stored. This can happen when using hydrators with a read-only hint to hydrate data from an external source and then using `merge` to manage the document for a later write to the database.