### PR TITLE
Don't generate proxies for query result documents

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
@@ -64,7 +64,7 @@ EOT
         $dm = $this->getHelper('documentManager')->getDocumentManager();
         
         $metadatas = array_filter($dm->getMetadataFactory()->getAllMetadata(), function (ClassMetadata $classMetadata) {
-            return !$classMetadata->isEmbeddedDocument && !$classMetadata->isMappedSuperclass;
+            return !$classMetadata->isEmbeddedDocument && !$classMetadata->isMappedSuperclass && !$classMetadata->isQueryResultDocument;
         });
         $metadatas = MetadataFilter::filter($metadatas, $input->getOption('filter'));
 

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
@@ -123,7 +123,7 @@ class CreateCommand extends AbstractCommand
     {
         $classMetadata = $this->getMetadataFactory()->getMetadataFor($document);
 
-        if (!$classMetadata->isEmbeddedDocument && !$classMetadata->isMappedSuperclass) {
+        if (!$classMetadata->isEmbeddedDocument && !$classMetadata->isMappedSuperclass && !$classMetadata->isQueryResultDocument) {
             $this->getDocumentManager()->getProxyFactory()->generateProxyClasses(array($classMetadata));
         }
     }
@@ -131,7 +131,7 @@ class CreateCommand extends AbstractCommand
     protected function processProxy(SchemaManager $sm)
     {
         $classes = array_filter($this->getMetadataFactory()->getAllMetadata(), function (ClassMetadata $classMetadata) {
-            return !$classMetadata->isEmbeddedDocument && !$classMetadata->isMappedSuperclass;
+            return !$classMetadata->isEmbeddedDocument && !$classMetadata->isMappedSuperclass && !$classMetadata->isQueryResultDocument;
         });
 
         $this->getDocumentManager()->getProxyFactory()->generateProxyClasses($classes);


### PR DESCRIPTION
Follows up on #1628 and adds query result documents to the proxy generation exclusion list.