### PR TITLE
Add generic reference as replacement for DBRef

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -1222,10 +1222,11 @@ Optional attributes:
 -
     simple - deprecated (use ``storeAs: id``)
 -
-    storeAs - Indicates how to store the reference. ``id`` uses ``MongoId``,
-    ``dbRef`` uses a `DBRef`_ without ``$db`` value and ``dbRefWithDb`` stores
-    a full `DBRef`_ (``$ref``, ``$id``, and ``$db``). Note that ``id``
-    references are not compatible with the discriminators.
+    storeAs - Indicates how to store the reference. ``id`` stores the identifier,
+    ``ref`` an embedded object containing the ``id`` field and (optionally) a
+    discriminator. ``dbRef`` and ``dbRefWithDb`` store a ``DBRef`` object. They
+    are deprecated in favor of ``ref``. Note that ``id`` references are not
+    compatible with the discriminators.
 -
     cascade - Cascade Option
 -
@@ -1297,8 +1298,8 @@ Optional attributes:
     simple - deprecated (use ``storeAs: id``)
 -
     storeAs - Indicates how to store the reference. ``id`` uses ``MongoId``,
-    ``dbRef`` uses a `DBRef`_ without ``$db`` value and ``dbRefWithDb`` stores
-    a full `DBRef`_ (``$ref``, ``$id``, and ``$db``). Note that ``id``
+    ``ref`` stores fields ``id`` and ``ref`` (similar to DBRef without $ prefix) value and ``refWithDb`` stores
+    a additionally db as parameter. ``dbRef`` and ``dbRefWithDb`` use ``DBRef``, they are deprecated in favor of ref and refWithDb. Note that ``id``
     references are not compatible with the discriminators.
 -
     cascade - Cascade Option

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -1218,25 +1218,26 @@ documents.
 Optional attributes:
 
 -
-    targetDocument - A |FQCN| of the target document.
+    targetDocument - A |FQCN| of the target document. A ``targetDocument`` is
+    required when using ``storeAs: id``.
 -
     simple - deprecated (use ``storeAs: id``)
 -
     storeAs - Indicates how to store the reference. ``id`` stores the identifier,
     ``ref`` an embedded object containing the ``id`` field and (optionally) a
-    discriminator. ``dbRef`` and ``dbRefWithDb`` store a ``DBRef`` object. They
+    discriminator. ``dbRef`` and ``dbRefWithDb`` store a `DBRef`_ object. They
     are deprecated in favor of ``ref``. Note that ``id`` references are not
     compatible with the discriminators.
 -
     cascade - Cascade Option
 -
     discriminatorField - The field name to store the discriminator value within
-    the `DBRef`_ object.
+    the reference object.
 -
     discriminatorMap - Map of discriminator values to class names.
 -
     defaultDiscriminatorValue - A default value for discriminatorField if no value
-    has been set in the embedded document.
+    has been set in the referenced document.
 -
     inversedBy - The field name of the inverse side. Only allowed on owning side.
 -
@@ -1293,24 +1294,26 @@ Defines an instance variable holds a related document instance.
 Optional attributes:
 
 -
-    targetDocument - A |FQCN| of the target document.
+    targetDocument - A |FQCN| of the target document. A ``targetDocument`` is
+    required when using ``storeAs: id``.
 -
     simple - deprecated (use ``storeAs: id``)
 -
-    storeAs - Indicates how to store the reference. ``id`` uses ``MongoId``,
-    ``ref`` stores fields ``id`` and ``ref`` (similar to DBRef without $ prefix) value and ``refWithDb`` stores
-    a additionally db as parameter. ``dbRef`` and ``dbRefWithDb`` use ``DBRef``, they are deprecated in favor of ref and refWithDb. Note that ``id``
-    references are not compatible with the discriminators.
+    storeAs - Indicates how to store the reference. ``id`` stores the identifier,
+    ``ref`` an embedded object containing the ``id`` field and (optionally) a
+    discriminator. ``dbRef`` and ``dbRefWithDb`` store a `DBRef`_ object. They
+    are deprecated in favor of ``ref``. Note that ``id`` references are not
+    compatible with the discriminators.
 -
     cascade - Cascade Option
 -
     discriminatorField - The field name to store the discriminator value within
-    the `DBRef`_ object.
+    the reference object.
 -
     discriminatorMap - Map of discriminator values to class names.
 -
     defaultDiscriminatorValue - A default value for discriminatorField if no value
-    has been set in the embedded document.
+    has been set in the referenced document.
 -
     inversedBy - The field name of the inverse side. Only allowed on owning side.
 -

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -1225,7 +1225,7 @@ Optional attributes:
 -
     storeAs - Indicates how to store the reference. ``id`` stores the identifier,
     ``ref`` an embedded object containing the ``id`` field and (optionally) a
-    discriminator. ``dbRef`` and ``dbRefWithDb`` store a `DBRef`_ object. They
+    discriminator. ``dbRef`` and ``dbRefWithDb`` store a `DBRef`_ object and
     are deprecated in favor of ``ref``. Note that ``id`` references are not
     compatible with the discriminators.
 -
@@ -1301,7 +1301,7 @@ Optional attributes:
 -
     storeAs - Indicates how to store the reference. ``id`` stores the identifier,
     ``ref`` an embedded object containing the ``id`` field and (optionally) a
