### PR TITLE
Doctrine\ODM\MongoDB\LockException when using versioning, a custom name for the version field and embedMany

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -268,7 +268,7 @@ class CollectionPersister
         $id = $class->getDatabaseIdentifierValue($this->uow->getDocumentIdentifier($document));
         $query = array('_id' => $id);
         if ($class->isVersioned) {
-            $query[$class->versionField] = $class->reflFields[$class->versionField]->getValue($document);
+            $query[$class->fieldMappings[$class->versionField]['name']] = $class->reflFields[$class->versionField]->getValue($document);
         }
         $collection = $this->dm->getDocumentCollection($className);
         $result = $collection->update($query, $newObj, $options);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
@@ -47,7 +47,7 @@ class VersionedDocument
     /** @ODM\Id */
     public $id;
     
-    /** @ODM\Field(type="int") @ODM\Version */
+    /** @ODM\Field(type="int", name="_version") @ODM\Version */
     public $version = 1;
     
     /** @ODM\Field(type="string") */


### PR DESCRIPTION
I have a versioned document, with a version field, using a custom name.
"version" is the field name I use in the PHP object and "_version" is the name I use in the underlying document.
I have added an embedMany field and can no longer update my document.
A Doctrine\ODM\MongoDB\LockException is thrown.

It seems that the problem comes from the CollectionPersister, that adds the version field name to the query, when it should instead use the related field mapping name. 