### PR TITLE
Store redundant fields in references

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -136,6 +136,7 @@
       <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
       <xs:element name="sort" type="odm:sort-map" minOccurs="0" />
       <xs:element name="criteria" type="odm:criteria-map" minOccurs="0" />
+      <xs:element name="redundant-fields" type="odm:redundant-field-list" minOccurs="0" />
     </xs:sequence>
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
@@ -157,6 +158,7 @@
       <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
       <xs:element name="sort" type="odm:sort-map" minOccurs="0" />
       <xs:element name="criteria" type="odm:criteria-map" minOccurs="0" />
+      <xs:element name="redundant-fields" type="odm:redundant-field-list" minOccurs="0" />
     </xs:sequence>
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="collection-class" type="xs:string" />
@@ -182,6 +184,16 @@
     <xs:sequence>
       <xs:element name="sort" type="odm:sort-type" minOccurs="1" maxOccurs="unbounded"/>
     </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="redundant-field-list">
+    <xs:sequence>
+      <xs:element name="field" type="odm:redundant-field" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="redundant-field">
+    <xs:attribute name="name" type="xs:string" use="required"/>
   </xs:complexType>
 
   <xs:complexType name="criteria-type">

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceMany.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceMany.php
@@ -42,10 +42,11 @@ final class ReferenceMany extends AbstractField
     public $inversedBy;
     public $mappedBy;
     public $repositoryMethod;
-    public $sort = array();
-    public $criteria = array();
+    public $sort = [];
+    public $criteria = [];
     public $limit;
     public $skip;
     public $strategy = CollectionHelper::DEFAULT_STRATEGY;
     public $collectionClass;
+    public $redundantFields = [];
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceOne.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceOne.php
@@ -41,8 +41,9 @@ final class ReferenceOne extends AbstractField
     public $inversedBy;
     public $mappedBy;
     public $repositoryMethod;
-    public $sort = array();
-    public $criteria = array();
+    public $sort = [];
+    public $criteria = [];
     public $limit;
     public $skip;
+    public $redundantFields = [];
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -1323,6 +1323,14 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
             throw MappingException::simpleReferenceRequiresTargetDocument($this->name, $mapping['fieldName']);
         }
 
+        if (isset($mapping['reference'])
+            && isset($mapping['storeAs'])
+            && $mapping['storeAs'] === ClassMetadataInfo::REFERENCE_STORE_AS_ID
+            && ! empty($mapping['redundantFields'])
+        ) {
+            throw MappingException::simpleReferenceCannotHaveRedundantFields($this->name, $mapping['fieldName']);
+        }
+
         if (isset($mapping['reference']) && empty($mapping['targetDocument']) && empty($mapping['discriminatorMap']) &&
                 (isset($mapping['mappedBy']) || isset($mapping['inversedBy']))) {
             throw MappingException::owningAndInverseReferencesRequireTargetDocument($this->name, $mapping['fieldName']);

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -338,6 +338,12 @@ class XmlDriver extends FileDriver
         if (isset($attributes['also-load'])) {
             $mapping['alsoLoadFields'] = explode(',', $attributes['also-load']);
         }
+        if (isset($reference->{'redundant-fields'})) {
+            foreach ($reference->{'redundant-fields'}->{'field'} as $redundantField) {
+                $attr = $redundantField->attributes();
+                $mapping['redundantFields'][] = (string) $attr['name'];
+            }
+        }
         $this->addFieldMapping($class, $mapping);
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
@@ -304,6 +304,9 @@ class YamlDriver extends FileDriver
         if (isset($reference['criteria'])) {
             $mapping['criteria'] = $reference['criteria'];
         }
+        if (isset($reference['redundantFields'])) {
+            $mapping['redundantFields'] = (array) $reference['redundantFields'];
+        }
         $this->addFieldMapping($class, $mapping);
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -265,6 +265,16 @@ class MappingException extends BaseMappingException
     }
 
     /**
+     * @param string $className
+     * @param string $fieldName
+     * @return MappingException
+     */
+    public static function redundantAssociationNotAllowed($className, $fieldName)
+    {
+        return new self("Association $className::$fieldName can not be stored as redundant field");
+    }
+
+    /**
      * @param string $strategy
      * @param string $className
      * @param string $fieldName

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -255,6 +255,16 @@ class MappingException extends BaseMappingException
     }
 
     /**
+     * @param string $className
+     * @param string $fieldName
+     * @return MappingException
+     */
+    public static function simpleReferenceCannotHaveRedundantFields($className, $fieldName)
+    {
+        return new self("Simple reference $className::$fieldName may not store redundant fields");
+    }
+
+    /**
      * @param string $strategy
      * @param string $className
      * @param string $fieldName

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -279,4 +279,7 @@ class ReferenceStoreAsDocument
 
     /** @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="dbRefWithDb") */
     public $ref3;
+
+    /** @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="dbRef", redundantFields={"username"}) */
+    public $ref4;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -244,6 +244,19 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertArrayHasKey('$db', $dbRef);
     }
 
