### PR TITLE
[1.2] Deprecate requireIndexes and stuff thereto related

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -424,6 +424,9 @@ Optional attributes:
         //...
     }
 
+.. note::
+    Requiring Indexes was deprecated in 1.2 and will be removed in 2.0.
+
 @EmbedMany
 ----------
 

--- a/docs/en/reference/indexes.rst
+++ b/docs/en/reference/indexes.rst
@@ -443,6 +443,9 @@ index.
 Requiring Indexes
 -----------------
 
+.. note::
+    Requiring Indexes was deprecated in 1.2 and will be removed in 2.0.
+
 Sometimes you may want to require indexes for all your queries to ensure you don't let stray unindexed queries
 make it to the database and cause performance problems.
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Document.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Document.php
@@ -30,6 +30,7 @@ final class Document extends AbstractDocument
     public $collection;
     public $repositoryClass;
     public $indexes = array();
+    /** @deprecated */
     public $requireIndexes = false;
     public $shardKey;
     public $slaveOkay;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -227,6 +227,8 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
 
     /**
      * READ-ONLY: Whether or not queries on this document should require indexes.
+     *
+     * @deprecated property was deprecated in 1.2 and will be removed in 2.0
      */
     public $requireIndexes = false;
 
@@ -807,6 +809,8 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
      * Set whether or not queries on this document should require indexes.
      *
      * @param bool $requireIndexes
+     *
+     * @deprecated method was deprecated in 1.2 and will be removed in 2.0
      */
     public function setRequireIndexes($requireIndexes)
     {

--- a/lib/Doctrine/ODM/MongoDB/MongoDBException.php
+++ b/lib/Doctrine/ODM/MongoDB/MongoDBException.php
@@ -102,6 +102,8 @@ class MongoDBException extends \Exception
      * @param string $className
      * @param string $unindexedFields
      * @return MongoDBException
+     *
+     * @deprecated method was deprecated in 1.2 and will be removed in 2.0
      */
     public static function queryNotIndexed($className, $unindexedFields)
     {

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -107,6 +107,8 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
      *
      * @param bool $requireIndexes
      * @return $this
+     *
+     * @deprecated method was deprecated in 1.2 and will be removed in 2.0
      */
     public function requireIndexes($requireIndexes = true)
     {

--- a/lib/Doctrine/ODM/MongoDB/Query/FieldExtractor.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/FieldExtractor.php
@@ -24,6 +24,8 @@ namespace Doctrine\ODM\MongoDB\Query;
  * a given mongodb query. Used for checking if query is indexed.
  *
  * @see Doctrine\ODM\MongoDB\Query::isIndexed()
+ *
+ * @deprecated class was deprecated in 1.2 and will be removed in 2.0
  */
 class FieldExtractor
 {

--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -87,6 +87,8 @@ class Query extends \Doctrine\MongoDB\Query\Query
     /**
      * Constructor.
      *
+     * Please note that $requireIndexes was deprecated in 1.2 and will be removed in 2.0
+     *
      * @param DocumentManager $dm
      * @param ClassMetadata $class
      * @param Collection $collection
@@ -95,7 +97,7 @@ class Query extends \Doctrine\MongoDB\Query\Query
      * @param boolean $hydrate
      * @param boolean $refresh
      * @param array $primers
-     * @param null $requireIndexes
+     * @param null $requireIndexes deprecated
      * @param boolean $readOnly
      */
     public function __construct(DocumentManager $dm, ClassMetadata $class, Collection $collection, array $query = array(), array $options = array(), $hydrate = true, $refresh = false, array $primers = array(), $requireIndexes = null, $readOnly = false)
@@ -190,6 +192,8 @@ class Query extends \Doctrine\MongoDB\Query\Query
      * Gets the fields involved in this query.
      *
      * @return array $fields An array of fields names used in this query.
+     *
+     * @deprecated method was deprecated in 1.2 and will be removed in 2.0
      */
     public function getFieldsInQuery()
     {
@@ -204,6 +208,8 @@ class Query extends \Doctrine\MongoDB\Query\Query
      * Check if this query is indexed.
      *
      * @return bool
+     *
+     * @deprecated method was deprecated in 1.2 and will be removed in 2.0
      */
     public function isIndexed()
     {
@@ -220,6 +226,8 @@ class Query extends \Doctrine\MongoDB\Query\Query
      * Gets an array of the unindexed fields in this query.
      *
      * @return array
+     *
+     * @deprecated method was deprecated in 1.2 and will be removed in 2.0
      */
     public function getUnindexedFields()
     {


### PR DESCRIPTION
As promised, follow up to #1476. Right now the feature is more broken than working thus giving developer false sense of security. To name few things that are wrong:

1. [Compound index order is not respected](https://github.com/doctrine/mongodb-odm/issues/761)
2. [Index intersection](https://docs.mongodb.com/manual/core/index-intersection/) added in Mongo 2.6 is not considered
3. [`$or` clauses can use own indexes](https://docs.mongodb.com/manual/reference/operator/query/or/#or-clauses-and-indexes) and that's not considered

I even took a stab at some of things listed above in #812 - it reached +1.2k and still was wrong. In my opinion all this adds unnecessary complexity and things to maintain, especially if Mongo would again introduce some new index-related feature making simple true/false switch not enough.