### PR TITLE
Change serialization of inheritance fields

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -123,7 +123,7 @@ class ClassMetadata extends ClassMetadataInfo
             $serialized[] = 'customRepositoryClassName';
         }
 
-        if ($this->inheritanceType != self::INHERITANCE_TYPE_NONE) {
+        if ($this->inheritanceType != self::INHERITANCE_TYPE_NONE || $this->discriminatorField !== null) {
             $serialized[] = 'inheritanceType';
             $serialized[] = 'discriminatorField';
             $serialized[] = 'discriminatorValue';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
+use Documents\CmsUser;
 
 class ClassMetadataTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
@@ -204,5 +205,38 @@ class ClassMetadataTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $cm = new ClassMetadata('Documents\CmsUser');
         $cm->mapField(array('fieldName' => 'namee', 'columnName' => 'name', 'type' => 'string'));
+    }
+
+    /**
+     * @param ClassMetadata $cm
+     * @dataProvider dataProviderMetadataClasses
+     */
+    public function testEmbeddedDocumentWithDiscriminator(ClassMetadata $cm)
+    {
+        $cm->setDiscriminatorField('discriminator');
+        $cm->setDiscriminatorValue('discriminatorValue');
+
+        $serialized = serialize($cm);
+        $cm = unserialize($serialized);
+
+        $this->assertSame('discriminator', $cm->discriminatorField);
+        $this->assertSame('discriminatorValue', $cm->discriminatorValue);
+    }
+
+    public static function dataProviderMetadataClasses()
+    {
+        $document = new ClassMetadata(CmsUser::class);
+
+        $embeddedDocument = new ClassMetadata(CmsUser::class);
+        $embeddedDocument->isEmbeddedDocument = true;
+
+        $mappedSuperclass = new ClassMetadata(CmsUser::class);
+        $mappedSuperclass->isMappedSuperclass = true;
+
+        return [
+            'document' => [$document],
+            'mappedSuperclass' => [$mappedSuperclass],
+            'embeddedDocument' => [$embeddedDocument],
+        ];
     }
 }


### PR DESCRIPTION
Fixes #1271.

The previous solution would always require specifying an inheritance type, which makes sense for documents but seems weird for embedded documents. With this PR, this changes to serialize the inheritance information (inheritance type and discriminator data) if an inheritance type was specified or if the discriminator field was given. This should fix hard to find cases where data can't be stored or loaded once the metadata was loaded from cache.