### PR TITLE
Add CustomType class to let use convertToPHPValue method instead of closureToPHP (no reflection)

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -234,6 +234,7 @@ EOF
         if (isset(\$data['%1\$s']) || (! empty(\$this->class->fieldMappings['%2\$s']['nullable']) && array_key_exists('%1\$s', \$data))) {
             \$value = \$data['%1\$s'];
             if (\$value !== null) {
+                \$typeIdentifier = \$this->class->fieldMappings['%2\$s']['type'];
                 %3\$s
             } else {
                 \$return = null;

--- a/lib/Doctrine/ODM/MongoDB/Types/ClosureToPHP.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/ClosureToPHP.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\ODM\MongoDB\Types;
 
-trait CustomType
+trait ClosureToPHP
 {
     /**
      * @return string Redirects to the method convertToPHPValue from child class

--- a/lib/Doctrine/ODM/MongoDB/Types/CustomType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/CustomType.php
@@ -2,14 +2,14 @@
 
 namespace Doctrine\ODM\MongoDB\Types;
 
-class CustomType extends Type
+trait CustomType
 {
     /**
      * @return string Redirects to the method convertToPHPValue from child class
      */
     final public function closureToPHP()
     {
-        $fqcn = self::class;
+        $fqcn = Type::class;
 
         return sprintf('
             $type = \%s::getType($typeIdentifier);

--- a/lib/Doctrine/ODM/MongoDB/Types/CustomType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/CustomType.php
@@ -1,4 +1,21 @@
 <?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
 
 namespace Doctrine\ODM\MongoDB\Types;
 
@@ -9,10 +26,8 @@ trait CustomType
      */
     final public function closureToPHP()
     {
-        $fqcn = Type::class;
-
         return sprintf('
             $type = \%s::getType($typeIdentifier);
-            $return = $type->convertToPHPValue($value);', $fqcn);
+            $return = $type->convertToPHPValue($value);', Type::class);
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Types/CustomType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/CustomType.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Types;
+
+class CustomType extends Type
+{
+    /**
+     * @return string Redirects to the method convertToPHPValue from child class
+     */
+    final public function closureToPHP()
+    {
+        $fqcn = self::class;
+
+        return sprintf('
+            $type = \%s::getType($typeIdentifier);
+            $return = $type->convertToPHPValue($value);', $fqcn);
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Types\CustomType;
+use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\Type;
 
 class CustomTypeTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
@@ -43,7 +43,7 @@ class CustomTypeTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
 class DateCollectionType
 {
-    use CustomType;
+    use ClosureToPHP;
 
     // Note: this method is called by PersistenceBuilder
     public function convertToDatabaseValue($value)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
@@ -67,19 +67,21 @@ class DateCollectionType
 
     public function convertToPHPValue($value)
     {
-        return array_map(
-            function ($v) {
-                if ($v instanceof \MongoDate) {
-                    $date = new \DateTime();
-                    $date->setTimestamp($v->sec);
+        if ($value === null) {
+            return null;
+        }
 
-                    return $date;
-                } else {
-                    return new \DateTime($v);
-                }
-            },
-            $value
-        );
+        if (!is_array($value)) {
+            throw new CustomTypeException('Array expected.');
+        }
+
+        $converter = Type::getType('date');
+
+        $value = array_map(function($date) use ($converter) {
+            return $converter->convertToPHPValue($date);
+        }, array_values($value));
+
+        return $value;
     }
 
     // Note: this method is never called

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
@@ -41,8 +41,10 @@ class CustomTypeTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     }
 }
 
-class DateCollectionType extends CustomType
+class DateCollectionType
 {
+    use CustomType;
+
     // Note: this method is called by PersistenceBuilder
     public function convertToDatabaseValue($value)
     {


### PR DESCRIPTION
Issue #1509

Notes: Per suggested by @malarzm here it is another approach from PR #1510 avoiding reflection to instantiate a `Type`.
