### PR TITLE
Update default repository factory

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Repository/DefaultRepositoryFactory.php
@@ -21,15 +21,16 @@ class DefaultRepositoryFactory implements RepositoryFactory
      */
     public function getRepository(DocumentManager $documentManager, $documentName)
     {
-        $documentName = ltrim($documentName, '\\');
+        $metadata = $documentManager->getClassMetadata($documentName);
+        $hashKey = $metadata->getName();
 
-        if (isset($this->repositoryList[$documentName])) {
-            return $this->repositoryList[$documentName];
+        if (isset($this->repositoryList[$hashKey])) {
+            return $this->repositoryList[$hashKey];
         }
 
-        $repository = $this->createRepository($documentManager, $documentName);
+        $repository = $this->createRepository($documentManager, ltrim($documentName, '\\'));
 
-        $this->repositoryList[$documentName] = $repository;
+        $this->repositoryList[$hashKey] = $repository;
 
         return $repository;
     }

--- a/lib/Doctrine/ODM/MongoDB/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Repository/DefaultRepositoryFactory.php
@@ -22,7 +22,7 @@ class DefaultRepositoryFactory implements RepositoryFactory
     public function getRepository(DocumentManager $documentManager, $documentName)
     {
         $metadata = $documentManager->getClassMetadata($documentName);
-        $hashKey = $metadata->getName();
+        $hashKey = $metadata->getName() . spl_object_hash($documentManager);
 
         if (isset($this->repositoryList[$hashKey])) {
             return $this->repositoryList[$hashKey];

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
@@ -1,20 +1,21 @@
 <?php
 
-namespace Doctrine\ODM\MongoDB\Tests;
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH267Test extends BaseTest
 {
     public function testNestedReferences()
     {
         // Users
-        $user1 = new User('Tom Petty');
-        $user2 = new User('Grateful Dead');
-        $user3 = new User('Neil Young');
+        $user1 = new GH267User('Tom Petty');
+        $user2 = new GH267User('Grateful Dead');
+        $user3 = new GH267User('Neil Young');
 
         // Company
-        $company = new BuyerCompany();
+        $company = new GH267BuyerCompany();
 
         $user1->setCompany($company);
         $user2->setCompany($company);
@@ -35,7 +36,7 @@ class GH267Test extends BaseTest
         // Clear out DM and read from DB afresh
         $this->dm->clear();
 
-        $qb = $this->dm->createQueryBuilder(__NAMESPACE__ . '\User')
+        $qb = $this->dm->createQueryBuilder(GH267User::class)
             ->field('_id')->equals($user1Id);
 
         $query = $qb->getQuery();
@@ -55,7 +56,7 @@ class GH267Test extends BaseTest
 /**
  * @ODM\Document(collection="users")
  */
-class User
+class GH267User
 {   
     /** @ODM\Id */
     protected $id;
@@ -64,7 +65,7 @@ class User
     protected $name;
 
     /**
-     * @ODM\ReferenceOne(name="company", targetDocument="Company", discriminatorMap={"seller"="SellerCompany", "buyer"="BuyerCompany"}, inversedBy="users")
+     * @ODM\ReferenceOne(name="company", targetDocument="GH267Company", discriminatorMap={"seller"="SellerCompany", "buyer"="BuyerCompany"}, inversedBy="users")
      */
     protected $company;
 
@@ -108,15 +109,15 @@ class User
  * @ODM\Document(collection="companies")
  * @ODM\InheritanceType("SINGLE_COLLECTION")
  * @ODM\DiscriminatorField(fieldName="type")
- * @ODM\DiscriminatorMap({"seller"="SellerCompany", "buyer"="BuyerCompany"}) 
+ * @ODM\DiscriminatorMap({"seller"="GH267SellerCompany", "buyer"="GH267BuyerCompany"})
  */
-class Company
+class GH267Company
 {   
     /** @ODM\Id */
     protected $id;
 
     /**
-     * @ODM\ReferenceMany(targetDocument="User", mappedBy="company")
+     * @ODM\ReferenceMany(targetDocument="GH267User", mappedBy="company")
      */
     protected $users;
 
@@ -144,7 +145,7 @@ class Company
 /**
  * @ODM\Document(collection="companies")
  */
-class BuyerCompany extends Company
+class GH267BuyerCompany extends GH267Company
 {   
 
 }
@@ -152,7 +153,7 @@ class BuyerCompany extends Company
 /**
  * @ODM\Document(collection="companies")
  */
-class SellerCompany extends Company
+class GH267SellerCompany extends GH267Company
 {   
 
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/RepositoryFactoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/RepositoryFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Repository\DefaultRepositoryFactory;
 use Doctrine\ODM\MongoDB\Repository\RepositoryFactory;
 use Documents\User;
 
@@ -25,6 +26,20 @@ class RepositoryFactoryTest extends BaseTest
         $this->assertSame(
             $this->dm->getRepository(User::class),
             $this->dm->getRepository(\Proxies\__CG__\Documents\User::class)
+        );
+    }
+
+    public function testRepositoriesAreDifferentForDifferentDms()
+    {
+        $conf = $this->getConfiguration();
+        $conf->setRepositoryFactory(new DefaultRepositoryFactory());
+
+        $dm1 = DocumentManager::create(null, $conf);
+        $dm2 = DocumentManager::create(null, $conf);
+
+        $this->assertNotSame(
+            $dm1->getRepository(User::class),
+            $dm2->getRepository(User::class)
         );
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/RepositoryFactoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/RepositoryFactoryTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Repository\RepositoryFactory;
+use Documents\User;
+
+class RepositoryFactoryTest extends BaseTest
+{
+    public function testRepositoryFactoryCanBeReplaced()
+    {
+        $factory = $this->createMock(RepositoryFactory::class);
+        $factory->expects($this->once())->method('getRepository');
+
+        $conf = $this->getConfiguration();
+        $conf->setRepositoryFactory($factory);
+        $dm = DocumentManager::create(null, $conf);
+
+        $dm->getRepository(User::class);
+    }
+
+    public function testRepositoriesAreSameForSameClasses()
+    {
+        $this->assertSame(
+            $this->dm->getRepository(User::class),
+            $this->dm->getRepository(\Proxies\__CG__\Documents\User::class)
+        );
+    }
+}


### PR DESCRIPTION
Lately I realized that our implementation is a bit off compared to ORM's one so here are 2 bug-fixes (since they're touching the same class and even in same place I packed both into same PR). Once we merge this I'd add `AbstractRepositoryFactory` as writing own one is quite tedious (copy default one and add your instantiation logic, I think we could add something like [AbstractPersistentCollectionFactory](https://github.com/doctrine/mongodb-odm/blob/b5d0c89cd63b3e05f58071c1025f7b776fcaa157/lib/Doctrine/ODM/MongoDB/PersistentCollection/AbstractPersistentCollectionFactory.php))