### PR TITLE
Improved Yaml ParseException exception message

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
@@ -25,6 +25,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as MappingClassMetadata;
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\Yaml\Exception\ParseException;
 
 /**
  * The YamlDriver reads the mapping metadata from yaml schema files.
@@ -340,7 +341,13 @@ class YamlDriver extends FileDriver
      */
     protected function loadMappingFile($file)
     {
-        return Yaml::parse(file_get_contents($file));
+        try {
+            return Yaml::parse(file_get_contents($file));
+        }
+        catch (ParseException $e) {
+            $e->setParsedFile($file);
+            throw $e;
+        }
     }
 
     private function setShardKey(ClassMetadataInfo $class, array $shardKey)


### PR DESCRIPTION
Presently, if a Yaml mapping file has a parse error, it can be tough to track down as the resulting error message only tells you the line of the error and not the filename.

This PR adds a better exception error message that appends the filepath to the end of the parse exception.

The current PR catches only "\Symfony\Component\Yaml\Exception\ParseException" and perhaps it would be better to catch all exceptions, but then I don't know which exception class to "re-throw". Thoughts?