### PR TITLE
Update tests and wrong version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/common": "~2.4",
         "doctrine/cache": "~1.0",
         "doctrine/inflector": "~1.0",
-        "doctrine/instantiator": "^1.0",
+        "doctrine/instantiator": "^1.0.1",
         "doctrine/mongodb": "~1.3"
     },
     "require-dev": {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
@@ -260,13 +260,13 @@ class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             array('date', 'none', new \DateTime(date('Y-m-d')), new \DateTime(date('Y-m-d')), 'MongoDate'),
 
             // bin
-            array('bin', 'none', 'ABRWTIFGPEeSFf69fISAOA==', 'ABRWTIFGPEeSFf69fISAOA==', 'MongoBinData'),
+            array('bin', 'none', 'test-data', 'test-data', 'MongoBinData'),
             array('bin', 'uuid', null, null, 'MongoBinData'),
-            array('bin_func', 'none', 'ABRWTIFGPEeSFf69fISAOA==', 'ABRWTIFGPEeSFf69fISAOA==', 'MongoBinData'),
-            array('bin_bytearray', 'none', 'ABRWTIFGPEeSFf69fISAOA==', 'ABRWTIFGPEeSFf69fISAOA==', 'MongoBinData'),
+            array('bin_func', 'none', 'test-data', 'test-data', 'MongoBinData'),
+            array('bin_bytearray', 'none', 'test-data', 'test-data', 'MongoBinData'),
             array('bin_uuid', 'none', 'TestTestTestTest', 'TestTestTestTest', 'MongoBinData'),
-            array('bin_md5', 'none', 'ABRWTIFGPEeSFf69fISAOA==', 'ABRWTIFGPEeSFf69fISAOA==', 'MongoBinData'),
-            array('bin_custom', 'none', 'ABRWTIFGPEeSFf69fISAOA==', 'ABRWTIFGPEeSFf69fISAOA==', 'MongoBinData'),
+            array('bin_md5', 'none', md5('test'), md5('test'), 'MongoBinData'),
+            array('bin_custom', 'none', 'test-data', 'test-data', 'MongoBinData'),
 
             // hash
             array('hash', 'none', array('key' => 'value'), array('key' => 'value'), 'array'),
@@ -296,12 +296,12 @@ class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function getTestBinIdsData()
     {
         return array(
-            array('bin', 0, 'ABRWTIFGPEeSFf69fISAOA=='),
-            array('bin_func', \MongoBinData::FUNC, 'ABRWTIFGPEeSFf69fISAOA=='),
-            array('bin_bytearray', \MongoBinData::BYTE_ARRAY, 'ABRWTIFGPEeSFf69fISAOA=='),
+            array('bin', 0, 'test-data'),
+            array('bin_func', \MongoBinData::FUNC, 'test-data'),
+            array('bin_bytearray', \MongoBinData::BYTE_ARRAY, 'test-data'),
             array('bin_uuid', \MongoBinData::UUID, 'testtesttesttest'),
-            array('bin_md5', \MongoBinData::MD5, 'ABRWTIFGPEeSFf69fISAOA=='),
-            array('bin_custom', \MongoBinData::CUSTOM, 'ABRWTIFGPEeSFf69fISAOA=='),
+            array('bin_md5', \MongoBinData::MD5, md5('test')),
+            array('bin_custom', \MongoBinData::CUSTOM, 'test-data'),
         );
     }
 


### PR DESCRIPTION
As @jmikola mentioned in https://github.com/doctrine/mongodb-odm/pull/1646#discussion_r141097347, using base64 encoded data isn't necessary for binary data types. To avoid any confusion, we switch to using regular PHP strings.

This also fixes a small error in the composer version constraint for doctrine/instantiator. It didn't allow 1.0.0 before, it shouldn't allow it now.