### PR TITLE
Prevent spl_object_hash collisions

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -242,12 +242,20 @@ class UnitOfWork implements PropertyChangedListener
     private $persistenceBuilder;
 
     /**
-     * Array of parent associations between embedded documents
+     * Array of parent associations between embedded documents.
      *
-     * @todo We might need to clean up this array in clear(), doDetach(), etc.
      * @var array
      */
     private $parentAssociations = array();
+
+    /**
+     * Array of embedded documents known to UnitOfWork. We need to hold them to prevent spl_object_hash
+     * collisions in case already managed object is lost due to GC (so now it won't). Embedded documents
+     * found during doDetach are removed from the registry, to empty it altogether clear() can be utilized.
+     *
+     * @var array
+     */
+    private $embeddedDocumentsRegistry = array();
 
     /**
      * Initializes a new UnitOfWork instance, bound to the given DocumentManager.
@@ -288,6 +296,7 @@ class UnitOfWork implements PropertyChangedListener
     public function setParentAssociation($document, $mapping, $parent, $propertyPath)
     {
         $oid = spl_object_hash($document);
+        $this->embeddedDocumentsRegistry[$oid] = $document;
         $this->parentAssociations[$oid] = array($mapping, $parent, $propertyPath);
     }
 
@@ -2185,7 +2194,7 @@ class UnitOfWork implements PropertyChangedListener
                     $this->documentDeletions[$oid], $this->documentIdentifiers[$oid],
                     $this->documentStates[$oid], $this->originalDocumentData[$oid],
                     $this->parentAssociations[$oid], $this->documentUpserts[$oid],
-                    $this->hasScheduledCollections[$oid]);
+                    $this->hasScheduledCollections[$oid], $this->embeddedDocumentsRegistry[$oid]);
                 break;
             case self::STATE_NEW:
             case self::STATE_DETACHED:
@@ -2488,7 +2497,8 @@ class UnitOfWork implements PropertyChangedListener
             $this->collectionUpdates =
             $this->collectionDeletions =
             $this->parentAssociations =
-            $this->orphanRemovals = 
+            $this->embeddedDocumentsRegistry =
+            $this->orphanRemovals =
             $this->hasScheduledCollections = array();
         } else {
             $visited = array();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class SplObjectHashCollisionsTest extends BaseTest
+{
+    /**
+     * @dataProvider provideParentAssociationsIsCleared
+     */
+    public function testParentAssociationsIsCleared($f)
+    {
+        $d = new SplColDoc();
+        $d->one = new SplColEmbed('d.one.v1');
+        $d->many[] = new SplColEmbed('d.many.0.v1');
+        $d->many[] = new SplColEmbed('d.many.1.v1');
+
+        $this->dm->persist($d);
+        $this->expectCount('parentAssociations', 3);
+        $this->expectCount('embeddedDocumentsRegistry', 3);
+        $f($this->dm, $d);
+        $this->expectCount('parentAssociations', 0);
+        $this->expectCount('embeddedDocumentsRegistry', 0);
+    }
+
+    /**
+     * @dataProvider provideParentAssociationsIsCleared
+     */
+    public function testParentAssociationsLeftover($f, $leftover)
+    {
+        $d = new SplColDoc();
+        $d->one = new SplColEmbed('d.one.v1');
+        $d->many[] = new SplColEmbed('d.many.0.v1');
+        $d->many[] = new SplColEmbed('d.many.1.v1');
+        $this->dm->persist($d);
+        $d->one = new SplColEmbed('d.one.v2');
+        $this->dm->flush();
+
+        $this->expectCount('parentAssociations', 4);
+        $this->expectCount('embeddedDocumentsRegistry', 4);
+        $f($this->dm, $d);
+        $this->expectCount('parentAssociations', $leftover);
+        $this->expectCount('embeddedDocumentsRegistry', $leftover);
+    }
+
+    public function provideParentAssociationsIsCleared()
+    {
+        return array(
+            array( function (DocumentManager $dm) { $dm->clear(); }, 0 ),
+            array( function (DocumentManager $dm, $doc) { $dm->clear(get_class($doc)); }, 1 ),
+            array( function (DocumentManager $dm, $doc) { $dm->detach($doc); }, 1 ),
+        );
+    }
+
+    private function expectCount($prop, $expected)
+    {
+        $ro = new \ReflectionObject($this->uow);
+        $rp = $ro->getProperty($prop);
+        $rp->setAccessible(true);
+        $this->assertCount($expected, $rp->getValue($this->uow));
+    }
+}
+
+/** @ODM\Document */
+class SplColDoc
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\Field(type="string") */
+    public $name;
+
+    /** @ODM\EmbedOne */
+    public $one;
+
+    /** @ODM\EmbedMany */
+    public $many = array();
+}
+
+/** @ODM\EmbeddedDocument */
+class SplColEmbed
+{
+    /** @ODM\Field(type="string") */
+    public $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
This is a backport of #1430 into the 1.0.x branch to fix potential object hash collision with embedded documents.

Supersedes #1430 and #1023.