-    discriminator. ``dbRef`` and ``dbRefWithDb`` store a `DBRef`_ object. They
+    discriminator. ``dbRef`` and ``dbRefWithDb`` store a `DBRef`_ object and
     are deprecated in favor of ``ref``. Note that ``id`` references are not
     compatible with the discriminators.
 -

--- a/docs/en/reference/reference-mapping.rst
+++ b/docs/en/reference/reference-mapping.rst
@@ -360,6 +360,7 @@ The ``storeAs`` option has three possible values:
 
 - **dbRefWithDb**: Uses a `DBRef`_ with ``$ref``, ``$id``, and ``$db`` fields (this is the default)
 - **dbRef**: Uses a `DBRef`_ with ``$ref`` and ``$id``
+- **ref**: Uses a custom embedded object with an ``id`` field
 - **id**: Uses a ``MongoId``
 
 .. note::

--- a/docs/en/reference/reference-mapping.rst
+++ b/docs/en/reference/reference-mapping.rst
@@ -356,12 +356,12 @@ fields and as ``MongoId``, it is possible to save references as `DBRef`_ without
 the ``$db`` field. This solves problems when the database name changes (and also
 reduces the amount of storage used).
 
-The ``storeAs`` option has three possible values:
+The ``storeAs`` option has the following possible values:
 
 - **dbRefWithDb**: Uses a `DBRef`_ with ``$ref``, ``$id``, and ``$db`` fields (this is the default)
 - **dbRef**: Uses a `DBRef`_ with ``$ref`` and ``$id``
 - **ref**: Uses a custom embedded object with an ``id`` field
-- **id**: Uses a ``MongoId``
+- **id**: Uses the identifier of the referenced object
 
 .. note::
 

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -124,6 +124,7 @@
   <xs:simpleType name="reference-store-as">
     <xs:restriction base="xs:token">
       <xs:enumeration value="id"/>
