### PR TITLE
Fix ->mod() example, add ()->addAnd description

### DIFF
--- a/docs/en/reference/query-builder-api.rst
+++ b/docs/en/reference/query-builder-api.rst
@@ -406,10 +406,15 @@ Query for active administrator users:
 .. code-block:: php
 
     <?php
-
+    
     $qb = $dm->createQueryBuilder('User')
         ->field('type')->equals('admin')
         ->field('active')->equals(true);
+    
+    // Or using addAnd()
+    $qb = $dm->createQueryBuilder('User');
+    $qb->addAnd($qb->expr()->field('type')->equals('admin'));
+    $qb->addAnd($qb->expr()->field('active')->equals(true));
 
 Query for articles that have some tags:
 
@@ -556,7 +561,7 @@ in the Mongo docs.
     <?php
 
     $qb = $dm->createQueryBuilder('Transaction')
-        ->field('field')->mod('field', array(10, 1));
+        ->field('field')->mod(10, 1);
 
 Read more about the
 `$mod operator <https://docs.mongodb.com/manual/reference/operator/query/mod/>`_ in the Mongo docs.


### PR DESCRIPTION
Two fixes in Mongo ODM documentation for QueryBilder - Conditional Operators:
 * The example of `mod` is `field('field')->mod('field', array(10, 1))` while the signature is `public function mod($divisor, $remainder = 0)`.
 * Also added an example for `addAnd` which is useful for nested conditions.