### PR TITLE
Support priming references in inverse many relationships

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -1238,6 +1238,10 @@ Optional attributes:
 -
     collectionClass - A |FQCN| of class that implements ``Collection`` interface
     and is used to hold documents. Doctrine's ``ArrayCollection`` is used by default
+-
+    prime - A list of references contained in the target document that will be
+    initialized when the collection is loaded. Only allowed for inverse
+    references.
 
 .. code-block:: php
 

--- a/docs/en/reference/priming-references.rst
+++ b/docs/en/reference/priming-references.rst
@@ -78,7 +78,7 @@ builder's ``prime()`` method allows us to do just that.
 
 In this case, priming will allow us to load all users and referenced accounts in
 two database queries. If the accounts had used an
-:ref:`inhertiance mapping <inheritance_mapping>`, priming might require several
+:ref:`inheritance mapping <inheritance_mapping>`, priming might require several
 queries (one per discriminated class name).
 
 .. note::
@@ -92,6 +92,40 @@ queries (one per discriminated class name).
     Hydration must be enabled in the query builder for priming to work properly.
     Disabling hydration will cause the DBRef to be returned for a referenced
     document instead of the hydrated document object.
+
+Inverse references
+------------------
+
+.. note::
+
+    This feature was added in version 1.2.
+
+When using inverse references (references mapped using ``mappedBy`` or
+``repositoryMethod``) you can also enable primers on one-to-many references by
+specifying them in the mapping:
+
+.. code-block:: php
+
+    <?php
+
+    /** @Document */
+    class User
+    {
+        /** @ReferenceMany(targetDocument="Account", prime={"user"}) */
+        private $accounts;
+    }
+
+When the collection is initialized, the configured primers are automatically
+added to the query.
+
+.. note::
+
+    When using inverse references with ``repositoryMethod``, be sure to return
+    an eager cursor from the repository method if you want to rely on primers
+    defined in the mapping. If the result is not an eager cursor, an exception
+    will be thrown and the collection won't be loaded. Also, any primers you
+    might have added in the ``repositoryMethod`` are overwritten with those
+    specified in the mapping.
 
 Primer Callback
 ---------------

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -157,6 +157,7 @@
       <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
       <xs:element name="sort" type="odm:sort-map" minOccurs="0" />
       <xs:element name="criteria" type="odm:criteria-map" minOccurs="0" />
+      <xs:element name="prime" type="odm:primers" minOccurs="0" />
     </xs:sequence>
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="collection-class" type="xs:string" />
@@ -193,6 +194,16 @@
     <xs:sequence>
       <xs:element name="criteria" type="odm:criteria-type" minOccurs="1" maxOccurs="unbounded"/>
     </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="primers">
+    <xs:sequence>
+      <xs:element name="field" type="odm:primer-field" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="primer-field">
+    <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
   </xs:complexType>
 
   <xs:complexType name="emptyType"/>

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceMany.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceMany.php
@@ -42,10 +42,11 @@ final class ReferenceMany extends AbstractField
     public $inversedBy;
     public $mappedBy;
     public $repositoryMethod;
-    public $sort = array();
-    public $criteria = array();
+    public $sort = [];
+    public $criteria = [];
     public $limit;
     public $skip;
     public $strategy = CollectionHelper::DEFAULT_STRATEGY;
     public $collectionClass;
+    public $prime = [];
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -1382,6 +1382,10 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
             }
         }
 
+        if (!empty($mapping['prime']) && ($mapping['association'] !== self::REFERENCE_MANY || !$mapping['isInverseSide'])) {
+            throw MappingException::referencePrimersOnlySupportedForInverseReferenceMany($this->name, $mapping['fieldName']);
+        }
+
         $this->applyStorageStrategy($mapping);
 
         $this->fieldMappings[$mapping['fieldName']] = $mapping;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -302,6 +302,7 @@ class XmlDriver extends FileDriver
             'repositoryMethod' => isset($attributes['repository-method']) ? (string) $attributes['repository-method'] : null,
             'limit'            => isset($attributes['limit']) ? (integer) $attributes['limit'] : null,
             'skip'             => isset($attributes['skip']) ? (integer) $attributes['skip'] : null,
