### PR TITLE
PHP5.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/cache": "~1.0",
         "doctrine/inflector": "~1.0",
         "doctrine/instantiator": "~1.0.1",
-        "doctrine/mongodb": "~1.2"
+        "doctrine/mongodb": "1.2.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8|~5.0",


### PR DESCRIPTION
Fixed version doctrine/mongodb < 1.3 compatible to PHP5.3. version mongodb  1.3 is not compatible with PHP 5.3