### PR TITLE
Fix deprecation messages for slaveOkay

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Cursor.php
+++ b/lib/Doctrine/ODM/MongoDB/Cursor.php
@@ -555,7 +555,7 @@ class Cursor implements CursorInterface
     public function slaveOkay($ok = true)
     {
         @trigger_error(
-            sprintf('%s was deprecated in version 1.2 - use setReadPreference on the query instead.'),
+            sprintf('%s was deprecated in version 1.2 - use setReadPreference on the query instead.', __METHOD__),
             E_USER_DEPRECATED
         );
         $ok = (boolean) $ok;

--- a/lib/Doctrine/ODM/MongoDB/Cursor.php
+++ b/lib/Doctrine/ODM/MongoDB/Cursor.php
@@ -554,11 +554,14 @@ class Cursor implements CursorInterface
      */
     public function slaveOkay($ok = true)
     {
-        @trigger_error(
-            sprintf('%s was deprecated in version 1.2 - use setReadPreference on the query instead.', __METHOD__),
-            E_USER_DEPRECATED
-        );
         $ok = (boolean) $ok;
+        if ($ok) {
+            @trigger_error(
+                sprintf('%s was deprecated in version 1.2 - use setReadPreference on the query instead.', __METHOD__),
+                E_USER_DEPRECATED
+            );
+        }
+
         $this->baseCursor->slaveOkay($ok);
         $this->unitOfWorkHints[Query::HINT_SLAVE_OKAY] = $ok;
         return $this;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -836,10 +836,13 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
      */
     public function setSlaveOkay($slaveOkay)
     {
-        @trigger_error(
-            sprintf('%s was deprecated in version 1.2 and will be removed in 2.0.', __METHOD__),
-            E_USER_DEPRECATED
-        );
+        if ($slaveOkay) {
+            @trigger_error(
+                sprintf('%s was deprecated in version 1.2 and will be removed in 2.0.', __METHOD__),
+                E_USER_DEPRECATED
+            );
+        }
+
         $this->slaveOkay = $slaveOkay === null ? null : (boolean) $slaveOkay;
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -879,10 +879,13 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
      */
     public function setRequireIndexes($requireIndexes)
     {
-        @trigger_error(
-            'requireIndexes was deprecated in version 1.2 and will be removed altogether in 2.0.',
-            E_USER_DEPRECATED
-        );
+        if ($requireIndexes) {
+            @trigger_error(
+                'requireIndexes was deprecated in version 1.2 and will be removed altogether in 2.0.',
+                E_USER_DEPRECATED
+            );
+        }
+
         $this->requireIndexes = $requireIndexes;
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -837,7 +837,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
     public function setSlaveOkay($slaveOkay)
     {
         @trigger_error(
-            sprintf('%s was deprecated in version 1.2 and will be removed in 2.0.'),
+            sprintf('%s was deprecated in version 1.2 and will be removed in 2.0.', __METHOD__),
             E_USER_DEPRECATED
         );
         $this->slaveOkay = $slaveOkay === null ? null : (boolean) $slaveOkay;

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -371,10 +371,13 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
      */
     public function slaveOkay($bool = true)
     {
-        @trigger_error(
-            sprintf('%s was deprecated in version 1.2 - use setReadPreference instead.', __METHOD__),
-            E_USER_DEPRECATED
-        );
+        if ($bool) {
+            @trigger_error(
+                sprintf('%s was deprecated in version 1.2 - use setReadPreference instead.', __METHOD__),
+                E_USER_DEPRECATED
+            );
+        }
+
         return parent::slaveOkay($bool);
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -372,7 +372,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function slaveOkay($bool = true)
     {
         @trigger_error(
-            sprintf('%s was deprecated in version 1.2 - use setReadPreference instead.'),
+            sprintf('%s was deprecated in version 1.2 - use setReadPreference instead.', __METHOD__),
             E_USER_DEPRECATED
         );
         return parent::slaveOkay($bool);


### PR DESCRIPTION
Fixes an empty deprecation message due to `sprintf` being called with too few arguments.

Testing the new master branch, I found that we trigger too many deprecation notices when using the annotation driver. This pull request changes that behavior, now deprecation notices are only triggered if `slaveOkay` or `requireIndexes` are being turned on.