+            'prime'            => [],
         );
 
         if (isset($attributes['fieldName'])) {
@@ -338,6 +339,13 @@ class XmlDriver extends FileDriver
         if (isset($attributes['also-load'])) {
             $mapping['alsoLoadFields'] = explode(',', $attributes['also-load']);
         }
+        if (isset($reference->{'prime'})) {
+            foreach ($reference->{'prime'}->{'field'} as $field) {
+                $attr = $field->attributes();
+                $mapping['prime'][] = (string) $attr['name'];
+            }
+        }
+
         $this->addFieldMapping($class, $mapping);
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
@@ -270,7 +270,7 @@ class YamlDriver extends FileDriver
     {
         $defaultStrategy = $type == 'one' ? ClassMetadataInfo::STORAGE_STRATEGY_SET : CollectionHelper::DEFAULT_STRATEGY;
         $mapping = array(
-            'cascade'          => isset($reference['cascade']) ? $reference['cascade'] : null,
+            'cascade'          => isset($reference['cascade']) ? $reference['cascade'] : [],
             'orphanRemoval'    => isset($reference['orphanRemoval']) ? $reference['orphanRemoval'] : false,
             'type'             => $type,
             'reference'        => true,
@@ -285,6 +285,7 @@ class YamlDriver extends FileDriver
             'repositoryMethod' => isset($reference['repositoryMethod']) ? (string) $reference['repositoryMethod'] : null,
             'limit'            => isset($reference['limit']) ? (integer) $reference['limit'] : null,
             'skip'             => isset($reference['skip']) ? (integer) $reference['skip'] : null,
+            'prime'            => isset($reference['prime']) ? $reference['prime'] : [],
         );
         if (isset($reference['name'])) {
             $mapping['name'] = $reference['name'];

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -385,4 +385,15 @@ class MappingException extends BaseMappingException
     {
         return new self("Cannot use class '$className' as collection for out stage. Sharded collections are not allowed.");
     }
+
+    /**
+     * @param string $className
+     * @param string $fieldName
+     *
+     * @return MappingException
+     */
+    public static function referencePrimersOnlySupportedForInverseReferenceMany($className, $fieldName)
+    {
+        return new self("Cannot use reference priming on '$fieldName' in class '$className'. Reference priming is only supported for inverse references");
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
@@ -4,9 +4,12 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Proxy\Proxy;
 use Doctrine\ODM\MongoDB\Query\Query;
 use Documents\Account;
 use Documents\Agent;
+use Documents\BlogPost;
+use Documents\Comment;
 use Documents\Functional\EmbeddedWhichReferences;
 use Documents\Functional\EmbedNamed;
 use Documents\Functional\FavoritesUser;
@@ -37,7 +40,7 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $this->dm->createQueryBuilder('Documents\User')
+        $this->dm->createQueryBuilder(User::class)
             ->field('username')->prime(true)
             ->getQuery()
             ->toArray();
@@ -54,7 +57,7 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $this->dm->createQueryBuilder('Documents\User')
+        $this->dm->createQueryBuilder(User::class)
             ->field('simpleReferenceOneInverse')->prime(true)
             ->getQuery()
             ->toArray();
@@ -62,7 +65,7 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testPrimeImpliesEagerCursor()
     {
-        $query = $this->dm->createQueryBuilder('Documents\User')
+        $query = $this->dm->createQueryBuilder(User::class)
             ->field('account')
             ->prime(true)
             ->getQuery()
@@ -77,7 +80,7 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
      */
     public function testPrimeForbidsLazyCursor()
     {
-        $this->dm->createQueryBuilder('Documents\User')
+        $this->dm->createQueryBuilder(User::class)
             ->field('account')
             ->prime(true)
             ->eagerCursor(false);
@@ -85,7 +88,7 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testFieldPrimingCanBeToggled()
     {
-        $this->dm->createQueryBuilder('Documents\User')
+        $this->dm->createQueryBuilder(User::class)
             ->field('account')
             ->prime(true)
             ->prime(false)
@@ -97,7 +100,7 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
      */
     public function testLazyCursorForbidsPrime()
     {
-        $this->dm->createQueryBuilder('Documents\User')
+        $this->dm->createQueryBuilder(User::class)
             ->eagerCursor(false)
             ->field('account')
             ->prime(true);
@@ -114,12 +117,12 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $qb = $this->dm->createQueryBuilder('Documents\User')
+        $qb = $this->dm->createQueryBuilder(User::class)
             ->field('account')->prime(true)
             ->field('groups')->prime(true);
 
         foreach ($qb->getQuery() as $user) {
-            $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $user->getAccount());
+            $this->assertInstanceOf(Proxy::class, $user->getAccount());
             $this->assertTrue($user->getAccount()->__isInitialized());
 
             $this->assertCount(2, $user->getGroups());
@@ -128,8 +131,8 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
              * initialized, they will not be hydrated as proxy objects.
              */
             foreach ($user->getGroups() as $group) {
-                $this->assertNotInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $group);
-                $this->assertInstanceOf('Documents\Group', $group);
+                $this->assertNotInstanceOf(Proxy::class, $group);
+                $this->assertInstanceOf(Group::class, $group);
             }
         }
     }
@@ -152,19 +155,19 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $qb = $this->dm->createQueryBuilder('Documents\SimpleReferenceUser')
+        $qb = $this->dm->createQueryBuilder(SimpleReferenceUser::class)
             ->field('user')->prime(true)
             ->field('users')->prime(true);
 
         foreach ($qb->getQuery() as $simpleUser) {
-            $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $simpleUser->getUser());
+            $this->assertInstanceOf(Proxy::class, $simpleUser->getUser());
             $this->assertTrue($simpleUser->getUser()->__isInitialized());
 
             $this->assertCount(2, $simpleUser->getUsers());
 
             foreach ($simpleUser->getUsers() as $user) {
-                $this->assertNotInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $user);
-                $this->assertInstanceOf('Documents\User', $user);
+                $this->assertNotInstanceOf(Proxy::class, $user);
+                $this->assertInstanceOf(User::class, $user);
             }
         }
     }
@@ -208,7 +211,7 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $qb = $this->dm->createQueryBuilder('Documents\Functional\EmbedNamed')
+        $qb = $this->dm->createQueryBuilder(EmbedNamed::class)
             ->field('embeddedDoc.referencedDoc')->prime(true)
             ->field('embeddedDoc.referencedDocs')->prime(true)
             ->field('embeddedDocs.referencedDoc')->prime(true)
@@ -216,21 +219,21 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         ;
 
         foreach ($qb->getQuery() as $root) {
-            $this->assertNotInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $root->embeddedDoc);
-            $this->assertInstanceOf('Documents\Functional\EmbeddedWhichReferences', $root->embeddedDoc);
+            $this->assertNotInstanceOf(Proxy::class, $root->embeddedDoc);
+            $this->assertInstanceOf(EmbeddedWhichReferences::class, $root->embeddedDoc);
 
             $this->assertCount(2, $root->embeddedDocs);
             foreach ($root->embeddedDocs as $embeddedDoc) {
-                $this->assertNotInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $embeddedDoc);
-                $this->assertInstanceOf('Documents\Functional\EmbeddedWhichReferences', $embeddedDoc);
+                $this->assertNotInstanceOf(Proxy::class, $embeddedDoc);
+                $this->assertInstanceOf(EmbeddedWhichReferences::class, $embeddedDoc);
 
-                $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $embeddedDoc->referencedDoc);
+                $this->assertInstanceOf(Proxy::class, $embeddedDoc->referencedDoc);
                 $this->assertTrue($embeddedDoc->referencedDoc->__isInitialized());
 
                 $this->assertCount(2, $embeddedDoc->referencedDocs);
                 foreach ($embeddedDoc->referencedDocs as $referencedDoc) {
-                    $this->assertNotInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $referencedDoc);
-                    $this->assertInstanceOf('Documents\Functional\Reference', $referencedDoc);
+                    $this->assertNotInstanceOf(Proxy::class, $referencedDoc);
+                    $this->assertInstanceOf(Reference::class, $referencedDoc);
                 }
             }
         }
