### PR TITLE
Remove default value from type attribute

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -79,7 +79,7 @@
     </xs:sequence>
     <xs:attribute name="id" type="xs:boolean" default="false" />
     <xs:attribute name="name" type="xs:NMTOKEN" />
-    <xs:attribute name="type" type="xs:NMTOKEN" default="string" />
+    <xs:attribute name="type" type="xs:NMTOKEN" />
     <xs:attribute name="strategy" type="xs:NMTOKEN" default="set" />
     <xs:attribute name="fieldName" type="xs:NMTOKEN" />
     <xs:attribute name="embed" type="xs:boolean" />


### PR DESCRIPTION
The XSD defines a default value (`string`) for the `type` attribute of the `field` tag. PhpStorm (or an extension?) even issues a warning ("Redundant default attribute value assignment") when I set the attribute to `string`.

So either the code has to be changed to reflect the XML definition, or the definition needs to be changed - which this PR does.