### PR TITLE
Add fieldTypeName to yml-generator

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -339,50 +339,48 @@ You can define your own ID generator by extending the
 ``Doctrine\ODM\MongoDB\Id\AbstractIdGenerator`` class and specifying the class
 as an option for the ``CUSTOM`` strategy:
 
-.. configuration-block::
+.. code-block:: php
 
-    .. code-block:: php
+	<?php
 
-        <?php
+	/** Document */
+	class MyPersistentClass
+	{
+		/** @Id(strategy="CUSTOM", type="string", options={"class"="Vendor\Specific\Generator"}) */
+		private $id;
 
-        /** Document */
-        class MyPersistentClass
-        {
-            /** @Id(strategy="CUSTOM", type="string", options={"class"="Vendor\Specific\Generator"}) */
-            private $id;
+		public function setId($id)
+		{
+			$this->id = $id;
+		}
 
-            public function setId($id)
-            {
-                $this->id = $id;
-            }
+		//...
+	}
 
-            //...
-        }
+.. code-block:: xml
 
-    .. code-block:: xml
+	<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+							xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+												http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-        <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
-                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
-                                                    http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+		<document name="MyPersistentClass">
+			<field name="id" id="true" strategy="CUSTOM" type="string">
+				<id-generator-option name="class" value="Vendor\Specific\Generator" />
+			</field>
+		</document>
+	</doctrine-mongo-mapping>
 
-            <document name="MyPersistentClass">
-                <field name="id" id="true" strategy="CUSTOM" type="string">
-                    <id-generator-option name="class" value="Vendor\Specific\Generator" />
-                </field>
-            </document>
-        </doctrine-mongo-mapping>
+.. code-block:: yaml
 
-    .. code-block:: yaml
-
-        MyPersistentClass:
-          fields:
-            id:
-              id: true
-              strategy: CUSTOM
-              type: string
-              options:
-                class: Vendor\Specific\Generator
+	MyPersistentClass:
+	  fields:
+		id:
+		  id: true
+		  strategy: CUSTOM
+		  type: string
+		  options:
+			class: Vendor\Specific\Generator
 
 
 
@@ -398,45 +396,43 @@ the most flexible.
 
 Example:
 
-.. configuration-block::
+.. code-block:: php
 
-    .. code-block:: php
+	<?php
 
-        <?php
+	namespace Documents;
 
-        namespace Documents;
+	/** @Document */
+	class User
+	{
+		// ...
 
-        /** @Document */
-        class User
-        {
-            // ...
+		/** @Field(type="string") */
+		private $username;
+	}
 
-            /** @Field(type="string") */
-            private $username;
-        }
+.. code-block:: xml
 
-    .. code-block:: xml
+	<?xml version="1.0" encoding="UTF-8"?>
+	<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+					xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+					xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+					http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+	  <document name="Documents\User">
+			<field fieldName="id" id="true" />
+			<field fieldName="username" type="string" />
+	  </document>
+	</doctrine-mongo-mapping>
 
-        <?xml version="1.0" encoding="UTF-8"?>
-        <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
-                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
-                        http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
-          <document name="Documents\User">
-                <field fieldName="id" id="true" />
-                <field fieldName="username" type="string" />
-          </document>
-        </doctrine-mongo-mapping>
+.. code-block:: yaml
 
-    .. code-block:: yaml
-
-        Documents\User:
-          fields:
-            id:
-              type: id
-              id: true
-            username:
-              type: string
+	Documents\User:
+	  fields:
+		id:
+		  type: id
+		  id: true
+		username:
+		  type: string
 
 In that example we mapped the property ``id`` to the field ``id``
 using the mapping type ``id`` and the property ``name`` is mapped
@@ -446,24 +442,67 @@ same as the property names. To specify a different name for the
 field, you can use the ``name`` attribute of the Field annotation
 as follows:
 
-.. configuration-block::
+.. code-block:: php
 
-    .. code-block:: php
+	<?php
 
-        <?php
+	/** @Field(name="db_name") */
+	private $name;
 
-        /** @Field(name="db_name") */
-        private $name;
+.. code-block:: xml
 
-    .. code-block:: xml
+	<field fieldName="name" name="db_name" />
 
-        <field fieldName="name" name="db_name" />
+.. code-block:: yaml
 
-    .. code-block:: yaml
+	name:
+	  name: db_name
 
-        name:
-          name: db_name
+The default field type generated in comments is taken from "type".
+To define a different or custom field type name (type in the 
+comments  of the field and get/set-Methods) you can use
+"fieldTypeName" as follows:
 
