### PR TITLE
Remove version check in SchemaManager

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -428,14 +428,7 @@ class SchemaManager
     {
         $class = $this->dm->getClassMetadata($documentName);
         if ($class->isMappedSuperclass || $class->isEmbeddedDocument) {
-            throw new \InvalidArgumentException('Cannot delete document indexes for mapped super classes or embedded documents.');
-        }
-
-        $serverStatus = $this->dm->getDocumentDatabase($documentName)->command(['serverStatus' => true]);
-        $version = $serverStatus['version'];
-
-        if (version_compare($version, '3.0.0') >= 0) {
-            return;
+            throw new \InvalidArgumentException('Cannot create databases for mapped super classes or embedded documents.');
         }
 
         $this->dm->getDocumentDatabase($documentName)->execute('function() { return true; }');

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
@@ -45,6 +45,10 @@ class CreateCommand extends AbstractCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if ($input->getOption(self::DB)) {
+            @trigger_error('The ' . self::DB . ' option is deprecated and will be removed in ODM 2.0', E_USER_DEPRECATED);
+        }
+
         foreach ($this->createOrder as $option) {
             if ($input->getOption($option)) {
                 $create[] = $option;


### PR DESCRIPTION
This PR removes the version check in SchemaManager introduced with #1521. This is necessary since the `serverStatus` command requires extra privileges which may or may not have been given to the user being used. Instead, users should skip the creation of the database by passing the `--collection` and `--index` options, omitting the `--db` option when creating the schema using the `schema:create` command.

The deprecation of the `createDatabases` and `createDocumentDatabase` methods in `SchemaManager` stays intact; the methods will be removed with ODM 2.0.