### PR TITLE
[2.0] Remove DiscriminatorField's name and fieldName

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DiscriminatorField.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DiscriminatorField.php
@@ -28,18 +28,4 @@ use Doctrine\Common\Annotations\Annotation;
  */
 final class DiscriminatorField extends Annotation
 {
-    /**
-     * Available for BC, but AnnotationDriver will consider $value first.
-     *
-     * @deprecated property was deprecated in 1.2 and will be removed in 2.0
-     */
-    public $name;
-
-    /**
-     * Available for BC, but AnnotationDriver will consider $name and $value
-     * first.
-     *
-     * @deprecated property was deprecated in 1.0.0-BETA10 and will be removed in 2.0
-     */
-    public $fieldName;
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -85,14 +85,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
             } elseif ($annot instanceof ODM\InheritanceType) {
                 $class->setInheritanceType(constant(MappingClassMetadata::class . '::INHERITANCE_TYPE_'.$annot->value));
             } elseif ($annot instanceof ODM\DiscriminatorField) {
-                // $fieldName property is deprecated, but fall back for BC
-                if (isset($annot->value)) {
-                    $class->setDiscriminatorField($annot->value);
-                } elseif (isset($annot->name)) {
-                    $class->setDiscriminatorField($annot->name);
-                } elseif (isset($annot->fieldName)) {
-                    $class->setDiscriminatorField($annot->fieldName);
-                }
+                $class->setDiscriminatorField($annot->value);
             } elseif ($annot instanceof ODM\DiscriminatorMap) {
                 $class->setDiscriminatorMap($annot->value);
             } elseif ($annot instanceof ODM\DiscriminatorValue) {


### PR DESCRIPTION
PR deprecating `name` and fixing our test suite will be sent soon (travis will be green again after #1479 is merged and this rebased)