### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -16,7 +16,7 @@ class CollectionPersisterTest extends BaseTest
         $persister->delete($user->phonenumbers, array());
 
         $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
-        $this->assertFalse(isset($user['phonenumbers']), 'Test that the phonenumbers field was deleted');
+        $this->assertArrayNotHasKey('phonenumbers', $user, 'Test that the phonenumbers field was deleted');
     }
 
     public function testDeleteEmbedMany()
@@ -26,7 +26,7 @@ class CollectionPersisterTest extends BaseTest
         $persister->delete($user->categories, array());
 
         $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
-        $this->assertFalse(isset($user['categories']), 'Test that the categories field was deleted');
+        $this->assertArrayNotHasKey('categories', $user, 'Test that the categories field was deleted');
     }
 
     public function testDeleteNestedEmbedMany()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -98,7 +98,7 @@ class CollectionPersisterTest extends BaseTest
         $this->dm->flush();
 
         $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
-        $this->assertEquals(4, count($check['phonenumbers']));
+        $this->assertCount(4, $check['phonenumbers']);
         $this->assertEquals((string) $check['phonenumbers'][2]['$id'], $user->phonenumbers[2]->id);
         $this->assertEquals((string) $check['phonenumbers'][3]['$id'], $user->phonenumbers[3]->id);
 
@@ -107,7 +107,7 @@ class CollectionPersisterTest extends BaseTest
         $this->dm->flush();
 
         $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
-        $this->assertEquals(4, count($check['categories']));
+        $this->assertCount(4, $check['categories']);
 
         $user->categories[3]->children[0] = new CollectionPersisterCategory('Test');
         $user->categories[3]->children[1] = new CollectionPersisterCategory('Test');
@@ -116,8 +116,8 @@ class CollectionPersisterTest extends BaseTest
         $this->dm->flush();
 
         $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
-        $this->assertEquals(2, count($check['categories'][3]['children']));
-        $this->assertEquals(2, count($check['categories'][3]['children']['1']['children']));
+        $this->assertCount(2, $check['categories'][3]['children']);
+        $this->assertCount(2, $check['categories'][3]['children']['1']['children']);
     }
 
     private function getTestUser($username)
@@ -342,6 +342,3 @@ class CollectionPersisterComment
     $this->by = $by;
   }
 }
-
-
-

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionsTest.php
@@ -29,12 +29,12 @@ class CollectionsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $test = $this->dm->getDocumentCollection('Documents\Bars\Bar')->findOne();
-        $this->assertEquals(2, count($test['locations']));
+        $this->assertCount(2, $test['locations']);
 
         $bar = $this->dm->find('Documents\Bars\Bar', $bar->getId());
         $this->assertNotNull($bar);
         $locations = $bar->getLocations();
-        $this->assertEquals(2, count($locations));
+        $this->assertCount(2, $locations);
         $this->assertEquals('changed', $locations[0]->getName());
 
         unset($locations[0], $locations[1]);
@@ -44,7 +44,7 @@ class CollectionsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $bar = $this->dm->find('Documents\Bars\Bar', $bar->getId());
         $this->assertNotNull($bar);
         $locations = $bar->getLocations();
-        $this->assertEquals(0, count($locations));
+        $this->assertCount(0, $locations);
 
         $bar->addLocation(new Location('West Nashville'));
         $bar->addLocation(new Location('East Nashville'));
@@ -57,17 +57,17 @@ class CollectionsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->assertNotNull($bar);
         $locations = $bar->getLocations();
-        $this->assertEquals(3, count($locations));
+        $this->assertCount(3, $locations);
         $locations = $bar->getLocations();
         $locations->clear();
-        $this->assertEquals(0, count($locations));
+        $this->assertCount(0, $locations);
         $this->dm->flush();
         $this->dm->clear();
         $bar = $this->dm->find('Documents\Bars\Bar', $bar->getId());
         $locations = $bar->getLocations();
-        $this->assertEquals(0, count($locations));
+        $this->assertCount(0, $locations);
         $this->dm->flush();
-        
+
         $bar->setLocations(new ArrayCollection([ new Location('Cracow') ]));
         $this->uow->computeChangeSets();
         $changeSet = $this->uow->getDocumentChangeSet($bar);
@@ -87,7 +87,7 @@ class CollectionsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $coll->batchInsert($insert);
 
         $data = iterator_to_array($coll->find());
-        $this->assertEquals(3, count($data));
+        $this->assertCount(3, $data);
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
@@ -96,10 +96,10 @@ class CommitImprovementTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->assertCount(1, $user->getPhonenumbers()); // so we got a number on postPersist
         $this->assertTrue($user->getPhonenumbers()->isDirty()); // but they should be dirty
-        
+
         $collection = $this->dm->getDocumentCollection(get_class($user));
         $inDb = $collection->findOne();
-        $this->assertTrue( ! isset($inDb['phonenumbers']), 'Collection modified in postPersist should not be in database without recomputing change set');
+        $this->assertFalse(isset($inDb['phonenumbers']), 'Collection modified in postPersist should not be in database without recomputing change set');
 
         $this->dm->flush();
         $this->assertCount(2, $user->getPhonenumbers()); // so we got a number on postUpdate

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
@@ -99,7 +99,7 @@ class CommitImprovementTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $collection = $this->dm->getDocumentCollection(get_class($user));
         $inDb = $collection->findOne();
-        $this->assertFalse(isset($inDb['phonenumbers']), 'Collection modified in postPersist should not be in database without recomputing change set');
+        $this->assertArrayNotHasKey('phonenumbers', $inDb, 'Collection modified in postPersist should not be in database without recomputing change set');
 
         $this->dm->flush();
         $this->assertCount(2, $user->getPhonenumbers()); // so we got a number on postUpdate

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomFieldNameTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomFieldNameTest.php
@@ -13,9 +13,9 @@ class CustomFieldNameTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->dm->persist($test);
         $this->dm->flush();
-        
+
         $test = $this->dm->getDocumentCollection(__NAMESPACE__.'\CustomFieldName')->findOne();
-        $this->assertTrue(isset($test['login']));
+        $this->assertArrayHasKey('login', $test);
         $this->assertEquals('test', $test['login']);
     }
 
@@ -48,7 +48,7 @@ class CustomFieldNameTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
 
         $test = $this->dm->getDocumentCollection(__NAMESPACE__.'\CustomFieldName')->findOne();
-        $this->assertTrue(isset($test['login']));
+        $this->assertArrayHasKey('login', $test);
         $this->assertEquals('ok', $test['login']);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
@@ -93,7 +93,7 @@ class DateTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $test = $this->dm->getDocumentCollection('Documents\User')->findOne(array('username' => 'datetest2'));
-        $this->assertTrue(isset($test['createdAt']));
+        $this->assertArrayHasKey('createdAt', $test);
 
         $user = $this->dm->getRepository('Documents\User')->findOneBy(array('username' => 'datetest2'));
         $this->assertInstanceOf(\DateTime::class, $user->getCreatedAt());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
@@ -16,7 +16,7 @@ class DateTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->persist($user);
         $this->dm->flush();
 
-        $this->assertTrue($user->getCreatedAt() instanceof \DateTime);
+        $this->assertInstanceOf(\DateTime::class, $user->getCreatedAt());
 
         $user->setCreatedAt('1985-09-01 00:00:00');
         $this->dm->flush();
@@ -25,7 +25,7 @@ class DateTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user = $this->dm->getRepository('Documents\User')->findOneByUsername('w00ting');
         $this->assertNotNull($user);
         $this->assertEquals('w00ting', $user->getUsername());
-        $this->assertTrue($user->getCreatedAt() instanceof \DateTime);
+        $this->assertInstanceOf(\DateTime::class, $user->getCreatedAt());
         $this->assertEquals('09/01/1985', $user->getCreatedAt()->format('m/d/Y'));
     }
 
@@ -96,7 +96,7 @@ class DateTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue(isset($test['createdAt']));
 
         $user = $this->dm->getRepository('Documents\User')->findOneBy(array('username' => 'datetest2'));
-        $this->assertTrue($user->getCreatedAt() instanceof \DateTime);
+        $this->assertInstanceOf(\DateTime::class, $user->getCreatedAt());
         $this->assertEquals('1900-01-01', $user->getCreatedAt()->format('Y-m-d'));
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DetachedDocumentTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DetachedDocumentTest.php
@@ -29,7 +29,7 @@ class DetachedDocumentTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $user2 = $this->dm->merge($user);
 
-        $this->assertFalse($user === $user2);
+        $this->assertNotSame($user, $user2);
         $this->assertTrue($this->dm->contains($user2));
         $this->assertEquals('Roman B.', $user2->name);
     }
@@ -61,7 +61,7 @@ class DetachedDocumentTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $ph2 = new CmsPhonenumber;
         $ph2->phonenumber = '56789';
         $user->addPhonenumber($ph2);
-        $this->assertEquals(2, count($user->getPhonenumbers()));
+        $this->assertCount(2, $user->getPhonenumbers());
         $this->assertFalse($this->dm->contains($user));
 
         $this->dm->persist($ph2);
