### PR TITLE
Fix DocumentManager::getHydratorFactory() return type

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -257,7 +257,7 @@ class DocumentManager implements ObjectManager
      * Gets the Hydrator factory used by the DocumentManager to generate and get hydrators
      * for each type of document.
      *
-     * @return \Doctrine\ODM\MongoDB\Hydrator\HydratorInterface
+     * @return HydratorFactory
      */
     public function getHydratorFactory()
     {


### PR DESCRIPTION
Hi,

`DocumentManager::getHydratorFactory()` return type is wrong, see https://github.com/doctrine/mongodb-odm/blob/f7379e4eeaffcd33d83fb4b0fcc4ccce1acb8a4e/lib/Doctrine/ODM/MongoDB/DocumentManager.php#L84