### PR TITLE
Deprecate AnnotationDriver::registerAnnotationClasses

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php
@@ -17,6 +17,11 @@
  * <http://www.doctrine-project.org>.
  */
 
+@trigger_error(
+    sprintf('Loading annotations with %s is deprecated - register class loader through AnnotationRegistry::registerLoader instead.', __FILE__),
+    E_USER_DEPRECATED
+);
+
 require_once __DIR__ . '/AbstractDocument.php';
 require_once __DIR__ . '/Document.php';
 require_once __DIR__ . '/EmbeddedDocument.php';

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -48,9 +48,15 @@ class AnnotationDriver extends AbstractAnnotationDriver
      * Registers annotation classes to the common registry.
      *
      * This method should be called when bootstrapping your application.
+     *
+     * @deprecated method was deprecated in 1.2 and will be removed in 2.0. Register class loader through AnnotationRegistry::registerLoader instead.
      */
     public static function registerAnnotationClasses()
     {
+        @trigger_error(
+            sprintf('%s is deprecated - register class loader through AnnotationRegistry::registerLoader instead.', __METHOD__),
+            E_USER_DEPRECATED
+        );
         AnnotationRegistry::registerFile(__DIR__ . '/../Annotations/DoctrineAnnotations.php');
     }
 


### PR DESCRIPTION
I wonder if I should add trigger in `DoctrineAnnotations.php` in case somebody required that file on one's own...