@@ -71,14 +71,14 @@ class DetachedDocumentTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $phonenumbers = $user->getPhonenumbers();
 
-        $this->assertEquals(2, count($phonenumbers));
+        $this->assertCount(2, $phonenumbers);
         $this->assertSame($user, $phonenumbers[0]->getUser());
         $this->assertSame($user, $phonenumbers[1]->getUser());
 
         $this->dm->flush();
 
         $this->assertTrue($this->dm->contains($user));
-        $this->assertEquals(2, count($user->getPhonenumbers()));
+        $this->assertCount(2, $user->getPhonenumbers());
         $phonenumbers = $user->getPhonenumbers();
         $this->assertTrue($this->dm->contains($phonenumbers[0]));
         $this->assertTrue($this->dm->contains($phonenumbers[1]));
@@ -121,15 +121,15 @@ class DetachedDocumentTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $address2 = $this->dm->find(get_class($address), $address->id);
-        $this->assertTrue($address2->user instanceof Proxy);
+        $this->assertInstanceOf(Proxy::class, $address2->user);
         $this->assertFalse($address2->user->__isInitialized());
         $detachedAddress2 = unserialize(serialize($address2));
-        $this->assertTrue($detachedAddress2->user instanceof Proxy);
+        $this->assertInstanceOf(Proxy::class, $detachedAddress2->user);
         $this->assertFalse($detachedAddress2->user->__isInitialized());
 
         $managedAddress2 = $this->dm->merge($detachedAddress2);
-        $this->assertTrue($managedAddress2->user instanceof Proxy);
-        $this->assertFalse($managedAddress2->user === $detachedAddress2->user);
+        $this->assertInstanceOf(Proxy::class, $managedAddress2->user);
+        $this->assertNotSame($managedAddress2->user, $detachedAddress2->user);
         $this->assertFalse($managedAddress2->user->__isInitialized());
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EcommerceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EcommerceTest.php
@@ -41,15 +41,15 @@ class EcommerceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $product = $this->getProduct();
         $price =  $product->getOption('small')->getPrice(true);
         $currency = $price->getCurrency();
-        $this->assertTrue($currency instanceof Currency);
-        $this->assertEquals(3, count($product->getOptions()));
+        $this->assertInstanceOf(Currency::class, $currency);
+        $this->assertCount(3, $product->getOptions());
         $this->assertEquals(12.99, $product->getOption('small')->getPrice());
 
         $usdCurrency = $this->dm->getRepository('Documents\Ecommerce\Currency')->findOneBy(array('name' => 'USD'));
         $this->assertNotNull($usdCurrency);
         $usdCurrency->setMultiplier('2');
 
-        $this->assertTrue($product->getOption('small')->getStockItem() instanceof \Documents\Ecommerce\StockItem);
+        $this->assertInstanceOf(\Documents\Ecommerce\StockItem::class, $product->getOption('small')->getStockItem());
         $this->assertNotNull($product->getOption('small')->getStockItem()->getId());
         $this->assertEquals(12.99 * 2, $product->getOption('small')->getPrice());
     }
@@ -59,7 +59,7 @@ class EcommerceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $product = $this->getProduct();
         $price =  $product->getOption('small')->getPrice(true);
         $currency = $price->getCurrency();
-        $this->assertTrue($currency instanceof Currency);
+        $this->assertInstanceOf(Currency::class, $currency);
         $this->assertNotNull($currency->getId());
         $this->assertEquals($currency, $this->dm->getRepository('Documents\Ecommerce\Currency')->findOneBy(array('name' => Currency::USD)));
     }
@@ -68,16 +68,16 @@ class EcommerceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $product = $this->getProduct();
 
-        $this->assertEquals(3, count($product->getOptions()));
+        $this->assertCount(3, $product->getOptions());
         $product->removeOption('small');
-        $this->assertEquals(2, count($product->getOptions()));
+        $this->assertCount(2, $product->getOptions());
         $this->dm->flush();
         $this->dm->detach($product);
         unset($product);
         $this->assertFalse(isset($product));
 
         $product = $this->getProduct();
-        $this->assertEquals(2, count($product->getOptions()));
+        $this->assertCount(2, $product->getOptions());
     }
 
     protected function getProduct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
@@ -412,7 +412,7 @@ class EmbeddedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $check = $this->dm->getDocumentCollection('Documents\User')->findOne();
         $this->assertEmpty($check['phonenumbers']);
-        $this->assertFalse(isset($check['address']));
+        $this->assertArrayNotHasKey('address', $check);
     }
 
     public function testRemoveAddDeepEmbedded()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
@@ -70,7 +70,7 @@ class EmbeddedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $test = $this->dm->find('Documents\Functional\EmbeddedTestLevel0', $test->id);
-        $this->assertEquals(2, count($test->level1));
+        $this->assertCount(2, $test->level1);
         $this->assertEquals('changed', $test->level1[0]->name);
         $this->assertEquals('testing', $test->level1[1]->name);
 
@@ -78,7 +78,7 @@ class EmbeddedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $this->assertEquals(1, count($test->level1));
+        $this->assertCount(1, $test->level1);
     }
 
     public function testOneEmbedded()
@@ -560,7 +560,7 @@ class EmbeddedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear(); //get clean results from mongo
         $test1 = $this->dm->find(get_class($test1), $test1->id);
 
-        $this->assertEquals(1, count($test1->embedMany));
+        $this->assertCount(1, $test1->embedMany);
     }
 
     public function testReusedEmbeddedDocumentsAreClonedInFact()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilesTest.php
@@ -90,7 +90,7 @@ class FilesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $check = $this->dm->getDocumentCollection(get_class($image))->findOne();
         $this->assertFalse(isset($check['$pushAll']));
         $this->assertTrue(isset($check['profiles']));
-        $this->assertEquals(1, count($check['profiles']));
+        $this->assertCount(1, $check['profiles']);
         $this->assertEquals($profile->getProfileId(), (string) $check['profiles'][0]['$id']);
     }
 
@@ -133,7 +133,7 @@ class FilesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $image = $profile->getImage();
         $this->assertEquals('Test', $image->getName());
         $this->assertEquals(__DIR__ . '/FilesTest.php', $image->getFile()->getFilename());
-        $this->assertEquals(file_get_contents(__DIR__ . '/FilesTest.php'), $image->getFile()->getBytes());
+        $this->assertStringEqualsFile(__DIR__ . '/FilesTest.php', $image->getFile()->getBytes());
 
         $image->getFile()->setBytes('test');
         $this->dm->flush();
@@ -160,7 +160,7 @@ class FilesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $test = $this->dm->getRepository(__NAMESPACE__.'\TestFile')->find($test->id);
         $this->assertNotNull($test);
-        $this->assertEquals(file_get_contents($path), $test->theFile->getBytes());
+        $this->assertStringEqualsFile($path, $test->theFile->getBytes());
     }
 
     public function testFilesEmptyQueryReturnsNull()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilesTest.php
@@ -88,8 +88,8 @@ class FilesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
 
         $check = $this->dm->getDocumentCollection(get_class($image))->findOne();
-        $this->assertFalse(isset($check['$pushAll']));
-        $this->assertTrue(isset($check['profiles']));
+        $this->assertArrayNotHasKey('$pushAll', $check);
+        $this->assertArrayHasKey('profiles', $check);
         $this->assertCount(1, $check['profiles']);
         $this->assertEquals($profile->getProfileId(), (string) $check['profiles'][0]['$id']);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FlushTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FlushTest.php
@@ -121,7 +121,7 @@ class FlushTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush($user);
 
         $this->assertTrue($this->dm->contains($otherUser), "Other user is contained in DocumentManager");
-        $this->assertTrue($otherUser->id > 0, "other user has an id");
+        $this->assertGreaterThan(0, $otherUser->id, "other user has an id");
     }
 
     public function testFlushAndCascadePersist()
@@ -145,7 +145,7 @@ class FlushTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush($user);
 
         $this->assertTrue($this->dm->contains($address), "Other user is contained in DocumentManager");
-        $this->assertTrue($address->id > 0, "other user has an id");
+        $this->assertGreaterThan(0, $address->id, "other user has an id");
     }
 
     public function testProxyIsIgnored()
@@ -170,7 +170,7 @@ class FlushTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush($user);
 
         $this->assertTrue($this->dm->contains($otherUser), "Other user is contained in DocumentManager");
-        $this->assertTrue($otherUser->id > 0, "other user has an id");
+        $this->assertGreaterThan(0, $otherUser->id, "other user has an id");
     }
 
     protected function assertSize($size)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -78,7 +78,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals($discriminator, $check['discriminator']);
         $this->assertEquals(3, $check['count']);
         $this->assertEquals(5, $check['hits']);
-        $this->assertEquals(2, count($check['groups']));
+        $this->assertCount(2, $check['groups']);
         $this->assertEquals($group->getId(), (string) $check['groups'][0]['$id']);
         $this->assertEquals($group2->getId(), (string) $check['groups'][1]['$id']);
         $this->assertTrue(isset($check['username']));