+.. code-block:: xml
+
+	<field fieldName="created_at" fieldTypeName="\DateTime" />
+
+.. code-block:: yaml
+
+	name:
+	  fieldTypeName: \DateTime
+
+This will give us the following code:
+
+.. code-block:: php
+	  
+	/**
+     * @var \DateTime $created_at
+     */
+    protected $created_at;
+
+	/**
+     * Get createdAt
+     *
+     * @return \DateTime $createdAt
+     */
+    public function getCreatedAt()
+    {
+        return $this->created_at;
+    }
+
+	/**
+     * Set createdAt
+     *
+     * @param \DateTime $createdAt
+     * @return self
+     */
+    public function setCreatedAt(\DateTime $createdAt)
+    {
+        $this->created_at = $createdAt;
+        return $this;
+    }
+		  
 Custom Mapping Types
 --------------------
 

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -339,48 +339,50 @@ You can define your own ID generator by extending the
 ``Doctrine\ODM\MongoDB\Id\AbstractIdGenerator`` class and specifying the class
 as an option for the ``CUSTOM`` strategy:
 
-.. code-block:: php
+.. configuration-block::
 
-	<?php
+    .. code-block:: php
 
-	/** Document */
-	class MyPersistentClass
-	{
-		/** @Id(strategy="CUSTOM", type="string", options={"class"="Vendor\Specific\Generator"}) */
-		private $id;
+        <?php
 
-		public function setId($id)
-		{
-			$this->id = $id;
-		}
+        /** Document */
+        class MyPersistentClass
+        {
+            /** @Id(strategy="CUSTOM", type="string", options={"class"="Vendor\Specific\Generator"}) */
+            private $id;
 
-		//...
-	}
+            public function setId($id)
+            {
+                $this->id = $id;
+            }
 
-.. code-block:: xml
+            //...
+        }
 
-	<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
-							xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-							xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
-												http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+    .. code-block:: xml
 
-		<document name="MyPersistentClass">
-			<field name="id" id="true" strategy="CUSTOM" type="string">
-				<id-generator-option name="class" value="Vendor\Specific\Generator" />
-			</field>
-		</document>
-	</doctrine-mongo-mapping>
+        <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                                                    http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-.. code-block:: yaml
+            <document name="MyPersistentClass">
+                <field name="id" id="true" strategy="CUSTOM" type="string">
+                    <id-generator-option name="class" value="Vendor\Specific\Generator" />
+                </field>
+            </document>
+        </doctrine-mongo-mapping>
 
-	MyPersistentClass:
-	  fields:
-		id:
-		  id: true
-		  strategy: CUSTOM
-		  type: string
-		  options:
-			class: Vendor\Specific\Generator
+    .. code-block:: yaml
+
+        MyPersistentClass:
+          fields:
+            id:
+              id: true
+              strategy: CUSTOM
+              type: string
+              options:
+                class: Vendor\Specific\Generator
 
 
 
@@ -396,43 +398,45 @@ the most flexible.
 
 Example:
 
-.. code-block:: php
+.. configuration-block::
 
-	<?php
+    .. code-block:: php
 
-	namespace Documents;
+        <?php
 
-	/** @Document */
-	class User
-	{
-		// ...
+        namespace Documents;
 
-		/** @Field(type="string") */
-		private $username;
-	}
+        /** @Document */
+        class User
+        {
+            // ...
 
-.. code-block:: xml
+            /** @Field(type="string") */
+            private $username;
+        }
 
-	<?xml version="1.0" encoding="UTF-8"?>
-	<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
-					xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-					xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
-					http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
-	  <document name="Documents\User">
-			<field fieldName="id" id="true" />
-			<field fieldName="username" type="string" />
-	  </document>
-	</doctrine-mongo-mapping>
+    .. code-block:: xml
 
-.. code-block:: yaml
+        <?xml version="1.0" encoding="UTF-8"?>
+        <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                        http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+          <document name="Documents\User">
+                <field fieldName="id" id="true" />
+                <field fieldName="username" type="string" />
+          </document>
+        </doctrine-mongo-mapping>
 
-	Documents\User:
-	  fields:
-		id:
-		  type: id
-		  id: true
-		username:
-		  type: string
+    .. code-block:: yaml
+
+        Documents\User:
+          fields:
+            id:
+              type: id
+              id: true
+            username:
+              type: string
 
 In that example we mapped the property ``id`` to the field ``id``
 using the mapping type ``id`` and the property ``name`` is mapped
@@ -442,21 +446,23 @@ same as the property names. To specify a different name for the
 field, you can use the ``name`` attribute of the Field annotation
 as follows:
 
-.. code-block:: php
+.. configuration-block::
 
-	<?php
+    .. code-block:: php
 
-	/** @Field(name="db_name") */
-	private $name;
+        <?php
 
-.. code-block:: xml
+        /** @Field(name="db_name") */
+        private $name;
 
