### PR TITLE
Fix upserts for documents with YAML mapping

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
@@ -146,7 +146,7 @@ class PersistenceBuilder
                 if ($new === null && $mapping['nullable'] !== true) {
                     $updateData['$unset'][$mapping['name']] = true;
                 } else {
-                    if ($new !== null && $mapping['strategy'] === ClassMetadataInfo::STORAGE_STRATEGY_INCREMENT) {
+                    if ($new !== null && isset($mapping['strategy']) && $mapping['strategy'] === ClassMetadataInfo::STORAGE_STRATEGY_INCREMENT) {
                         $operator = '$inc';
                         $value = Type::getType($mapping['type'])->convertToDatabaseValue($new - $old);
                     } else {
@@ -244,7 +244,7 @@ class PersistenceBuilder
             // Scalar fields
             if ( ! isset($mapping['association'])) {
                 if ($new !== null || $mapping['nullable'] === true) {
-                    if ($new !== null && $mapping['strategy'] === ClassMetadataInfo::STORAGE_STRATEGY_INCREMENT) {
+                    if ($new !== null && empty($mapping['id']) && isset($mapping['strategy']) && $mapping['strategy'] === ClassMetadataInfo::STORAGE_STRATEGY_INCREMENT) {
                         $operator = '$inc';
                         $value = Type::getType($mapping['type'])->convertToDatabaseValue($new - $old);
                     } else {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1435/Doctrine.ODM.MongoDB.Tests.GH1435Document.dcm.yml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1435/Doctrine.ODM.MongoDB.Tests.GH1435Document.dcm.yml
@@ -1,0 +1,8 @@
+Doctrine\ODM\MongoDB\Tests\GH1435Document:
+    collection: documents
+    fields:
+        id:
+            id: true
+        name:
+            type: string
+            nullable: true

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1435/Doctrine.ODM.MongoDB.Tests.GH1435DocumentIncrement.dcm.yml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1435/Doctrine.ODM.MongoDB.Tests.GH1435DocumentIncrement.dcm.yml
@@ -1,0 +1,9 @@
+Doctrine\ODM\MongoDB\Tests\GH1435DocumentIncrement:
+    collection: documents
+    fields:
+        id:
+            id: true
+            strategy: increment
+        name:
+            type: string
+            nullable: true

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1435Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1435Test.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests;
+
+use Doctrine\ODM\MongoDB\Mapping\Driver\YamlDriver;
+
+class GH1435Test extends BaseTest
+{
+    public function testUpsert()
+    {
+        $id = (string) new \MongoId();
+
+        $document = new GH1435Document();
+        $document->id = $id;
+        $document->name = 'test';
+
+        $this->dm->persist($document);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $document = $this->dm->find(GH1435Document::class, $id);
+        $this->assertNotNull($document);
+        $this->assertEquals('test', $document->name);
+    }
+
+    public function testUpsertWithIncrement()
+    {
+        $id = 10;
+
+        $document = new GH1435DocumentIncrement();
+        $document->id = $id;
+        $document->name = 'test';
+
+        $this->dm->persist($document);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $document = $this->dm->find(GH1435DocumentIncrement::class, $id);
+        $this->assertNotNull($document);
+        $this->assertEquals('test', $document->name);
+    }
+
+    public function testUpdateWithIncrement()
+    {
+        $document = new GH1435DocumentIncrement();
+        $document->name = 'test';
+
+        $this->dm->persist($document);
+        $this->dm->flush($document);
+        $this->dm->clear();
+
+        $document = $this->dm->getRepository(GH1435DocumentIncrement::class)->findOneBy([]);
+        $this->assertNotNull($document);
+        $this->assertEquals('test', $document->name);
+
+        $document->id += 5;
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $document = $this->dm->getRepository(GH1435DocumentIncrement::class)->findOneBy([]);
+        $this->assertNotNull($document);
+        $this->assertSame(1, $document->id);
+    }
+
+    protected function createMetadataDriverImpl()
+    {
+        return new YamlDriver(__DIR__ . '/GH1435');
+    }
+}
+
+class GH1435Document
+{
+    public $id;
+
+    public $name;
+}
+
+class GH1435DocumentIncrement
+{
+    public $id;
+
+    public $name;
+}


### PR DESCRIPTION
Fixes #1435.

This also uncovered a bug where using the increment strategy for ID generation could lead to errors when upserting documents due to a name conflict with strategies.