@@ -94,7 +94,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals($discriminator, $check['discriminator']);
         $this->assertEquals(3, $check['count']);
         $this->assertEquals(100, $check['hits']);
-        $this->assertEquals(2, count($check['groups']));
+        $this->assertCount(2, $check['groups']);
         $this->assertEquals($group->getId(), (string) $check['groups'][0]['$id']);
         $this->assertEquals($group2->getId(), (string) $check['groups'][1]['$id']);
         $this->assertTrue(isset($check['username']));
@@ -181,7 +181,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals('Song #3', $test['songs'][1]['name']);
         $this->assertEquals('Song #4', $test['songs'][2]['name']);
         $this->assertEquals('Song #5', $test['songs'][3]['name']);
-        $this->assertEquals(4, count($test['songs']));
+        $this->assertCount(4, $test['songs']);
 
         $songs->clear();
         $this->dm->flush();
@@ -253,16 +253,16 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $coll = $this->dm->getDocumentCollection('Documents\User');
         $document = $coll->findOne(array('username' => 'joncolltest'));
-        $this->assertEquals(2, count($document['logs']));
+        $this->assertCount(2, $document['logs']);
 
         $document = $this->dm->getRepository('Documents\User')->findOneBy(array('username' => 'joncolltest'));
-        $this->assertEquals(2, count($document->getLogs()));
+        $this->assertCount(2, $document->getLogs());
         $document->log(array('test'));
         $this->dm->flush();
         $this->dm->clear();
 
         $document = $this->dm->getRepository('Documents\User')->findOneBy(array('username' => 'joncolltest'));
-        $this->assertEquals(3, count($document->getLogs()));
+        $this->assertCount(3, $document->getLogs());
         $document->setLogs(array('ok', 'test'));
         $this->dm->flush();
         $this->dm->clear();
@@ -282,7 +282,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $user = $this->dm->getRepository('Documents\User')->findOneBy(array('username' => 'testing'));
-        $this->assertEquals(2, count($user->getPhonenumbers()));
+        $this->assertCount(2, $user->getPhonenumbers());
     }
 
     public function testIncrement()
@@ -426,8 +426,8 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->getSingleResult();
 
         $this->assertEquals(200000.00, $result['salary']);
-        $this->assertEquals(2, count($result['projects']));
-        $this->assertEquals(1, count($result['notes']));
+        $this->assertCount(2, $result['projects']);
+        $this->assertCount(1, $result['notes']);
         $this->assertEquals('Gave user 100k a year raise', $result['notes'][0]);
     }
 
@@ -700,15 +700,15 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         );
         $q = $qb->getQuery();
         $test = $q->execute();
-        $this->assertEquals(3, count($test));
+        $this->assertCount(3, $test);
 
         $test = $this->dm->getRepository('Documents\Functional\SameCollection1')->findAll();
-        $this->assertEquals(2, count($test));
+        $this->assertCount(2, $test);
 
         $qb = $this->dm->createQueryBuilder('Documents\Functional\SameCollection1');
         $query = $qb->getQuery();
         $test = $query->execute();
-        $this->assertEquals(2, count($test));
+        $this->assertCount(2, $test);
     }
 
     /**
@@ -753,8 +753,8 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertInstanceOf('Documents\Functional\EmbeddedTestLevel1', $check->level1[1]);
         $this->assertInstanceOf('Documents\Functional\EmbeddedTestLevel2', $check->level1[1]->level2[0]);
         $this->assertInstanceOf('Documents\Functional\EmbeddedTestLevel2', $check->level1[1]->level2[1]);
-        $this->assertEquals(2, count($check->level1));
-        $this->assertEquals(2, count($check->level1[1]->level2));
+        $this->assertCount(2, $check->level1);
+        $this->assertCount(2, $check->level1[1]->level2);
     }
 
     public function testEmbeddedInheritance()
@@ -782,7 +782,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $test->oneLevel1->level2[] = $level2;
 
         // OK, there is one level2
-        $this->assertEquals(1, count($test->oneLevel1->level2));
+        $this->assertCount(1, $test->oneLevel1->level2);
 
         // save again
         $this->dm->flush();
@@ -792,7 +792,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $test = $this->dm->find('Documents\Functional\EmbeddedTestLevel0b', $test->id);
 
         // Uh oh, the level2 was not persisted!
-        $this->assertEquals(1, count($test->oneLevel1->level2));
+        $this->assertCount(1, $test->oneLevel1->level2);
     }
 
     public function testModifyGroupsArrayDirectly()
@@ -823,13 +823,13 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $user->setGroups($groups);
 
-        $this->assertEquals(1, count($user->getGroups()));
+        $this->assertCount(1, $user->getGroups());
 
         $this->dm->flush();
         $this->dm->clear();
 
         $user = $this->dm->find('Documents\User', $user->getId());
-        $this->assertEquals(1, count($user->getGroups()));
+        $this->assertCount(1, $user->getGroups());
     }
 
     public function testReplaceEntireGroupsArray()
@@ -864,13 +864,13 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $user->setGroups(array($group2));
 
-        $this->assertEquals(1, count($user->getGroups()));
+        $this->assertCount(1, $user->getGroups());
 
         $this->dm->flush();
         $this->dm->clear();
 
         $user = $this->dm->find('Documents\User', $user->getId());
-        $this->assertEquals(1, count($user->getGroups()));
+        $this->assertCount(1, $user->getGroups());
     }
 
     public function testFunctionalParentAssociations()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -81,7 +81,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertCount(2, $check['groups']);
         $this->assertEquals($group->getId(), (string) $check['groups'][0]['$id']);
         $this->assertEquals($group2->getId(), (string) $check['groups'][1]['$id']);
-        $this->assertTrue(isset($check['username']));
+        $this->assertArrayHasKey('username', $check);
         $this->assertEquals('test', $check['username']);
 
         $user = new $className();
@@ -97,7 +97,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertCount(2, $check['groups']);
         $this->assertEquals($group->getId(), (string) $check['groups'][0]['$id']);
         $this->assertEquals($group2->getId(), (string) $check['groups'][1]['$id']);
-        $this->assertTrue(isset($check['username']));
+        $this->assertArrayHasKey('username', $check);
         $this->assertEquals('test', $check['username']);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdentifiersTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdentifiersTest.php
@@ -43,7 +43,7 @@ class IdentifiersTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->persist($user);
         $this->dm->flush();
 
-        $this->assertTrue($user->getId() !== '');
+        $this->assertNotSame('', $user->getId());
     }
 
     public function testIdentityMap()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
@@ -49,19 +49,19 @@ class IndexesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue(isset($indexes[3]['keys']['embedded_secondary.embeddedMany.name']));
         $this->assertEquals(1, $indexes[3]['keys']['embedded_secondary.embeddedMany.name']);
     }
-    
+
     public function testDiscriminatedEmbeddedIndexes()
     {
         $class = $this->dm->getClassMetadata(__NAMESPACE__.'\DocumentWithIndexInDiscriminatedEmbeds');
         $sm = $this->dm->getSchemaManager();
         $indexes = $sm->getDocumentIndexes($class->name);
-        
+
         $this->assertTrue(isset($indexes[0]['keys']['embedded.name']));
         $this->assertEquals(1, $indexes[0]['keys']['embedded.name']);
-        
+
         $this->assertTrue(isset($indexes[1]['keys']['embedded.embeddedMany.name']));
         $this->assertEquals(1, $indexes[1]['keys']['embedded.embeddedMany.name']);
-        
+
         $this->assertTrue(isset($indexes[2]['keys']['embedded.value']));
         $this->assertEquals(1, $indexes[2]['keys']['embedded.value']);
     }
@@ -217,7 +217,7 @@ class IndexesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->getSchemaManager()->ensureDocumentIndexes($className);
 
         $indexes = $this->dm->getSchemaManager()->getDocumentIndexes($className);
-        $this->assertFalse(empty($indexes[0]['options']['partialFilterExpression']));
+        $this->assertNotEmpty($indexes[0]['options']['partialFilterExpression']);
         $this->assertSame(array('counter' => array('$gt' => 5)), $indexes[0]['options']['partialFilterExpression']);
         $this->assertTrue($indexes[0]['options']['unique']);
     }
@@ -412,13 +412,13 @@ class DocumentWithIndexInDiscriminatedEmbeds
 {
     /** @ODM\Id */
     public $id;
-    
-    /** 
+
+    /**
      * @ODM\EmbedOne(
      *  discriminatorMap={
      *   "d1"="EmbeddedDocumentWithIndexes",
      *   "d2"="YetAnotherEmbeddedDocumentWithIndex",
-     * }) 
+     * })
      */
     public $embedded;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/InheritanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/InheritanceTest.php