-	<field fieldName="name" name="db_name" />
+    .. code-block:: xml
 
-.. code-block:: yaml
+        <field fieldName="name" name="db_name" />
 
-	name:
-	  name: db_name
+    .. code-block:: yaml
+
+        name:
+          name: db_name
 
 The default field type generated in comments is taken from "type".
 To define a different or custom field type name (type in the 
@@ -502,7 +508,7 @@ This will give us the following code:
         $this->created_at = $createdAt;
         return $this;
     }
-		  
+
 Custom Mapping Types
 --------------------
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -2053,6 +2053,15 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
     /**
      * {@inheritDoc}
      */
+    public function getTypeNameOfField($fieldName)
+    {
+        return (isset($this->fieldMappings[$fieldName]) && isset($this->fieldMappings[$fieldName]['fieldTypeName'])) ?
+            $this->fieldMappings[$fieldName]['fieldTypeName'] : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getAssociationTargetClass($assocName)
     {
         if ( ! isset($this->associationMappings[$assocName])) {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -254,6 +254,9 @@ class XmlDriver extends FileDriver
         if (isset($attributes['fieldName'])) {
             $mapping['fieldName'] = (string) $attributes['fieldName'];
         }
+        if (isset($attributes['fieldTypeName'])) {
+            $mapping['fieldTypeName'] = (string) $attributes['fieldTypeName'];
+        }
         if (isset($embed->{'discriminator-field'})) {
             $attr = $embed->{'discriminator-field'};
             $mapping['discriminatorField'] = (string) $attr['name'];
@@ -304,6 +307,9 @@ class XmlDriver extends FileDriver
 
         if (isset($attributes['fieldName'])) {
             $mapping['fieldName'] = (string) $attributes['fieldName'];
+        }
+        if (isset($attributes['fieldTypeName'])) {
+            $mapping['fieldTypeName'] = (string) $attributes['fieldTypeName'];
         }
         if (isset($reference->{'discriminator-field'})) {
             $attr = $reference->{'discriminator-field'};

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
@@ -252,6 +252,9 @@ class YamlDriver extends FileDriver
         if (isset($embed['name'])) {
             $mapping['name'] = $embed['name'];
         }
+        if (isset($embed['fieldTypeName'])) {
+            $mapping['fieldTypeName'] = $embed['fieldTypeName'];
+        }
         if (isset($embed['discriminatorField'])) {
             $mapping['discriminatorField'] = $this->parseDiscriminatorField($embed['discriminatorField']);
         }
@@ -286,6 +289,9 @@ class YamlDriver extends FileDriver
         );
         if (isset($reference['name'])) {
             $mapping['name'] = $reference['name'];
+        }
+        if (isset($reference['fieldTypeName'])) {
+            $mapping['fieldTypeName'] = $reference['fieldTypeName'];
         }
         if (isset($reference['discriminatorField'])) {
             $mapping['discriminatorField'] = $this->parseDiscriminatorField($reference['discriminatorField']);

--- a/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
@@ -661,20 +661,22 @@ public function <methodName>()
         $methods = array();
 
         foreach ($metadata->fieldMappings as $fieldMapping) {
+            $typeHint = isset($fieldMapping['fieldTypeName']) ? $fieldMapping['fieldTypeName'] : $fieldMapping['type'];
+            
             if (isset($fieldMapping['id'])) {
                 if ($metadata->generatorType == ClassMetadataInfo::GENERATOR_TYPE_NONE) {
-                    if ($code = $this->generateDocumentStubMethod($metadata, 'set', $fieldMapping['fieldName'], $fieldMapping['type'])) {
+                    if ($code = $this->generateDocumentStubMethod($metadata, 'set', $fieldMapping['fieldName'], $typeHint)) {
                         $methods[] = $code;
                     }
                 }
-                if ($code = $code = $this->generateDocumentStubMethod($metadata, 'get', $fieldMapping['fieldName'], $fieldMapping['type'])) {
+                if ($code = $code = $this->generateDocumentStubMethod($metadata, 'get', $fieldMapping['fieldName'], $typeHint)) {
                     $methods[] = $code;
                 }
             } elseif ( ! isset($fieldMapping['association'])) {
-                if ($code = $code = $this->generateDocumentStubMethod($metadata, 'set', $fieldMapping['fieldName'], $fieldMapping['type'])) {
+                if ($code = $code = $this->generateDocumentStubMethod($metadata, 'set', $fieldMapping['fieldName'], $typeHint)) {
                     $methods[] = $code;
                 }
-                if ($code = $code = $this->generateDocumentStubMethod($metadata, 'get', $fieldMapping['fieldName'], $fieldMapping['type'])) {
+                if ($code = $code = $this->generateDocumentStubMethod($metadata, 'get', $fieldMapping['fieldName'], $typeHint)) {
                     $methods[] = $code;
                 }
             } elseif ($fieldMapping['type'] === ClassMetadataInfo::ONE) {
@@ -789,7 +791,7 @@ public function <methodName>()
         $description = ucfirst($type) . ' ' . $variableName;
 
         $types = Type::getTypesMap();
-        $methodTypeHint = $typeHint && ! isset($types[$typeHint]) ? '\\' . $typeHint . ' ' : null;
+        $methodTypeHint = $typeHint && ! isset($types[$typeHint]) ? (mb_substr($typeHint, 0, 1) != '\\' ? '\\' : '') . $typeHint . ' ' : null;
         $variableType = $typeHint ? $typeHint . ' ' : null;
 
         $replacements = array(
@@ -901,7 +903,11 @@ public function <methodName>()
                 $lines[] = $this->spaces . ' * @var $' . $fieldMapping['fieldName'];
             }
         } else {
-            $lines[] = $this->spaces . ' * @var ' . $fieldMapping['type'] . ' $' . $fieldMapping['fieldName'];
+            if (isset($fieldMapping['fieldTypeName'])){
+                $lines[] = $this->spaces . ' * @var ' . $fieldMapping['fieldTypeName'] . ' $' . $fieldMapping['fieldName'];
+            } else {
+                $lines[] = $this->spaces . ' * @var ' . $fieldMapping['type'] . ' $' . $fieldMapping['fieldName'];
+            }
         }
 
         if ($this->generateAnnotations) {

--- a/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/DocumentGenerator.php
@@ -661,6 +661,7 @@ public function <methodName>()
         $methods = array();
 
         foreach ($metadata->fieldMappings as $fieldMapping) {
+            // fieldTypeName is optional in the yml-configuration, otherwise the non-optional type is used as field type name
             $typeHint = isset($fieldMapping['fieldTypeName']) ? $fieldMapping['fieldTypeName'] : $fieldMapping['type'];
             
             if (isset($fieldMapping['id'])) {
@@ -673,10 +674,10 @@ public function <methodName>()
                     $methods[] = $code;
                 }
             } elseif ( ! isset($fieldMapping['association'])) {
-                if ($code = $code = $this->generateDocumentStubMethod($metadata, 'set', $fieldMapping['fieldName'], $typeHint)) {
+                if ($code = $this->generateDocumentStubMethod($metadata, 'set', $fieldMapping['fieldName'], $typeHint)) {
                     $methods[] = $code;
                 }
-                if ($code = $code = $this->generateDocumentStubMethod($metadata, 'get', $fieldMapping['fieldName'], $typeHint)) {
+                if ($code = $this->generateDocumentStubMethod($metadata, 'get', $fieldMapping['fieldName'], $typeHint)) {
                     $methods[] = $code;
                 }
             } elseif ($fieldMapping['type'] === ClassMetadataInfo::ONE) {
@@ -791,7 +792,7 @@ public function <methodName>()
         $description = ucfirst($type) . ' ' . $variableName;
 
         $types = Type::getTypesMap();
-        $methodTypeHint = $typeHint && ! isset($types[$typeHint]) ? (mb_substr($typeHint, 0, 1) != '\\' ? '\\' : '') . $typeHint . ' ' : null;
+        $methodTypeHint = $typeHint && ! isset($types[$typeHint]) ? (substr($typeHint, 0, 1) !== '\\' ? '\\' : '') . $typeHint . ' ' : null;
         $variableType = $typeHint ? $typeHint . ' ' : null;
 
         $replacements = array(
@@ -903,6 +904,8 @@ public function <methodName>()
                 $lines[] = $this->spaces . ' * @var $' . $fieldMapping['fieldName'];
             }
         } else {
+            // fieldTypeName is optional in the yml-configuration, otherwise the non-optional type is used as field type name
+            
             if (isset($fieldMapping['fieldTypeName'])){
                 $lines[] = $this->spaces . ' * @var ' . $fieldMapping['fieldTypeName'] . ' $' . $fieldMapping['fieldName'];
             } else {


### PR DESCRIPTION
If you implement and register a custom type there is no way to define a destination type/field name for the generated fields and methods.

With this change you can define in the yml-file:

        created_at:
            type: mycustomtype
            fieldTypeName: \DateTime

This results in:

```
    /**
     * @var \DateTime $created_at
     */
    protected $created_at;

/**
     * Get createdAt
     *
     * @return \DateTime $createdAt
     */
    public function getCreatedAt()
    {
        return $this->created_at;
    }

/**
     * Set createdAt
     *
     * @param \DateTime $createdAt
     * @return self
     */
    public function setCreatedAt( \DateTime $createdAt)
    {
        $this->created_at = $createdAt;
        return $this;
    }
```