@@ -268,7 +271,7 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $qb = $this->dm->createQueryBuilder('Documents\ReferenceUser')
+        $qb = $this->dm->createQueryBuilder(ReferenceUser::class)
             ->field('user')->prime(true)
             ->field('users')->prime(true)
             ->field('parentUser')->prime(true)
@@ -279,36 +282,36 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         /** @var ReferenceUser $referenceUser */
         foreach ($qb->getQuery() as $referenceUser) {
             // storeAs=id reference
-            $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $referenceUser->getUser());
+            $this->assertInstanceOf(Proxy::class, $referenceUser->getUser());
             $this->assertTrue($referenceUser->getUser()->__isInitialized());
 
             $this->assertCount(1, $referenceUser->getUsers());
 
             foreach ($referenceUser->getUsers() as $user) {
-                $this->assertNotInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $user);
-                $this->assertInstanceOf('Documents\User', $user);
+                $this->assertNotInstanceOf(Proxy::class, $user);
+                $this->assertInstanceOf(User::class, $user);
             }
 
             // storeAs=dbRef reference
-            $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $referenceUser->getParentUser());
+            $this->assertInstanceOf(Proxy::class, $referenceUser->getParentUser());
             $this->assertTrue($referenceUser->getParentUser()->__isInitialized());
 
             $this->assertCount(1, $referenceUser->getParentUsers());
 
             foreach ($referenceUser->getParentUsers() as $user) {
-                $this->assertNotInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $user);
-                $this->assertInstanceOf('Documents\User', $user);
+                $this->assertNotInstanceOf(Proxy::class, $user);
+                $this->assertInstanceOf(User::class, $user);
             }
 
             // storeAs=dbRefWithDb reference