@@ -17,8 +17,8 @@ class InheritanceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $this->assertTrue($user->getId() !== '');
-        $this->assertTrue($user->getProfile()->getProfileId() !== '');
+        $this->assertNotSame('', $user->getId());
+        $this->assertNotSame('', $user->getProfile()->getProfileId());
 
         $qb = $this->dm->createQueryBuilder('Documents\SpecialUser')
             ->field('id')
@@ -33,7 +33,7 @@ class InheritanceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $query = $qb->getQuery();
         $user = $query->getSingleResult();
         $this->assertEquals('Wage', $user->getProfile()->getLastName());
-        $this->assertTrue($user instanceof \Documents\SpecialUser);
+        $this->assertInstanceOf(\Documents\SpecialUser::class, $user);
     }
 
     public function testSingleCollectionInhertiance()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LifecycleTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LifecycleTest.php
@@ -13,21 +13,21 @@ class LifecycleTest extends BaseTest
         $this->dm->persist($parent);
         $this->dm->flush();
 
-        $this->assertEquals(1, count($parent->getChildren()));
+        $this->assertCount(1, $parent->getChildren());
 
         $parent->setName('parent #changed');
 
         $this->dm->flush();
         $this->dm->flush();
 
-        $this->assertEquals(1, count($parent->getChildren()));
+        $this->assertCount(1, $parent->getChildren());
 
         $this->dm->clear();
 
         $parent = $this->dm->getRepository(__NAMESPACE__.'\ParentObject')->find($parent->getId());
         $this->assertNotNull($parent);
         $this->assertEquals('parent #changed', $parent->getName());
-        $this->assertEquals(1, count($parent->getChildren()));
+        $this->assertCount(1, $parent->getChildren());
         $this->assertEquals('changed', $parent->getChildEmbedded()->getName());
     }
 
@@ -45,7 +45,7 @@ class LifecycleTest extends BaseTest
 
         $parent = $this->dm->getRepository(__NAMESPACE__.'\ParentObject')->find($parent->getId());
         $this->assertNotNull($parent);
-        $this->assertEquals(1, count($parent->getChildren()));
+        $this->assertCount(1, $parent->getChildren());
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
@@ -234,7 +234,7 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->unlock($article);
 
         $check = $this->dm->getDocumentCollection(get_class($article))->findOne();
-        $this->assertFalse(isset($check['locked']));
+        $this->assertArrayNotHasKey('locked', $check);
         $this->assertNull($article->locked);
     }
 
@@ -338,7 +338,7 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $check = $this->dm->getDocumentCollection(__NAMESPACE__.'\LockInt')->findOne();
         $this->assertEquals(2, $check['version']);
-        $this->assertFalse(isset($check['locked']));
+        $this->assertArrayNotHasKey('locked', $check);
         $this->assertEquals('test', $check['title']);
     }
 
@@ -357,7 +357,7 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $check = $this->dm->getDocumentCollection(__NAMESPACE__.'\LockInt')->findOne();
         $this->assertEquals(2, $check['version']);
-        $this->assertFalse(isset($check['locked']));
+        $this->assertArrayNotHasKey('locked', $check);
         $this->assertEquals('test', $check['title']);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/MapReduceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/MapReduceTest.php
@@ -143,7 +143,7 @@ class MapReduceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $cursor = $query->execute();
         $this->assertEquals(10, $cursor->count());
         $results = $cursor->toArray();
-        $this->assertTrue(is_array($results[0]));
+        $this->assertInternalType('array', $results[0]);
     }
 
     public function testMapReduce2()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
@@ -35,7 +35,7 @@ class NestedDocumentsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $doc = $this->dm->find(__NAMESPACE__.'\Order', $order->id);
         $this->assertInstanceOf(__NAMESPACE__.'\Order', $order);
-        $this->assertTrue(is_string($doc->product->id));
+        $this->assertInternalType('string', $doc->product->id);
         $this->assertEquals((string) $test['product']['_id'], $doc->product->id);
         $this->assertEquals('Order', $doc->title);
         $this->assertEquals('Product', $doc->product->title);
@@ -87,7 +87,7 @@ class NestedDocumentsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals('Child 1 Changed', $children[0]->getName());
         $this->assertEquals('Child 2 Changed', $children[0]->getChild(0)->getName());
         $this->assertEquals('Root Changed', $category->getName());
-        $this->assertEquals(2, count($category->getChildren()));
+        $this->assertCount(2, $category->getChildren());
     }
 
     public function testNestedReference()
@@ -102,7 +102,7 @@ class NestedDocumentsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $test = $this->dm->getRepository(__NAMESPACE__.'\Hierarchy')->findOneBy(array('name' => 'Root'));
- 
+
         $this->assertNotNull($test);
         $child1 = $test->getChild('Child 1')->setName('Child 1 Changed');
         $child2 = $test->getChild('Child 2')->setName('Child 2 Changed');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
@@ -128,7 +128,7 @@ class NestedDocumentsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals('Child 3 Changed', $child3->getName());
 
         $test = $this->dm->getDocumentCollection(__NAMESPACE__.'\Hierarchy')->findOne(array('name' => 'Child 1 Changed'));
-        $this->assertFalse(isset($test['children']), 'Test empty array is not stored');
+        $this->assertArrayNotHasKey('children', $test, 'Test empty array is not stored');
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OwningAndInverseReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OwningAndInverseReferencesTest.php
@@ -32,7 +32,7 @@ class OwningAndInverseReferencedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
         $this->assertEquals($customer->cart->id, $customer->cart->id);
 
         $check = $this->dm->getDocumentCollection(get_class($customer))->findOne();
-        $this->assertTrue(isset($check['cart']));
+        $this->assertArrayHasKey('cart', $check);
         $this->assertEquals('test', $check['cart']);
 
         $customer->cart = null;
@@ -41,7 +41,7 @@ class OwningAndInverseReferencedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
         $this->dm->clear();
 
         $check = $this->dm->getDocumentCollection(get_class($customer))->findOne();
-        $this->assertTrue(isset($check['cart']));
+        $this->assertArrayHasKey('cart', $check);
         $this->assertEquals('ok', $check['cart']);
 
         $customer = $this->dm->getRepository('Documents\Customer')->find($customer->id);
@@ -59,10 +59,10 @@ class OwningAndInverseReferencedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
         $this->dm->clear();
 
         $check = $this->dm->getDocumentCollection(get_class($product))->findOne();
-        $this->assertFalse(isset($check['tags']));
+        $this->assertArrayNotHasKey('tags', $check);
 
         $check = $this->dm->getDocumentCollection('Documents\Feature')->findOne();
-        $this->assertTrue(isset($check['product']));
+        $this->assertArrayHasKey('product', $check);
 
         $product = $this->dm->createQueryBuilder(get_class($product))
             ->getQuery()
@@ -85,7 +85,7 @@ class OwningAndInverseReferencedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
 
         $check = $this->dm->getDocumentCollection(get_class($node))->findOne(array('parent' => array('$exists' => false)));
         $this->assertNotNull($check);
-        $this->assertFalse(isset($check['children']));
+        $this->assertArrayNotHasKey('children', $check);
 
         $root = $this->dm->createQueryBuilder(get_class($node))
             ->field('children')->exists(false)
@@ -118,7 +118,7 @@ class OwningAndInverseReferencedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
         $this->assertCount(1, $check['tags']);
 
         $check = $this->dm->getDocumentCollection('Documents\Tag')->findOne();
-        $this->assertFalse(isset($check['blogPosts']));
+        $this->assertArrayNotHasKey('blogPosts', $check);
 
         $blogPost = $this->dm->createQueryBuilder('Documents\BlogPost')
             ->getQuery()
@@ -156,7 +156,7 @@ class OwningAndInverseReferencedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
             ->hydrate(false)
             ->getQuery()
             ->getSingleResult();
-        $this->assertFalse(isset($check['friendsWithMe']));
+        $this->assertArrayNotHasKey('friendsWithMe', $check);
 
         $user = $this->dm->createQueryBuilder('Documents\FriendUser')
             ->field('name')->equals('fabpot')

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OwningAndInverseReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OwningAndInverseReferencesTest.php
@@ -68,7 +68,7 @@ class OwningAndInverseReferencedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
             ->getQuery()
             ->getSingleResult();
         $features = $product->features;
-        $this->assertEquals(2, count($features));
+        $this->assertCount(2, $features);
         $this->assertEquals('Pages', $features[0]->name);
         $this->assertEquals('Cover', $features[1]->name);
     }
@@ -92,15 +92,15 @@ class OwningAndInverseReferencedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
             ->getQuery()
             ->getSingleResult();
         $this->assertInstanceOf('Documents\BrowseNode', $root);
-        $this->assertEquals(2, count($root->children));
+        $this->assertCount(2, $root->children);
 
         unset($root->children[0]);
         $this->dm->flush();
 
-        $this->assertEquals(1, count($root->children));
+        $this->assertCount(1, $root->children);
 
         $this->dm->refresh($root);
-        $this->assertEquals(2, count($root->children));
+        $this->assertCount(2, $root->children);
     }
 
     public function testManyToMany()
