### PR TITLE
Rename doesn't work inside unix volumes 

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -419,7 +419,8 @@ EOF
 
             $tmpFileName = $fileName . '.' . uniqid('', true);
             file_put_contents($tmpFileName, $code);
-            rename($tmpFileName, $fileName);
+            copy($tmpFileName, $fileName);
+            unlink($tmpFileName);
             chmod($fileName, 0664);
         }
     }


### PR DESCRIPTION
but copy and unlink is identical and has no issue.