### PR TITLE
Allow creating references to "empty" identifiers

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -675,7 +675,7 @@ class DocumentManager implements ObjectManager
         $class = $this->getClassMetadata(get_class($document));
         $id = $this->unitOfWork->getDocumentIdentifier($document);
 
-        if ( ! $id) {
+        if ($id === null) {
             throw new \RuntimeException(
                 sprintf('Cannot create a DBRef for class %s without an identifier. Have you forgotten to persist/merge the document first?', $class->name)
             );

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -196,6 +196,17 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->createDBRef($d);
     }
 
+    public function testCreateDbRefWithNonNullEmptyId()
+    {
+        $phonenumber = new \Documents\CmsPhonenumber();
+        $phonenumber->phonenumber = 0;
+        $this->dm->persist($phonenumber);
+
+        $dbRef = $this->dm->createDBRef($phonenumber);
+
+        $this->assertSame(array('$ref' => 'CmsPhonenumber', '$id' => 0, '$db' => DOCTRINE_MONGODB_DATABASE), $dbRef);
+    }
+
     /**
      * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
      * @expectedExceptionMessage Simple reference must not target document using Single Collection Inheritance, Documents\Tournament\Participant targeted.


### PR DESCRIPTION
Fixes #1394. This allows using falsey values as identifiers with references. All other checks to identifiers I could find explicitely check for null values, so it makes sense to do the same in createDbRef.