### PR TITLE
Use createMock where possible

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -230,16 +230,12 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     private function getMockClassMetadataFactory()
     {
-        return $this->getMockBuilder('Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock('Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory');
     }
 
     private function getMockCollection()
     {
-        return $this->getMockBuilder('Doctrine\MongoDB\Collection')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock('Doctrine\MongoDB\Collection');
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -380,7 +380,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $collection = $this->getMock('\MongoCollection', ['batchInsert'], [], '', false);
+        $collection = $this->createMock('\MongoCollection');
         $collection->expects($this->any())
             ->method('batchInsert')
             ->with($this->isType('array'), $this->logicalAnd($this->arrayHasKey('w'), $this->contains($writeConcern)));
@@ -404,7 +404,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $collection = $this->getMock('\MongoCollection', ['update'], [], '', false);
+        $collection = $this->createMock('\MongoCollection');
         $collection->expects($this->any())
             ->method('update')
             ->with($this->isType('array'), $this->isType('array'), $this->logicalAnd($this->arrayHasKey('w'), $this->contains($writeConcern)));
@@ -429,7 +429,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $collection = $this->getMock('\MongoCollection', ['remove', 'batchInsert'], [], '', false);
+        $collection = $this->createMock('\MongoCollection');
         $collection->expects($this->once())
             ->method('remove')
             ->with($this->isType('array'), $this->logicalAnd($this->arrayHasKey('w'), $this->contains($writeConcern)));
@@ -451,7 +451,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $class = DocumentPersisterTestDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $collection = $this->getMock('\MongoCollection', ['batchInsert'], [], '', false);
+        $collection = $this->createMock('\MongoCollection');
         $collection->expects($this->any())
             ->method('batchInsert')
             ->with($this->isType('array'), $this->equalTo(array('w' => 0)));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataFactoryTest.php
@@ -68,9 +68,7 @@ class ClassMetadataFactoryTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $config = new Configuration();
         $config->setMetadataDriverImpl($driver);
 
-        $em = $this->getMockBuilder('Doctrine\Common\EventManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $em = $this->createMock('Doctrine\Common\EventManager');
 
         $dm = new DocumentManagerMock();
         $dm->config = $config;

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
@@ -181,9 +181,7 @@ class PersistentCollectionTest extends BaseTest
      */
     private function getMockDocumentManager()
     {
-        return $this->getMockBuilder('Doctrine\ODM\MongoDB\DocumentManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock('Doctrine\ODM\MongoDB\DocumentManager');
     }
 
     /**
@@ -191,9 +189,7 @@ class PersistentCollectionTest extends BaseTest
      */
     private function getMockUnitOfWork()
     {
-        return $this->getMockBuilder('Doctrine\ODM\MongoDB\UnitOfWork')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock('Doctrine\ODM\MongoDB\UnitOfWork');
     }
 
     /**
@@ -201,6 +197,6 @@ class PersistentCollectionTest extends BaseTest
      */
     private function getMockCollection()
     {
-        return $this->getMock('Doctrine\Common\Collections\Collection');
+        return $this->createMock('Doctrine\Common\Collections\Collection');
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -184,18 +184,10 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testReferencesUsesMinimalKeys()
     {
-        $dm = $this->getMockBuilder('Doctrine\\ODM\\MongoDB\\DocumentManager')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $uw = $this->getMockBuilder('Doctrine\ODM\MongoDB\UnitOfWork')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $documentPersister = $this->getMockBuilder('Doctrine\ODM\MongoDB\Persisters\DocumentPersister')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $class = $this->getMockBuilder('Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $dm = $this->createMock('Doctrine\\ODM\\MongoDB\\DocumentManager');
+        $uw = $this->createMock('Doctrine\ODM\MongoDB\UnitOfWork');
+        $documentPersister = $this->createMock('Doctrine\ODM\MongoDB\Persisters\DocumentPersister');
+        $class = $this->createMock('Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata');
 
         $expected = array('foo.$id' => '1234');
 
@@ -225,18 +217,10 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testReferencesUsesAllKeys()
     {
-        $dm = $this->getMockBuilder('Doctrine\\ODM\\MongoDB\\DocumentManager')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $uw = $this->getMockBuilder('Doctrine\ODM\MongoDB\UnitOfWork')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $documentPersister = $this->getMockBuilder('Doctrine\ODM\MongoDB\Persisters\DocumentPersister')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $class = $this->getMockBuilder('Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $dm = $this->createMock('Doctrine\\ODM\\MongoDB\\DocumentManager');
+        $uw = $this->createMock('Doctrine\ODM\MongoDB\UnitOfWork');
+        $documentPersister = $this->createMock('Doctrine\ODM\MongoDB\Persisters\DocumentPersister');
+        $class = $this->createMock('Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata');
 
         $expected = array('foo.$ref' => 'coll', 'foo.$id' => '1234', 'foo.$db' => 'db');
 
@@ -266,18 +250,10 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testReferencesUsesSomeKeys()
     {
-        $dm = $this->getMockBuilder('Doctrine\\ODM\\MongoDB\\DocumentManager')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $uw = $this->getMockBuilder('Doctrine\ODM\MongoDB\UnitOfWork')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $documentPersister = $this->getMockBuilder('Doctrine\ODM\MongoDB\Persisters\DocumentPersister')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $class = $this->getMockBuilder('Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $dm = $this->createMock('Doctrine\\ODM\\MongoDB\\DocumentManager');
+        $uw = $this->createMock('Doctrine\ODM\MongoDB\UnitOfWork');
+        $documentPersister = $this->createMock('Doctrine\ODM\MongoDB\Persisters\DocumentPersister');
+        $class = $this->createMock('Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata');
 
         $expected = array('foo.$ref' => 'coll', 'foo.$id' => '1234');
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/BsonFilterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/BsonFilterTest.php
@@ -29,8 +29,6 @@ class BsonFilterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
  
     public function testCreateMockOfFilter()
     {
-        $this->getMockBuilder('\Doctrine\ODM\MongoDB\Query\Filter\BsonFilter')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->createMock('\Doctrine\ODM\MongoDB\Query\Filter\BsonFilter');
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -614,16 +614,12 @@ class SchemaManagerTest extends \PHPUnit_Framework_TestCase
 
     private function getMockCollection()
     {
-        return $this->getMockBuilder('Doctrine\MongoDB\Collection')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock('Doctrine\MongoDB\Collection');
     }
 
     private function getMockDatabase()
     {
-        return $this->getMockBuilder('Doctrine\MongoDB\Database')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock('Doctrine\MongoDB\Database');
     }
 
     private function getMockDocumentManager()
@@ -631,9 +627,7 @@ class SchemaManagerTest extends \PHPUnit_Framework_TestCase
         $config = new Configuration();
         $config->setMetadataDriverImpl(AnnotationDriver::create(__DIR__ . '/../../../../Documents'));
 
-        $em = $this->getMockBuilder('Doctrine\Common\EventManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $em = $this->createMock('Doctrine\Common\EventManager');
 
         $dm = new DocumentManagerMock();
         $dm->eventManager = $em;
@@ -644,17 +638,13 @@ class SchemaManagerTest extends \PHPUnit_Framework_TestCase
 
     private function getMockUnitOfWork()
     {
-        $documentPersister = $this->getMockBuilder('Doctrine\ODM\MongoDB\Persisters\DocumentPersister')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $documentPersister = $this->createMock('Doctrine\ODM\MongoDB\Persisters\DocumentPersister');
 
         $documentPersister->expects($this->any())
             ->method('prepareFieldName')
             ->will($this->returnArgument(0));
 
-        $uow = $this->getMockBuilder('Doctrine\ODM\MongoDB\UnitOfWork')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $uow = $this->createMock('Doctrine\ODM\MongoDB\UnitOfWork');
 
         $uow->expects($this->any())
             ->method('getDocumentPersister')
@@ -665,8 +655,6 @@ class SchemaManagerTest extends \PHPUnit_Framework_TestCase
 
     private function getMockConnection()
     {
-        return $this->getMockBuilder('Doctrine\MongoDB\Connection')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock('Doctrine\MongoDB\Connection');
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -649,43 +649,31 @@ class UnitOfWorkTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     /**
      * Gets mock HydratorFactory instance
      *
-     * @return Doctrine\ODM\MongoDB\Hydrator\HydratorFactory
+     * @return \Doctrine\ODM\MongoDB\Hydrator\HydratorFactory
      */
     private function getMockHydratorFactory()
     {
-        return $this->getMockBuilder('Doctrine\ODM\MongoDB\Hydrator\HydratorFactory')
-            ->disableOriginalClone()
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock('Doctrine\ODM\MongoDB\Hydrator\HydratorFactory');
     }
 
     /**
      * Gets mock EventManager instance
      *
-     * @return Doctrine\Common\EventManager
+     * @return \Doctrine\Common\EventManager
      */
     private function getMockEventManager()
     {
-        return $this->getMockBuilder('Doctrine\Common\EventManager')
-            ->disableOriginalClone()
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock('Doctrine\Common\EventManager');
     }
 
     private function getMockPersistenceBuilder()
     {
-        return $this->getMockBuilder('Doctrine\ODM\MongoDB\Persisters\PersistenceBuilder')
-            ->disableOriginalClone()
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock('Doctrine\ODM\MongoDB\Persisters\PersistenceBuilder');
     }
 
     private function getMockDocumentManager()
     {
-        return $this->getMockBuilder('Doctrine\ODM\MongoDB\DocumentManager')
-            ->disableOriginalClone()
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock('Doctrine\ODM\MongoDB\DocumentManager');
     }
 
     private function getMockDocumentPersister(PersistenceBuilder $pb, ClassMetadata $class)


### PR DESCRIPTION
as `getMock` was deprecated. As a bonus I changed now unnecessary long `getMockBuilder` to `createMock` too