### PR TITLE
Don't use ignore-platform-reqs when installing mongo-php-adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_script:
   - composer self-update
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then yes '' | pecl -q install -f mongo-${DRIVER_VERSION}; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then pecl install -f mongodb-${DRIVER_VERSION}; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then composer config "platform.ext-mongo" "1.6.16" && composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}"; fi
   - composer update ${COMPOSER_FLAGS}
 
 script:

--- a/docs/en/reference/introduction.rst
+++ b/docs/en/reference/introduction.rst
@@ -471,23 +471,7 @@ dependency to ODM. To do this, run the following command:
 
 ::
 
-    $ composer require "alcaeus/mongo-php-adapter"
-
-Next, manually add a ``provide`` section to your ``composer.json``:
-
-.. code-block:: json
-
-    "provide": {
-        "ext-mongo": "1.6.14"
-    }
-
-This section needs to be added to work around a composer issue with libraries
-providing platform packages (such as ``ext-mongo``). Now, you may install ODM as
-described above:
-
-::
-
-    $ composer require "doctrine/mongodb-odm"
+    $ composer config "platform.ext-mongo" "1.6.16" && composer require "alcaeus/mongo-php-adapter"
 
 .. _MongoDB: https://www.mongodb.com/
 .. _10gen: http://www.10gen.com


### PR DESCRIPTION
Using `ignore-platform-reqs` can cause a bunch of errors down the line (e.g. by installing incompatible package versions not suited for the current PHP version). Thus, `ext-mongodb` is provided via `config.platform`.