### PR TITLE
Bump PHPUnit requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "doctrine/mongodb": "~1.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8|~5.0",
+        "phpunit/phpunit": "~5.4",
         "symfony/yaml": "~2.3|~3.0"
     },
     "suggest": {


### PR DESCRIPTION
We're using `createMock` which was introduced in `5.4` (and sometimes it's not picked automatically https://github.com/doctrine/mongodb-odm/pull/1463#issuecomment-240723486)