### PR TITLE
[1.2] Deprecate DiscriminatorField's properties

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DiscriminatorField.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DiscriminatorField.php
@@ -30,6 +30,8 @@ final class DiscriminatorField extends Annotation
 {
     /**
      * Available for BC, but AnnotationDriver will consider $value first.
+     *
+     * @deprecated property was deprecated in 1.2 and will be removed in 2.0
      */
     public $name;
 
@@ -37,7 +39,7 @@ final class DiscriminatorField extends Annotation
      * Available for BC, but AnnotationDriver will consider $name and $value
      * first.
      *
-     * @deprecated
+     * @deprecated property was deprecated in 1.0.0-BETA10 and will be removed in 2.0
      */
     public $fieldName;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
@@ -197,7 +197,7 @@ class ParentDocumentWithDiscriminator extends ParentDocument
 /**
  * @ODM\Document(collection="discriminator_child")
  * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField(fieldName="discriminator")
+ * @ODM\DiscriminatorField("discriminator")
  * @ODM\DiscriminatorMap({"simple"="ChildDocumentWithDiscriminatorSimple", "complex"="ChildDocumentWithDiscriminatorComplex"})
  * @ODM\DefaultDiscriminatorValue("simple")
  */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -503,7 +503,7 @@ class DocumentPersisterTestDocument
 /**
  * @ODM\EmbeddedDocument
  * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField(fieldName="type")
+ * @ODM\DiscriminatorField("type")
  * @ODM\DiscriminatorMap({
  *     "reference"="Doctrine\ODM\MongoDB\Tests\Functional\DocumentPersisterTestDocumentReference",
  *     "embed"="Doctrine\ODM\MongoDB\Tests\Functional\DocumentPersisterTestDocumentEmbed"

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
@@ -90,7 +90,7 @@ class ReferenceDiscriminatorsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 /**
 * @ODM\Document(collection="rdt_action")
 * @ODM\InheritanceType("SINGLE_COLLECTION")
-* @ODM\DiscriminatorField(fieldName="discriminator")
+* @ODM\DiscriminatorField("discriminator")
 * @ODM\DiscriminatorMap({"action"="Action", "commentable_action"="CommentableAction"})
 */
 class Action

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
@@ -107,7 +107,7 @@ class User
 /**
  * @ODM\Document(collection="companies")
  * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField(fieldName="type")
+ * @ODM\DiscriminatorField("type")
  * @ODM\DiscriminatorMap({"seller"="SellerCompany", "buyer"="BuyerCompany"}) 
  */
 class Company

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH389Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH389Test.php
@@ -55,7 +55,7 @@ class RootDocument
 
 /**
  * @ODM\MappedSuperClass
- * @ODM\DiscriminatorField(fieldName="foobar")
+ * @ODM\DiscriminatorField("foobar")
  * @ODM\DiscriminatorMap({
  *     "empty"="EmptyEmbeddedDocument"
  * })

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH788Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH788Test.php
@@ -397,7 +397,7 @@ class GH788Document
 /**
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField(fieldName="type")
+ * @ODM\DiscriminatorField("type")
  * @ODM\DiscriminatorMap({"a"="GH788DocumentListed"})
  */
 class GH788DocumentListed extends GH788Document
@@ -443,7 +443,7 @@ class GH788InlineRefUnlisted extends GH788InlineRefListed
 
 /**
  * @ODM\EmbeddedDocument
- * @ODM\DiscriminatorField(fieldName="type")
+ * @ODM\DiscriminatorField("type")
  * @ODM\DiscriminatorMap({"d"="GH788ExternEmbedListed"})
  */
 class GH788ExternEmbedListed
@@ -463,7 +463,7 @@ class GH788ExternEmbedUnlisted extends GH788ExternEmbedListed
 /**
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField(fieldName="type")
+ * @ODM\DiscriminatorField("type")
  * @ODM\DiscriminatorMap({"e"="GH788ExternRefListed"})
  */
 class GH788ExternRefListed

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH942Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH942Test.php
@@ -52,7 +52,7 @@ class GH942Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 /**
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField(fieldName="type")
+ * @ODM\DiscriminatorField("type")
  */
 class GH942Document
 {
@@ -68,7 +68,7 @@ class GH942Document
 /**
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField(fieldName="type")
+ * @ODM\DiscriminatorField("type")
  * @ODM\DiscriminatorMap({"p"="GH942DocumentParent"})
  */
 class GH942DocumentParent

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
@@ -69,7 +69,7 @@ class GH971Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 /**
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField(fieldName="type")
+ * @ODM\DiscriminatorField("type")
  * @ODM\DiscriminatorMap({"car"="Car", "bicycle"="Bicycle", "tandem"="Tandem"})
  */
 class Vehicle

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM50Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM50Test.php
@@ -19,7 +19,7 @@ class MODM50Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 /**
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField(fieldName="type")
+ * @ODM\DiscriminatorField("type")
  * @ODM\DiscriminatorMap({
  *      "file"="MODM50File",
  *      "image"="MODM50Image"

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -355,7 +355,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
 
 /**
  * @ODM\Document(collection="cms_users", writeConcern=1)
- * @ODM\DiscriminatorField(fieldName="discr")
+ * @ODM\DiscriminatorField("discr")
  * @ODM\DiscriminatorMap({"default"="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser"})
  * @ODM\DefaultDiscriminatorValue("default")
  * @ODM\HasLifecycleCallbacks

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -140,7 +140,7 @@ class BuilderTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 /**
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField(fieldName="type")
+ * @ODM\DiscriminatorField("type")
  * @ODM\DiscriminatorMap({"ca"="ChildA", "cb"="ChildB", "cc"="ChildC"})
  */
 class ParentClass

--- a/tests/Documents/Functional/SameCollection1.php
+++ b/tests/Documents/Functional/SameCollection1.php
@@ -6,7 +6,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
  * @ODM\Document(collection="same_collection")
- * @ODM\DiscriminatorField(fieldName="type")
+ * @ODM\DiscriminatorField("type")
  * @ODM\DiscriminatorMap({"test1"="Documents\Functional\SameCollection1", "test2"="Documents\Functional\SameCollection2"})
  * @ODM\DefaultDiscriminatorValue("test1")
  */

--- a/tests/Documents/Functional/SameCollection2.php
+++ b/tests/Documents/Functional/SameCollection2.php
@@ -6,7 +6,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
  * @ODM\Document(collection="same_collection")
- * @ODM\DiscriminatorField(fieldName="type")
+ * @ODM\DiscriminatorField("type")
  * @ODM\DiscriminatorMap({"test1"="Documents\Functional\SameCollection1", "test2"="Documents\Functional\SameCollection2"})
  * @ODM\DefaultDiscriminatorValue("test1")
  */

--- a/tests/Documents/Project.php
+++ b/tests/Documents/Project.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /**
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField(fieldName="type")
+ * @ODM\DiscriminatorField("type")
  * @ODM\DiscriminatorMap({"project"="Documents\Project", "sub-project"="Documents\SubProject", "other-sub-project"="Documents\OtherSubProject"})
  */
 class Project

--- a/tests/Documents/Server.php
+++ b/tests/Documents/Server.php
@@ -7,7 +7,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /**
  * @ODM\Document(collection="servers")
  * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField(fieldName="stype")
+ * @ODM\DiscriminatorField("stype")
  * @ODM\DiscriminatorMap({
  * "server"="Server",
  * "server_guest"="GuestServer"

--- a/tests/Documents/UserUpsert.php
+++ b/tests/Documents/UserUpsert.php
@@ -7,7 +7,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /**
  * @ODM\Document(collection="users_upsert")
  * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField(fieldName="discriminator")
+ * @ODM\DiscriminatorField("discriminator")
  * @ODM\DiscriminatorMap({
  *     "user"="Documents\UserUpsert",
  *     "child"="Documents\UserUpsertChild"

--- a/tests/Documents/UserUpsertIdStrategyNone.php
+++ b/tests/Documents/UserUpsertIdStrategyNone.php
@@ -7,7 +7,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /**
  * @ODM\Document(collection="users_upsert_id_strategy_none")
  * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField(fieldName="discriminator")
+ * @ODM\DiscriminatorField("discriminator")
  * @ODM\DiscriminatorMap({
  *     "user"="Documents\UserUpsertIdStrategyNone"
  * })


### PR DESCRIPTION
Advocated usage is now `@ODM\DiscriminatorField("foo")`