@@ -115,7 +115,7 @@ class OwningAndInverseReferencedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
         $this->dm->clear();
 
         $check = $this->dm->getDocumentCollection(get_class($blogPost))->findOne();
-        $this->assertEquals(1, count($check['tags']));
+        $this->assertCount(1, $check['tags']);
 
         $check = $this->dm->getDocumentCollection('Documents\Tag')->findOne();
         $this->assertFalse(isset($check['blogPosts']));
@@ -123,7 +123,7 @@ class OwningAndInverseReferencedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
         $blogPost = $this->dm->createQueryBuilder('Documents\BlogPost')
             ->getQuery()
             ->getSingleResult();
-        $this->assertEquals(1, count($blogPost->tags));
+        $this->assertCount(1, $blogPost->tags);
 
         $this->dm->clear();
 
@@ -163,7 +163,7 @@ class OwningAndInverseReferencedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
             ->getQuery()
             ->getSingleResult();
 
-        $this->assertEquals(1, count($user->friendsWithMe));
+        $this->assertCount(1, $user->friendsWithMe);
         $this->assertEquals('jwage', $user->friendsWithMe[0]->name);
 
         $this->dm->clear();
@@ -173,7 +173,7 @@ class OwningAndInverseReferencedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
             ->getQuery()
             ->getSingleResult();
 
-        $this->assertEquals(1, count($user->friendsWithMe));
+        $this->assertCount(1, $user->friendsWithMe);
         $this->assertEquals('jwage', $user->friendsWithMe[0]->name);
 
         $this->dm->clear();
@@ -183,11 +183,11 @@ class OwningAndInverseReferencedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
             ->getQuery()
             ->getSingleResult();
 
-        $this->assertEquals(2, count($user->myFriends));
+        $this->assertCount(2, $user->myFriends);
         $this->assertEquals('fabpot', $user->myFriends[0]->name);
         $this->assertEquals('romanb', $user->myFriends[1]->name);
 
-        $this->assertEquals(2, count($user->friendsWithMe));
+        $this->assertCount(2, $user->friendsWithMe);
         $this->assertEquals('fabpot', $user->friendsWithMe[0]->name);
         $this->assertEquals('romanb', $user->friendsWithMe[1]->name);
 
@@ -232,7 +232,7 @@ class OwningAndInverseReferencedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
             ->getSingleResult();
         $this->assertEquals('Comment 1', $blogPost->firstComment->getText());
         $this->assertEquals('Comment 2', $blogPost->latestComment->getText());
-        $this->assertEquals(2, count($blogPost->last5Comments));
+        $this->assertCount(2, $blogPost->last5Comments);
 
         $this->assertEquals('Comment 2', $blogPost->last5Comments[0]->getText());
         $this->assertEquals('Comment 1', $blogPost->last5Comments[1]->getText());
@@ -251,7 +251,7 @@ class OwningAndInverseReferencedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
         $blogPost = $this->dm->createQueryBuilder('Documents\BlogPost')
             ->getQuery()
             ->getSingleResult();
-        $this->assertEquals(2, count($blogPost->adminComments));
+        $this->assertCount(2, $blogPost->adminComments);
         $this->assertEquals('Comment 4 by admin', $blogPost->adminComments[0]->getText());
         $this->assertEquals('Comment 3 by admin', $blogPost->adminComments[1]->getText());
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionCloneTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionCloneTest.php
@@ -51,7 +51,7 @@ class PersistentCollectionCloneTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $user1 = $this->dm->find(get_class($user1), $user1->id);
 
-        $this->assertEquals(2, count($user1->groups));
+        $this->assertCount(2, $user1->groups);
     }
 
     public function testClonePersistentCollectionAndShare()
@@ -67,8 +67,8 @@ class PersistentCollectionCloneTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user1 = $this->dm->find(get_class($user1), $user1->id);
         $user2 = $this->dm->find(get_class($user1), $user2->id);
 
-        $this->assertEquals(2, count($user1->groups));
-        $this->assertEquals(2, count($user2->groups));
+        $this->assertCount(2, $user1->groups);
+        $this->assertCount(2, $user2->groups);
     }
 
     public function testCloneThenDirtyPersistentCollection()
@@ -88,8 +88,8 @@ class PersistentCollectionCloneTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user1 = $this->dm->find(get_class($user1), $user1->id);
         $user2 = $this->dm->find(get_class($user1), $user2->id);
 
-        $this->assertEquals(3, count($user2->groups));
-        $this->assertEquals(2, count($user1->groups));
+        $this->assertCount(3, $user2->groups);
+        $this->assertCount(2, $user1->groups);
     }
 
     public function testNotCloneAndPassAroundFlush()
@@ -102,7 +102,7 @@ class PersistentCollectionCloneTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user2->groups = $user1->groups;
         $user2->groups->add($group3);
 
-        $this->assertEQuals(1, count($user1->groups->getInsertDiff()));
+        $this->assertCount(1, $user1->groups->getInsertDiff());
 
         $this->dm->persist($group3);
         $this->dm->flush();
@@ -111,7 +111,7 @@ class PersistentCollectionCloneTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user1 = $this->dm->find(get_class($user1), $user1->id);
         $user2 = $this->dm->find(get_class($user1), $user2->id);
 
-        $this->assertEquals(3, count($user2->groups));
-        $this->assertEquals(3, count($user1->groups));
+        $this->assertCount(3, $user2->groups);
+        $this->assertCount(3, $user1->groups);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
@@ -221,7 +221,7 @@ class QueryTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $q = $qb->getQuery();
         $users = array_values($q->execute()->toArray());
 