+      <xs:enumeration value="ref"/>
       <xs:enumeration value="dbRef"/>
       <xs:enumeration value="dbRefWithDb"/>
     </xs:restriction>

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
@@ -96,26 +96,44 @@ class Lookup extends BaseStage\Lookup
         parent::from($targetMapping->getCollection());
 
         if ($referenceMapping['isOwningSide']) {
-            if ($referenceMapping['storeAs'] !== ClassMetadataInfo::REFERENCE_STORE_AS_ID) {
-                throw MappingException::cannotLookupNonIdReference($this->class->name, $fieldName);
+            switch ($referenceMapping['storeAs']) {
+                case ClassMetadataInfo::REFERENCE_STORE_AS_ID:
+                    $referencedFieldName = $referenceMapping['name'];
+                    break;
+
+                case ClassMetadataInfo::REFERENCE_STORE_AS_REF:
+                    $referencedFieldName = $referenceMapping['name'] . '.id';
+                    break;
+
+                default:
+                   throw MappingException::cannotLookupNonIdReference($this->class->name, $fieldName);
             }
 
             $this
                 ->foreignField('_id')
-                ->localField($referenceMapping['name']);
+                ->localField($referencedFieldName);
         } else {
             if (isset($referenceMapping['repositoryMethod'])) {
                 throw MappingException::repositoryMethodLookupNotAllowed($this->class->name, $fieldName);
             }
 
             $mappedByMapping = $targetMapping->getFieldMapping($referenceMapping['mappedBy']);
-            if ($mappedByMapping['storeAs'] !== ClassMetadataInfo::REFERENCE_STORE_AS_ID) {
-                throw MappingException::cannotLookupNonIdReference($this->class->name, $fieldName);
+            switch ($mappedByMapping['storeAs']) {
+                case ClassMetadataInfo::REFERENCE_STORE_AS_ID:
+                    $referencedFieldName = $mappedByMapping['name'];
+                    break;
+
+                case ClassMetadataInfo::REFERENCE_STORE_AS_REF:
+                    $referencedFieldName = $mappedByMapping['name'] . '.id';
+                    break;
+
+                default:
+                    throw MappingException::cannotLookupNonIdReference($this->class->name, $fieldName);
             }
 
             $this
                 ->localField('_id')
-                ->foreignField($mappedByMapping['name']);
+                ->foreignField($referencedFieldName);
         }
 
         return $this;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
@@ -98,11 +98,8 @@ class Lookup extends BaseStage\Lookup
         if ($referenceMapping['isOwningSide']) {
             switch ($referenceMapping['storeAs']) {
                 case ClassMetadataInfo::REFERENCE_STORE_AS_ID:
-                    $referencedFieldName = $referenceMapping['name'];
-                    break;
-
                 case ClassMetadataInfo::REFERENCE_STORE_AS_REF:
-                    $referencedFieldName = $referenceMapping['name'] . '.id';
+                    $referencedFieldName = ClassMetadataInfo::getReferenceFieldName($referenceMapping['storeAs'], $referenceMapping['name']);
                     break;
 
                 default:
@@ -120,11 +117,8 @@ class Lookup extends BaseStage\Lookup
             $mappedByMapping = $targetMapping->getFieldMapping($referenceMapping['mappedBy']);
             switch ($mappedByMapping['storeAs']) {
                 case ClassMetadataInfo::REFERENCE_STORE_AS_ID:
-                    $referencedFieldName = $mappedByMapping['name'];
-                    break;
-
                 case ClassMetadataInfo::REFERENCE_STORE_AS_REF:
-                    $referencedFieldName = $mappedByMapping['name'] . '.id';
+                    $referencedFieldName = ClassMetadataInfo::getReferenceFieldName($mappedByMapping['storeAs'], $mappedByMapping['name']);
                     break;
 
                 default:

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -260,7 +260,7 @@ EOF
                 \$mongoId = \$reference;
             } else {
                 \$className = \$this->unitOfWork->getClassNameForAssociation(\$this->class->fieldMappings['%2\$s'], \$reference);
-                \$mongoId = \$reference['\$id'];
+                \$mongoId = \$reference[ClassMetadataInfo::getReferencePrefix(\$this->class->fieldMappings['%2\$s']['storeAs']) . 'id'];
             }
             \$targetMetadata = \$this->dm->getClassMetadata(\$className);
             \$id = \$targetMetadata->getPHPIdentifierValue(\$mongoId);
@@ -296,7 +296,7 @@ EOF
         \$className = \$mapping['targetDocument'];
         \$targetClass = \$this->dm->getClassMetadata(\$mapping['targetDocument']);
         \$mappedByMapping = \$targetClass->fieldMappings[\$mapping['mappedBy']];
-        \$mappedByFieldName = isset(\$mappedByMapping['storeAs']) && \$mappedByMapping['storeAs'] === ClassMetadataInfo::REFERENCE_STORE_AS_ID ? \$mapping['mappedBy'] : \$mapping['mappedBy'].'.\$id';
+        \$mappedByFieldName = isset(\$mappedByMapping['storeAs']) && \$mappedByMapping['storeAs'] === ClassMetadataInfo::REFERENCE_STORE_AS_ID ? \$mapping['mappedBy'] : \$mapping['mappedBy'].'.'.ClassMetadataInfo::getReferencePrefix(\$mappedByMapping['storeAs']).'id';
         \$criteria = array_merge(
             array(\$mappedByFieldName => \$data['_id']),
             isset(\$this->class->fieldMappings['%2\$s']['criteria']) ? \$this->class->fieldMappings['%2\$s']['criteria'] : array()

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -255,13 +255,8 @@ EOF
         /** @ReferenceOne */
         if (isset(\$data['%1\$s'])) {
             \$reference = \$data['%1\$s'];
-            if (isset(\$this->class->fieldMappings['%2\$s']['storeAs']) && \$this->class->fieldMappings['%2\$s']['storeAs'] === ClassMetadataInfo::REFERENCE_STORE_AS_ID) {
-                \$className = \$this->class->fieldMappings['%2\$s']['targetDocument'];
-                \$mongoId = \$reference;
-            } else {
-                \$className = \$this->unitOfWork->getClassNameForAssociation(\$this->class->fieldMappings['%2\$s'], \$reference);
-                \$mongoId = \$reference[ClassMetadataInfo::getReferencePrefix(\$this->class->fieldMappings['%2\$s']['storeAs']) . 'id'];
-            }
+            \$className = \$this->unitOfWork->getClassNameForAssociation(\$this->class->fieldMappings['%2\$s'], \$reference);
+            \$mongoId = ClassMetadataInfo::getReferenceId(\$reference, \$this->class->fieldMappings['%2\$s']['storeAs']);
             \$targetMetadata = \$this->dm->getClassMetadata(\$className);
             \$id = \$targetMetadata->getPHPIdentifierValue(\$mongoId);
             \$return = \$this->dm->getReference(\$className, \$id);
@@ -296,7 +291,7 @@ EOF
         \$className = \$mapping['targetDocument'];
         \$targetClass = \$this->dm->getClassMetadata(\$mapping['targetDocument']);
         \$mappedByMapping = \$targetClass->fieldMappings[\$mapping['mappedBy']];
-        \$mappedByFieldName = isset(\$mappedByMapping['storeAs']) && \$mappedByMapping['storeAs'] === ClassMetadataInfo::REFERENCE_STORE_AS_ID ? \$mapping['mappedBy'] : \$mapping['mappedBy'].'.'.ClassMetadataInfo::getReferencePrefix(\$mappedByMapping['storeAs']).'id';
+        \$mappedByFieldName = ClassMetadataInfo::getReferenceFieldName(\$mappedByMapping['storeAs'], \$mapping['mappedBy']);
         \$criteria = array_merge(
             array(\$mappedByFieldName => \$data['_id']),
             isset(\$this->class->fieldMappings['%2\$s']['criteria']) ? \$this->class->fieldMappings['%2\$s']['criteria'] : array()

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -484,18 +484,37 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
      */
     public static function getReferenceId($reference, $storeAs)
     {
-        return $reference[ClassMetadataInfo::getReferencePrefix($storeAs) . 'id'];
+        return $storeAs === ClassMetadataInfo::REFERENCE_STORE_AS_ID ? $reference : $reference[ClassMetadataInfo::getReferencePrefix($storeAs) . 'id'];
     }
 
     /**
-     * Returns the reference prefix used for a referene
+     * Returns the reference prefix used for a reference
      * @param string $storeAs
+     * @return string
+     */
+    private static function getReferencePrefix($storeAs)
+    {
+        if (!in_array($storeAs, [ClassMetadataInfo::REFERENCE_STORE_AS_REF, ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF, ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF_WITH_DB])) {
+            throw new \LogicException('Can only get a reference prefix for DBRef and reference arrays');
+        }
+
+        return $storeAs === ClassMetadataInfo::REFERENCE_STORE_AS_REF ? '' : '$';
+    }
+
+    /**
+     * Returns a fully qualified field name for a given reference
+     * @param string $storeAs
+     * @param string $pathPrefix The field path prefix
      * @return string
      * @internal
      */
-    public static function getReferencePrefix($storeAs)
+    public static function getReferenceFieldName($storeAs, $pathPrefix = '')
     {
-        return $storeAs === ClassMetadataInfo::REFERENCE_STORE_AS_REF ? '' : '$';
+        if ($storeAs === ClassMetadataInfo::REFERENCE_STORE_AS_ID) {
+            return $pathPrefix;
+        }
+
+        return ($pathPrefix ? $pathPrefix . '.' : '') . static::getReferencePrefix($storeAs) . 'id';
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -477,7 +477,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
 
     /**
      * Helper method to get reference id of ref* type references
-     * @param array  $reference
+     * @param mixed  $reference
      * @param string $storeAs
      * @return mixed
      * @internal

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -103,6 +103,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
     const REFERENCE_STORE_AS_ID = 'id';
     const REFERENCE_STORE_AS_DB_REF = 'dbRef';
     const REFERENCE_STORE_AS_DB_REF_WITH_DB = 'dbRefWithDb';
+    const REFERENCE_STORE_AS_REF = 'ref';
 
     /* The inheritance mapping types */
     /**
@@ -472,6 +473,29 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
     {
         $this->name = $documentName;
         $this->rootDocumentName = $documentName;
+    }
+
+    /**
+     * Helper method to get reference id of ref* type references
+     * @param array  $reference
+     * @param string $storeAs
+     * @return mixed
+     * @internal
+     */
+    public static function getReferenceId($reference, $storeAs)
+    {
+        return $reference[ClassMetadataInfo::getReferencePrefix($storeAs) . 'id'];
+    }
+
+    /**
+     * Returns the reference prefix used for a referene
+     * @param string $storeAs
+     * @return string
+     * @internal
+     */
+    public static function getReferencePrefix($storeAs)
+    {
+        return $storeAs === ClassMetadataInfo::REFERENCE_STORE_AS_REF ? '' : '$';
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1429,7 +1429,7 @@ class DocumentPersister
      */
     private function prepareDbRefElement($fieldName, $value, array $mapping, $inNewObj)
     {
-        $dbRef = $this->dm->createDBRef($value, $mapping);
+        $dbRef = $this->dm->createReference($value, $mapping);
         if ($inNewObj || $mapping['storeAs'] === ClassMetadataInfo::REFERENCE_STORE_AS_ID) {
             return [[$fieldName, $dbRef]];
         }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
@@ -308,7 +308,7 @@ class PersistenceBuilder
      */
     public function prepareReferencedDocumentValue(array $referenceMapping, $document)
     {
-        return $this->dm->createDBRef($document, $referenceMapping);
+        return $this->dm->createReference($document, $referenceMapping);
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Expr.php
@@ -79,18 +79,22 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
             if ($storeAs === ClassMetadataInfo::REFERENCE_STORE_AS_ID) {
                 $this->query[$mapping['name']] = $dbRef;
             } else {
-                $keys = array('ref' => true, 'id' => true, 'db' => true);
+                if ($storeAs === ClassMetadataInfo::REFERENCE_STORE_AS_REF) {
+                    $keys = ['id' => true];
+                } else {
+                    $keys = ['$ref' => true, '$id' => true, '$db' => true];
 
-                if ($storeAs === ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF) {
-                    unset($keys['db']);
-                }
+                    if ($storeAs === ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF) {
+                        unset($keys['$db']);
+                    }
 
-                if (isset($mapping['targetDocument'])) {
-                    unset($keys['ref'], $keys['db']);
+                    if (isset($mapping['targetDocument'])) {
+                        unset($keys['$ref'], $keys['$db']);
+                    }
                 }
 
                 foreach ($keys as $key => $value) {
-                    $this->query[$mapping['name'] . '.$' . $key] = $dbRef['$' . $key];
+                    $this->query[$mapping['name'] . '.' . $key] = $dbRef[$key];
                 }
             }
         } else {
@@ -117,18 +121,22 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
             if ($storeAs === ClassMetadataInfo::REFERENCE_STORE_AS_ID) {
                 $this->query[$mapping['name']] = $dbRef;
             } else {
-                $keys = array('ref' => true, 'id' => true, 'db' => true);
+                if ($storeAs === ClassMetadataInfo::REFERENCE_STORE_AS_REF) {
+                    $keys = ['id' => true];
+                } else {
+                    $keys = ['$ref' => true, '$id' => true, '$db' => true];
 
-                if ($storeAs === ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF) {
-                    unset($keys['db']);
-                }
+                    if ($storeAs === ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF) {
+                        unset($keys['$db']);
+                    }
 
-                if (isset($mapping['targetDocument'])) {
-                    unset($keys['ref'], $keys['db']);
+                    if (isset($mapping['targetDocument'])) {
+                        unset($keys['$ref'], $keys['$db']);
+                    }
                 }
 
                 foreach ($keys as $key => $value) {
-                    $this->query[$mapping['name']]['$elemMatch']['$' . $key] = $dbRef['$' . $key];
+                    $this->query[$mapping['name']]['$elemMatch'][$key] = $dbRef[$key];
                 }
             }
         } else {

--- a/lib/Doctrine/ODM/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Expr.php
@@ -73,7 +73,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
     {
         if ($this->currentField) {
             $mapping = $this->getReferenceMapping();
-            $dbRef = $this->dm->createDBRef($document, $mapping);
+            $dbRef = $this->dm->createReference($document, $mapping);
             $storeAs = array_key_exists('storeAs', $mapping) ? $mapping['storeAs'] : null;
 
             if ($storeAs === ClassMetadataInfo::REFERENCE_STORE_AS_ID) {
@@ -98,7 +98,9 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
                 }
             }
         } else {
-            $dbRef = $this->dm->createDBRef($document);
+            @trigger_error('Calling ' . __METHOD__ . ' without a current field set will no longer be possible in ODM 2.0.', E_USER_DEPRECATED);
+
+            $dbRef = $this->dm->createReference($document);
             $this->query = $dbRef;
         }
 
@@ -115,7 +117,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
     {
         if ($this->currentField) {
             $mapping = $this->getReferenceMapping();
-            $dbRef = $this->dm->createDBRef($document, $mapping);
+            $dbRef = $this->dm->createReference($document, $mapping);
             $storeAs = array_key_exists('storeAs', $mapping) ? $mapping['storeAs'] : null;
 
             if ($storeAs === ClassMetadataInfo::REFERENCE_STORE_AS_ID) {
@@ -140,7 +142,9 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
                 }
             }
         } else {
-            $dbRef = $this->dm->createDBRef($document);
+            @trigger_error('Calling ' . __METHOD__ . ' without a current field set will no longer be possible in ODM 2.0.', E_USER_DEPRECATED);
+
+            $dbRef = $this->dm->createReference($document);
             $this->query['$elemMatch'] = $dbRef;
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
@@ -255,17 +255,15 @@ class ReferencePrimer
     {
         $mapping = $persistentCollection->getMapping();
 
-
         if ($mapping['storeAs'] === ClassMetadataInfo::REFERENCE_STORE_AS_ID) {
             $className = $mapping['targetDocument'];
             $class = $this->dm->getClassMetadata($className);
         }
 
         foreach ($persistentCollection->getMongoData() as $reference) {
-            if ($mapping['storeAs'] === ClassMetadataInfo::REFERENCE_STORE_AS_ID) {
-                $id = $reference;
-            } else {
-                $id = $reference[ClassMetadataInfo::getReferencePrefix($mapping['storeAs']) . 'id'];
+            $id = ClassMetadataInfo::getReferenceId($reference, $mapping['storeAs']);
+
+            if ($mapping['storeAs'] !== ClassMetadataInfo::REFERENCE_STORE_AS_ID) {
                 $className = $this->uow->getClassNameForAssociation($mapping, $reference);
                 $class = $this->dm->getClassMetadata($className);
             }

--- a/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
@@ -255,6 +255,7 @@ class ReferencePrimer
     {
         $mapping = $persistentCollection->getMapping();
 
+
         if ($mapping['storeAs'] === ClassMetadataInfo::REFERENCE_STORE_AS_ID) {
             $className = $mapping['targetDocument'];
             $class = $this->dm->getClassMetadata($className);
@@ -264,7 +265,7 @@ class ReferencePrimer
             if ($mapping['storeAs'] === ClassMetadataInfo::REFERENCE_STORE_AS_ID) {
                 $id = $reference;
             } else {
-                $id = $reference['$id'];
+                $id = $reference[ClassMetadataInfo::getReferencePrefix($mapping['storeAs']) . 'id'];
                 $className = $this->uow->getClassNameForAssociation($mapping, $reference);
                 $class = $this->dm->getClassMetadata($className);
             }

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -195,7 +195,7 @@ class SchemaManager
                         if ($key == $fieldMapping['name']) {
                             $key = $fieldMapping['storeAs'] === ClassMetadataInfo::REFERENCE_STORE_AS_ID
                                 ? $key
-                                : $key . '.$id';
+                                : $key . '.' . ClassMetadataInfo::getReferencePrefix($fieldMapping['storeAs']) . 'id';
                         }
                         $newKeys[$key] = $v;
                     }

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -193,9 +193,7 @@ class SchemaManager
                     $newKeys = array();
                     foreach ($index['keys'] as $key => $v) {
                         if ($key == $fieldMapping['name']) {
-                            $key = $fieldMapping['storeAs'] === ClassMetadataInfo::REFERENCE_STORE_AS_ID
-                                ? $key
-                                : $key . '.' . ClassMetadataInfo::getReferencePrefix($fieldMapping['storeAs']) . 'id';
+                            $key = ClassMetadataInfo::getReferenceFieldName($fieldMapping['storeAs'], $key);
                         }
                         $newKeys[$key] = $v;
                     }

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2625,7 +2625,7 @@ class UnitOfWork implements PropertyChangedListener
                 : $discriminatorValue;
         }
 
-            $class = $this->dm->getClassMetadata($mapping['targetDocument']);
+        $class = $this->dm->getClassMetadata($mapping['targetDocument']);
 
         if (isset($class->discriminatorField, $data[$class->discriminatorField])) {
             $discriminatorValue = $data[$class->discriminatorField];

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LookupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LookupTest.php
@@ -4,11 +4,17 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
-    public function testLookupStage()
+    /**
+     * @before
+     */
+    public function prepareTest()
     {
         $this->requireMongoDB32('$lookup tests require at least MongoDB 3.2.0');
         $this->insertTestData();
+    }
 
+    public function testLookupStage()
+    {
         $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
         $builder
             ->lookup('user')
@@ -36,9 +42,6 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageWithClassName()
     {
-        $this->requireMongoDB32('$lookup tests require at least MongoDB 3.2.0');
-        $this->insertTestData();
-
         $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
         $builder
             ->lookup(\Documents\User::class)
@@ -68,9 +71,6 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageWithCollectionName()
     {
-        $this->requireMongoDB32('$lookup tests require at least MongoDB 3.2.0');
-        $this->insertTestData();
-
         $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
         $builder
             ->lookup('randomCollectionName')
@@ -99,9 +99,6 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageReferenceMany()
     {
-        $this->requireMongoDB32('$lookup tests require at least MongoDB 3.2.0');
-        $this->insertTestData();
-
         $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
         $builder
             ->unwind('$users')
@@ -135,9 +132,6 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageReferenceManyStoreAsRef()
     {
-        $this->requireMongoDB32('$lookup tests require at least MongoDB 3.2.0');
-        $this->insertTestData();
-
         $builder = $this->dm->createAggregationBuilder(\Documents\ReferenceUser::class);
         $builder
             ->unwind('$referencedUsers')
@@ -171,9 +165,7 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageReferenceManyWithoutUnwindMongoDB32()
     {
-        $this->requireMongoDB32('$lookup tests require at least MongoDB 3.2.0');
         $this->skipOnMongoDB34('$lookup tests without unwind will not work on MongoDB 3.4.0');
-        $this->insertTestData();
 
         $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
         $builder
@@ -202,7 +194,6 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testLookupStageReferenceManyWithoutUnwindMongoDB34()
     {
         $this->requireMongoDB34('$lookup tests with unwind require at least MongoDB 3.4.0');
-        $this->insertTestData();
 
         $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
         $builder
@@ -232,9 +223,6 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageReferenceOneInverse()
     {
-        $this->requireMongoDB32('$lookup tests require at least MongoDB 3.2.0');
-        $this->insertTestData();
-
         $builder = $this->dm->createAggregationBuilder(\Documents\User::class);
         $builder
             ->match()
@@ -267,9 +255,6 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageReferenceManyInverse()
     {
-        $this->requireMongoDB32('$lookup tests require at least MongoDB 3.2.0');
-        $this->insertTestData();
-
         $builder = $this->dm->createAggregationBuilder(\Documents\User::class);
         $builder
             ->match()
@@ -302,9 +287,6 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageReferenceOneInverseStoreAsRef()
     {
-        $this->requireMongoDB32('$lookup tests require at least MongoDB 3.2.0');
-        $this->insertTestData();
-
         $builder = $this->dm->createAggregationBuilder(\Documents\User::class);
         $builder
             ->match()
@@ -337,9 +319,6 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageReferenceManyInverseStoreAsRef()
     {
-        $this->requireMongoDB32('$lookup tests require at least MongoDB 3.2.0');
-        $this->insertTestData();
-
         $builder = $this->dm->createAggregationBuilder(\Documents\User::class);
         $builder
             ->match()

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\ODM\MongoDB\Tests;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\Mocks\DocumentManagerMock;
+use Documents\CmsPhonenumber;
 
 class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
@@ -195,16 +196,16 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testCannotCreateDbRefWithoutId()
     {
         $d = new \Documents\User();
-        $this->dm->createDBRef($d);
+        $this->dm->createReference($d, ['storeAs' => ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF]);
     }
 
     public function testCreateDbRefWithNonNullEmptyId()
     {
-        $phonenumber = new \Documents\CmsPhonenumber();
+        $phonenumber = new CmsPhonenumber();
         $phonenumber->phonenumber = 0;
         $this->dm->persist($phonenumber);
 
-        $dbRef = $this->dm->createDBRef($phonenumber);
+        $dbRef = $this->dm->createReference($phonenumber, ['storeAs' => ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF, 'targetDocument' => CmsPhonenumber::class]);
 
         $this->assertSame(array('$ref' => 'CmsPhonenumber', '$id' => 0), $dbRef);
     }
@@ -219,7 +220,7 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $r = new \Documents\Tournament\ParticipantSolo('Maciej');
         $this->dm->persist($r);
         $class = $this->dm->getClassMetadata(get_class($d));
-        $this->dm->createDBRef($r, $class->associationMappings['ref']);
+        $this->dm->createReference($r, $class->associationMappings['ref']);
     }
 
     public function testDifferentStoreAsDbReferences()
@@ -229,21 +230,21 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $d = new ReferenceStoreAsDocument();
         $class = $this->dm->getClassMetadata(get_class($d));
 
-        $dbRef = $this->dm->createDBRef($r, $class->associationMappings['ref1']);
+        $dbRef = $this->dm->createReference($r, $class->associationMappings['ref1']);
         $this->assertInstanceOf('MongoId', $dbRef);
 
-        $dbRef = $this->dm->createDBRef($r, $class->associationMappings['ref2']);
+        $dbRef = $this->dm->createReference($r, $class->associationMappings['ref2']);
         $this->assertCount(2, $dbRef);
         $this->assertArrayHasKey('$ref', $dbRef);
         $this->assertArrayHasKey('$id', $dbRef);
 
-        $dbRef = $this->dm->createDBRef($r, $class->associationMappings['ref3']);
+        $dbRef = $this->dm->createReference($r, $class->associationMappings['ref3']);
         $this->assertCount(3, $dbRef);
         $this->assertArrayHasKey('$ref', $dbRef);
         $this->assertArrayHasKey('$id', $dbRef);
         $this->assertArrayHasKey('$db', $dbRef);
 
-        $dbRef = $this->dm->createDBRef($r, $class->associationMappings['ref4']);
+        $dbRef = $this->dm->createReference($r, $class->associationMappings['ref4']);
         $this->assertCount(1, $dbRef);
         $this->assertArrayHasKey('id', $dbRef);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -242,6 +242,10 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertArrayHasKey('$ref', $dbRef);
         $this->assertArrayHasKey('$id', $dbRef);
         $this->assertArrayHasKey('$db', $dbRef);
+
+        $dbRef = $this->dm->createDBRef($r, $class->associationMappings['ref4']);
+        $this->assertCount(1, $dbRef);
+        $this->assertArrayHasKey('id', $dbRef);
     }
 
     private function getMockClassMetadataFactory()
@@ -279,4 +283,7 @@ class ReferenceStoreAsDocument
 
     /** @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="dbRefWithDb") */
     public $ref3;
+
+    /** @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="ref") */
+    public $ref4;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -345,6 +345,83 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
     }
 
+    public function testPrepareQueryOrNewObjWithEmbeddedReferenceToTargetDocumentWithNormalIdType()
+    {
+        $class = DocumentPersisterTestHashIdDocument::class;
+        $documentPersister = $this->uow->getDocumentPersister($class);
+
+        $id = new \MongoId();
+
+        $value = array('embeddedRef.id' => (string) $id);
+        $expected = array('embeddedRef.id' => $id);
+
+        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
+
+        $value = array('embeddedRef.id' => array('$exists' => true));
+        $expected = array('embeddedRef.id' => array('$exists' => true));
+
+        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
+
+        $value = array('embeddedRef.id' => array('$elemMatch' => (string) $id));
+        $expected = array('embeddedRef.id' => array('$elemMatch' => $id));
+
+        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
+
+        $value = array('embeddedRef.id' => array('$in' => array((string) $id)));
+        $expected = array('embeddedRef.id' => array('$in' => array($id)));
+
+        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
+
+        $value = array('embeddedRef.id' => array('$not' => array('$elemMatch' => (string) $id)));
+        $expected = array('embeddedRef.id' => array('$not' => array('$elemMatch' => $id)));
+
+        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
+
+        $value = array('embeddedRef.id' => array('$not' => array('$in' => array((string) $id))));
+        $expected = array('embeddedRef.id' => array('$not' => array('$in' => array($id))));
+
+        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
+    }
+
+    /**
+     * @dataProvider provideHashIdentifiers
+     */
+    public function testPrepareQueryOrNewObjWithEmbeddedReferenceToTargetDocumentWithHashIdType($hashId)
+    {
+        $class = DocumentPersisterTestDocument::class;
+        $documentPersister = $this->uow->getDocumentPersister($class);
+
+        $value = array('embeddedRef.id' => $hashId);
+        $expected = array('embeddedRef.id' => (object) $hashId);
+
+        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
+
+        $value = array('embeddedRef.id' => array('$exists' => true));
+        $expected = array('embeddedRef.id' => array('$exists' => true));
+
+        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
+
+        $value = array('embeddedRef.id' => array('$elemMatch' => $hashId));
+        $expected = array('embeddedRef.id' => array('$elemMatch' => (object) $hashId));
+
+        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
+
+        $value = array('embeddedRef.id' => array('$in' => array($hashId)));
+        $expected = array('embeddedRef.id' => array('$in' => array((object) $hashId)));
+
+        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
+
+        $value = array('embeddedRef.id' => array('$not' => array('$elemMatch' => $hashId)));
+        $expected = array('embeddedRef.id' => array('$not' => array('$elemMatch' => (object) $hashId)));
+
+        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
+
+        $value = array('embeddedRef.id' => array('$not' => array('$in' => array($hashId))));
+        $expected = array('embeddedRef.id' => array('$not' => array('$in' => array((object) $hashId))));
+
+        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
+    }
+
     /**
      * @return array
      */
@@ -547,6 +624,9 @@ class DocumentPersisterTestDocument
 
     /** @ODM\ReferenceOne(targetDocument="DocumentPersisterTestHashIdDocument", storeAs="dbRefWithDb") */
     public $complexRef;
+
+    /** @ODM\ReferenceOne(targetDocument="DocumentPersisterTestHashIdDocument", storeAs="ref") */
+    public $embeddedRef;
 }
 
 /** @ODM\Document */
@@ -628,6 +708,9 @@ class DocumentPersisterTestHashIdDocument
 
     /** @ODM\ReferenceOne(targetDocument="DocumentPersisterTestDocument", storeAs="dbRefWithDb") */
     public $complexRef;
+
+    /** @ODM\ReferenceOne(targetDocument="DocumentPersisterTestDocument", storeAs="ref") */
+    public $embeddedRef;
 }
 
 /** @ODM\Document(writeConcern="majority") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 use Doctrine\ODM\MongoDB\Proxy\Proxy;
 use Doctrine\ODM\MongoDB\Query\Query;
 use Documents\Account;
@@ -446,7 +447,7 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->persist($group);
         $this->dm->flush();
 
-        $groupDBRef = $this->dm->createDBRef($group);
+        $groupDBRef = $this->dm->createReference($group, ['storeAs' => ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF, 'targetDocument' => Group::class]);
 
         $this->dm->clear();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -149,7 +149,7 @@ class BuilderTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->field($field)->addToSet($f)
             ->getQuery()->debug();
 
-        $expected = $this->dm->createDBRef($f, $this->dm->getClassMetadata($class)->fieldMappings[$field]);
+        $expected = $this->dm->createReference($f, $this->dm->getClassMetadata($class)->fieldMappings[$field]);
         $this->assertEquals($expected, $q1['newObj']['$addToSet'][$field]);
     }
 
@@ -173,7 +173,7 @@ class BuilderTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->field($field)->set($f)
             ->getQuery()->debug();
 
-        $expected = $this->dm->createDBRef($f, $this->dm->getClassMetadata($class)->fieldMappings[$field]);
+        $expected = $this->dm->createReference($f, $this->dm->getClassMetadata($class)->fieldMappings[$field]);
         $this->assertEquals($expected, $q1['newObj']['$set'][$field]);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -206,7 +206,7 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->will($this->returnValue($expected));
         $class->expects($this->once())
             ->method('getFieldMapping')
-            ->will($this->returnValue(array('targetDocument' => 'Foo', 'name' => 'foo')));
+            ->will($this->returnValue(array('targetDocument' => 'Foo', 'name' => 'foo', 'storeAs' => ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF_WITH_DB)));
 
         $expr = new Expr($dm);
         $expr->setClassMetadata($class);
@@ -239,7 +239,7 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->will($this->returnValue($expected));
         $class->expects($this->once())
             ->method('getFieldMapping')
-            ->will($this->returnValue(array('name' => 'foo')));
+            ->will($this->returnValue(array('name' => 'foo', 'storeAs' => ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF_WITH_DB)));
 
         $expr = new Expr($dm);
         $expr->setClassMetadata($class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -192,7 +192,7 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $expected = array('foo.$id' => '1234');
 
         $dm->expects($this->once())
-            ->method('createDBRef')
+            ->method('createReference')
             ->will($this->returnValue(array('$ref' => 'coll', '$id' => '1234', '$db' => 'db')));
         $dm->expects($this->once())
             ->method('getUnitOfWork')
@@ -225,7 +225,7 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $expected = array('foo.$ref' => 'coll', 'foo.$id' => '1234', 'foo.$db' => 'db');
 
         $dm->expects($this->once())
-            ->method('createDBRef')
+            ->method('createReference')
             ->will($this->returnValue(array('$ref' => 'coll', '$id' => '1234', '$db' => 'db')));
         $dm->expects($this->once())
             ->method('getUnitOfWork')
@@ -258,7 +258,7 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $expected = array('foo.$ref' => 'coll', 'foo.$id' => '1234');
 
         $dm->expects($this->once())
-            ->method('createDBRef')
+            ->method('createReference')
             ->will($this->returnValue(array('$ref' => 'coll', '$id' => '1234')));
         $dm->expects($this->once())
             ->method('getUnitOfWork')

--- a/tests/Documents/ReferenceUser.php
+++ b/tests/Documents/ReferenceUser.php
@@ -59,6 +59,20 @@ class ReferenceUser
     public $otherUsers = array();
 
     /**
+     * @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="ref")
+     *
+     * @var User
+     */
+    public $referencedUser;
+
+    /**
+     * @ODM\ReferenceMany(targetDocument="Documents\User", storeAs="ref")
+     *
+     * @var User[]
+     */
+    public $referencedUsers = array();
+
+    /**
      * @ODM\Field(type="string")
      *
      * @var string
@@ -159,6 +173,38 @@ class ReferenceUser
     public function getOtherUsers()
     {
         return $this->otherUsers;
+    }
+
+    /**
+     * @param User $referencedUser
+     */
+    public function setReferencedUser(User $referencedUser)
+    {
+        $this->referencedUser = $referencedUser;
+    }
+
+    /**
+     * @return User
+     */
+    public function getreferencedUser()
+    {
+        return $this->referencedUser;
+    }
+
+    /**
+     * @param User $referencedUser
+     */
+    public function addReferencedUser(User $referencedUser)
+    {
+        $this->referencedUsers[] = $referencedUser;
+    }
+
+    /**
+     * @return User[]
+     */
+    public function getReferencedUsers()
+    {
+        return $this->referencedUsers;
     }
 
     /**

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -80,6 +80,12 @@ class User extends BaseDocument
     /** @ODM\ReferenceMany(targetDocument="Documents\SimpleReferenceUser", mappedBy="users") */
     protected $simpleReferenceManyInverse;
 
+    /** @ODM\ReferenceOne(targetDocument="Documents\ReferenceUser", mappedBy="referencedUser") */
+    protected $embeddedReferenceOneInverse;
+
+    /** @ODM\ReferenceMany(targetDocument="Documents\ReferenceUser", mappedBy="referencedUsers") */
+    protected $embeddedReferenceManyInverse;
+
     /** @ODM\Field(type="collection") */
     private $logs = array();
 


### PR DESCRIPTION
Supersedes #1566.

As discussed in our last hangout, this is what remains of the DBRef replacement. DBRef is not deprecated (yet), athough we might decide to deprecate it at this time. At this time the PR is feature complete, I'd like to write a whole bunch of tests to ensure the whole discriminator handling/omitting target collection name works as I'd expect it to.

The new reference object only stores an ID and optionally a discriminator field. The main difference to DBRef is that it can be used in aggregation pipeline stages that don't handle DBRef objects because of the `$` in field names (e.g. `$lookup` and `$graphLookup`).

I'll also revisit #1527 to see if we can store additional fields in the reference (which would also apply to DBRef objects).