### PR TITLE
Deprecate Query Builder's group

### DIFF
--- a/docs/en/reference/aggregation-builder.rst
+++ b/docs/en/reference/aggregation-builder.rst
@@ -281,6 +281,8 @@ You can also use fields defined in previous stages:
             ->field('purchaseYear')
             ->equals(2016);
 
+.. _aggregation_builder_group:
+
 $group
 ~~~~~~
 

--- a/docs/en/reference/query-builder-api.rst
+++ b/docs/en/reference/query-builder-api.rst
@@ -946,6 +946,13 @@ Here is an example where we remove users who have never logged in:
 Group Queries
 -------------
 
+.. note::
+
+    Due to deprecation of ``group`` command in MongoDB 3.4 the ODM
+    also deprecates its usage through Query Builder in 1.2. Please
+    use :ref:`$group stage <aggregation_builder_group>` of the
+    Aggregation Builder instead.
+
 The last type of supported query is a group query. It performs an
 operation similar to SQL's GROUP BY command.
 

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -344,6 +344,19 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     }
 
     /**
+     * @inheritdoc
+     * @deprecated Deprecated in version 1.2 - use Aggregation Builder's group stage instead.
+     */
+    public function group($keys, array $initial, $reduce = null, array $options = [])
+    {
+        @trigger_error(
+            sprintf('%s was deprecated in version 1.2 - use Aggregation Builder\'s group stage instead.', __METHOD__),
+            E_USER_DEPRECATED
+        );
+        return parent::group($keys, $initial, $reduce, $options);
+    }
+
+    /**
      * Gets the Query executable.
      *
      * @param array $options


### PR DESCRIPTION
The `group` command [was deprecated in MongoDB 3.4](https://docs.mongodb.com/v3.4/reference/method/db.collection.group/)