### PR TITLE
Correct Class Name in Custom Mapping Type Docs

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -472,7 +472,7 @@ handy when you're missing a specific mapping type or when you want
 to replace the existing implementation of a mapping type.
 
 In order to create a new mapping type you need to subclass
-``Doctrine\ODM\MongoDB\Mapping\Types\Type`` and implement/override
+``Doctrine\ODM\MongoDB\Types\Type`` and implement/override
 the methods. Here is an example skeleton of such a custom type
 class:
 
@@ -482,7 +482,7 @@ class:
 
     namespace My\Project\Types;
 
-    use Doctrine\ODM\MongoDB\Mapping\Types\Type;
+    use Doctrine\ODM\MongoDB\Types\Type;
 
     /**
      * My custom datatype.
@@ -521,7 +521,7 @@ Restrictions to keep in mind:
 
 When you have implemented the type you still need to let Doctrine
 know about it. This can be achieved through the
-``Doctrine\ODM\MongoDB\Mapping\Types#registerType($name, $class)``
+``Doctrine\ODM\MongoDB\Types\Type#registerType($name, $class)``
 method.
 
 Here is an example:


### PR DESCRIPTION
Docs were using an old class name. With these changes, was able to follow documentation and create an custom mapping type.