### PR TITLE
Remove suggest mongo-php-adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
         "symfony/yaml": "~2.3|~3.0"
     },
     "suggest": {
-        "symfony/yaml": "Enables the YAML metadata mapping driver",
-        "alcaeus/mongo-php-adapter": "Allows usage of PHP 7"
+        "symfony/yaml": "Enables the YAML metadata mapping driver"
     },
     "autoload": {
         "psr-0": { "Doctrine\\ODM\\MongoDB": "lib/" }


### PR DESCRIPTION
It is already suggested by doctrine/mongodb which is required by this
library.