### PR TITLE
Add PHP 7.1 and MongoDB 3.2 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,25 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
 
 env:
   global:
     - DOCTRINE_MONGODB_SERVER="mongodb://localhost:27017"
     - KEY_SERVER="hkp://keyserver.ubuntu.com:80"
-    - MONGO_REPO_URI="http://repo.mongodb.com/apt/ubuntu"
+    - MONGO_REPO_URI="https://repo.mongodb.com/apt/ubuntu"
     - MONGO_REPO_TYPE="precise/mongodb-enterprise/"
     - SOURCES_LOC="/etc/apt/sources.list.d/mongodb.list"
     - DRIVER_VERSION="stable"
     - ADAPTER_VERSION="^1.0.0"
-  matrix:
-    - SERVER_VERSION="2.6"
     - SERVER_VERSION="3.2"
 
 matrix:
   include:
     - php: 5.6
-      env: DRIVER_VERSION="1.5.8" SERVER_VERSION="2.6" PREFER_LOWEST="--prefer-lowest"
+      env: DRIVER_VERSION="1.5.8" SERVER_VERSION="2.6" COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.6
+      env: DRIVER_VERSION="stable" SERVER_VERSION="3.0"
 
 before_install:
   - sudo apt-key adv --keyserver ${KEY_SERVER} --recv 7F0CEB10
@@ -42,7 +43,7 @@ before_script:
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then yes '' | pecl -q install -f mongo-${DRIVER_VERSION}; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then pecl install -f mongodb-${DRIVER_VERSION}; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
-  - composer update ${PREFER_LOWEST}
+  - composer update ${COMPOSER_FLAGS}
 
 script:
   - ./vendor/bin/phpunit --coverage-clover=coverage.clover

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
@@ -50,7 +50,9 @@ class DocumentPersisterGetShardKeyQueryTest extends BaseTest
 
         $this->assertInstanceOf('MongoDate', $shardKeyQuery['date']);
         $this->assertSame($o->date->getTimestamp(), $shardKeyQuery['date']->sec);
-        $this->assertSame(0, $shardKeyQuery['date']->usec);
+
+        $microseconds = (int)floor(((int)$o->date->format('u')) / 1000) * 1000;
+        $this->assertSame($microseconds, $shardKeyQuery['date']->usec);
     }
 
     public function testShardById()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
@@ -28,7 +28,6 @@ class TypeTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             array(Type::getType(Type::INTEGER), 42),
             array(Type::getType(Type::FLOAT), 3.14),
             array(Type::getType(Type::STRING), 'ohai'),
-            array(Type::getType(Type::DATE), new \DateTime()),
             array(Type::getType(Type::KEY), 0),
             array(Type::getType(Type::KEY), 1),
             array(Type::getType(Type::TIMESTAMP), time()),
@@ -72,6 +71,18 @@ class TypeTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             array(Type::getType(Type::BINDATACUSTOM), new MongoBinData('foobarbaz', MongoBinData::CUSTOM)),
             array(Type::getType(Type::OBJECTID), new \MongoId()),
         );
+    }
+
+    public function testConvertDatePreservesMilliseconds()
+    {
+        $date = new \DateTime();
+        $expectedDate = clone $date;
+
+        $cleanMicroseconds = (int) floor(((int) $date->format('u')) / 1000) * 1000;
+        $expectedDate->modify($date->format('H:i:s') . '.' . $cleanMicroseconds);
+
+        $type = Type::getType(Type::DATE);
+        $this->assertEquals($expectedDate, $type->convertToPHPValue($type->convertToDatabaseValue($date)));
     }
 
     public function testConvertImmutableDate()


### PR DESCRIPTION
With the old matrix, we'd have 10 builds, which seems excessive. Since there's no need to test every PHP version against every MongoDB version, we only test PHP 5.6 against each MongoDB version.

Note: tests against MongoDB 3.4 are not possible at this time; I'll add them once MongoDB 3.4 is available on the repository we're using in our travis builds.