### PR TITLE
Ensure GridFS collections are dropped properly

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -373,9 +373,7 @@ class SchemaManager
         if ($class->isMappedSuperclass || $class->isEmbeddedDocument) {
             throw new \InvalidArgumentException('Cannot delete document indexes for mapped super classes or embedded documents.');
         }
-        $this->dm->getDocumentDatabase($documentName)->dropCollection(
-            $class->getCollection()
-        );
+        $this->dm->getDocumentCollection($documentName)->drop();
     }
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1468Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1468Test.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Documents;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class GH1468Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testFilesCollectionIsDroppedProperly()
+    {
+        $file = new Documents\File();
+        $this->dm->persist($file);
+        $this->dm->flush();
+        $this->assertCount(1, $this->dm->getRepository(get_class($file))->findAll());
+
+        $this->dm->getSchemaManager()->dropCollections();
+        $this->assertCount(0, $this->dm->getRepository(get_class($file))->findAll());
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -228,13 +228,13 @@ class SchemaManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDropCollections()
     {
-        foreach ($this->documentDatabases as $class => $database) {
+        foreach ($this->documentCollections as $class => $collection) {
             if (in_array($class, $this->indexedClasses + $this->someNonIndexedClasses)) {
-                $database->expects($this->once())
-                    ->method('dropCollection')
-                    ->with($this->classMetadatas[$class]->collection);
+                $collection->expects($this->once())
+                    ->method('drop')
+                    ->with();
             } elseif (in_array($class, $this->someMappedSuperclassAndEmbeddedClasses)) {
-                $database->expects($this->never())->method('dropCollection');
+                $collection->expects($this->never())->method('drop');
             }
         }
 
@@ -243,13 +243,13 @@ class SchemaManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDropDocumentCollection()
     {
-        foreach ($this->documentDatabases as $class => $database) {
+        foreach ($this->documentCollections as $class => $collection) {
             if ($class === 'Documents\CmsArticle') {
-                $database->expects($this->once())
-                    ->method('dropCollection')
-                    ->with($this->classMetadatas[$class]->collection);
+                $collection->expects($this->once())
+                    ->method('drop')
+                    ->with();
             } else {
-                $database->expects($this->never())->method('dropCollection');
+                $collection->expects($this->never())->method('drop');
             }
         }
 


### PR DESCRIPTION
This PR aims to ensure also a GridFS collection is dropped when calling `$dm->getSchemaManager()->dropCollections();`. Currently dropping a GridFS collection has no affect and the data remains in there.