-            $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $referenceUser->getOtherUser());
+            $this->assertInstanceOf(Proxy::class, $referenceUser->getOtherUser());
             $this->assertTrue($referenceUser->getOtherUser()->__isInitialized());
 
             $this->assertCount(1, $referenceUser->getOtherUsers());
 
             foreach ($referenceUser->getOtherUsers() as $user) {
-                $this->assertNotInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $user);
-                $this->assertInstanceOf('Documents\User', $user);
+                $this->assertNotInstanceOf(Proxy::class, $user);
+                $this->assertInstanceOf(User::class, $user);
             }
         }
     }
@@ -328,17 +331,17 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $qb = $this->dm->createQueryBuilder('Documents\Functional\FavoritesUser')
+        $qb = $this->dm->createQueryBuilder(FavoritesUser::class)
             ->field('favorites')->prime(true);
 
         foreach ($qb->getQuery() as $user) {
             $favorites = $user->getFavorites()->toArray();
 
-            $this->assertNotInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $favorites[0]);
-            $this->assertInstanceOf('Documents\Group', $favorites[0]);
+            $this->assertNotInstanceOf(Proxy::class, $favorites[0]);
+            $this->assertInstanceOf(Group::class, $favorites[0]);
 
-            $this->assertNotInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $favorites[1]);
-            $this->assertInstanceOf('Documents\Project', $favorites[1]);
+            $this->assertNotInstanceOf(Proxy::class, $favorites[1]);
+            $this->assertInstanceOf(Project::class, $favorites[1]);
         }
     }
 
