### PR TITLE
Fixed typo in map-reduce doc

### DIFF
--- a/docs/en/reference/map-reduce.rst
+++ b/docs/en/reference/map-reduce.rst
@@ -58,7 +58,7 @@ of MongoDB via the ODM's query builder. Here is a simple map reduce example:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('Documents\User')
+    $qb = $dm->createQueryBuilder('Documents\Event')
         ->field('type')
         ->equals('sale')
         ->map('function() { emit(this.user.$id, 1); }')


### PR DESCRIPTION
There is a typo, if we want to map-reduce the event document based, we need to `createQueryBuilder` on top of the document `Documents\Event`