### PR TITLE
Add read only documents

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -396,6 +396,9 @@ Optional attributes:
 -
    indexes - Specifies an array of indexes for this document.
 -
+   readOnly - Prevents document from being updated: it can only be inserted,
+   upserted or removed.
+-
    requireIndexes - Specifies whether or not queries for this document should
    require indexes by default. This may also be specified per query.
 -
@@ -416,6 +419,7 @@ Optional attributes:
      *     indexes={
      *         @Index(keys={"username"="desc"}, options={"unique"=true})
      *     },
+     *     readOnly=true,
      *     requireIndexes=true
      * )
      */

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -62,6 +62,7 @@
     <xs:attribute name="change-tracking-policy" type="odm:change-tracking-policy" />
     <xs:attribute name="require-indexes" type="xs:boolean" />
     <xs:attribute name="slave-okay" type="xs:boolean" />
+    <xs:attribute name="read-only" type="xs:boolean" />
   </xs:complexType>
 
   <xs:complexType name="field">

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Document.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Document.php
@@ -30,6 +30,7 @@ final class Document extends AbstractDocument
     public $collection;
     public $repositoryClass;
     public $indexes = array();
+    public $readOnly = false;
     /** @deprecated */
     public $requireIndexes = false;
     public $shardKey;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -172,6 +172,10 @@ class ClassMetadata extends ClassMetadataInfo
             $serialized[] = 'collectionMax';
         }
 
