### PR TITLE
Fix counting of inverse collections with limit

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -445,8 +445,8 @@ trait PersistentCollectionTrait
         if ($this->mapping['isInverseSide'] && ! $this->initialized) {
             $documentPersister = $this->uow->getDocumentPersister(get_class($this->owner));
             $count += empty($this->mapping['repositoryMethod'])
-                ? $documentPersister->createReferenceManyInverseSideQuery($this)->count()
-                : $documentPersister->createReferenceManyWithRepositoryMethodCursor($this)->count();
+                ? $documentPersister->createReferenceManyInverseSideQuery($this)->count(true)
+                : $documentPersister->createReferenceManyWithRepositoryMethodCursor($this)->count(true);
         }
 
         return $count + ($this->initialized ? 0 : count($this->mongoData));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1572Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1572Test.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\DocumentRepository;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class GH1572Test extends BaseTest
+{
+    public function testPersistentCollectionCount()
+    {
+        $blog = new GH1572Blog();
+        $this->dm->persist($blog);
+
+        $this->dm->persist(new GH1572Post($blog));
+        $this->dm->persist(new GH1572Post($blog));
+        $this->dm->persist(new GH1572Post($blog));
+        $this->dm->persist(new GH1572Post($blog));
+
+        $this->dm->flush();
+        $this->dm->refresh($blog);
+
+        $this->assertInstanceOf(PersistentCollectionInterface::class, $blog->allPosts);
+        $this->assertFalse($blog->allPosts->isInitialized());
+        $this->assertCount(4, $blog->allPosts);
+
+        $this->assertInstanceOf(PersistentCollectionInterface::class, $blog->latestPosts);
+        $this->assertFalse($blog->latestPosts->isInitialized());
+        $this->assertCount(2, $blog->latestPosts);
+
+        $this->assertInstanceOf(PersistentCollectionInterface::class, $blog->latestPostsRepositoryMethod);
+        $this->assertFalse($blog->latestPostsRepositoryMethod->isInitialized());
+        $this->assertCount(2, $blog->latestPostsRepositoryMethod);
+    }
+}
+
+/** @ODM\Document */
+class GH1572Blog
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\ReferenceMany(targetDocument="GH1572Post", mappedBy="blog") */
+    public $allPosts = [];
+
+    /** @ODM\ReferenceMany(targetDocument="GH1572Post", mappedBy="blog", sort={"id"="asc"}, limit=2) */
+    public $latestPosts = [];
+
+    /** @ODM\ReferenceMany(targetDocument="GH1572Post", repositoryMethod="getPostsForBlog", limit=2) */
+    public $latestPostsRepositoryMethod = [];
+}
+
+/** @ODM\Document(repositoryClass="GH1572PostRepository") */
+class GH1572Post
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\ReferenceOne(targetDocument="GH1572Blog") */
+    public $blog;
+
+    public function __construct(GH1572Blog $blog)
+    {
+        $this->blog = $blog;
+        $blog->allPosts[] = $this;
+    }
+}
+
+class GH1572PostRepository extends DocumentRepository
+{
+    public function getPostsForBlog($blog)
+    {
+        return $this->createQueryBuilder()
+            ->field('blog')
+            ->references($blog)
+            ->getQuery()
+            ->getIterator();
+    }
+}


### PR DESCRIPTION
Fixes an issue where having an inverse reference with a limit set would return the wrong number of elements when the collection isn't initialized.