-        $this->assertEquals(4, count($users));
+        $this->assertCount(4, $users);
     }
 
     /**
@@ -332,7 +332,7 @@ class QueryTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         );
         $query = $qb->getQuery();
         $articles = array_values($query->execute()->toArray());
-        $this->assertEquals(2, count($articles));
+        $this->assertCount(2, $articles);
         $this->assertEquals('1985-09-02', $articles[0]->getCreatedAt()->format('Y-m-d'));
         $this->assertEquals('1985-09-03', $articles[1]->getCreatedAt()->format('Y-m-d'));
     }
@@ -346,7 +346,7 @@ class QueryTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $qb = $this->dm->createQueryBuilder('Documents\Article');
         $query = $qb->getQuery();
-        $this->assertTrue($query instanceof \Doctrine\MongoDB\IteratorAggregate);
+        $this->assertInstanceOf(\Doctrine\MongoDB\IteratorAggregate::class, $query);
         foreach ($query as $article) {
             $this->assertEquals('Documents\Article', get_class($article));
         }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
@@ -265,7 +265,7 @@ class QueryTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->hydrate(false);
         $query = $qb->getQuery();
         $user = $query->getSingleResult();
-        $this->assertFalse(isset($user['hits']));
+        $this->assertArrayNotHasKey('hits', $user);
     }
 
     public function testGroup()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
@@ -67,7 +67,7 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $profile = $user->getProfile();
 
-        $this->assertTrue($profile instanceof \Proxies\__CG__\Documents\Profile);
+        $this->assertInstanceOf(\Proxies\__CG__\Documents\Profile::class, $profile);
 
         $profile->getFirstName();
 
@@ -88,7 +88,7 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $user = $this->dm->find(get_class($user), $user->getId());
-        $this->assertTrue($user->getProfileNotify() instanceof \Doctrine\Common\Persistence\Proxy);
+        $this->assertInstanceOf(\Doctrine\Common\Persistence\Proxy::class, $user->getProfileNotify());
         $this->assertFalse($user->getProfileNotify()->__isInitialized());
 
         $user->getProfileNotify()->setLastName('Malarz');
@@ -177,9 +177,9 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $groups = $user->getGroups();
 
-        $this->assertTrue($groups instanceof PersistentCollection);
-        $this->assertTrue($groups[0]->getId() !== '');
-        $this->assertTrue($groups[1]->getId() !== '');
+        $this->assertInstanceOf(PersistentCollection::class, $groups);
+        $this->assertNotSame('', $groups[0]->getId());
+        $this->assertNotSame('', $groups[1]->getId());
         $this->dm->clear();
 
         $qb = $this->dm->createQueryBuilder('Documents\User')
@@ -198,9 +198,9 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $groups = $user2->getGroups();
 
-        $this->assertTrue($groups instanceof PersistentCollection);
-        $this->assertTrue($groups[0] instanceof Group);
-        $this->assertTrue($groups[1] instanceof Group);
+        $this->assertInstanceOf(PersistentCollection::class, $groups);
+        $this->assertInstanceOf(Group::class, $groups[0]);
+        $this->assertInstanceOf(Group::class, $groups[1]);
 
         $this->assertTrue($groups->isInitialized());
 
@@ -217,9 +217,9 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $groups = $user3->getGroups();
 
         $this->assertEquals('test', $groups[0]->getName());
-        $this->assertEquals(1, count($groups));
+        $this->assertCount(1, $groups);
     }
-    
+
     public function testFlushInitializesEmptyPersistentCollection()
     {
         $user = new User();
@@ -249,7 +249,7 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->persist($user);
         $this->dm->flush();
         $this->dm->clear();
-        
+
         $user = $this->dm->getRepository('Documents\User')->find($user->getId());
 
         $user->addGroup(new Group('Group 1'));
@@ -274,11 +274,11 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
 
         $groups = $user->getUniqueGroups();
-        $this->assertEquals(3, count($groups));
+        $this->assertCount(3, $groups);
 
-        $this->assertTrue($groups instanceof PersistentCollection);
-        $this->assertTrue($groups[0]->getId() !== '');
-        $this->assertTrue($groups[1]->getId() !== '');
+        $this->assertInstanceOf(PersistentCollection::class, $groups);
+        $this->assertNotSame('', $groups[0]->getId());
+        $this->assertNotSame('', $groups[1]->getId());
         $this->dm->clear();
 
         $qb = $this->dm->createQueryBuilder('Documents\User')
@@ -295,11 +295,11 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $groups->isEmpty();
         $this->assertFalse($groups->isInitialized());
 
-        $this->assertEquals(2, count($groups));
+        $this->assertCount(2, $groups);
 
-        $this->assertTrue($groups instanceof PersistentCollection);
-        $this->assertTrue($groups[0] instanceof Group);
-        $this->assertTrue($groups[1] instanceof Group);
+        $this->assertInstanceOf(PersistentCollection::class, $groups);
+        $this->assertInstanceOf(Group::class, $groups[0]);
+        $this->assertInstanceOf(Group::class, $groups[1]);
 
         $this->assertTrue($groups->isInitialized());
 
@@ -316,7 +316,7 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $groups = $user3->getUniqueGroups();
 
         $this->assertEquals('test', $groups[0]->getName());
-        $this->assertEquals(1, count($groups));
+        $this->assertCount(1, $groups);
     }
 
     public function testSortReferenceManyOwningSide()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RepositoriesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RepositoriesTest.php
@@ -40,10 +40,10 @@ class RepositoriesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testFind()
     {
         $user2 = $this->repository->find($this->user->getId());
-        $this->assertTrue($this->user === $user2);
+        $this->assertSame($this->user, $user2);
 
         $user3 = $this->repository->findOneBy(array('username' => 'w00ting'));
-        $this->assertTrue($user2 === $user3);
+        $this->assertSame($user2, $user3);
     }
 
     public function testCriteria()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SimpleTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SimpleTest.php
@@ -25,6 +25,6 @@ class SimpleTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
 
         $test = $this->dm->getDocumentCollection('Documents\Bars\Bar')->findOne();
-        $this->assertEquals(2, count($test['locations']));
+        $this->assertCount(2, $test['locations']);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1294Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1294Test.php
@@ -29,7 +29,7 @@ class GH1294Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->equals(new \MongoRegex("/^bbb.*$/i"))
             ->getQueryArray();
 
-        $this->assertTrue(($res['_id'] instanceof \MongoRegex));
+        $this->assertInstanceOf(\MongoRegex::class, $res['_id']);
         $this->assertEquals('^bbb.*$', $res['_id']->regex);
         $this->assertEquals('i', $res['_id']->flags);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH245Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH245Test.php
@@ -21,10 +21,10 @@ class GH245Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
 		$user = $this->dm->find(get_class($order), $order->id);
 
-		$this->assertTrue(is_int($order->id));
+		$this->assertInternalType('int', $order->id);
 
 		$check = $this->dm->getDocumentCollection(get_class($orderLog))->findOne();
-		$this->assertTrue(is_int($check['order']['$id']));
+		$this->assertInternalType('int', $check['order']['$id']);
 	}
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH944Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH944Test.php
@@ -17,20 +17,20 @@ class GH944Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $d = $this->dm->find(get_class($d), $d->id);
-        $this->assertEquals(2, count($d->data));
+        $this->assertCount(2, $d->data);
         $d->removeByText('1');
-        $this->assertEquals(1, count($d->data));
+        $this->assertCount(1, $d->data);
         $this->dm->flush();
 
         $d = $this->dm->find(get_class($d), $d->id);
-        $this->assertEquals(1, count($d->data));
+        $this->assertCount(1, $d->data);
         $d->removeByText('2');
-        $this->assertEquals(0, count($d->data));
+        $this->assertCount(0, $d->data);
         $this->dm->flush();
         $this->dm->clear();
 
         $d = $this->dm->find(get_class($d), $d->id);
-        $this->assertEquals(0, count($d->data));
+        $this->assertCount(0, $d->data);
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
@@ -23,12 +23,12 @@ class MODM116Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $check = $this->dm->getDocumentCollection(get_class($parent))->find()->toArray();
         $check = array_values($check);
-        $this->assertEquals(1, count($check));
+        $this->assertCount(1, $check);
         $this->assertEquals('test', $check[0]['name']);
 
         $check = $this->dm->getDocumentCollection(get_class($parent->getChild()))->find()->toArray();
         $check = array_values($check);
-        $this->assertEquals(1, count($check));
+        $this->assertCount(1, $check);
         $this->assertEquals('ok', $check[0]['name']);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM140Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM140Test.php
@@ -94,8 +94,8 @@ class MODM140Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $test = $this->dm->getRepository('Documents\Functional\EmbeddedTestLevel0')->findOneBy(array('name' => 'test'));
-        $this->assertEquals(1, count($test->level1));
-        $this->assertEquals(2, count($test->level1[0]->level2));
+        $this->assertCount(1, $test->level1);
+        $this->assertCount(2, $test->level1[0]->level2);
 
         $level1 = new EmbeddedTestLevel1();
         $level1->name = "test level 1 #2";
@@ -114,30 +114,30 @@ class MODM140Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $test = $this->dm->getRepository('Documents\Functional\EmbeddedTestLevel0')->findOneBy(array('name' => 'test'));
-        $this->assertEquals(2, count($test->level1));
-        $this->assertEquals(2, count($test->level1[0]->level2));
-        $this->assertEquals(2, count($test->level1[1]->level2));
+        $this->assertCount(2, $test->level1);
+        $this->assertCount(2, $test->level1[0]->level2);
+        $this->assertCount(2, $test->level1[1]->level2);
     }
-	
+
 }
 
 /** @ODM\Document */
-class Category 
+class Category
 {
 	/** @ODM\Id */
 	protected $id;
-	
+
 	/** @ODM\Field(type="string") */
 	public $name;
-	
+
 	/** @ODM\EmbedMany(targetDocument="Post") */
 	public $posts;
-	
+
 	public function __construct()
 	{
 		$this->posts = new ArrayCollection();
 	}
-	
+
 }
 
 /** @ODM\EmbeddedDocument */
@@ -145,7 +145,7 @@ class Post
 {
 	/** @ODM\EmbedMany(targetDocument="PostVersion") */
 	public $versions;
-	
+
 	/** @ODM\ReferenceMany(targetDocument="Comment") */
 	public $comments;
 
@@ -154,7 +154,7 @@ class Post
 		$this->versions = new ArrayCollection();
 		$this->comments = new ArrayCollection();
 	}
-	
+
 }
 
 /** @ODM\EmbeddedDocument */
@@ -162,12 +162,12 @@ class PostVersion
 {
 	/** @ODM\Field(type="string") */
 	public $name;
-	
+
 	public function __construct($name)
 	{
 		$this->name = $name;
 	}
-	
+
 }
 
 /** @ODM\Document */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM42Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM42Test.php
@@ -25,7 +25,7 @@ class MODM42Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $dir = $this->dm->find(__NAMESPACE__.'\Directory', $dir->getId());
         $this->assertNotNull($dir);
-        $this->assertEquals(2, count($dir->getFiles()));
+        $this->assertCount(2, $dir->getFiles());
         foreach($dir->getFiles() as $file) {
             $this->assertInstanceOf('Doctrine\MongoDB\GridFSFile', $file->getMongoFile());
         }
@@ -79,7 +79,7 @@ class File
         return $this->id;
     }
 
