### PR TITLE
Test against MongoDB 3.2 and 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
 before_script:
   - curl -XPUT http://localhost:8889/v1/sharded_clusters/myCluster --data @tests/sharded.json | python -m json.tool
   - composer self-update
-  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then yes '' | pecl -q install -f mongo-${DRIVER_VERSION} && echo "extension=mongo.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then yes '' | pecl -q install -f mongo-${DRIVER_VERSION}; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then pecl install -f mongodb-${DRIVER_VERSION}; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
   - composer install --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 matrix:
   include:
     - php: 5.6
-      env: DRIVER_VERSION="1.5.8" SERVER_VERSION="2.6"
+      env: DRIVER_VERSION="1.5.8" SERVER_VERSION="2.6" PREFER_LOWEST="--prefer-lowest"
 
 before_install:
   - sudo apt-key adv --keyserver ${KEY_SERVER} --recv 7F0CEB10
@@ -42,7 +42,7 @@ before_script:
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then yes '' | pecl -q install -f mongo-${DRIVER_VERSION}; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then pecl install -f mongodb-${DRIVER_VERSION}; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
-  - composer install --dev
+  - composer update ${PREFER_LOWEST}
 
 script:
   - ./vendor/bin/phpunit --coverage-clover=coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,51 @@
+sudo: required
+
 language: php
 
 php:
   - 5.6
+  - 7.0
 
 env:
   global:
-    - DOCTRINE_MONGODB_SERVER=mongodb://localhost:27017
+    - DOCTRINE_MONGODB_SERVER="mongodb://localhost:27017"
+    - KEY_SERVER="hkp://keyserver.ubuntu.com:80"
+    - MONGO_REPO_URI="http://repo.mongodb.com/apt/ubuntu"
+    - MONGO_REPO_TYPE="precise/mongodb-enterprise/"
+    - SOURCES_LOC="/etc/apt/sources.list.d/mongodb.list"
+    - DRIVER_VERSION="stable"
+    - ADAPTER_VERSION="^1.0.0"
   matrix:
-    - MONGO_VERSION=1.5.8
-    - MONGO_VERSION=stable
+    - SERVER_VERSION="2.6"
+    - SERVER_VERSION="3.2"
 
 matrix:
   include:
-    - php: 7.0
-      env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable
+    - php: 5.6
+      env: DRIVER_VERSION="1.5.8" SERVER_VERSION="2.6"
 
+before_install:
+  - sudo apt-key adv --keyserver ${KEY_SERVER} --recv 7F0CEB10
+  - sudo apt-key adv --keyserver ${KEY_SERVER} --recv EA312927
+  - echo "deb ${MONGO_REPO_URI} ${MONGO_REPO_TYPE}${SERVER_VERSION} multiverse" | sudo tee ${SOURCES_LOC}
+  - sudo apt-get update -qq
 
-services: mongodb
-
-before_script:
-  - if [ "x${MONGO_VERSION}" != "x" ]; then yes '' | pecl -q install -f mongo-${MONGO_VERSION} && echo "extension=mongo.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi
-  - sudo service mongodb stop
+install:
+  - sudo apt-get install mongodb-enterprise
+  - if nc -z localhost 27017; then sudo service mongod stop; fi
   - sudo pip install mongo-orchestration
   - sudo mongo-orchestration start
+
+before_script:
   - curl -XPUT http://localhost:8889/v1/sharded_clusters/myCluster --data @tests/sharded.json | python -m json.tool
   - composer self-update
-  - if [ "x${MONGODB_VERSION}" != "x" ]; then pecl install -f mongodb-${MONGODB_VERSION}; fi
-  - if [ "x${ADAPTER_VERSION}" != "x" ]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then yes '' | pecl -q install -f mongo-${DRIVER_VERSION} && echo "extension=mongo.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then pecl install -f mongodb-${DRIVER_VERSION}; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
   - composer install --dev
 
 script:
-    - ./vendor/bin/phpunit --coverage-clover=coverage.clover
+  - ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
 after_script:
     - wget https://scrutinizer-ci.com/ocular.phar

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -27,6 +27,15 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
             return;
         }
 
+        // Check if the database exists. Calling listCollections on a non-existing
+        // database in a sharded setup will cause an invalid command cursor to be
+        // returned
+        $databases = $this->dm->getConnection()->listDatabases();
+        $databaseNames = array_map(function ($database) { return $database['name']; }, $databases['databases']);
+        if (! in_array(DOCTRINE_MONGODB_DATABASE, $databaseNames)) {
+            return;
+        }
+
         $collections = $this->dm->getConnection()->selectDatabase(DOCTRINE_MONGODB_DATABASE)->listCollections();
 
         foreach ($collections as $collection) {


### PR DESCRIPTION
We need MongoDB 3.2 to test the upcoming `$lookup` stages in the aggregation builder. For better compatibility we also test against MongoDB 2.6 which is the lowest version required for most aggregation queries.