### PR TITLE
Fix best-practices.rst

### DIFF
--- a/docs/en/reference/best-practices.rst
+++ b/docs/en/reference/best-practices.rst
@@ -54,7 +54,7 @@ Don't use special characters
 
 Avoid using any non-ASCII characters in class, field, table or
 column names. Doctrine itself is not unicode-safe in many places
-and will not be until PHP itself is fully unicode-aware (PHP7).
+and will not be until PHP itself is fully unicode-aware.
 
 Initialize collections in the constructor
 -----------------------------------------


### PR DESCRIPTION
PHP 7 is not fully unicode-aware yet.
Like Doctrine ORM's docs( http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/best-practices.html#don-t-use-special-characters ),
we should remove a part of "(PHP 7)" .