### PR TITLE
[DOCS] Missing instruction in example

### DIFF
--- a/docs/en/reference/introduction.rst
+++ b/docs/en/reference/introduction.rst
@@ -177,6 +177,7 @@ Doctrine:
     $manager->setName('Manager');
     $manager->setSalary(100000);
     $manager->setStarted(new DateTime());
+    $manager->addProject($project);
 
     $dm->persist($employee);
     $dm->persist($address);


### PR DESCRIPTION
In the result of the example the `$project` is assigned to the `$manager`, but this method is missing from the initial instructions