@@ -352,11 +355,11 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $qb = $this->dm->createQueryBuilder('Documents\Agent')
+        $qb = $this->dm->createQueryBuilder(Agent::class)
             ->field('server')->prime(true);
 
         foreach ($qb->getQuery() as $agent) {
-            $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $agent->server);
+            $this->assertInstanceOf(Proxy::class, $agent->server);
             $this->assertTrue($agent->server->__isInitialized());
         }
     }
@@ -371,22 +374,22 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $this->dm->createQueryBuilder('Documents\Group')->getQuery()->toArray();
+        $this->dm->createQueryBuilder(Group::class)->getQuery()->toArray();
 
         $invoked = 0;
         $primer = function(DocumentManager $dm, ClassMetadata $class, array $ids, array $hints) use (&$invoked) {
             $invoked++;
         };
 
-        $qb = $this->dm->createQueryBuilder('Documents\User')
+        $qb = $this->dm->createQueryBuilder(User::class)
             ->field('groups')->prime($primer);
 
         foreach ($qb->getQuery() as $user) {
             $this->assertCount(2, $user->getGroups());
 
             foreach ($user->getGroups() as $group) {
-                $this->assertNotInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $group);
-                $this->assertInstanceOf('Documents\Group', $group);
+                $this->assertNotInstanceOf(Proxy::class, $group);
+                $this->assertInstanceOf(Group::class, $group);
             }
         }
 
@@ -416,7 +419,7 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             $invokedArgs[] = func_get_args();
         };
 
-        $this->dm->createQueryBuilder('Documents\User')
+        $this->dm->createQueryBuilder(User::class)
             ->field('account')->prime($primer)
             ->field('groups')->prime($primer)
             ->slaveOkay(true)
@@ -447,7 +450,7 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->dm->clear();
 
-        $qb = $this->dm->createQueryBuilder('Documents\User')
+        $qb = $this->dm->createQueryBuilder(User::class)
             ->findAndUpdate()
             ->returnNew(true)
             ->field('groups')->push($groupDBRef)->prime(true);
@@ -457,8 +460,8 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertCount(1, $user->getGroups());
 
         foreach ($user->getGroups() as $group) {
-            $this->assertNotInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $group);
-            $this->assertInstanceOf('Documents\Group', $group);
+            $this->assertNotInstanceOf(Proxy::class, $group);
+            $this->assertInstanceOf(Group::class, $group);
         }
     }
 
@@ -477,7 +480,7 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->dm->clear();
 
-        $qb = $this->dm->createQueryBuilder('Documents\User')
+        $qb = $this->dm->createQueryBuilder(User::class)
             ->field('username')->equals('SomeName')
             ->field('phonenumbers.lastCalledBy')->prime(true);
 
@@ -488,8 +491,8 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $phonenumber = $phonenumbers->current();
 
-        $this->assertNotInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $phonenumber);
-        $this->assertInstanceOf('Documents\Phonenumber', $phonenumber);
+        $this->assertNotInstanceOf(Proxy::class, $phonenumber);
+        $this->assertInstanceOf(Phonenumber::class, $phonenumber);
     }
 
     public function testPrimeEmbeddedReferenceTwoLevelsDeep()
@@ -513,7 +516,7 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $qb = $this->dm->createQueryBuilder('Documents\Ecommerce\ConfigurableProduct')
+        $qb = $this->dm->createQueryBuilder(ConfigurableProduct::class)
             ->field('name')->equals('Bundle')
             ->field('options.money.currency')->prime(true);
 
@@ -532,7 +535,7 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         /** @var Currency $currency */
         $currency = $money->getCurrency();
 
-        $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $currency);
+        $this->assertInstanceOf(Proxy::class, $currency);
         $this->assertTrue($currency->__isInitialized());
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -4,9 +4,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Mapping\Driver;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
+use TestDocuments\PrimedCollectionDocument;
 
 require_once 'fixtures/InvalidPartialFilterDocument.php';
 require_once 'fixtures/PartialFilterDocument.php';