-    public function getMongoFile() 
+    public function getMongoFile()
     {
         return $this->file;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM56Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM56Test.php
@@ -23,7 +23,7 @@ class MODM56Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->assertEquals('Parent', $test['name']);
         $this->assertInstanceOf('\MongoDate', $test['updatedAt']);
-        $this->assertEquals(2, count($test['children']));
+        $this->assertCount(2, $test['children']);
         $this->assertEquals('Child One', $test['children'][0]['name']);
         $this->assertEquals('Child Two', $test['children'][1]['name']);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM66Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM66Test.php
@@ -21,7 +21,7 @@ class MODM66Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->refresh($a);
         $b = $a->getB()->toArray();
 
-        $this->assertEquals(2, count($b));
+        $this->assertCount(2, $b);
 
         $this->assertEquals(array(
             $b1->getId(), $b2->getId()
@@ -45,7 +45,7 @@ class MODM66Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->refresh($a);
         $b = $a->getB()->toArray();
 
-        $this->assertEquals(2, count($b));
+        $this->assertCount(2, $b);
 
         $this->assertEquals(array(
             $b1->getId(), $b2->getId()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
@@ -20,7 +20,7 @@ class MODM70Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 		$this->dm->refresh($avatar);
 
 		$parts = $avatar->getAvatarParts();
-		$this->assertEquals(2, count($parts));
+		$this->assertCount(2, $parts);
 		$this->assertEquals('#FFF', $parts[1]->getColor());
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -79,7 +79,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
      */
     public function testFieldMappings($class)
     {
-        $this->assertEquals(14, count($class->fieldMappings));
+        $this->assertCount(14, $class->fieldMappings);
         $this->assertTrue(isset($class->fieldMappings['id']));
         $this->assertTrue(isset($class->fieldMappings['version']));
         $this->assertTrue(isset($class->fieldMappings['lock']));
@@ -96,7 +96,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
      */
     public function testAssociationMappings($class)
     {
-        $this->assertEquals(6, count($class->associationMappings));
+        $this->assertCount(6, $class->associationMappings);
         $this->assertTrue(isset($class->associationMappings['address']));
         $this->assertTrue(isset($class->associationMappings['phonenumbers']));
         $this->assertTrue(isset($class->associationMappings['groups']));
@@ -158,7 +158,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
     public function testVersionFieldMappings($class)
     {
         $this->assertEquals('int', $class->fieldMappings['version']['type']);
-        $this->assertTrue(!empty($class->fieldMappings['version']['version']));
+        $this->assertNotEmpty($class->fieldMappings['version']['version']);
 
         return $class;
     }
@@ -170,7 +170,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
     public function testLockFieldMappings($class)
     {
         $this->assertEquals('int', $class->fieldMappings['lock']['type']);
-        $this->assertTrue(!empty($class->fieldMappings['lock']['lock']));
+        $this->assertNotEmpty($class->fieldMappings['lock']['lock']);
 
         return $class;
     }
@@ -181,7 +181,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
      */
     public function testAssocations($class)
     {
-        $this->assertEquals(14, count($class->fieldMappings));
+        $this->assertCount(14, $class->fieldMappings);
 
         return $class;
     }
@@ -193,7 +193,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
     public function testOwningOneToOneAssocation($class)
     {
         $this->assertTrue(isset($class->fieldMappings['address']));
-        $this->assertTrue(is_array($class->fieldMappings['address']));
+        $this->assertInternalType('array', $class->fieldMappings['address']);
         // Check cascading
         $this->assertTrue($class->fieldMappings['address']['isCascadeRemove']);
         $this->assertFalse($class->fieldMappings['address']['isCascadePersist']);
@@ -329,13 +329,13 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
 
         $this->assertTrue(isset($indexes[0]['keys']['createdAt']));
         $this->assertEquals(1, $indexes[0]['keys']['createdAt']);
-        $this->assertTrue( ! empty($indexes[0]['options']));
+        $this->assertNotEmpty($indexes[0]['options']);
         $this->assertTrue(isset($indexes[0]['options']['expireAfterSeconds']));
         $this->assertSame(3600, $indexes[0]['options']['expireAfterSeconds']);
 
         $this->assertTrue(isset($indexes[1]['keys']['email']));
         $this->assertEquals(-1, $indexes[1]['keys']['email']);
-        $this->assertTrue( ! empty($indexes[1]['options']));
+        $this->assertNotEmpty($indexes[1]['options']);
         $this->assertTrue(isset($indexes[1]['options']['unique']));
         $this->assertEquals(true, $indexes[1]['options']['unique']);
         $this->assertTrue(isset($indexes[1]['options']['dropDups']));
@@ -343,13 +343,13 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
 
         $this->assertTrue(isset($indexes[2]['keys']['lock']));
         $this->assertEquals(1, $indexes[2]['keys']['lock']);
-        $this->assertTrue( ! empty($indexes[2]['options']));
+        $this->assertNotEmpty($indexes[2]['options']);
         $this->assertTrue(isset($indexes[2]['options']['partialFilterExpression']));
         $this->assertSame(array('version' => array('$gt' => 1), 'discr' => array('$eq' => 'default')), $indexes[2]['options']['partialFilterExpression']);
 
         $this->assertTrue(isset($indexes[3]['keys']['mysqlProfileId']));
         $this->assertEquals(-1, $indexes[3]['keys']['mysqlProfileId']);
-        $this->assertTrue( ! empty($indexes[3]['options']));
+        $this->assertNotEmpty($indexes[3]['options']);
         $this->assertTrue(isset($indexes[3]['options']['unique']));
         $this->assertEquals(true, $indexes[3]['options']['unique']);
         $this->assertTrue(isset($indexes[3]['options']['dropDups']));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
@@ -29,8 +29,8 @@ class BasicInheritanceMappingTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $class = $this->factory->getMetadataFor('Doctrine\ODM\MongoDB\Tests\Mapping\DocumentSubClass');
 
-        $this->assertTrue(empty($class->subClasses));
-        $this->assertTrue(empty($class->parentClasses));
+        $this->assertEmpty($class->subClasses);
+        $this->assertEmpty($class->parentClasses);
         $this->assertTrue(isset($class->fieldMappings['id']));
         $this->assertTrue(isset($class->fieldMappings['name']));
     }
@@ -39,8 +39,8 @@ class BasicInheritanceMappingTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $class = $this->factory->getMetadataFor('Doctrine\ODM\MongoDB\Tests\Mapping\DocumentSubClass2');
 
-        $this->assertTrue(empty($class->subClasses));
-        $this->assertTrue(empty($class->parentClasses));
+        $this->assertEmpty($class->subClasses);
+        $this->assertEmpty($class->parentClasses);
 
         $this->assertTrue(isset($class->fieldMappings['mapped1']));
         $this->assertTrue(isset($class->fieldMappings['mapped2']));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataFactoryTest.php
@@ -31,7 +31,7 @@ class ClassMetadataFactoryTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals(array(), $cm1->parentClasses);
         $this->assertEquals(ClassMetadata::INHERITANCE_TYPE_NONE, $cm1->inheritanceType);
         $this->assertTrue($cm1->hasField('name'));
-        $this->assertEquals(4, count($cm1->fieldMappings));
+        $this->assertCount(4, $cm1->fieldMappings);
 
         // Go
         $cm1 = $cmf->getMetadataFor('Doctrine\ODM\MongoDB\Tests\Mapping\TestDocument1');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -13,8 +13,8 @@ class ClassMetadataTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $cm = new ClassMetadata('Documents\CmsUser');
 
         // Test initial state
-        $this->assertTrue(count($cm->getReflectionProperties()) == 0);
-        $this->assertTrue($cm->reflClass instanceof \ReflectionClass);
+        $this->assertCount(0, $cm->getReflectionProperties());
+        $this->assertInstanceOf(\ReflectionClass::class, $cm->reflClass);
         $this->assertEquals('Documents\CmsUser', $cm->name);
         $this->assertEquals('Documents\CmsUser', $cm->rootDocumentName);
         $this->assertEquals(array(), $cm->subClasses);
@@ -35,26 +35,26 @@ class ClassMetadataTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $cm->setCollectionCapped(true);
         $cm->setCollectionMax(1000);
         $cm->setCollectionSize(500);
-        $this->assertTrue(is_array($cm->getFieldMapping('phonenumbers')));
-        $this->assertEquals(1, count($cm->fieldMappings));
-        $this->assertEquals(1, count($cm->associationMappings));
+        $this->assertInternalType('array', $cm->getFieldMapping('phonenumbers'));
+        $this->assertCount(1, $cm->fieldMappings);
+        $this->assertCount(1, $cm->associationMappings);
 
         $serialized = serialize($cm);
         $cm = unserialize($serialized);
 
         // Check state
-        $this->assertTrue(count($cm->getReflectionProperties()) > 0);
+        $this->assertGreaterThan(0, $cm->getReflectionProperties());
         $this->assertEquals('Documents', $cm->namespace);
-        $this->assertTrue($cm->reflClass instanceof \ReflectionClass);
+        $this->assertInstanceOf(\ReflectionClass::class, $cm->reflClass);
         $this->assertEquals('Documents\CmsUser', $cm->name);
         $this->assertEquals('UserParent', $cm->rootDocumentName);
         $this->assertEquals(array('Documents\One', 'Documents\Two', 'Documents\Three'), $cm->subClasses);
         $this->assertEquals(array('UserParent'), $cm->parentClasses);
         $this->assertEquals('Documents\UserRepository', $cm->customRepositoryClassName);
         $this->assertEquals('disc', $cm->discriminatorField);
-        $this->assertTrue(is_array($cm->getFieldMapping('phonenumbers')));
-        $this->assertEquals(1, count($cm->fieldMappings));
-        $this->assertEquals(1, count($cm->associationMappings));
+        $this->assertInternalType('array', $cm->getFieldMapping('phonenumbers'));
+        $this->assertCount(1, $cm->fieldMappings);
+        $this->assertCount(1, $cm->associationMappings);
         $this->assertEquals('customFileProperty', $cm->file);
         $this->assertEquals('customDistanceProperty', $cm->distance);
         $this->assertTrue($cm->slaveOkay);
@@ -120,7 +120,7 @@ class ClassMetadataTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         ));
 
         $assoc = $cm->fieldMappings['groups'];
-        $this->assertTrue(is_array($assoc));
+        $this->assertInternalType('array', $assoc);
     }
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
@@ -181,7 +181,7 @@ class PersistentCollectionTest extends BaseTest
         $collection = $this->getMockCollection();
         $collection->expects($this->once())->method('offsetExists')->willReturn(false);
         $pcoll = new PersistentCollection($collection, $this->getMockDocumentManager(), $this->getMockUnitOfWork());
-        $this->assertFalse(isset($pcoll[0]));
+        $this->assertArrayNotHasKey(0, $pcoll);
     }
 
     public function testOffsetGetIsForwarded()

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -47,7 +47,7 @@ class QueryTest extends BaseTest
         $users = $query->execute();
 
         $this->assertInstanceOf('Doctrine\MongoDB\CursorInterface', $users);
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
     }
 
     public function testReferences()
@@ -237,7 +237,7 @@ class QueryTest extends BaseTest
             ->field('_id')->in($ids);
         $query = $qb->getQuery();
         $results = $query->toArray();
-        $this->assertEquals(1, count($results));
+        $this->assertCount(1, $results);
     }
 
     public function testEmbeddedSet()
@@ -285,7 +285,7 @@ class QueryTest extends BaseTest
         $query = $qb->getQuery();
         $debug = $query->debug('query');
 
-        $this->assertTrue(array_key_exists('eO.eO.e1.eO.eP.pO._id', $debug));
+        $this->assertArrayHasKey('eO.eO.e1.eO.eP.pO._id', $debug);
         $this->assertEquals($mongoId, $debug['eO.eO.e1.eO.eP.pO._id']);
     }
 
