### PR TITLE
Throw deprecation warning on nested flushes

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Mocks/ExceptionThrowingListenerMock.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mocks/ExceptionThrowingListenerMock.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Mocks;
+
+use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
+use Doctrine\ODM\MongoDB\Event\PreUpdateEventArgs;
+use Doctrine\Common\EventSubscriber;
+
+class ExceptionThrowingListenerMock implements EventSubscriber
+{
+    public function getSubscribedEvents()
+    {
+        return [
+            'onFlush',
+        ];
+    }
+
+    public function onFlush(OnFlushEventArgs $args)
+    {
+        throw new \Exception('This should not happen');
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -635,6 +635,23 @@ class UnitOfWorkTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals(array(), $this->uow->getDocumentChangeSet($user->getAvatar()));
     }
 
+    public function testCommitsInProgressIsUpdatedOnException()
+    {
+        $this->dm->getEventManager()->addEventSubscriber(
+            new \Doctrine\ODM\MongoDB\Tests\Mocks\ExceptionThrowingListenerMock()
+        );
+        $user = new \Documents\ForumUser();
+        $user->username = '12345';
+
+        $this->dm->persist($user);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('This should not happen');
+
+        $this->dm->flush();
+        $this->assertAttributeSame(0, 'commitsInProgress', $this->dm->getUnitOfWork());
+    }
+
 
     protected function getDocumentManager()
     {


### PR DESCRIPTION
As indicated in #1051, calling `flush` in an event subscriber can have unwanted side effects and shouldn't be done. To prepare people for this change, ODM 1.2 will throw deprecation warnings to give users a chance to fix offending event subscribers before 2.0 starts throwing exceptions.