### PR TITLE
Use $strict param in functions that have it

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Sort.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Sort.php
@@ -33,7 +33,7 @@ class Sort extends Stage
 
         foreach ($fields as $fieldName => $order) {
             if (is_string($order)) {
-                if (in_array($order, $allowedMetaSort)) {
+                if (in_array($order, $allowedMetaSort, true)) {
                     $order = ['$meta' => $order];
                 } else {
                     $order = strtolower($order) === 'asc' ? 1 : -1;

--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -719,7 +719,7 @@ class DocumentManager implements ObjectManager
         if (! isset($referenceMapping['targetDocument'])) {
             $discriminatorField = $referenceMapping['discriminatorField'];
             $discriminatorValue = isset($referenceMapping['discriminatorMap'])
-                ? array_search($class->name, $referenceMapping['discriminatorMap'])
+                ? array_search($class->name, $referenceMapping['discriminatorMap'], true)
                 : $class->name;
 
             /* If the discriminator value was not found in the map, use the full

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -249,7 +249,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                 $methods = get_class_methods($customGenerator);
                 foreach ($idGenOptions as $name => $value) {
                     $method = 'set' . ucfirst($name);
-                    if ( ! in_array($method, $methods)) {
+                    if ( ! in_array($method, $methods, true)) {
                         throw MappingException::missingGeneratorSetter(get_class($customGenerator), $name);
                     }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -462,7 +462,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
      */
     private static function getReferencePrefix($storeAs)
     {
-        if (!in_array($storeAs, [ClassMetadataInfo::REFERENCE_STORE_AS_REF, ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF, ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF_WITH_DB])) {
+        if (!in_array($storeAs, [ClassMetadataInfo::REFERENCE_STORE_AS_REF, ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF, ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF_WITH_DB], true)) {
             throw new \LogicException('Can only get a reference prefix for DBRef and reference arrays');
         }
 
@@ -648,7 +648,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
      */
     public function addLifecycleCallback($callback, $event)
     {
-        if (isset($this->lifecycleCallbacks[$event]) && in_array($callback, $this->lifecycleCallbacks[$event])) {
+        if (isset($this->lifecycleCallbacks[$event]) && in_array($callback, $this->lifecycleCallbacks[$event], true)) {
             return;
         }
 
@@ -865,7 +865,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
                 continue;
             }
 
-            if (in_array($this->fieldMappings[$field]['type'], ['many', 'collection'])) {
+            if (in_array($this->fieldMappings[$field]['type'], ['many', 'collection'], true)) {
                 throw MappingException::noMultiKeyShardKeys($this->getName(), $field);
             }
 
@@ -1212,7 +1212,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
 
         $cascades = isset($mapping['cascade']) ? array_map('strtolower', (array) $mapping['cascade']) : array();
 
-        if (in_array('all', $cascades) || isset($mapping['embedded'])) {
+        if (in_array('all', $cascades, true) || isset($mapping['embedded'])) {
             $cascades = array('remove', 'persist', 'refresh', 'merge', 'detach');
         }
 
@@ -1222,11 +1222,11 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
             $mapping['cascade'] = $cascades;
         }
 
-        $mapping['isCascadeRemove'] = in_array('remove', $cascades);
-        $mapping['isCascadePersist'] = in_array('persist', $cascades);
-        $mapping['isCascadeRefresh'] = in_array('refresh', $cascades);
-        $mapping['isCascadeMerge'] = in_array('merge', $cascades);
-        $mapping['isCascadeDetach'] = in_array('detach', $cascades);
+        $mapping['isCascadeRemove'] = in_array('remove', $cascades, true);
+        $mapping['isCascadePersist'] = in_array('persist', $cascades, true);
+        $mapping['isCascadeRefresh'] = in_array('refresh', $cascades, true);
+        $mapping['isCascadeMerge'] = in_array('merge', $cascades, true);
+        $mapping['isCascadeDetach'] = in_array('detach', $cascades, true);
 
         if (isset($mapping['id']) && $mapping['id'] === true) {
             $mapping['name'] = '_id';
@@ -1373,7 +1373,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
             $mapping['strategy'] = $defaultStrategy;
         }
 
-        if (! in_array($mapping['strategy'], $allowedStrategies)) {
+        if (! in_array($mapping['strategy'], $allowedStrategies, true)) {
             throw MappingException::invalidStorageStrategy($this->name, $mapping['fieldName'], $mapping['type'], $mapping['strategy']);
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -119,7 +119,7 @@ class XmlDriver extends FileDriver
                 foreach ($attributes as $key => $value) {
                     $mapping[$key] = (string) $value;
                     $booleanAttributes = array('id', 'reference', 'embed', 'unique', 'sparse');
-                    if (in_array($key, $booleanAttributes)) {
+                    if (in_array($key, $booleanAttributes, true)) {
                         $mapping[$key] = ('true' === $mapping[$key]);
                     }
                 }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1001,7 +1001,7 @@ class DocumentPersister
 
         foreach ($query as $key => $value) {
             // Recursively prepare logical query clauses
-            if (in_array($key, array('$and', '$or', '$nor')) && is_array($value)) {
+            if (in_array($key, array('$and', '$or', '$nor'), true) && is_array($value)) {
                 foreach ($value as $k2 => $v2) {
                     $preparedQuery[$key][$k2] = $this->prepareQueryOrNewObj($v2, $isNewObj);
                 }
@@ -1236,12 +1236,12 @@ class DocumentPersister
     {
         foreach ($expression as $k => $v) {
             // Ignore query operators whose arguments need no type conversion
-            if (in_array($k, array('$exists', '$type', '$mod', '$size'))) {
+            if (in_array($k, array('$exists', '$type', '$mod', '$size'), true)) {
                 continue;
             }
 
             // Process query operators whose argument arrays need type conversion
-            if (in_array($k, array('$in', '$nin', '$all')) && is_array($v)) {
+            if (in_array($k, array('$in', '$nin', '$all'), true) && is_array($v)) {
                 foreach ($v as $k2 => $v2) {
                     $expression[$k][$k2] = $class->getDatabaseIdentifierValue($v2);
                 }
@@ -1325,13 +1325,13 @@ class DocumentPersister
     {
         $discriminatorValues = array($metadata->discriminatorValue);
         foreach ($metadata->subClasses as $className) {
-            if ($key = array_search($className, $metadata->discriminatorMap)) {
+            if ($key = array_search($className, $metadata->discriminatorMap, true)) {
                 $discriminatorValues[] = $key;
             }
         }
 
         // If a defaultDiscriminatorValue is set and it is among the discriminators being queries, add NULL to the list
-        if ($metadata->defaultDiscriminatorValue && array_search($metadata->defaultDiscriminatorValue, $discriminatorValues) !== false) {
+        if ($metadata->defaultDiscriminatorValue && array_search($metadata->defaultDiscriminatorValue, $discriminatorValues, true) !== false) {
             $discriminatorValues[] = null;
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
@@ -369,7 +369,7 @@ class PersistenceBuilder
         if ( ! isset($embeddedMapping['targetDocument'])) {
             $discriminatorField = $embeddedMapping['discriminatorField'];
             $discriminatorValue = isset($embeddedMapping['discriminatorMap'])
-                ? array_search($class->name, $embeddedMapping['discriminatorMap'])
+                ? array_search($class->name, $embeddedMapping['discriminatorMap'], true)
                 : $class->name;
 
             /* If the discriminator value was not found in the map, use the full

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -1820,7 +1820,7 @@ class Builder
             $discriminatorValues = $this->getDiscriminatorValues($documentNames);
 
             // If a defaultDiscriminatorValue is set and it is among the discriminators being queries, add NULL to the list
-            if ($metadata->defaultDiscriminatorValue && array_search($metadata->defaultDiscriminatorValue, $discriminatorValues) !== false) {
+            if ($metadata->defaultDiscriminatorValue && array_search($metadata->defaultDiscriminatorValue, $discriminatorValues, true) !== false) {
                 $discriminatorValues[] = null;
             }
 

--- a/lib/Doctrine/ODM/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Expr.php
@@ -345,7 +345,7 @@ class Expr
      */
     public function currentDate($type = 'date')
     {
-        if (! in_array($type, ['date', 'timestamp'])) {
+        if (! in_array($type, ['date', 'timestamp'], true)) {
             throw new \InvalidArgumentException('Type for currentDate operator must be date or timestamp.');
         }
 

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2193,7 +2193,7 @@ class UnitOfWork implements PropertyChangedListener
                     throw LockException::lockFailedVersionMissmatch($document, $lockVersion, $documentVersion);
                 }
             }
-        } elseif (in_array($lockMode, array(LockMode::PESSIMISTIC_READ, LockMode::PESSIMISTIC_WRITE))) {
+        } elseif (in_array($lockMode, array(LockMode::PESSIMISTIC_READ, LockMode::PESSIMISTIC_WRITE), true)) {
             $this->getDocumentPersister($class->name)->lock($document, $lockMode);
         }
     }

--- a/lib/Doctrine/ODM/MongoDB/Utility/CollectionHelper.php
+++ b/lib/Doctrine/ODM/MongoDB/Utility/CollectionHelper.php
@@ -61,7 +61,7 @@ class CollectionHelper
                 ClassMetadataInfo::STORAGE_STRATEGY_SET_ARRAY,
                 ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET,
                 ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET_ARRAY
-            ]
+            ], true
         );
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -37,7 +37,7 @@ abstract class BaseTest extends TestCase
         $databaseNames = array_map(function (DatabaseInfo $database) {
             return $database->getName();
         }, $databases);
-        if (! in_array(DOCTRINE_MONGODB_DATABASE, $databaseNames)) {
+        if (! in_array(DOCTRINE_MONGODB_DATABASE, $databaseNames, true)) {
             return;
         }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/PreUpdateEventArgsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/PreUpdateEventArgsTest.php
@@ -86,12 +86,12 @@ class CollectionsAreInChangeSetListener
     {
         switch (get_class($e->getDocument())) {
             case Book::class:
-                if (in_array(Book::class, $this->allowed)) {
+                if (in_array(Book::class, $this->allowed, true)) {
                     $this->phpunit->assertTrue($e->hasChangedField('chapters'));
                 }
                 break;
             case Chapter::class:
-                if (in_array(Chapter::class, $this->allowed)) {
+                if (in_array(Chapter::class, $this->allowed, true)) {
                     $this->phpunit->assertTrue($e->hasChangedField('pages'));
                 }
                 break;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1017Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1017Test.php
@@ -24,7 +24,7 @@ class GH1017Test extends BaseTest
 
             $owner->embedded = new GH1017EmbeddedDocument();
             $oid = spl_object_hash($owner->embedded);
-            if (in_array($oid, $usedHashes)) {
+            if (in_array($oid, $usedHashes, true)) {
                 // Collision found, let's test state of embedded doc
                 $this->assertEquals(
                     UnitOfWork::STATE_NEW,

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
@@ -106,7 +106,7 @@ class Avatar
 
 	public function removeAvatarPart($part)
 	{
-		$key = array_search($this->avatarParts, $part);
+		$key = array_search($this->avatarParts, $part, true);
 		if ($key !== false) {
 			unset($this->avatarParts[$key]);
 		}

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -78,7 +78,7 @@ class SchemaManagerTest extends TestCase
     public function testEnsureIndexes()
     {
         foreach ($this->documentCollections as $class => $collection) {
-            if (in_array($class, $this->indexedClasses)) {
+            if (in_array($class, $this->indexedClasses, true)) {
                 $collection->expects($this->once())->method('createIndex');
             } else {
                 $collection->expects($this->never())->method('createIndex');
@@ -157,9 +157,9 @@ class SchemaManagerTest extends TestCase
     public function testDeleteIndexes()
     {
         foreach ($this->documentCollections as $class => $collection) {
-            if (in_array($class, $this->indexedClasses)) {
+            if (in_array($class, $this->indexedClasses, true)) {
                 $collection->expects($this->once())->method('dropIndexes');
-            } elseif (in_array($class, $this->someMappedSuperclassAndEmbeddedClasses)) {
+            } elseif (in_array($class, $this->someMappedSuperclassAndEmbeddedClasses, true)) {
                 $collection->expects($this->never())->method('dropIndexes');
             }
         }
@@ -206,9 +206,9 @@ class SchemaManagerTest extends TestCase
     public function testCreateCollections()
     {
         foreach ($this->documentDatabases as $class => $database) {
-            if (in_array($class, $this->indexedClasses + $this->someNonIndexedClasses)) {
+            if (in_array($class, $this->indexedClasses + $this->someNonIndexedClasses, true)) {
                 $database->expects($this->once())->method('createCollection');
-            } elseif (in_array($class, $this->someMappedSuperclassAndEmbeddedClasses)) {
+            } elseif (in_array($class, $this->someMappedSuperclassAndEmbeddedClasses, true)) {
                 $database->expects($this->never())->method('createCollection');
             }
         }
@@ -219,11 +219,11 @@ class SchemaManagerTest extends TestCase
     public function testDropCollections()
     {
         foreach ($this->documentCollections as $class => $collection) {
-            if (in_array($class, $this->indexedClasses + $this->someNonIndexedClasses)) {
+            if (in_array($class, $this->indexedClasses + $this->someNonIndexedClasses, true)) {
                 $collection->expects($this->once())
                     ->method('drop')
                     ->with();
-            } elseif (in_array($class, $this->someMappedSuperclassAndEmbeddedClasses)) {
+            } elseif (in_array($class, $this->someMappedSuperclassAndEmbeddedClasses, true)) {
                 $collection->expects($this->never())->method('drop');
             }
         }
@@ -262,9 +262,9 @@ class SchemaManagerTest extends TestCase
     public function testDropDatabases()
     {
         foreach ($this->documentDatabases as $class => $database) {
-            if (in_array($class, $this->indexedClasses + $this->someNonIndexedClasses)) {
+            if (in_array($class, $this->indexedClasses + $this->someNonIndexedClasses, true)) {
                 $database->expects($this->once())->method('drop');
-            } elseif (in_array($class, $this->someMappedSuperclassAndEmbeddedClasses)) {
+            } elseif (in_array($class, $this->someMappedSuperclassAndEmbeddedClasses, true)) {
                 $database->expects($this->never())->method('drop');
             }
         }

--- a/tests/Documents/Article.php
+++ b/tests/Documents/Article.php
@@ -66,11 +66,11 @@ class Article
 
     public function removeTag($tag)
     {
-        if ( ! in_array($tag, $this->tags))
+        if ( ! in_array($tag, $this->tags, true))
         {
             return;
         }
-        unset($this->tags[array_search($tag, $this->tags)]);
+        unset($this->tags[array_search($tag, $this->tags, true)]);
     }
 
     public function getTags()

--- a/tests/Documents/Ecommerce/ConfigurableProduct.php
+++ b/tests/Documents/Ecommerce/ConfigurableProduct.php
@@ -94,7 +94,7 @@ class ConfigurableProduct
         if ($this->options instanceof \Doctrine\Common\Collections\Collection) {
             $index = $this->options->indexOf($option);
         } else {
-            $index = array_search($option, $this->options);
+            $index = array_search($option, $this->options, true);
         }
         unset($this->options[$index]);
         return $this;

--- a/tests/Documents/Ecommerce/Currency.php
+++ b/tests/Documents/Ecommerce/Currency.php
@@ -32,7 +32,7 @@ class Currency
     public function __construct($name, $multiplier = 1)
     {
         $name = (string) $name;
-        if ( ! in_array($name, self::getAll())) {
+        if ( ! in_array($name, self::getAll(), true)) {
             throw new \InvalidArgumentException(
                 'Currency must be one of ' . implode(', ', self::getAll()) .
                 $name . 'given'


### PR DESCRIPTION
Some functions, e.g. `in_array`, have a third param to enable strict comparison :shield: