### PR TITLE
Fix hasMethod() and hasProperty() when generating traits.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
@@ -438,7 +438,7 @@ public function <methodName>()
 
     private function hasProperty($property, ClassMetadataInfo $metadata)
     {
-        if ($this->extendsClass() || class_exists($metadata->name)) {
+        if ($this->extendsClass() || class_exists($metadata->name) || trait_exists($metadata->name)) {
             // don't generate property if its already on the base class.
             $reflClass = new \ReflectionClass($this->getClassToExtend() ?: $metadata->name);
 
@@ -461,7 +461,7 @@ public function <methodName>()
 
     private function hasMethod($method, ClassMetadataInfo $metadata)
     {
-        if ($this->extendsClass() || class_exists($metadata->name)) {
+        if ($this->extendsClass() || class_exists($metadata->name) || trait_exists($metadata->name)) {
             // don't generate method if its already on the base class.
             $reflClass = new \ReflectionClass($this->getClassToExtend() ?: $metadata->name);
 


### PR DESCRIPTION
When generating document classes, and using a trait as a mappedSuperclass, the properties and methods defined by the trait get duplicated.

The call to class_exists() in `DocumentGenerator::hasProperty()` and `DocumentGenerator::hasMethod()` fails when using a trait, causing methods to be duplicated in a trait superclass.

This PR solved the issue for me.