### PR TITLE
Fix Lookup::from() return type

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
@@ -58,7 +58,7 @@ class Lookup extends BaseStage\Lookup
 
     /**
      * @param string $from
-     * @return $this
+     * @return Lookup|BaseStage\Lookup
      */
     public function from($from)
     {


### PR DESCRIPTION
Hi,

This PR fixes `Lookup::from()` return type, which is either `Lookup` or `BaseStage\Lookup`. `$this` should be used when the same instance is returned, which is not the case here.