### PR TITLE
Add alternative to deprecated annotations

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Bin.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Bin.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="bin")` instead.
  */
 final class Bin extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinCustom.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinCustom.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="bin_custom")` instead.
  */
 final class BinCustom extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinFunc.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinFunc.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="bin_func")` instead.
  */
 final class BinFunc extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinMD5.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinMD5.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="bin_md5")` instead.
  */
 final class BinMD5 extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinUUID.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinUUID.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="bin_uuid")` instead.
  */
 final class BinUUID extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinUUIDRFC4122.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BinUUIDRFC4122.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="bin_rfc4122")` instead.
  */
 final class BinUUIDRFC4122 extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Bool.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Bool.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="bool")` instead.
  */
 final class Bool extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Boolean.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Boolean.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="boolean")` instead.
  */
 final class Boolean extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Collection.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Collection.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="collection")` instead.
  */
 final class Collection extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Date.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Date.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="date")` instead.
  */
 final class Date extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Float.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Float.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="float")` instead.
  */
 final class Float extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Hash.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Hash.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="hash")` instead.
  */
 final class Hash extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Int.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Int.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="int")` instead.
  */
 final class Int extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Integer.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Integer.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="integer")` instead.
  */
 final class Integer extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Key.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Key.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="key")` instead.
  */
 final class Key extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ObjectId.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ObjectId.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="object_id")` instead.
  */
 final class ObjectId extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Raw.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Raw.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="raw")` instead.
  */
 final class Raw extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/String.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/String.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="string")` instead.
  */
 final class String extends AbstractField
 {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Timestamp.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Timestamp.php
@@ -21,7 +21,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
  * @Annotation
- * @deprecated This class will be removed in ODM 2.0
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(type="timestamp")` instead.
  */
 final class Timestamp extends AbstractField
 {


### PR DESCRIPTION
Following discussion from https://github.com/doctrine/mongodb-odm/issues/1459#issuecomment-255722659
Instead of just saying that this class is deprecated (and probably got a lot of issues related to that) add an alternative to it.