### PR TITLE
Fix changeset missing old value for exchanged associations

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -840,7 +840,11 @@ class UnitOfWork implements PropertyChangedListener
                 $oid2 = spl_object_hash($obj);
 
                 if (isset($this->documentChangeSets[$oid2])) {
-                    $this->documentChangeSets[$oid][$mapping['fieldName']] = array($value, $value);
+                    if (empty($this->documentChangeSets[$oid][$mapping['fieldName']])) {
+                        // instance of $value is the same as it was previously otherwise there would be
+                        // change set already in place
+                        $this->documentChangeSets[$oid][$mapping['fieldName']] = array($value, $value);
+                    }
 
                     if ( ! $isNewDocument) {
                         $this->scheduleForUpdate($document);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Documents\Bars\Bar;
 use Documents\Bars\Location;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -65,6 +66,14 @@ class CollectionsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $bar = $this->dm->find('Documents\Bars\Bar', $bar->getId());
         $locations = $bar->getLocations();
         $this->assertEquals(0, count($locations));
+        $this->dm->flush();
+        
+        $bar->setLocations(new ArrayCollection([ new Location('Cracow') ]));
+        $this->uow->computeChangeSets();
+        $changeSet = $this->uow->getDocumentChangeSet($bar);
+        $this->assertNotEmpty($changeSet['locations']);
+        $this->assertSame($locations, $changeSet['locations'][0]);
+        $this->assertSame($bar->getLocations(), $changeSet['locations'][1]);
     }
 
     public function testCreateCollections()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
@@ -108,6 +108,16 @@ class EmbeddedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->getSingleResult();
         $this->assertNotNull($user);
         $this->assertEquals($addressClone, $user->getAddress());
+
+        $oldAddress = $user->getAddress();
+        $address = new Address();
+        $address->setAddress('Someplace else');
+        $user->setAddress($address);
+        $this->uow->computeChangeSets();
+        $changeSet = $this->uow->getDocumentChangeSet($user);
+        $this->assertNotEmpty($changeSet['address']);
+        $this->assertSame($oldAddress, $changeSet['address'][0]);
+        $this->assertSame($user->getAddress(), $changeSet['address'][1]);
     }
 
     public function testRemoveOneEmbedded()

--- a/tests/Documents/Bars/Bar.php
+++ b/tests/Documents/Bars/Bar.php
@@ -45,4 +45,9 @@ class Bar
     {
         return $this->locations;
     }
+    
+    public function setLocations($locations)
+    {
+        $this->locations = $locations;
+    }
 }


### PR DESCRIPTION
Found this bug while working on new change sets; in https://github.com/doctrine/mongodb-odm/pull/1339 I was so happy that collections are in the change set that I haven't checked what was in the change set :) By the way fixed the same thing for when embedded document is exchanged.