### PR TITLE
Failing test for findOneBy

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
@@ -499,7 +499,9 @@ class AtomicSetTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         // Simulate another PHP request which loads this record.
         $this->dm->clear();
+        $this->ql->clear();
         $book = $this->dm->getRepository(Book::CLASSNAME)->findOneBy(array('_id' => $book->id));
+        $this->assertCount(1, $this->ql, 'Getting a book should require one query');
 
         // Modify the chapter's name.
         $book->chapters->first()->name = "First chapter A";


### PR DESCRIPTION
In response for: https://github.com/doctrine/mongodb-odm/issues/1449
I've quickly extended one of the tests to show that querying for a single document takes 3 queries vs expected 1.
To run the test:
```
phpunit --filter testOnlyEmbeddedDocumentUpdated AtomicSetTest tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
```