@@ -362,14 +362,14 @@ class QueryTest extends BaseTest
         $p->pet = new Pet('Blackie', $p);
         $this->dm->persist($p);
         $this->dm->flush();
-        
+
         $readOnly = $this->dm->createQueryBuilder()
             ->find(Person::class)
             ->field('id')->equals($p->id)
             ->readOnly()
             ->getQuery()->getSingleResult();
-        
-        $this->assertTrue($p !== $readOnly);
+
+        $this->assertNotSame($p, $readOnly);
         $this->assertTrue($this->uow->isInIdentityMap($p));
         $this->assertFalse($this->uow->isInIdentityMap($readOnly));
         $this->assertFalse($this->uow->isInIdentityMap($readOnly->pet));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/DocumentGeneratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/DocumentGeneratorTest.php
@@ -204,9 +204,9 @@ class DocumentGeneratorTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertFileExists($this->tmpDir . "/" . $this->namespace . "/User.php");
         require $this->tmpDir . "/" . $this->namespace . "/User.php";
         $reflClass = new \ReflectionClass($metadata->name);
-        $this->assertSame($reflClass->hasProperty('address'), false);
-        $this->assertSame($reflClass->hasMethod('setAddress'), false);
-        $this->assertSame($reflClass->hasMethod('getAddress'), false);
+        $this->assertFalse($reflClass->hasProperty('address'));
+        $this->assertFalse($reflClass->hasMethod('setAddress'));
+        $this->assertFalse($reflClass->hasMethod('getAddress'));
     }
 
     public function testTraitPropertiesAndMethodsAreNotDuplicatedInChildClasses()
@@ -220,9 +220,9 @@ class DocumentGeneratorTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertFileExists($this->tmpDir . "/" . $this->namespace . "/DDC2372Admin.php");
         require $this->tmpDir . "/" . $this->namespace . "/DDC2372Admin.php";
         $reflClass = new \ReflectionClass($metadata->name);
-        $this->assertSame($reflClass->hasProperty('address'), false);
-        $this->assertSame($reflClass->hasMethod('setAddress'), false);
-        $this->assertSame($reflClass->hasMethod('getAddress'), false);
+        $this->assertFalse($reflClass->hasProperty('address'));
+        $this->assertFalse($reflClass->hasMethod('setAddress'));
+        $this->assertFalse($reflClass->hasMethod('getAddress'));
     }
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -348,7 +348,7 @@ class UnitOfWorkTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->uow->computeChangeSets();
         $changeset = $this->uow->getDocumentChangeSet($test);
-        $this->assertFalse(isset($changeset['notSaved']));
+        $this->assertArrayNotHasKey('notSaved', $changeset);
     }
 
     /**
@@ -563,7 +563,7 @@ class UnitOfWorkTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->uow->computeChangeSets();
         $changeSet = $this->uow->getDocumentChangeSet($address);
 
-        $this->assertTrue(isset($changeSet['city']));
+        $this->assertArrayHasKey('city', $changeSet);
         $this->assertEquals('Nashville', $changeSet['city'][1]);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -117,9 +117,9 @@ class UnitOfWorkTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->uow->persist($user);
 
         // Check
-        $this->assertEquals(0, count($userPersister->getInserts()));
-        $this->assertEquals(0, count($userPersister->getUpdates()));
-        $this->assertEquals(0, count($userPersister->getDeletes()));
+        $this->assertCount(0, $userPersister->getInserts());
+        $this->assertCount(0, $userPersister->getUpdates());
+        $this->assertCount(0, $userPersister->getDeletes());
         $this->assertTrue($this->uow->isInIdentityMap($user));
         // should no longer be scheduled for insert
         $this->assertTrue($this->uow->isScheduledForInsert($user));
@@ -131,9 +131,9 @@ class UnitOfWorkTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->uow->commit();
 
         // Check.
-        $this->assertEquals(1, count($userPersister->getInserts()));
-        $this->assertEquals(0, count($userPersister->getUpdates()));
-        $this->assertEquals(0, count($userPersister->getDeletes()));
+        $this->assertCount(1, $userPersister->getInserts());
+        $this->assertCount(0, $userPersister->getUpdates());
+        $this->assertCount(0, $userPersister->getDeletes());
 
         // should have an id
         $this->assertNotNull($user->id);
@@ -170,13 +170,13 @@ class UnitOfWorkTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertNotNull($user->id);
         $this->assertNotNull($avatar->id);
 
-        $this->assertEquals(1, count($userPersister->getInserts()));
-        $this->assertEquals(0, count($userPersister->getUpdates()));
-        $this->assertEquals(0, count($userPersister->getDeletes()));
+        $this->assertCount(1, $userPersister->getInserts());
+        $this->assertCount(0, $userPersister->getUpdates());
+        $this->assertCount(0, $userPersister->getDeletes());
 
-        $this->assertEquals(1, count($avatarPersister->getInserts()));
-        $this->assertEquals(0, count($avatarPersister->getUpdates()));
-        $this->assertEquals(0, count($avatarPersister->getDeletes()));
+        $this->assertCount(1, $avatarPersister->getInserts());
+        $this->assertCount(0, $avatarPersister->getUpdates());
+        $this->assertCount(0, $avatarPersister->getDeletes());
     }
 
     public function testChangeTrackingNotify()
@@ -198,7 +198,7 @@ class UnitOfWorkTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->uow->persist($entity);
         $this->uow->commit();
 
-        $this->assertEquals(1, count($persister->getUpserts()));
+        $this->assertCount(1, $persister->getUpserts());
         $this->assertTrue($this->uow->isInIdentityMap($entity));
         $this->assertFalse($this->uow->isScheduledForDirtyCheck($entity));
 
@@ -218,7 +218,7 @@ class UnitOfWorkTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->uow->persist($item);
         $this->uow->commit();
 
-        $this->assertEquals(1, count($itemPersister->getUpserts()));
+        $this->assertCount(1, $itemPersister->getUpserts());
         $this->assertTrue($this->uow->isInIdentityMap($item));
         $this->assertFalse($this->uow->isScheduledForDirtyCheck($item));
 
@@ -234,8 +234,8 @@ class UnitOfWorkTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $updates = $itemPersister->getUpdates();
 
-        $this->assertEquals(1, count($updates));
-        $this->assertTrue($updates[0] === $item);
+        $this->assertCount(1, $updates);
+        $this->assertSame($updates[0], $item);
     }
 
     /**


### PR DESCRIPTION
Continuing to refactory tests, like #1676, I used:
- `assertCount` instead of `count` function;
- `assertInstanceOf` instead of `instanceof` operator;
- `assertArrayHasKey` instead of `array_key_exists` function;
- `assertInternalType` instead of `is_*` functions;
- `assertFalse` instead of strict comparisons with `false` keyword;
- `assertGreaterThan` for mathematical comparisons;
- `assertSame` and `assertNotSame` instead of strict comparisons;
- `assertContains` instead of `in_array` function;
- `assertEmpty` and `assertNotEmpty` instead of `empty` function.