+require_once 'fixtures/PrimedCollectionDocument.php';
 require_once 'fixtures/User.php';
 require_once 'fixtures/EmbeddedDocument.php';
 require_once 'fixtures/QueryResultDocument.php';
@@ -164,6 +166,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'limit' => null,
             'skip' => null,
             'orphanRemoval' => true,
+            'prime' => [],
         ), $classMetadata->fieldMappings['profile']);
 
         $this->assertEquals(array(
@@ -192,6 +195,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'limit' => null,
             'skip' => null,
             'orphanRemoval' => false,
+            'prime' => [],
         ), $classMetadata->fieldMappings['account']);
 
         $this->assertEquals(array(
@@ -220,6 +224,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             'limit' => null,
             'skip' => null,
             'orphanRemoval' => false,
+            'prime' => [],
         ), $classMetadata->fieldMappings['groups']);
 
         $this->assertEquals(
@@ -324,5 +329,69 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
                 ],
             ],
         ], $classMetadata->getIndexes());
+    }
+
+    public function testCollectionPrimers()
+    {
+        $classMetadata = new ClassMetadata(PrimedCollectionDocument::class);
+        $this->driver->loadMetadataForClass(PrimedCollectionDocument::class, $classMetadata);
+
+        $this->assertEquals([
+            'association' => 2,
+            'fieldName' => 'references',
+            'name' => 'references',
+            'type' => 'many',
+            'reference' => true,
+            'storeAs' => ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF_WITH_DB,
+            'simple' => false,
+            'targetDocument' => PrimedCollectionDocument::class,
+            'collectionClass' => null,
+            'cascade' => [],
+            'isCascadeDetach' => false,
+            'isCascadeMerge' => false,
+            'isCascadePersist' => false,
+            'isCascadeRefresh' => false,
+            'isCascadeRemove' => false,
+            'isInverseSide' => false,
+            'isOwningSide' => true,
+            'nullable' => false,
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL,
+            'inversedBy' => null,
+            'mappedBy' => null,
+            'repositoryMethod' => null,
+            'limit' => null,
+            'skip' => null,
+            'orphanRemoval' => false,
+            'prime' => [],
+        ], $classMetadata->fieldMappings['references']);
+
+        $this->assertEquals([
+            'association' => 2,
+            'fieldName' => 'inverseMappedBy',
+            'name' => 'inverseMappedBy',
+            'type' => 'many',
+            'reference' => true,
+            'storeAs' => ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF_WITH_DB,
+            'simple' => false,
+            'targetDocument' => PrimedCollectionDocument::class,
+            'collectionClass' => null,
+            'cascade' => [],
+            'isCascadeDetach' => false,
+            'isCascadeMerge' => false,
+            'isCascadePersist' => false,
+            'isCascadeRefresh' => false,
+            'isCascadeRemove' => false,
+            'isInverseSide' => true,
+            'isOwningSide' => false,
+            'nullable' => false,
+            'strategy' => ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL,
+            'inversedBy' => null,
+            'mappedBy' => 'references',
+            'repositoryMethod' => null,
+            'limit' => null,
+            'skip' => null,
+            'orphanRemoval' => false,
+            'prime' => ['references'],
+        ], $classMetadata->fieldMappings['inverseMappedBy']);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/PrimedCollectionDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/PrimedCollectionDocument.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace TestDocuments;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+class PrimedCollectionDocument
+{
+    protected $id;
+
+    protected $inverseMappedBy;
+
+    protected $references;
+
+    public function __construct()
+    {
+        $this->inverseMappedBy = new ArrayCollection();
+        $this->references = new ArrayCollection();
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getInverseMappedBy()
+    {
+        return $this->inverseMappedBy;
+    }
+
+    public function getReferences()
+    {
+        return $this->references;
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.PrimedCollectionDocument.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.PrimedCollectionDocument.dcm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="TestDocuments\PrimedCollectionDocument" collection="primed_collection">
+        <field name="id" id="true" />
+
+        <reference-many target-document="TestDocuments\PrimedCollectionDocument" field="references" />
+        <reference-many target-document="TestDocuments\PrimedCollectionDocument" field="inverseMappedBy" mapped-by="references">
+            <prime>
+                <field name="references" />
+            </prime>
+        </reference-many>
+    </document>
+</doctrine-mongo-mapping>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/yaml/TestDocuments.PrimedCollectionDocument.dcm.yml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/yaml/TestDocuments.PrimedCollectionDocument.dcm.yml
@@ -1,0 +1,15 @@
+TestDocuments\PrimedCollectionDocument:
+  db: documents
+  collection: primed_collection
+  fields:
+    id:
+      fieldName: id
+      id: true
+  referenceMany:
+    references:
+      targetDocument: TestDocuments\PrimedCollectionDocument
+    inverseMappedBy:
+      targetDocument: TestDocuments\PrimedCollectionDocument
+      mappedBy: references
+      prime:
+        - references

--- a/tests/Documents/BlogPost.php
+++ b/tests/Documents/BlogPost.php
@@ -17,7 +17,7 @@ class BlogPost
     /** @ODM\ReferenceMany(targetDocument="Tag", inversedBy="blogPosts", cascade={"all"}) */
     public $tags = array();
 
-    /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", cascade={"all"}) */
+    /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", cascade={"all"}, prime={"author"}) */
     public $comments = array();
 
     /** @ODM\ReferenceOne(targetDocument="Comment", mappedBy="parent", sort={"date"="asc"}) */
@@ -38,13 +38,16 @@ class BlogPost
     /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", repositoryMethod="findManyComments") */
     public $repoComments;
 
+    /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", repositoryMethod="findManyComments", prime={"author"}) */
+    public $repoCommentsWithPrimer;
+
     /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", strategy="set", repositoryMethod="findManyComments") */
     public $repoCommentsSet;
 
     /** @ODM\ReferenceMany(targetDocument="Comment", repositoryMethod="findManyComments") */
     public $repoCommentsWithoutMappedBy;
 
-    /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", repositoryMethod="findManyCommentsEager") */
+    /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", repositoryMethod="findManyCommentsEager", prime={"author"}) */
     public $repoCommentsEager;
 
     /** @ODM\ReferenceOne(targetDocument="User", inversedBy="posts", nullable=true) */

--- a/tests/Documents/Comment.php
+++ b/tests/Documents/Comment.php
@@ -14,6 +14,9 @@ class Comment
     /** @ODM\Field(type="string") */
     public $text;
 
+    /** @ODM\ReferenceOne(targetDocument="User", cascade={"all"}) */
+    public $author;
+
     /** @ODM\ReferenceOne(targetDocument="BlogPost", inversedBy="comments", cascade={"all"}) */
     public $parent;
 


### PR DESCRIPTION
This PR adds support for reference priming in inverse collections. This avoids having to declare a `repositoryMethod` just to use primers, e.g.:

```php
// Document
    /**
     * @ODM\ReferenceMany(
     *     targetDocument=User\Follow::class,
     *     repositoryMethod="getFollowers",
     *     sort={"createdAt"="desc"},
     *     cascade={"remove"},
     * )
     */
    protected $followers;

// Repository
    public function getFollowers(User $user)
    {
        return $this->createQueryBuilder()
            ->field('followed')
            ->equals($user)
            ->field('follower')
            ->prime()
            ->getQuery()
            ->getIterator();
    }
```

This can now be shortened using the new `primers` property:
```php
    /**
     * @ODM\ReferenceMany(
     *     targetDocument=User\Follow::class,
     *     mappedBy="followed",
     *     primers={"follower"=true}
     *     sort={"createdAt"="desc"},
     *     cascade={"remove"},
     * )
     */
    protected $followers;
```

While primers can technically be closures, this is not supported by the mapping drivers at this time.