### PR TITLE
Fix invalid test data for UUID bin data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 matrix:
   include:
     - php: 5.6
-      env: DRIVER_VERSION="1.5.8" SERVER_VERSION="3.0" COMPOSER_FLAGS="--prefer-lowest" KEY_ID="7F0CEB10"
+      env: DRIVER_VERSION="1.6.3" SERVER_VERSION="3.0" COMPOSER_FLAGS="--prefer-lowest" KEY_ID="7F0CEB10"
     - php: 5.6
       env: DRIVER_VERSION="stable" SERVER_VERSION="3.2" KEY_ID="EA312927"
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
@@ -29,7 +29,7 @@ class BinDataTest extends BaseTest
             array('bin', 'test', \MongoBinData::GENERIC),
             array('binFunc', 'test', \MongoBinData::FUNC),
             array('binByteArray', 'test', \MongoBinData::BYTE_ARRAY),
-            array('binUUID', 'test', \MongoBinData::UUID),
+            array('binUUID', 'testtesttesttest', \MongoBinData::UUID),
             array('binUUIDRFC4122', '1234567890ABCDEF', \MongoBinData::UUID_RFC4122),
             array('binMD5', 'test', \MongoBinData::MD5),
             array('binCustom', 'test', \MongoBinData::CUSTOM),

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
@@ -264,7 +264,7 @@ class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             array('bin', 'uuid', null, null, 'MongoBinData'),
             array('bin_func', 'none', 'ABRWTIFGPEeSFf69fISAOA==', 'ABRWTIFGPEeSFf69fISAOA==', 'MongoBinData'),
             array('bin_bytearray', 'none', 'ABRWTIFGPEeSFf69fISAOA==', 'ABRWTIFGPEeSFf69fISAOA==', 'MongoBinData'),
-            array('bin_uuid', 'none', 'ABRWTIFGPEeSFf69fISAOA==', 'ABRWTIFGPEeSFf69fISAOA==', 'MongoBinData'),
+            array('bin_uuid', 'none', 'TestTestTestTest', 'TestTestTestTest', 'MongoBinData'),
             array('bin_md5', 'none', 'ABRWTIFGPEeSFf69fISAOA==', 'ABRWTIFGPEeSFf69fISAOA==', 'MongoBinData'),
             array('bin_custom', 'none', 'ABRWTIFGPEeSFf69fISAOA==', 'ABRWTIFGPEeSFf69fISAOA==', 'MongoBinData'),
 
@@ -276,12 +276,12 @@ class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     /**
      * @dataProvider getTestBinIdsData
      */
-    public function testBinIds($type, $expectedMongoBinDataType)
+    public function testBinIds($type, $expectedMongoBinDataType, $id)
     {
         $className = $this->createIdTestClass($type, 'none');
 
         $object = new $className();
-        $object->id = 'ABRWTIFGPEeSFf69fISAOA==';
+        $object->id = $id;
 
         $this->dm->persist($object);
         $this->dm->flush();
@@ -296,12 +296,12 @@ class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function getTestBinIdsData()
     {
         return array(
-            array('bin', 0),
-            array('bin_func', \MongoBinData::FUNC),
-            array('bin_bytearray', \MongoBinData::BYTE_ARRAY),
-            array('bin_uuid', \MongoBinData::UUID),
-            array('bin_md5', \MongoBinData::MD5),
-            array('bin_custom', \MongoBinData::CUSTOM),
+            array('bin', 0, 'ABRWTIFGPEeSFf69fISAOA=='),
+            array('bin_func', \MongoBinData::FUNC, 'ABRWTIFGPEeSFf69fISAOA=='),
+            array('bin_bytearray', \MongoBinData::BYTE_ARRAY, 'ABRWTIFGPEeSFf69fISAOA=='),
+            array('bin_uuid', \MongoBinData::UUID, 'testtesttesttest'),
+            array('bin_md5', \MongoBinData::MD5, 'ABRWTIFGPEeSFf69fISAOA=='),
+            array('bin_custom', \MongoBinData::CUSTOM, 'ABRWTIFGPEeSFf69fISAOA=='),
         );
     }
 


### PR DESCRIPTION
This fixes failures when running the tests against the new 1.3.0 mongodb driver version.