### PR TITLE
Update mapping documentation

### DIFF
--- a/docs/en/reference/best-practices.rst
+++ b/docs/en/reference/best-practices.rst
@@ -3,21 +3,6 @@ Best Practices
 
 Here are some best practices you can follow when working with the Doctrine MongoDB ODM.
 
-Don't use public properties on documents
-----------------------------------------
-
-It is very important that you don't map public properties on
-documents, but only protected or private ones. The reason for this
-is simple, whenever you access a public property of a proxy object
-that hasn't been initialized yet the return value will be null.
-Doctrine cannot hook into this process and magically make the
-document lazy load.
-
-This can create situations where it is very hard to debug the
-current failure. We therefore urge you to map only private and
-protected properties on documents and use getter methods or magic
-\_\_get() to access them.
-
 Constrain relationships as much as possible
 -------------------------------------------
 

--- a/docs/en/reference/working-with-objects.rst
+++ b/docs/en/reference/working-with-objects.rst
@@ -309,14 +309,6 @@ Example:
     // $document now refers to the fully managed copy returned by the merge operation.
     // The DocumentManager $dm now manages the persistence of $document as usual.
 
-.. caution::
-
-    When you want to serialize/unserialize documents you
-    have to make all document properties protected, never private. The
-    reason for this is, if you serialize a class that was a proxy
-    instance before, the private variables won't be serialized and a
-    PHP Notice is thrown.
-
     The semantics of the merge operation, applied to a document X, are
     as follows:
 


### PR DESCRIPTION
Removed a couple of paragraphs from the docs. Serializing private properties from proxy object seems to no longer be a problem, see the following 3v4l snippet: https://3v4l.org/1Ufld

About public properties: while not recommended to be mapped, there is nothing there that wouldn't work. Public properties in proxy objects are unset and lazy loaded through the `__get` and `__set` magic accessors, properly triggering proxy initialization whenever accessed. Thus, I also removed that section from the documentation as it's not correct.