+        if ($this->isReadOnly) {
+            $serialized[] = 'isReadOnly';
+        }
+
         return $serialized;
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -456,6 +456,13 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
     public $reflClass;
 
     /**
+     * READ_ONLY: A flag for whether or not this document is read-only.
+     *
+     * @var bool
+     */
+    public $isReadOnly;
+
+    /**
      * Initializes a new ClassMetadata instance that will hold the object-document mapping
      * metadata of the class with the given name.
      *
@@ -2047,6 +2054,14 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
     public function setLockField($lockField)
     {
         $this->lockField = $lockField;
+    }
+
+    /**
+     * Marks this class as read only, no change tracking is applied to it.
+     */
+    public function markReadOnly()
+    {
+        $this->isReadOnly = true;
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -158,6 +158,9 @@ class AnnotationDriver extends AbstractAnnotationDriver
         if (isset($documentAnnot->slaveOkay)) {
             $class->setSlaveOkay($documentAnnot->slaveOkay);
         }
+        if (! empty($documentAnnot->readOnly)) {
+            $class->markReadOnly();
+        }
 
         foreach ($reflClass->getProperties() as $property) {
             if (($class->isMappedSuperclass && ! $property->isPrivate())

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -129,6 +129,9 @@ class XmlDriver extends FileDriver
         if (isset($xmlRoot['slave-okay'])) {
             $class->setSlaveOkay('true' === (string) $xmlRoot['slave-okay']);
         }
+        if (isset($xmlRoot['read-only']) && 'true' === (string) $xmlRoot['read-only']) {
+            $class->markReadOnly();
+        }
         if (isset($xmlRoot->field)) {
             foreach ($xmlRoot->field as $field) {
                 $mapping = array();

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
@@ -108,6 +108,9 @@ class YamlDriver extends FileDriver
         if (isset($element['slaveOkay'])) {
             $class->setSlaveOkay($element['slaveOkay']);
         }
+        if (! empty($element['readOnly'])) {
+            $class->markReadOnly();
+        }
         if (isset($element['fields'])) {
             foreach ($element['fields'] as $fieldName => $mapping) {
                 if (is_string($mapping)) {

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -709,6 +709,9 @@ class UnitOfWork implements PropertyChangedListener
             }
             $this->documentChangeSets[$oid] = $changeSet;
         } else {
+            if ($class->isReadOnly) {
+                return;
+            }
             // Document is "fully" MANAGED: it was already fully persisted before
             // and we have a copy of the original data
             $originalData = $this->originalDocumentData[$oid];
@@ -1164,6 +1167,10 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function executeUpdates(ClassMetadata $class, array $documents, array $options = array())
     {
+        if ($class->isReadOnly) {
+            return;
+        }
+
         $className = $class->name;
         $persister = $this->getDocumentPersister($className);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadOnlyDocumentTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadOnlyDocumentTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class ReadOnlyDocumentTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public function testCanBeInserted()
+    {
+        $rod = new ReadOnlyDocument('yay');
+        $this->dm->persist($rod);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $rod = $this->dm->find(ReadOnlyDocument::class, $rod->id);
+        $this->assertNotNull($rod);
+        $this->assertSame('yay', $rod->value);
+    }
+
+    public function testCanBeUpserted()
+    {
+        $rod = new ReadOnlyDocument('yay');
+        $rod->id = new \MongoId();
+        $this->dm->persist($rod);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $rod = $this->dm->find(ReadOnlyDocument::class, $rod->id);
+        $this->assertNotNull($rod);
+        $this->assertSame('yay', $rod->value);
+    }
+
+    public function testCanBeRemoved()
+    {
+        $rod = new ReadOnlyDocument('yay');
+        $this->dm->persist($rod);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $rod = $this->dm->find(ReadOnlyDocument::class, $rod->id);
+        $this->dm->remove($rod);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $rod = $this->dm->find(ReadOnlyDocument::class, $rod->id);
+        $this->assertNull($rod);
+    }
+
+    public function testChangingValueDoesNotProduceChangeSet()
+    {
+        $rod = new ReadOnlyDocument('yay');
+        $this->dm->persist($rod);
+        $this->dm->flush();
+        $rod->value = "o.O";
+        $this->uow->recomputeSingleDocumentChangeSet($this->dm->getClassMetadata(ReadOnlyDocument::class), $rod);
+        $this->assertEmpty($this->uow->getDocumentChangeSet($rod));
+    }
+
+    public function testCantBeUpdated()
+    {
+        $rod = new ReadOnlyDocument('yay');
+        $this->dm->persist($rod);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $rod = $this->dm->find(ReadOnlyDocument::class, $rod->id);
+        $rod->value = "o.O";
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $rod = $this->dm->find(ReadOnlyDocument::class, $rod->id);
+        $this->assertSame('yay', $rod->value);
+    }
+}
+
+/** @ODM\Document(readOnly=true) */
+class ReadOnlyDocument
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\Field(type="string") */
+    public $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -33,6 +33,17 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
     }
 
     /**
+     * @depends testLoadMapping
+     * @param ClassMetadata $class
+     */
+    public function testDocumentMarkedAsReadOnly($class)
+    {
+        $this->assertTrue($class->isReadOnly);
+
+        return $class;
+    }
+
+    /**
      * @depends testDocumentCollectionNameAndInheritance
      * @param ClassMetadata $class
      */
@@ -354,7 +365,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
 }
 
 /**
- * @ODM\Document(collection="cms_users", writeConcern=1)
+ * @ODM\Document(collection="cms_users", writeConcern=1, readOnly=true)
  * @ODM\DiscriminatorField("discr")
  * @ODM\DiscriminatorMap({"default"="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser"})
  * @ODM\DefaultDiscriminatorValue("default")

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
@@ -5,7 +5,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-    <document name="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser" collection="cms_users" writeConcern="1">
+    <document name="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser" collection="cms_users" writeConcern="1" read-only="true">
         <discriminator-field name="discr" />
         <discriminator-map>
             <discriminator-mapping value="default" class="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser" />

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.yml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.yml
@@ -2,6 +2,7 @@ Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser:
   type: document
   collection: cms_users
   writeConcern: 1
+  readOnly: 1
   discriminatorField:
     fieldName: discr
   discriminatorMap:


### PR DESCRIPTION
Closes #1602 (cc @tux-rampage)

Allowing document to be upserted opens a way to overwriting its value but otherwise it would be impossible to have read only document with user-generated identifier. We may want to revisit this once we have official `upsert` API :)