+    public function testDbRefWithRedundantField()
+    {
+        $r = new \Documents\User();
+        $r->setUsername('foo');
+        $this->dm->persist($r);
+        $d = new ReferenceStoreAsDocument();
+        $class = $this->dm->getClassMetadata(get_class($d));
+
+        $dbRef = $this->dm->createDBRef($r, $class->associationMappings['ref4']);
+        $this->assertArrayHasKey('username', $dbRef);
+        $this->assertSame('foo', $dbRef['username']);
+    }
+
     private function getMockClassMetadataFactory()
     {
         return $this->createMock('Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RedundantFieldsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RedundantFieldsTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class RedundantFieldsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testSimpleRedundantField()
+    {
+        $blog = new Blog('my-blog');
+        $this->dm->persist($blog);
+
+        $post = new Post($blog, 'My first post');
+        $this->dm->persist($post);
+        $this->dm->flush();
+
+        $rawPost = $this->dm->createQueryBuilder(Post::class)
+            ->find()
+            ->field('id')
+            ->equals($post->getId())
+            ->hydrate(false)
+            ->getQuery()
+            ->getSingleResult();
+
+        $this->assertSame('my-blog', $rawPost['blog']['title']);
+        $this->assertInstanceOf(\MongoDate::class, $rawPost['blog']['creationDate']);
+    }
+
+    public function testDatabaseValueIsPreparedInQuery()
+    {
+        $blog = new Blog('my-blog');
+        $this->dm->persist($blog);
+
+        $post = new Post($blog, 'My first post');
+        $this->dm->persist($post);
+        $this->dm->flush();
+
+        $result = $this->dm->createQueryBuilder(Post::class)
+            ->find()
+            ->field('blog.creationDate')
+            ->equals($blog->getCreationDate())
+            ->getQuery()
+            ->execute();
+
+        $this->assertCount(1, $result);
+    }
+}
+
+/**
+* @ODM\Document()
+*/
+class Blog
+{
+    /** @ODM\Id */
+    protected $id;
+
+    /** @ODM\Field(type="string") */
+    protected $title;
+
+    /** @ODM\Field(type="date") */
+    protected $creationDate;
+
+    public function __construct($title)
+    {
+        $this->title = $title;
+        $this->creationDate = new \DateTime();
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function getCreationDate()
+    {
+        return $this->creationDate;
+    }
+}
+
+/** @ODM\Document */
+class Post
+{
+    /** @ODM\Id */
+    protected $id;
+
+    /** @ODM\ReferenceOne(targetDocument="Blog", redundantFields={"title","creationDate"}) */
+    protected $blog;
+
+    /** @ODM\Field(type="string") */
+    protected $title;
+
+    public function __construct(Blog $blog, $title)
+    {
+        $this->blog = $blog;
+        $this->title = $title;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getBlog()
+    {
+        return $this->blog;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataInfoTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataInfoTest.php
@@ -494,6 +494,21 @@ class ClassMetadataInfoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $cm->mapManyEmbedded(['fieldName' => 'referenceMany']);
         $cm->setShardKey(array('referenceMany' => 1));
     }
+
+    /**
+     * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
+     * @expectedExceptionMessage Simple reference stdClass::referenceOne may not store redundant fields
+     */
+    public function testSimpleReferenceWithRedundantFieldsThrowsError()
+    {
+        $cm = new ClassMetadataInfo('stdClass');
+        $cm->mapOneReference([
+            'fieldName' => 'referenceOne',
+            'targetDocument' => 'stdClass',
+            'storeAs' => ClassMetadataInfo::REFERENCE_STORE_AS_ID,
+            'redundantFields' => ['foo', 'bar'],
+        ]);
+    }
 }
 
 class TestCustomRepositoryClass extends DocumentRepository

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -192,6 +192,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'limit' => null,
             'skip' => null,
             'orphanRemoval' => false,
+            'redundantFields' => ['name'],
         ), $classMetadata->fieldMappings['account']);
 
         $this->assertEquals(array(
@@ -220,6 +221,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'limit' => null,
             'skip' => null,
             'orphanRemoval' => false,
+            'redundantFields' => ['name'],
         ), $classMetadata->fieldMappings['groups']);
 
         $this->assertEquals(

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.User.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.User.dcm.xml
@@ -23,11 +23,17 @@
             <cascade>
                 <all />
             </cascade>
+            <redundant-fields>
+                <field name="name"/>
+            </redundant-fields>
         </reference-many>
         <reference-one target-document="Documents\Account" field="account">
             <cascade>
                 <all />
             </cascade>
+            <redundant-fields>
+                <field name="name"/>
+            </redundant-fields>
         </reference-one>
         <lifecycle-callbacks>
           <lifecycle-callback method="doStuffOnPrePersist" type="prePersist" />

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/yaml/TestDocuments.User.dcm.yml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/yaml/TestDocuments.User.dcm.yml
@@ -32,10 +32,12 @@ TestDocuments\User:
     account:
       targetDocument: Documents\Account
       cascade: all
+      redundantFields: [name]
   referenceMany:
     groups:
       targetDocument: Documents\Group
       cascade: all
+      redundantFields: [name]
   lifecycleCallbacks:
     prePersist: [doStuffOnPrePersist]
     postPersist: [doStuffOnPostPersist, doOtherStuffOnPostPersist]


### PR DESCRIPTION
References in MongoDB can be just IDs for a referenced document, or they can be full-fledged DBRef objects that can contain additional information. We use this functionality to add a discriminator value to properly hydrate a referenced document.

This PR allows developers to store additional fields from a referenced document within the reference, so it can be used in queries. There are two caveats at this time:
* The denormalized value won't be updated. This would require us to keep track of incoming references to a document and update all documents referencing ours when such a field is updated. Apart from the potentially long update query, this would only work within the first nesting level of documents due to [SERVER-831](https://jira.mongodb.org/browse/SERVER-831).
* The value is not yet used when creating proxy classes. This is because the current implementation of the proxy library doesn't allow for partially initialized proxies. This has been discussed in doctrine/doctrine2#1241 and I'd like to add that to ODM 2.0.