### PR TITLE
Unset a document update for a document on mongo exception or lock exception

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1171,7 +1171,15 @@ class UnitOfWork implements PropertyChangedListener
             $this->lifecycleEventManager->preUpdate($class, $document);
 
             if ( ! empty($this->documentChangeSets[$oid]) || $this->hasScheduledCollections($document)) {
-                $persister->update($document, $options);
+                try {
+                    $persister->update($document, $options);
+                } catch (\MongoException $e) {
+                    unset($this->documentUpdates[$oid]);
+                    throw $e;
+                } catch (LockException $e) {
+                    unset($this->documentUpdates[$oid]);
+                    throw $e;
+                }
             }
 
             unset($this->documentUpdates[$oid]);


### PR DESCRIPTION
While testing https://github.com/doctrine/mongodb-odm/pull/1592, I found that a caught lock exception results in a document remaining in the unit of work and on the next `flush()` call of that type of document, a second attempt to save the document to the db is made. If that attempt fails, the unit of work is permanently stuck in a bad state, as that's the first document to be updated.