### PR TITLE
Fix embedded document parent before computing changeset

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -746,6 +746,15 @@ class UnitOfWork implements PropertyChangedListener
                         $this->scheduleOrphanRemoval($orgValue);
                     }
 
+                    if ($actualValue !== null) {
+                        list(, $knownParent, ) = $this->getParentAssociation($actualValue);
+                        if ($knownParent && $knownParent !== $document) {
+                            $actualValue = clone $actualValue;
+                            $class->setFieldValue($document, $class->fieldMappings[$propName]['fieldName'], $actualValue);
+                            $this->setOriginalDocumentProperty(spl_object_hash($document), $class->fieldMappings[$propName]['fieldName'], $actualValue);
+                        }
+                    }
+
                     $changeSet[$propName] = array($orgValue, $actualValue);
                     continue;
                 }
@@ -2184,11 +2193,6 @@ class UnitOfWork implements PropertyChangedListener
                 }
             } elseif ($relatedDocuments !== null) {
                 if ( ! empty($mapping['embedded'])) {
-                    list(, $knownParent, ) = $this->getParentAssociation($relatedDocuments);
-                    if ($knownParent && $knownParent !== $document) {
-                        $relatedDocuments = clone $relatedDocuments;
-                        $class->setFieldValue($document, $mapping['fieldName'], $relatedDocuments);
-                    }
                     $this->setParentAssociation($relatedDocuments, $mapping, $document, $mapping['fieldName']);
                 }
                 $this->doPersist($relatedDocuments, $visited);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
@@ -577,8 +577,6 @@ class EmbeddedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->persist($test1);
         $this->dm->persist($test2);
 
-        $this->assertNotSame($test1->embed, $test2->embed);
-
         $this->dm->flush();
 
         $this->assertNotSame($test1->embed, $test2->embed);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1525Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1525Test.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class GH1525Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testEmbedClone()
+    {
+        $embedded = new GH1525Embedded('embedded');
+
+        $embedMany = new GH1525Embedded('embedMany');
+
+        for ($i = 0; $i < 2; ++$i) {
+            $parent = new GH1525Document('test' . $i);
+            $this->dm->persist($parent);
+            $this->dm->flush();
+
+            $parent->embedded = $embedded;
+            $parent->embedMany->add($embedMany);
+            $this->dm->flush();
+        }
+
+        $this->dm->clear();
+
+        for ($i = 0; $i < 2; ++$i) {
+            $test = $this->dm->getRepository(GH1525Document::class)->findOneBy(array('name' => 'test' . $i));
+
+            $this->assertInstanceOf(GH1525Document::class, $test);
+
+            $this->assertInstanceOf(GH1525Embedded::class, $test->embedded);
+            $this->assertSame($test->embedded->name, $embedded->name);
+
+            $this->assertCount(1, $test->embedMany);
+            $this->assertInstanceOf(GH1525Embedded::class, $test->embedMany[0]);
+            $this->assertSame($test->embedMany[0]->name, $embedMany->name);
+        }
+    }
+}
+
+/** @ODM\Document(collection="document_test") */
+class GH1525Document
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\Field(type="string") */
+    public $name;
+
+    /** @ODM\EmbedOne(targetDocument="GH1525Embedded") */
+    public $embedded;
+
+    /** @ODM\EmbedMany(targetDocument="GH1525Embedded") */
+    public $embedMany;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+        $this->embedMany = new ArrayCollection();
+    }
+}
+
+
+/** @ODM\EmbeddedDocument */
+class GH1525Embedded
+{
+    /** @ODM\Field(type="string") */
+    public $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
Fixes #1525.

The problem is that the changeset wrote down the old embedded document, which was then used when trying to persist changes. I don't like adding another check for the embedded document parent, maybe @malarzm has a better idea?