### PR TITLE
Remove usage of pushAll operator in CollectionPersister

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
   include:
     - php: 5.6
       env: DRIVER_VERSION="1.6.7" COMPOSER_FLAGS="--prefer-lowest" SERVER_VERSION="3.2" KEY_ID="EA312927"
+    - php: 7.2
+      env: SERVER_VERSION="3.6" KEY_ID="2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
 
 before_install:
   - sudo apt-key adv --keyserver ${KEY_SERVER} --recv ${KEY_ID}

--- a/docs/en/reference/introduction.rst
+++ b/docs/en/reference/introduction.rst
@@ -284,24 +284,32 @@ this:
                 [changes] => 2
             )
     
-        [$pushAll] => Array
+        [$push] => Array
             (
                 [notes] => Array
                     (
-                        [0] => Gave user 100k a year raise
+                        [$each] => Array
+                            (
+                                [0] => Gave user 100k a year raise
+                            )
+
                     )
-    
+
                 [projects] => Array
                     (
-                        [0] => Array
+                        [$each] => Array
                             (
-                                [$ref] => projects
-                                [$id] => 4c0310718ead0e767e030000
-                                [$db] => my_db
+                                [0] => Array
+                                    (
+                                        [$ref] => projects
+                                        [$id] => 4c0310718ead0e767e030000
+                                        [$db] => my_db
+                                    )
+
                             )
-    
+
                     )
-    
+
             )
     
         [$set] => Array

--- a/docs/en/reference/storage-strategies.rst
+++ b/docs/en/reference/storage-strategies.rst
@@ -55,10 +55,10 @@ stored as a BSON array.
 pushAll
 -------
 
-The ``pushAll`` strategy uses MongoDB's `$pushAll`_ operator to insert
-elements into the array. MongoDB does not allow elements to be added and removed
-from an array in a single operation, so this strategy relies on multiple update
-queries to remove and insert elements (in that order).
+The ``pushAll`` strategy uses MongoDB's `$push`_ operator in combination with
+`$each`_ to insert elements into the array. MongoDB does not allow elements to
+be added and removed from an array in a single operation, so this strategy
+relies on multiple update queries to remove and insert elements (in that order).
 
 .. _atomic_set:
 
@@ -92,6 +92,7 @@ BSON array.
 
 .. _`$addToSet`: https://docs.mongodb.com/manual/reference/operator/update/addToSet/
 .. _`$inc`: https://docs.mongodb.com/manual/reference/operator/update/inc/
-.. _`$pushAll`: https://docs.mongodb.com/manual/reference/operator/update/pushAll/
+.. _`$push`: https://docs.mongodb.com/manual/reference/operator/update/push/
+.. _`$each`: https://docs.mongodb.com/manual/reference/operator/update/each/
 .. _`$set`: https://docs.mongodb.com/manual/reference/operator/update/set/
 .. _`$unset`: https://docs.mongodb.com/manual/reference/operator/update/unset/

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilesTest.php
@@ -88,7 +88,7 @@ class FilesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
 
         $check = $this->dm->getDocumentCollection(get_class($image))->findOne();
-        $this->assertArrayNotHasKey('$pushAll', $check);
+        $this->assertArrayNotHasKey('$push', $check);
         $this->assertArrayHasKey('profiles', $check);
         $this->assertCount(1, $check['profiles']);
         $this->assertEquals($profile->getProfileId(), (string) $check['profiles'][0]['$id']);


### PR DESCRIPTION
MongoDB 3.6 removes the `$pushAll` operator, which has been deprecated since MongoDB 2.4. This pull request replaces `$pushAll` for `$push` with `$each`, as [recommended by MongoDB](https://docs.mongodb.com/manual/release-notes/3.6-compatibility/#pushall-compatibility).