### PR TITLE
Avoid call to MongoDBs deprecated eval

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -405,6 +405,8 @@ class SchemaManager
 
     /**
      * Create all the mapped document databases in the metadata factory.
+     *
+     * @deprecated Databases are created automatically by MongoDB (>= 3.0). Deprecated since ODM 1.2, to be removed in ODM 2.0.
      */
     public function createDatabases()
     {
@@ -421,6 +423,8 @@ class SchemaManager
      *
      * @param string $documentName
      * @throws \InvalidArgumentException
+     *
+     * @deprecated A database is created automatically by MongoDB (>= 3.0). Deprecated since ODM 1.2, to be removed in ODM 2.0.
      */
     public function createDocumentDatabase($documentName)
     {
@@ -428,6 +432,14 @@ class SchemaManager
         if ($class->isMappedSuperclass || $class->isEmbeddedDocument) {
             throw new \InvalidArgumentException('Cannot delete document indexes for mapped super classes or embedded documents.');
         }
+
+        $serverStatus = $this->dm->getDocumentDatabase($documentName)->command(['serverStatus' => true]);
+        $version = $serverStatus['version'];
+
+        if (version_compare($version, '3.0.0') >= 0) {
+            return;
+        }
+
         $this->dm->getDocumentDatabase($documentName)->execute('function() { return true; }');
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -253,19 +253,6 @@ class SchemaManagerTest extends \PHPUnit_Framework_TestCase
         $this->schemaManager->dropDocumentCollection(\Documents\CmsArticle::class);
     }
 
-    public function testCreateDocumentDatabase()
-    {
-        foreach ($this->documentDatabases as $class => $database) {
-            if ($class === \Documents\CmsArticle::class) {
-                $database->expects($this->once())->method('execute');
-            } else {
-                $database->expects($this->never())->method('execute');
-            }
-        }
-
-        $this->schemaManager->createDocumentDatabase(\Documents\CmsArticle::class);
-    }
-
     public function testDropDocumentDatabase()
     {
         foreach ($this->documentDatabases as $class => $database) {


### PR DESCRIPTION
By using the already existing `createCollection` instead of doing a fake command it's possbile to avoid calls to MongoDBs deprecated `eval`.

When using the `schema:create`-command at deploy time this will avoid MongoDB startup warnings like
```
"2016-10-21T14:05:35.870+0000 W COMMAND  [conn581654] the eval command is deprecated"
```