### PR TITLE
Prevent spl_object_hash collisions

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class SplObjectHashCollisionsTest extends BaseTest
+{
+    /**
+     * @dataProvider provideParentAssociationsIsCleared
+     */
+    public function testParentAssociationsIsCleared($f)
+    {
+        $d = new SplColDoc();
+        $d->one = new SplColEmbed('d.one.v1');
+        $d->many[] = new SplColEmbed('d.many.0.v1');
+        $d->many[] = new SplColEmbed('d.many.1.v1');
+
+        $this->dm->persist($d);
+        $this->expectCount('parentAssociations', 3);
+        $this->expectCount('embeddedDocumentsRegistry', 3);
+        $f($this->dm, $d);
+        $this->expectCount('parentAssociations', 0);
+        $this->expectCount('embeddedDocumentsRegistry', 0);
+    }
+
+    /**
+     * @dataProvider provideParentAssociationsIsCleared
+     */
+    public function testParentAssociationsLeftover($f, $leftover)
+    {
+        $d = new SplColDoc();
+        $d->one = new SplColEmbed('d.one.v1');
+        $d->many[] = new SplColEmbed('d.many.0.v1');
+        $d->many[] = new SplColEmbed('d.many.1.v1');
+        $this->dm->persist($d);
+        $d->one = new SplColEmbed('d.one.v2');
+        $this->dm->flush();
+
+        $this->expectCount('parentAssociations', 4);
+        $this->expectCount('embeddedDocumentsRegistry', 4);
+        $f($this->dm, $d);
+        $this->expectCount('parentAssociations', $leftover);
+        $this->expectCount('embeddedDocumentsRegistry', $leftover);
+    }
+
+    public function provideParentAssociationsIsCleared()
+    {
+        return [
+            [ function (DocumentManager $dm) { $dm->clear(); }, 0 ],
+            [ function (DocumentManager $dm, $doc) { $dm->clear(get_class($doc)); }, 1 ],
+            [ function (DocumentManager $dm, $doc) { $dm->detach($doc); }, 1 ],
+        ];
+    }
+
+    private function expectCount($prop, $expected)
+    {
+        $ro = new \ReflectionObject($this->uow);
+        $rp = $ro->getProperty($prop);
+        $rp->setAccessible(true);
+        $this->assertCount($expected, $rp->getValue($this->uow));
+    }
+}
+
+/** @ODM\Document */
+class SplColDoc
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\Field(type="string") */
+    public $name;
+
+    /** @ODM\EmbedOne */
+    public $one;
+
+    /** @ODM\EmbedMany */
+    public $many = [];
+}
+
+/** @ODM\EmbeddedDocument */
+class SplColEmbed
+{
+    /** @ODM\Field(type="string") */
+    public $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
This is improved version of #1023 which will remove embedded documents' instances from their "identity map" if that's possible.

@alcaeus @AronSzigetvari @amirmab would you mind running your test suites against this branch? It's based on current `dev-master` so you can run the tests with PHP 7. Offhand #1429 seems to be totally different can of worms as it still fails here, will try looking into that separately.