### PR TITLE
Relax version constraint for doctrine/instantiator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/common": "~2.4",
         "doctrine/cache": "~1.0",
         "doctrine/inflector": "~1.0",
-        "doctrine/instantiator": "~1.0.1",
+        "doctrine/instantiator": "^1.0",
         "doctrine/mongodb": "~1.3"
     },
     "require-dev": {


### PR DESCRIPTION
Fixes #1648. Allows installing doctrine/instantiator 1.1.x on machines with PHP 7.1.