### PR TITLE
Add phpcs to build and apply automatic fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ tests/PersistentCollections/*
 phpunit.xml
 composer.lock
 vendor/
+.phpcs-cache
+phpcs.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,16 @@ jobs:
         - composer update --prefer-lowest
 
     - stage: Code Quality
-      php: 7.2
-      env: SERVER_VERSION="3.6" KEY_ID="2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
+      php: 7.1
+      env: STATIC_ANALYSIS SERVER_VERSION="3.6" KEY_ID="2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
       script:
         - vendor/bin/phpstan analyse -l 1 lib
+
+    - stage: Code Quality
+      php: 7.1
+      env: CODING_STANDARDS SERVER_VERSION="3.6" KEY_ID="2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
+      script:
+        - vendor/bin/phpcs
 
 before_install:
   - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "require-dev": {
         "phpunit/phpunit": "^7.0",
         "jmikola/geojson": "^1.0",
-        "phpstan/phpstan": "^0.9.2"
+        "phpstan/phpstan": "^0.9.2",
+        "doctrine/coding-standard": "^4.0"
     },
     "autoload": {
         "psr-0": { "Doctrine\\ODM\\MongoDB": "lib/" }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
@@ -1,10 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use Doctrine\ODM\MongoDB\Types\Type;
+use function array_map;
+use function array_merge;
+use function func_get_args;
+use function is_array;
+use function is_string;
+use function substr;
 
 /**
  * Fluent interface for building aggregation pipelines.
@@ -57,7 +66,6 @@ class Expr
      * @param mixed|self $number
      * @return $this
      *
-     * @since 1.3
      */
     public function abs($number)
     {
@@ -180,7 +188,6 @@ class Expr
      * @param mixed|self $index
      * @return $this
      *
-     * @since 1.3
      */
     public function arrayElemAt($array, $index)
     {
@@ -231,7 +238,6 @@ class Expr
      * @param mixed|self $number
      * @return $this
      *
-     * @since 1.3
      */
     public function ceil($number)
     {
@@ -284,7 +290,6 @@ class Expr
      * @param mixed|self ...$arrays Additional expressions
      * @return $this
      *
-     * @since 1.3
      */
     public function concatArrays($array1, $array2, ...$arrays)
     {
@@ -338,7 +343,7 @@ class Expr
      * The date argument can be any expression as long as it resolves to a date.
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/dateToString/
-     * @param string $format
+     * @param string     $format
      * @param mixed|self $expression
      * @return $this
      */
@@ -455,7 +460,6 @@ class Expr
      * @param mixed|self $exponent
      * @return $this
      *
-     * @since 1.3
      */
     public function exp($exponent)
     {
@@ -467,7 +471,6 @@ class Expr
      *
      * @return static
      *
-     * @since 1.3
      */
     public function expr()
     {
@@ -515,7 +518,6 @@ class Expr
      * @param mixed|self $cond
      * @return $this
      *
-     * @since 1.3
      */
     public function filter($input, $as, $cond)
     {
@@ -546,7 +548,6 @@ class Expr
      * @param mixed|self $number
      * @return $this
      *
-     * @since 1.3
      */
     public function floor($number)
     {
@@ -632,7 +633,6 @@ class Expr
      * support matching by regular expressions.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/in/
-     * @since 1.5
      * @param mixed|self $expression
      * @param mixed|self $arrayExpression
      * @return $this
@@ -648,11 +648,10 @@ class Expr
      * found, returns -1.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/indexOfArray/
-     * @since 1.5
-     * @param mixed|self $arrayExpression Can be any valid expression as long as it resolves to an array.
+     * @param mixed|self $arrayExpression  Can be any valid expression as long as it resolves to an array.
      * @param mixed|self $searchExpression Can be any valid expression.
-     * @param mixed|self $start Optional. An integer, or a number that can be represented as integers (such as 2.0), that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
-     * @param mixed|self $end An integer, or a number that can be represented as integers (such as 2.0), that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
+     * @param mixed|self $start            Optional. An integer, or a number that can be represented as integers (such as 2.0), that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
+     * @param mixed|self $end              An integer, or a number that can be represented as integers (such as 2.0), that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      * @return $this
      */
     public function indexOfArray($arrayExpression, $searchExpression, $start = null, $end = null)
@@ -675,11 +674,10 @@ class Expr
      * found, returns -1.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/indexOfBytes/
-     * @since 1.5
-     * @param mixed|self $stringExpression Can be any valid expression as long as it resolves to a string.
+     * @param mixed|self $stringExpression    Can be any valid expression as long as it resolves to a string.
      * @param mixed|self $substringExpression Can be any valid expression as long as it resolves to a string.
-     * @param int|null $start An integral number that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
-     * @param int|null $end An integral number that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
+     * @param int|null   $start               An integral number that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
+     * @param int|null   $end                 An integral number that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      *
      * @return $this
      */
@@ -703,11 +701,10 @@ class Expr
      * not found, returns -1.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/indexOfCP/
-     * @since 1.5
-     * @param mixed|self $stringExpression Can be any valid expression as long as it resolves to a string.
+     * @param mixed|self $stringExpression    Can be any valid expression as long as it resolves to a string.
      * @param mixed|self $substringExpression Can be any valid expression as long as it resolves to a string.
-     * @param int|null $start An integral number that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
-     * @param int|null $end An integral number that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
+     * @param int|null   $start               An integral number that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
+     * @param int|null   $end                 An integral number that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      *
      * @return $this
      */
@@ -734,7 +731,6 @@ class Expr
      * @param mixed|self $expression
      * @return $this
      *
-     * @since 1.3
      */
     public function isArray($expression)
     {
@@ -748,7 +744,6 @@ class Expr
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/isoDayOfWeek/
-     * @since 1.5
      * @param mixed|self $expression
      * @return $this
      */
@@ -766,7 +761,6 @@ class Expr
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/isoWeek/
-     * @since 1.5
      * @param mixed|self $expression
      * @return $this
      */
@@ -784,7 +778,6 @@ class Expr
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/isoWeek/
-     * @since 1.5
      * @param mixed|self $expression
      * @return $this
      */
@@ -845,7 +838,6 @@ class Expr
      * @param mixed|self $number
      * @return $this
      *
-     * @since 1.3
      */
     public function ln($number)
     {
@@ -866,7 +858,6 @@ class Expr
      * @param mixed|self $base
      * @return $this
      *
-     * @since 1.3
      */
     public function log($number, $base)
     {
@@ -883,7 +874,6 @@ class Expr
      * @param mixed|self $number
      * @return $this
      *
-     * @since 1.3
      */
     public function log10($number)
     {
@@ -927,7 +917,7 @@ class Expr
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/map/
      * @param mixed|self $input An expression that resolves to an array.
-     * @param string $as        The variable name for the items in the input array. The in expression accesses each item in the input array by this variable.
+     * @param string     $as    The variable name for the items in the input array. The in expression accesses each item in the input array by this variable.
      * @param mixed|self $in    The expression to apply to each item in the input array. The expression accesses the item by its variable name.
      * @return $this
      */
@@ -1088,7 +1078,6 @@ class Expr
      * @param mixed|self $exponent
      * @return $this
      *
-     * @since 1.3
      */
     public function pow($number, $exponent)
     {
@@ -1114,10 +1103,9 @@ class Expr
      * $range generates the sequence from the specified starting number by successively incrementing the starting number by the specified step value up to but not including the end point.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/range/
-     * @since 1.5
      * @param mixed|self $start An integer that specifies the start of the sequence. Can be any valid expression that resolves to an integer.
-     * @param mixed|self $end An integer that specifies the exclusive upper limit of the sequence. Can be any valid expression that resolves to an integer.
-     * @param mixed|self $step Optional. An integer that specifies the increment value. Can be any valid expression that resolves to a non-zero integer. Defaults to 1.
+     * @param mixed|self $end   An integer that specifies the exclusive upper limit of the sequence. Can be any valid expression that resolves to an integer.
+     * @param mixed|self $step  Optional. An integer that specifies the increment value. Can be any valid expression that resolves to a non-zero integer. Defaults to 1.
      * @return $this
      */
     public function range($start, $end, $step = 1)
@@ -1130,10 +1118,9 @@ class Expr
      * a single value.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/reduce/
-     * @since 1.5
-     * @param mixed|self $input Can be any valid expression that resolves to an array.
+     * @param mixed|self $input        Can be any valid expression that resolves to an array.
      * @param mixed|self $initialValue The initial cumulative value set before in is applied to the first element of the input array.
-     * @param mixed|self $in A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
+     * @param mixed|self $in           A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
      * @return $this
      */
     public function reduce($input, $initialValue, $in)
@@ -1146,7 +1133,6 @@ class Expr
      * elements in reverse order.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/reverseArray/
-     * @since 1.5
      * @param mixed|self $expression
      * @return $this
      */
@@ -1271,12 +1257,11 @@ class Expr
      * Returns a subset of an array.
      *
      * @see https://docs.mongodb.org/manual/reference/operator/aggregation/slice/
-     * @param mixed|self $array
-     * @param mixed|self $n
+     * @param mixed|self      $array
+     * @param mixed|self      $n
      * @param mixed|self|null $position
      * @return $this
      *
-     * @since 1.3
      */
     public function slice($array, $n, $position = null)
     {
@@ -1295,8 +1280,7 @@ class Expr
      * returns the original string as the only element of an array.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/split/
-     * @since 1.5
-     * @param mixed|self $string The string to be split. Can be any valid expression as long as it resolves to a string.
+     * @param mixed|self $string    The string to be split. Can be any valid expression as long as it resolves to a string.
      * @param mixed|self $delimiter The delimiter to use when splitting the string expression. Can be any valid expression as long as it resolves to a string.
      *
      * @return $this
@@ -1332,7 +1316,6 @@ class Expr
      * @param mixed|self ...$expressions Additional samples
      * @return $this
      *
-     * @since 1.3
      */
     public function stdDevPop($expression1, ...$expressions)
     {
@@ -1351,7 +1334,6 @@ class Expr
      * @param mixed|self ...$expressions Additional samples
      * @return $this
      *
-     * @since 1.3
      */
     public function stdDevSamp($expression1, ...$expressions)
     {
@@ -1382,7 +1364,6 @@ class Expr
      * Returns the number of UTF-8 encoded bytes in the specified string.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/strLenBytes/
-     * @since 1.5
      * @param mixed|self $string
      *
      * @return $this
@@ -1396,7 +1377,6 @@ class Expr
      * Returns the number of UTF-8 code points in the specified string.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/strLenCP/
-     * @since 1.5
      * @param mixed|self $string
      *
      * @return $this
@@ -1431,10 +1411,9 @@ class Expr
      * specified.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/substrBytes/
-     * @since 1.5
      * @param mixed|self $string The string from which the substring will be extracted. Can be any valid expression as long as it resolves to a string.
-     * @param mixed|self $start Indicates the starting point of the substring. Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
-     * @param mixed|self $count Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
+     * @param mixed|self $start  Indicates the starting point of the substring. Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
+     * @param mixed|self $count  Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
      *
      * @return $this
      */
@@ -1451,10 +1430,9 @@ class Expr
      * specified.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/substrBytes/
-     * @since 1.5
      * @param mixed|self $string The string from which the substring will be extracted. Can be any valid expression as long as it resolves to a string.
-     * @param mixed|self $start Indicates the starting point of the substring. Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
-     * @param mixed|self $count Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
+     * @param mixed|self $start  Indicates the starting point of the substring. Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
+     * @param mixed|self $count  Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
      *
      * @return $this
      */
@@ -1531,7 +1509,6 @@ class Expr
      * @param mixed|self $number
      * @return $this
      *
-     * @since 1.3
      */
     public function trunc($number)
     {
@@ -1544,7 +1521,6 @@ class Expr
      * The argument can be any valid expression.
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/type/
-     * @since 1.5
      * @param mixed|self $expression
      *
      * @return $this
@@ -1588,10 +1564,9 @@ class Expr
      * input array, the first element of the second input array, etc.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/zip/
-     * @since 1.5
-     * @param mixed|self $inputs An array of expressions that resolve to arrays. The elements of these input arrays combine to form the arrays of the output array.
-     * @param bool|null $useLongestLength A boolean which specifies whether the length of the longest array determines the number of arrays in the output array.
-     * @param mixed|self|null $defaults An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
+     * @param mixed|self      $inputs           An array of expressions that resolve to arrays. The elements of these input arrays combine to form the arrays of the output array.
+     * @param bool|null       $useLongestLength A boolean which specifies whether the length of the longest array determines the number of arrays in the output array.
+     * @param mixed|self|null $defaults         An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
      * @return $this
      */
     public function zip($inputs, $useLongestLength = null, $defaults = null)
@@ -1627,7 +1602,7 @@ class Expr
     }
 
     /**
-     * @return \Doctrine\ODM\MongoDB\Persisters\DocumentPersister
+     * @return DocumentPersister
      */
     private function getDocumentPersister()
     {
@@ -1640,7 +1615,7 @@ class Expr
      * If there is a current field, the operator will be set on it; otherwise,
      * the operator is set at the top level of the query.
      *
-     * @param string $operator
+     * @param string            $operator
      * @param array|self[]|self $expression
      * @return $this
      */
@@ -1664,7 +1639,7 @@ class Expr
      */
     private function requiresCurrentField($method = null)
     {
-        if ( ! $this->currentField) {
+        if (! $this->currentField) {
             throw new \LogicException(($method ?: 'This method') . ' requires you set a current field using field().');
         }
     }
@@ -1732,5 +1707,4 @@ class Expr
 
         return $this;
     }
-
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation;
 
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
@@ -8,8 +10,6 @@ use GeoJson\Geometry\Point;
 /**
  * Fluent interface for building aggregation pipelines.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.2
  * @internal
  */
 abstract class Stage
@@ -19,9 +19,6 @@ abstract class Stage
      */
     protected $builder;
 
-    /**
-     * @param Builder $builder
-     */
     public function __construct(Builder $builder)
     {
         $this->builder = $builder;
@@ -92,8 +89,6 @@ abstract class Stage
      * the pipeline returns an error.
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/geoNear/
-     * @since 1.5
-     *
      * @return Stage\CollStats
      */
     public function collStats()
@@ -135,7 +130,7 @@ abstract class Stage
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/geoNear/
      *
      * @param float|array|Point $x
-     * @param float $y
+     * @param float             $y
      * @return Stage\GeoNear
      */
     public function geoNear($x, $y = null)
@@ -198,7 +193,7 @@ abstract class Stage
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/limit/
      *
-     * @param integer $limit
+     * @param int $limit
      * @return Stage\Limit
      */
     public function limit($limit)
@@ -298,7 +293,7 @@ abstract class Stage
      *
      * @see https://docs.mongodb.org/manual/reference/operator/aggregation/sample/
      *
-     * @param integer $size
+     * @param int $size
      * @return Stage\Sample
      */
     public function sample($size)
@@ -312,7 +307,7 @@ abstract class Stage
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/skip/
      *
-     * @param integer $skip
+     * @param int $skip
      * @return Stage\Skip
      */
     public function skip($skip)
@@ -343,7 +338,7 @@ abstract class Stage
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/sort/
      *
      * @param array|string $fieldName Field name or array of field/order pairs
-     * @param integer|string $order   Field order (if one field is specified)
+     * @param int|string   $order     Field order (if one field is specified)
      * @return Stage\Sort
      */
     public function sort($fieldName, $order = null)

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AbstractBucket.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AbstractBucket.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
@@ -7,14 +9,17 @@ use Doctrine\ODM\MongoDB\Aggregation\Expr;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use Doctrine\ODM\MongoDB\Types\Type;
+use function array_map;
+use function is_array;
+use function is_string;
+use function substr;
 
 /**
  * Abstract class with common functionality for $bucket and $bucketAuto stages
  *
  * @internal
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.5
  */
 abstract class AbstractBucket extends Stage
 {
@@ -102,7 +107,7 @@ abstract class AbstractBucket extends Stage
     }
 
     /**
-     * @return \Doctrine\ODM\MongoDB\Persisters\DocumentPersister
+     * @return DocumentPersister
      */
     private function getDocumentPersister()
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AddFields.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AddFields.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 /**
  * Fluent interface for adding a $addFields stage to an aggregation pipeline.
  *
- * @author Boris Guéry <guery.b@gmail.com>
  */
 final class AddFields extends Operator
 {
@@ -15,7 +16,7 @@ final class AddFields extends Operator
     public function getExpression()
     {
         return [
-            '$addFields' => $this->expr->getExpression()
+            '$addFields' => $this->expr->getExpression(),
         ];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 class Bucket extends AbstractBucket

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket/AbstractOutput.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket/AbstractOutput.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Bucket;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
@@ -10,8 +12,6 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
  * Abstract class with common functionality for output objects in bucket stages
  *
  * @internal
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.5
  */
 abstract class AbstractOutput extends Stage
 {
@@ -25,10 +25,6 @@ abstract class AbstractOutput extends Stage
      */
     private $expr;
 
-    /**
-     * @param Builder $builder
-     * @param Stage\AbstractBucket $bucket
-     */
     public function __construct(Builder $builder, Stage\AbstractBucket $bucket)
     {
         parent::__construct($builder);

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket/BucketAutoOutput.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket/BucketAutoOutput.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Bucket;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
@@ -8,15 +10,9 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 /**
  * Fluent interface for adding an output specification to a bucket stage.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.5
  */
 class BucketAutoOutput extends AbstractOutput
 {
-    /**
-     * @param Builder $builder
-     * @param Stage\BucketAuto $bucket
-     */
     public function __construct(Builder $builder, Stage\BucketAuto $bucket)
     {
         parent::__construct($builder, $bucket);

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket/BucketOutput.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket/BucketOutput.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Bucket;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
@@ -9,15 +11,9 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 /**
  * Fluent interface for adding an output specification to a bucket stage.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.5
  */
 class BucketOutput extends AbstractOutput
 {
-    /**
-     * @param Builder $builder
-     * @param Stage\Bucket $bucket
-     */
     public function __construct(Builder $builder, Stage\Bucket $bucket)
     {
         parent::__construct($builder, $bucket);

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/BucketAuto.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/BucketAuto.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 class BucketAuto extends AbstractBucket

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/CollStats.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/CollStats.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
@@ -8,14 +10,12 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 /**
  * Fluent interface for adding a $collStats stage to an aggregation pipeline.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.5
  */
 class CollStats extends Stage
 {
-    const LATENCY_STATS_NONE = 0;
-    const LATENCY_STATS_SIMPLE = 1;
-    const LATENCY_STATS_HISTOGRAMS = 2;
+    public const LATENCY_STATS_NONE = 0;
+    public const LATENCY_STATS_SIMPLE = 1;
+    public const LATENCY_STATS_HISTOGRAMS = 2;
 
     /**
      * @var int
@@ -27,9 +27,6 @@ class CollStats extends Stage
      */
     private $storageStats = false;
 
-    /**
-     * @param Builder $builder
-     */
     public function __construct(Builder $builder)
     {
         parent::__construct($builder);

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Count.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Count.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
@@ -8,8 +10,6 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 /**
  * Fluent interface for adding a $count stage to an aggregation pipeline.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.5
  */
 class Count extends Stage
 {
@@ -19,7 +19,6 @@ class Count extends Stage
     private $fieldName;
 
     /**
-     * @param Builder $builder
      * @param string $fieldName
      */
     public function __construct(Builder $builder, $fieldName)
@@ -35,7 +34,7 @@ class Count extends Stage
     public function getExpression()
     {
         return [
-            '$count' => $this->fieldName
+            '$count' => $this->fieldName,
         ];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Facet.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Facet.php
@@ -1,15 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
+use function array_map;
 
 /**
  * Fluent interface for adding a $facet stage to an aggregation pipeline.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.5
  */
 class Facet extends Stage
 {
@@ -29,7 +30,9 @@ class Facet extends Stage
     public function getExpression()
     {
         return [
-            '$facet' => array_map(function (Builder $builder) { return $builder->getPipeline(); }, $this->pipelines),
+            '$facet' => array_map(function (Builder $builder) {
+                return $builder->getPipeline();
+            }, $this->pipelines),
         ];
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GeoNear.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GeoNear.php
@@ -1,15 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use GeoJson\Geometry\Point;
+use function is_array;
 
 /**
  * Fluent interface for adding a $geoNear stage to an aggregation pipeline.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.2
  */
 class GeoNear extends Match
 {
@@ -44,24 +45,23 @@ class GeoNear extends Match
     private $near;
 
     /**
-     * @var integer
+     * @var int
      */
     private $num;
 
     /**
-     * @var boolean
+     * @var bool
      */
     private $spherical = false;
 
     /**
-     * @var boolean
+     * @var bool
      */
     private $uniqueDocs;
 
     /**
-     * @param Builder $builder
      * @param float|array|Point $x
-     * @param float $y
+     * @param float             $y
      */
     public function __construct(Builder $builder, $x, $y = null)
     {
@@ -79,20 +79,18 @@ class GeoNear extends Match
             'near' => $this->near,
             'spherical' => $this->spherical,
             'distanceField' => $this->distanceField,
-            'query' => $this->query->getQuery()
+            'query' => $this->query->getQuery(),
         ];
 
         foreach (['distanceMultiplier', 'includeLocs', 'maxDistance', 'minDistance', 'num', 'uniqueDocs'] as $option) {
-            if ( ! $this->$option) {
+            if (! $this->$option) {
                 continue;
             }
 
             $geoNear[$option] = $this->$option;
         }
 
-        return [
-            '$geoNear' => $geoNear
-        ];
+        return ['$geoNear' => $geoNear];
     }
 
     /**
@@ -137,7 +135,7 @@ class GeoNear extends Match
     /**
      * The maximum number of documents to return.
      *
-     * @param integer $limit
+     * @param int $limit
      * @return $this
      */
     public function limit($limit)
@@ -164,7 +162,6 @@ class GeoNear extends Match
      * @param float $minDistance
      * @return $this
      *
-     * @since 1.3
      */
     public function minDistance($minDistance)
     {
@@ -182,7 +179,7 @@ class GeoNear extends Match
      * used, the "spherical" option will default to true.
      *
      * @param float|array|Point $x
-     * @param float $y
+     * @param float             $y
      * @return $this
      */
     public function near($x, $y = null)
@@ -200,12 +197,12 @@ class GeoNear extends Match
     /**
      * The maximum number of documents to return.
      *
-     * @param integer $num
+     * @param int $num
      * @return $this
      */
     public function num($num)
     {
-        $this->num = (integer) $num;
+        $this->num = (int) $num;
 
         return $this;
     }
@@ -213,12 +210,12 @@ class GeoNear extends Match
     /**
      * Required if using a 2dsphere index. Determines how MongoDB calculates the distance.
      *
-     * @param boolean $spherical
+     * @param bool $spherical
      * @return $this
      */
     public function spherical($spherical = true)
     {
-        $this->spherical = (boolean) $spherical;
+        $this->spherical = (bool) $spherical;
 
         return $this;
     }
@@ -226,12 +223,12 @@ class GeoNear extends Match
     /**
      * If this value is true, the query returns a matching document once, even if more than one of the document’s location fields match the query.
      *
-     * @param boolean $uniqueDocs
+     * @param bool $uniqueDocs
      * @return $this
      */
     public function uniqueDocs($uniqueDocs = true)
     {
-        $this->uniqueDocs = (boolean) $uniqueDocs;
+        $this->uniqueDocs = (bool) $uniqueDocs;
 
         return $this;
     }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\Common\Persistence\Mapping\MappingException as BaseMappingException;
@@ -9,7 +11,12 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use Doctrine\ODM\MongoDB\Types\Type;
+use function array_map;
+use function is_array;
+use function is_string;
+use function substr;
 
 class GraphLookup extends Stage
 {
@@ -69,11 +76,8 @@ class GraphLookup extends Stage
     private $targetClass;
 
     /**
-     * @param Builder $builder
      * @param string $from Target collection for the $graphLookup operation to
      * search, recursively matching the connectFromField to the connectToField.
-     * @param DocumentManager $documentManager
-     * @param ClassMetadata $class
      */
     public function __construct(Builder $builder, $from, DocumentManager $documentManager, ClassMetadata $class)
     {
@@ -116,13 +120,13 @@ class GraphLookup extends Stage
     public function connectFromField($connectFromField)
     {
         // No targetClass mapping - simply use field name as is
-        if ( ! $this->targetClass) {
+        if (! $this->targetClass) {
             $this->connectFromField = $connectFromField;
             return $this;
         }
 
         // connectFromField doesn't have to be a reference - in this case, just convert the field name
-        if ( ! $this->targetClass->hasReference($connectFromField)) {
+        if (! $this->targetClass->hasReference($connectFromField)) {
             $this->connectFromField = $this->convertTargetFieldName($connectFromField);
             return $this;
         }
@@ -281,7 +285,7 @@ class GraphLookup extends Stage
      */
     private function fromReference($fieldName)
     {
-        if ( ! $this->class->hasReference($fieldName)) {
+        if (! $this->class->hasReference($fieldName)) {
             MappingException::referenceMappingNotFound($this->class->name, $fieldName);
         }
 
@@ -330,7 +334,7 @@ class GraphLookup extends Stage
             return array_map([$this, 'convertTargetFieldName'], $fieldName);
         }
 
-        if ( ! $this->targetClass) {
+        if (! $this->targetClass) {
             return $fieldName;
         }
 
@@ -338,8 +342,7 @@ class GraphLookup extends Stage
     }
 
     /**
-     * @param ClassMetadata $class
-     * @return \Doctrine\ODM\MongoDB\Persisters\DocumentPersister
+     * @return DocumentPersister
      */
     private function getDocumentPersister(ClassMetadata $class)
     {
@@ -348,7 +351,7 @@ class GraphLookup extends Stage
 
     private function getReferencedFieldName($fieldName, array $mapping)
     {
-        if ( ! $mapping['isOwningSide']) {
+        if (! $mapping['isOwningSide']) {
             if (isset($mapping['repositoryMethod']) || ! isset($mapping['mappedBy'])) {
                 throw MappingException::repositoryMethodLookupNotAllowed($this->class->name, $fieldName);
             }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup/Match.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup/Match.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\GraphLookup;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
@@ -14,10 +16,6 @@ class Match extends BaseMatch
      */
     private $graphLookup;
 
-    /**
-     * @param Builder $builder
-     * @param GraphLookup $graphLookup
-     */
     public function __construct(Builder $builder, GraphLookup $graphLookup)
     {
         parent::__construct($builder);

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Group.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Group.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
@@ -8,8 +10,6 @@ use Doctrine\ODM\MongoDB\Aggregation\Expr;
 /**
  * Fluent interface for adding a $group stage to an aggregation pipeline.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.2
  */
 class Group extends Operator
 {
@@ -34,7 +34,7 @@ class Group extends Operator
     public function getExpression()
     {
         return [
-            '$group' => $this->expr->getExpression()
+            '$group' => $this->expr->getExpression(),
         ];
     }
 
@@ -195,7 +195,6 @@ class Group extends Operator
      * @param mixed|Expr $expression
      * @return $this
      *
-     * @since 1.3
      */
     public function stdDevPop($expression)
     {
@@ -214,7 +213,6 @@ class Group extends Operator
      * @param mixed|Expr $expression
      * @return $this
      *
-     * @since 1.3
      */
     public function stdDevSamp($expression)
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/IndexStats.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/IndexStats.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
@@ -7,8 +9,6 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 /**
  * Fluent interface for adding a $indexStats stage to an aggregation pipeline.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.3
  */
 class IndexStats extends Stage
 {
@@ -18,7 +18,7 @@ class IndexStats extends Stage
     public function getExpression()
     {
         return [
-            '$indexStats' => new \stdClass()
+            '$indexStats' => new \stdClass(),
         ];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Limit.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Limit.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
@@ -8,25 +10,22 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 /**
  * Fluent interface for adding a $limit stage to an aggregation pipeline.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.2
  */
 class Limit extends Stage
 {
     /**
-     * @var integer
+     * @var int
      */
     private $limit;
 
     /**
-     * @param Builder $builder
-     * @param integer $limit
+     * @param int $limit
      */
     public function __construct(Builder $builder, $limit)
     {
         parent::__construct($builder);
 
-        $this->limit = (integer) $limit;
+        $this->limit = (int) $limit;
     }
 
     /**
@@ -35,7 +34,7 @@ class Limit extends Stage
     public function getExpression()
     {
         return [
-            '$limit' => $this->limit
+            '$limit' => $this->limit,
         ];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\Common\Persistence\Mapping\MappingException as BaseMappingException;
@@ -8,6 +10,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 
 /**
  * Fluent interface for building aggregation pipelines.
@@ -50,10 +53,7 @@ class Lookup extends Stage
     private $as;
 
     /**
-     * @param Builder $builder
      * @param string $from
-     * @param DocumentManager $documentManager
-     * @param ClassMetadata $class
      */
     public function __construct(Builder $builder, $from, DocumentManager $documentManager, ClassMetadata $class)
     {
@@ -130,7 +130,7 @@ class Lookup extends Stage
                 'localField' => $this->localField,
                 'foreignField' => $this->foreignField,
                 'as' => $this->as,
-            ]
+            ],
         ];
     }
 
@@ -170,9 +170,9 @@ class Lookup extends Stage
         return $this;
     }
 
-    protected function prepareFieldName($fieldName, ClassMetadata $class = null)
+    protected function prepareFieldName($fieldName, ?ClassMetadata $class = null)
     {
-        if ( ! $class) {
+        if (! $class) {
             return $fieldName;
         }
 
@@ -237,7 +237,7 @@ class Lookup extends Stage
     }
 
     /**
-     * @return \Doctrine\ODM\MongoDB\Persisters\DocumentPersister
+     * @return DocumentPersister
      */
     private function getDocumentPersister(ClassMetadata $class)
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Match.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Match.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Query\Expr;
 use GeoJson\Geometry\Geometry;
+use function func_get_args;
 
 /**
  * Fluent interface for building aggregation pipelines.
@@ -159,12 +162,12 @@ class Match extends Stage
      *
      * @see Expr::exists()
      * @see http://docs.mongodb.org/manual/reference/operator/exists/
-     * @param boolean $bool
+     * @param bool $bool
      * @return $this
      */
     public function exists($bool)
     {
-        $this->query->exists((boolean) $bool);
+        $this->query->exists((bool) $bool);
 
         return $this;
     }
@@ -220,7 +223,6 @@ class Match extends Stage
      *
      * @see Expr::geoWithin()
      * @see http://docs.mongodb.org/manual/reference/operator/geoWithin/
-     * @param Geometry $geometry
      * @return $this
      */
     public function geoWithin(Geometry $geometry)
@@ -306,9 +308,9 @@ class Match extends Stage
      *
      * @see Expr::geoWithinPolygon()
      * @see http://docs.mongodb.org/manual/reference/operator/polygon/
-     * @param array $point1 First point of the polygon
-     * @param array $point2 Second point of the polygon
-     * @param array $point3 Third point of the polygon
+     * @param array $point1    First point of the polygon
+     * @param array $point2    Second point of the polygon
+     * @param array $point3    Third point of the polygon
      * @param array ...$points Additional points of the polygon
      * @return $this
      */
@@ -481,8 +483,8 @@ class Match extends Stage
      *
      * @see Expr::mod()
      * @see http://docs.mongodb.org/manual/reference/operator/mod/
-     * @param float|integer $divisor
-     * @param float|integer $remainder
+     * @param float|int $divisor
+     * @param float|int $remainder
      * @return $this
      */
     public function mod($divisor, $remainder = 0)
@@ -574,12 +576,12 @@ class Match extends Stage
      *
      * @see Expr::size()
      * @see http://docs.mongodb.org/manual/reference/operator/size/
-     * @param integer $size
+     * @param int $size
      * @return $this
      */
     public function size($size)
     {
-        $this->query->size((integer) $size);
+        $this->query->size((int) $size);
 
         return $this;
     }
@@ -608,7 +610,7 @@ class Match extends Stage
      *
      * @see Expr::type()
      * @see http://docs.mongodb.org/manual/reference/operator/type/
-     * @param integer $type
+     * @param int $type
      * @return $this
      */
     public function type($type)

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Operator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Operator.php
@@ -1,16 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Expr;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
+use function func_get_args;
 
 /**
  * Fluent interface for adding operators to aggregation stages.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.2
  * @method $this switch()
  * @method $this case(mixed|Expr $expression)
  * @method $this then(mixed|Expr $expression)
@@ -35,7 +36,7 @@ abstract class Operator extends Stage
 
     /**
      * @param string $method
-     * @param array $args
+     * @param array  $args
      * @return $this
      */
     public function __call($method, $args)
@@ -56,7 +57,6 @@ abstract class Operator extends Stage
      * @param mixed|Expr $number
      * @return $this
      *
-     * @since 1.3
      */
     public function abs($number)
     {
@@ -168,7 +168,6 @@ abstract class Operator extends Stage
      * @param mixed|Expr $index
      * @return $this
      *
-     * @since 1.3
      */
     public function arrayElemAt($array, $index)
     {
@@ -188,7 +187,6 @@ abstract class Operator extends Stage
      * @param mixed|Expr $number
      * @return $this
      *
-     * @since 1.3
      */
     public function ceil($number)
     {
@@ -250,7 +248,6 @@ abstract class Operator extends Stage
      * @param mixed|Expr ...$arrays Additional expressions
      * @return $this
      *
-     * @since 1.3
      */
     public function concatArrays($array1, $array2, ...$arrays)
     {
@@ -288,7 +285,7 @@ abstract class Operator extends Stage
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/dateToString/
      * @see Expr::dateToString
-     * @param string $format
+     * @param string     $format
      * @param mixed|Expr $expression
      * @return $this
      */
@@ -397,7 +394,6 @@ abstract class Operator extends Stage
      * @param mixed|Expr $exponent
      * @return $this
      *
-     * @since 1.3
      */
     public function exp($exponent)
     {
@@ -448,7 +444,6 @@ abstract class Operator extends Stage
      * @param mixed|Expr $cond
      * @return $this
      *
-     * @since 1.3
      */
     public function filter($input, $as, $cond)
     {
@@ -468,7 +463,6 @@ abstract class Operator extends Stage
      * @param mixed|Expr $number
      * @return $this
      *
-     * @since 1.3
      */
     public function floor($number)
     {
@@ -538,7 +532,6 @@ abstract class Operator extends Stage
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/in/
      * @see Expr::in
-     * @since 1.5
      * @param mixed|Expr $expression
      * @param mixed|Expr $arrayExpression
      * @return $this
@@ -557,11 +550,10 @@ abstract class Operator extends Stage
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/indexOfArray/
      * @see Expr::indexOfArray
-     * @since 1.5
-     * @param mixed|Expr $arrayExpression Can be any valid expression as long as it resolves to an array.
+     * @param mixed|Expr $arrayExpression  Can be any valid expression as long as it resolves to an array.
      * @param mixed|Expr $searchExpression Can be any valid expression.
-     * @param mixed|Expr $start Optional. An integer, or a number that can be represented as integers (such as 2.0), that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
-     * @param mixed|Expr $end An integer, or a number that can be represented as integers (such as 2.0), that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
+     * @param mixed|Expr $start            Optional. An integer, or a number that can be represented as integers (such as 2.0), that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
+     * @param mixed|Expr $end              An integer, or a number that can be represented as integers (such as 2.0), that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      * @return $this
      */
     public function indexOfArray($arrayExpression, $searchExpression, $start = null, $end = null)
@@ -577,11 +569,10 @@ abstract class Operator extends Stage
      * found, returns -1.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/indexOfBytes/
-     * @since 1.5
-     * @param mixed|Expr $stringExpression Can be any valid expression as long as it resolves to a string.
+     * @param mixed|Expr $stringExpression    Can be any valid expression as long as it resolves to a string.
      * @param mixed|Expr $substringExpression Can be any valid expression as long as it resolves to a string.
-     * @param int|null $start An integral number that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
-     * @param int|null $end An integral number that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
+     * @param int|null   $start               An integral number that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
+     * @param int|null   $end                 An integral number that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      *
      * @return $this
      */
@@ -598,11 +589,10 @@ abstract class Operator extends Stage
      * not found, returns -1.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/indexOfCP/
-     * @since 1.5
-     * @param mixed|Expr $stringExpression Can be any valid expression as long as it resolves to a string.
+     * @param mixed|Expr $stringExpression    Can be any valid expression as long as it resolves to a string.
      * @param mixed|Expr $substringExpression Can be any valid expression as long as it resolves to a string.
-     * @param int|null $start An integral number that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
-     * @param int|null $end An integral number that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
+     * @param int|null   $start               An integral number that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
+     * @param int|null   $end                 An integral number that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      *
      * @return $this
      */
@@ -644,7 +634,6 @@ abstract class Operator extends Stage
      * @param mixed|Expr $expression
      * @return $this
      *
-     * @since 1.3
      */
     public function isArray($expression)
     {
@@ -660,7 +649,6 @@ abstract class Operator extends Stage
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/isoDayOfWeek/
-     * @since 1.5
      * @param mixed|Expr $expression
      * @return $this
      */
@@ -680,7 +668,6 @@ abstract class Operator extends Stage
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/isoWeek/
-     * @since 1.5
      * @param mixed|Expr $expression
      * @return $this
      */
@@ -700,7 +687,6 @@ abstract class Operator extends Stage
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/isoWeek/
-     * @since 1.5
      * @param mixed|Expr $expression
      * @return $this
      */
@@ -756,7 +742,6 @@ abstract class Operator extends Stage
      * @param mixed|Expr $number
      * @return $this
      *
-     * @since 1.3
      */
     public function ln($number)
     {
@@ -780,7 +765,6 @@ abstract class Operator extends Stage
      * @param mixed|Expr $base
      * @return $this
      *
-     * @since 1.3
      */
     public function log($number, $base)
     {
@@ -802,7 +786,6 @@ abstract class Operator extends Stage
      * @param mixed|Expr $number
      * @return $this
      *
-     * @since 1.3
      */
     public function log10($number)
     {
@@ -854,7 +837,7 @@ abstract class Operator extends Stage
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/map/
      * @see Expr::map
      * @param mixed|Expr $input An expression that resolves to an array.
-     * @param string $as        The variable name for the items in the input array. The in expression accesses each item in the input array by this variable.
+     * @param string     $as    The variable name for the items in the input array. The in expression accesses each item in the input array by this variable.
      * @param mixed|Expr $in    The expression to apply to each item in the input array. The expression accesses the item by its variable name.
      * @return $this
      */
@@ -1016,7 +999,6 @@ abstract class Operator extends Stage
      * @param mixed|Expr $exponent
      * @return $this
      *
-     * @since 1.3
      */
     public function pow($number, $exponent)
     {
@@ -1032,10 +1014,9 @@ abstract class Operator extends Stage
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/range/
      * @see Expr::range
-     * @since 1.5
      * @param mixed|Expr $start An integer that specifies the start of the sequence. Can be any valid expression that resolves to an integer.
-     * @param mixed|Expr $end An integer that specifies the exclusive upper limit of the sequence. Can be any valid expression that resolves to an integer.
-     * @param mixed|Expr $step Optional. An integer that specifies the increment value. Can be any valid expression that resolves to a non-zero integer. Defaults to 1.
+     * @param mixed|Expr $end   An integer that specifies the exclusive upper limit of the sequence. Can be any valid expression that resolves to an integer.
+     * @param mixed|Expr $step  Optional. An integer that specifies the increment value. Can be any valid expression that resolves to a non-zero integer. Defaults to 1.
      * @return $this
      */
     public function range($start, $end, $step = 1)
@@ -1051,10 +1032,9 @@ abstract class Operator extends Stage
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/reduce/
      * @see Expr::reduce
-     * @since 1.5
-     * @param mixed|Expr $input Can be any valid expression that resolves to an array.
+     * @param mixed|Expr $input        Can be any valid expression that resolves to an array.
      * @param mixed|Expr $initialValue The initial cumulative value set before in is applied to the first element of the input array.
-     * @param mixed|Expr $in A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
+     * @param mixed|Expr $in           A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
      * @return $this
      */
     public function reduce($input, $initialValue, $in)
@@ -1070,7 +1050,6 @@ abstract class Operator extends Stage
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/reverseArray/
      * @see Expr::reverseArray
-     * @since 1.5
      * @param mixed|Expr $expression
      * @return $this
      */
@@ -1220,12 +1199,11 @@ abstract class Operator extends Stage
      *
      * @see https://docs.mongodb.org/manual/reference/operator/aggregation/slice/
      * @see Expr::slice
-     * @param mixed|Expr $array
-     * @param mixed|Expr $n
+     * @param mixed|Expr      $array
+     * @param mixed|Expr      $n
      * @param mixed|Expr|null $position
      * @return $this
      *
-     * @since 1.3
      */
     public function slice($array, $n, $position = null)
     {
@@ -1242,8 +1220,7 @@ abstract class Operator extends Stage
      * returns the original string as the only element of an array.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/split/
-     * @since 1.5
-     * @param mixed|Expr $string The string to be split. Can be any valid expression as long as it resolves to a string.
+     * @param mixed|Expr $string    The string to be split. Can be any valid expression as long as it resolves to a string.
      * @param mixed|Expr $delimiter The delimiter to use when splitting the string expression. Can be any valid expression as long as it resolves to a string.
      *
      * @return $this
@@ -1299,7 +1276,6 @@ abstract class Operator extends Stage
      * Returns the number of UTF-8 encoded bytes in the specified string.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/strLenBytes/
-     * @since 1.5
      * @param mixed|Expr $string
      *
      * @return $this
@@ -1315,7 +1291,6 @@ abstract class Operator extends Stage
      * Returns the number of UTF-8 code points in the specified string.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/strLenCP/
-     * @since 1.5
      * @param mixed|Expr $string
      *
      * @return $this
@@ -1355,10 +1330,9 @@ abstract class Operator extends Stage
      * specified.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/substrBytes/
-     * @since 1.5
      * @param mixed|Expr $string The string from which the substring will be extracted. Can be any valid expression as long as it resolves to a string.
-     * @param mixed|Expr $start Indicates the starting point of the substring. Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
-     * @param mixed|Expr $count Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
+     * @param mixed|Expr $start  Indicates the starting point of the substring. Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
+     * @param mixed|Expr $count  Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
      *
      * @return $this
      */
@@ -1377,10 +1351,9 @@ abstract class Operator extends Stage
      * specified.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/substrBytes/
-     * @since 1.5
      * @param mixed|Expr $string The string from which the substring will be extracted. Can be any valid expression as long as it resolves to a string.
-     * @param mixed|Expr $start Indicates the starting point of the substring. Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
-     * @param mixed|Expr $count Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
+     * @param mixed|Expr $start  Indicates the starting point of the substring. Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
+     * @param mixed|Expr $count  Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
      *
      * @return $this
      */
@@ -1455,7 +1428,6 @@ abstract class Operator extends Stage
      * @param mixed|Expr $number
      * @return $this
      *
-     * @since 1.3
      */
     public function trunc($number)
     {
@@ -1470,7 +1442,6 @@ abstract class Operator extends Stage
      * The argument can be any valid expression.
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/type/
-     * @since 1.5
      * @param mixed|Expr $expression
      *
      * @return $this
@@ -1523,10 +1494,9 @@ abstract class Operator extends Stage
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/zip/
      * @see Expr::zip
-     * @since 1.5
-     * @param mixed|Expr $inputs An array of expressions that resolve to arrays. The elements of these input arrays combine to form the arrays of the output array.
-     * @param bool|null $useLongestLength A boolean which specifies whether the length of the longest array determines the number of arrays in the output array.
-     * @param mixed|Expr|null $defaults An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
+     * @param mixed|Expr      $inputs           An array of expressions that resolve to arrays. The elements of these input arrays combine to form the arrays of the output array.
+     * @param bool|null       $useLongestLength A boolean which specifies whether the length of the longest array determines the number of arrays in the output array.
+     * @param mixed|Expr|null $defaults         An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
      * @return $this
      */
     public function zip($inputs, $useLongestLength = null, $defaults = null)

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Out.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Out.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\Common\Persistence\Mapping\MappingException as BaseMappingException;
@@ -22,9 +24,7 @@ class Out extends Stage
     private $collection;
 
     /**
-     * @param Builder $builder
      * @param string $collection
-     * @param DocumentManager $documentManager
      */
     public function __construct(Builder $builder, $collection, DocumentManager $documentManager)
     {
@@ -40,7 +40,7 @@ class Out extends Stage
     public function getExpression()
     {
         return [
-            '$out' => $this->collection
+            '$out' => $this->collection,
         ];
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Project.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Project.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Expr;
+use function func_get_args;
 
 /**
  * Fluent interface for adding a $project stage to an aggregation pipeline.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.2
  */
 class Project extends Operator
 {
@@ -18,7 +19,7 @@ class Project extends Operator
     public function getExpression()
     {
         return [
-            '$project' => $this->expr->getExpression()
+            '$project' => $this->expr->getExpression(),
         ];
     }
 
@@ -33,7 +34,6 @@ class Project extends Operator
      * @param mixed|Expr ...$expressions Additional expressions
      * @return $this
      *
-     * @since 1.3
      */
     public function avg($expression1, ...$expressions)
     {
@@ -63,7 +63,6 @@ class Project extends Operator
      * If you specify the exclusion of a field other than _id, you cannot employ
      * any other $project specification forms.
      *
-     * @since 1.5
      * @param array $fields
      * @return $this
      */
@@ -86,7 +85,6 @@ class Project extends Operator
      * @param mixed|Expr ...$expressions Additional expressions
      * @return $this
      *
-     * @since 1.3
      */
     public function max($expression1, ...$expressions)
     {
@@ -105,7 +103,6 @@ class Project extends Operator
      * @param mixed|Expr ...$expressions Additional expressions
      * @return $this
      *
-     * @since 1.3
      */
     public function min($expression1, ...$expressions)
     {
@@ -125,7 +122,6 @@ class Project extends Operator
      * @param mixed|Expr ...$expressions Additional expressions
      * @return $this
      *
-     * @since 1.3
      */
     public function stdDevPop($expression1, ...$expressions)
     {
@@ -145,7 +141,6 @@ class Project extends Operator
      * @param mixed|Expr ...$expressions Additional expressions
      * @return $this
      *
-     * @since 1.3
      */
     public function stdDevSamp($expression1, ...$expressions)
     {
@@ -165,7 +160,6 @@ class Project extends Operator
      * @param mixed|Expr ...$expressions Additional expressions
      * @return $this
      *
-     * @since 1.3
      */
     public function sum($expression1, ...$expressions)
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Redact.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Redact.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 /**
  * Fluent interface for adding a $redact stage to an aggregation pipeline.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.2
  */
 class Redact extends Operator
 {
@@ -16,7 +16,7 @@ class Redact extends Operator
     public function getExpression()
     {
         return [
-            '$redact' => $this->expr->getExpression()
+            '$redact' => $this->expr->getExpression(),
         ];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceRoot.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceRoot.php
@@ -1,12 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Expr;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use Doctrine\ODM\MongoDB\Types\Type;
+use function array_map;
+use function is_array;
+use function is_string;
+use function substr;
 
 class ReplaceRoot extends Operator
 {
@@ -40,7 +47,7 @@ class ReplaceRoot extends Operator
     public function getExpression()
     {
         return [
-            '$replaceRoot' => $this->expression !== null ? $this->convertExpression($this->expression) : $this->expr->getExpression()
+            '$replaceRoot' => $this->expression !== null ? $this->convertExpression($this->expression) : $this->expr->getExpression(),
         ];
     }
 
@@ -56,7 +63,7 @@ class ReplaceRoot extends Operator
     }
 
     /**
-     * @return \Doctrine\ODM\MongoDB\Persisters\DocumentPersister
+     * @return DocumentPersister
      */
     private function getDocumentPersister()
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Sample.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Sample.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
@@ -8,25 +10,22 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 /**
  * Fluent interface for adding a $sample stage to an aggregation pipeline.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.3
  */
 class Sample extends Stage
 {
     /**
-     * @var integer
+     * @var int
      */
     private $size;
 
     /**
-     * @param Builder $builder
-     * @param integer $size
+     * @param int $size
      */
     public function __construct(Builder $builder, $size)
     {
         parent::__construct($builder);
 
-        $this->size = (integer) $size;
+        $this->size = (int) $size;
     }
 
     /**
@@ -35,7 +34,7 @@ class Sample extends Stage
     public function getExpression()
     {
         return [
-            '$sample' => ['size' => $this->size]
+            '$sample' => ['size' => $this->size],
         ];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Skip.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Skip.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
@@ -8,25 +10,22 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 /**
  * Fluent interface for adding a $skip stage to an aggregation pipeline.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.2
  */
 class Skip extends Stage
 {
     /**
-     * @var integer
+     * @var int
      */
     private $skip;
 
     /**
-     * @param Builder $builder
-     * @param integer $skip
+     * @param int $skip
      */
     public function __construct(Builder $builder, $skip)
     {
         parent::__construct($builder);
 
-        $this->skip = (integer) $skip;
+        $this->skip = (int) $skip;
     }
 
     /**
@@ -35,7 +34,7 @@ class Skip extends Stage
     public function getExpression()
     {
         return [
-            '$skip' => $this->skip
+            '$skip' => $this->skip,
         ];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Sort.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Sort.php
@@ -1,15 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
+use function in_array;
+use function is_array;
+use function is_string;
+use function strtolower;
 
 /**
  * Fluent interface for adding a $sort stage to an aggregation pipeline.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.2
  */
 class Sort extends Stage
 {
@@ -19,9 +23,8 @@ class Sort extends Stage
     private $sort = [];
 
     /**
-     * @param Builder $builder
      * @param array|string $fieldName Field name or array of field/order pairs
-     * @param int|string $order       Field order (if one field is specified)
+     * @param int|string   $order     Field order (if one field is specified)
      */
     public function __construct(Builder $builder, $fieldName, $order = null)
     {
@@ -50,7 +53,7 @@ class Sort extends Stage
     public function getExpression()
     {
         return [
-            '$sort' => $this->sort
+            '$sort' => $this->sort,
         ];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SortByCount.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SortByCount.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use function substr;
 
 class SortByCount extends Stage
 {
@@ -15,7 +18,6 @@ class SortByCount extends Stage
     private $fieldName;
 
     /**
-     * @param Builder $builder
      * @param string $fieldName Expression to group by. To specify a field path,
      * prefix the field name with a dollar sign $ and enclose it in quotes.
      * The expression can not evaluate to an object.
@@ -34,7 +36,7 @@ class SortByCount extends Stage
     public function getExpression()
     {
         return [
-            '$sortByCount' => $this->fieldName
+            '$sortByCount' => $this->fieldName,
         ];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Unwind.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Unwind.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
@@ -8,8 +10,6 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 /**
  * Fluent interface for adding a $unwind stage to an aggregation pipeline.
  *
- * @author alcaeus <alcaeus@alcaeus.org>
- * @since 1.2
  */
 class Unwind extends Stage
 {
@@ -29,7 +29,6 @@ class Unwind extends Stage
     private $preserveNullAndEmptyArrays = false;
 
     /**
-     * @param Builder $builder
      * @param string $fieldName
      */
     public function __construct(Builder $builder, $fieldName)
@@ -47,23 +46,21 @@ class Unwind extends Stage
         // Fallback behavior for MongoDB < 3.2
         if ($this->includeArrayIndex === null && ! $this->preserveNullAndEmptyArrays) {
             return [
-                '$unwind' => $this->fieldName
+                '$unwind' => $this->fieldName,
             ];
         }
 
         $unwind = ['path' => $this->fieldName];
 
         foreach (['includeArrayIndex', 'preserveNullAndEmptyArrays'] as $option) {
-            if ( ! $this->$option) {
+            if (! $this->$option) {
                 continue;
             }
 
             $unwind[$option] = $this->$option;
         }
 
-        return [
-            '$unwind' => $unwind
-        ];
+        return ['$unwind' => $unwind];
     }
 
     /**
@@ -73,7 +70,6 @@ class Unwind extends Stage
      * @param string $includeArrayIndex
      * @return $this
      *
-     * @since 1.3
      */
     public function includeArrayIndex($includeArrayIndex)
     {
@@ -89,7 +85,6 @@ class Unwind extends Stage
      * @param bool $preserveNullAndEmptyArrays
      * @return $this
      *
-     * @since 1.3
      */
     public function preserveNullAndEmptyArrays($preserveNullAndEmptyArrays = true)
     {

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB;
 
 use Doctrine\Common\Annotations\AnnotationReader;
@@ -14,6 +16,7 @@ use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionFactory;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionGenerator;
 use Doctrine\ODM\MongoDB\Repository\DefaultRepositoryFactory;
 use Doctrine\ODM\MongoDB\Repository\RepositoryFactory;
+use function trim;
 
 /**
  * Configuration class for the DocumentManager. When setting up your DocumentManager
@@ -25,7 +28,6 @@ use Doctrine\ODM\MongoDB\Repository\RepositoryFactory;
  *     $config = new Configuration();
  *     $dm = DocumentManager::create(new Connection(), $config);
  *
- * @since       1.0
  */
 class Configuration
 {
@@ -43,7 +45,7 @@ class Configuration
      *
      * @var integer
      */
-    const AUTOGENERATE_NEVER = 0;
+    public const AUTOGENERATE_NEVER = 0;
 
     /**
      * Always generates a new proxy/hydrator/persistent collection in every request.
@@ -53,7 +55,7 @@ class Configuration
      *
      * @var integer
      */
-    const AUTOGENERATE_ALWAYS = 1;
+    public const AUTOGENERATE_ALWAYS = 1;
 
     /**
      * Autogenerate the proxy/hydrator/persistent collection class when the file does not exist.
@@ -63,7 +65,7 @@ class Configuration
      *
      * @var integer
      */
-    const AUTOGENERATE_FILE_NOT_EXISTS = 2;
+    public const AUTOGENERATE_FILE_NOT_EXISTS = 2;
 
     /**
      * Generate the proxy/hydrator/persistent collection classes using eval().
@@ -73,7 +75,7 @@ class Configuration
      *
      * @var integer
      */
-    const AUTOGENERATE_EVAL = 3;
+    public const AUTOGENERATE_EVAL = 3;
 
     /**
      * Adds a namespace under a certain alias.
@@ -95,7 +97,7 @@ class Configuration
      */
     public function getDocumentNamespace($documentNamespaceAlias)
     {
-        if ( ! isset($this->attributes['documentNamespaces'][$documentNamespaceAlias])) {
+        if (! isset($this->attributes['documentNamespaces'][$documentNamespaceAlias])) {
             throw MongoDBException::unknownDocumentNamespace($documentNamespaceAlias);
         }
 
@@ -116,7 +118,6 @@ class Configuration
      * Set the document alias map
      *
      * @param array $documentNamespaces
-     * @return void
      */
     public function setDocumentNamespaces(array $documentNamespaces)
     {
@@ -126,7 +127,6 @@ class Configuration
     /**
      * Sets the cache driver implementation that is used for metadata caching.
      *
-     * @param MappingDriver $driverImpl
      * @todo Force parameter to be a Closure to ensure lazy evaluation
      *       (as soon as a metadata cache is in effect, the driver never needs to initialize).
      */
@@ -141,11 +141,11 @@ class Configuration
      * @param array $paths
      * @return Mapping\Driver\AnnotationDriver
      */
-    public function newDefaultAnnotationDriver($paths = array())
+    public function newDefaultAnnotationDriver($paths = [])
     {
         $reader = new AnnotationReader();
 
-        return new AnnotationDriver($reader, (array)$paths);
+        return new AnnotationDriver($reader, (array) $paths);
     }
 
     /**
@@ -161,7 +161,7 @@ class Configuration
     /**
      * Gets the cache driver implementation that is used for metadata caching.
      *
-     * @return \Doctrine\Common\Cache\Cache
+     * @return Cache
      */
     public function getMetadataCacheImpl()
     {
@@ -171,7 +171,6 @@ class Configuration
     /**
      * Sets the cache driver implementation that is used for metadata caching.
      *
-     * @param \Doctrine\Common\Cache\Cache $cacheImpl
      */
     public function setMetadataCacheImpl(Cache $cacheImpl)
     {
@@ -202,7 +201,7 @@ class Configuration
      * Gets a boolean flag that indicates whether proxy classes should always be regenerated
      * during each script execution.
      *
-     * @return boolean|integer
+     * @return bool|int
      */
     public function getAutoGenerateProxyClasses()
     {
@@ -213,7 +212,7 @@ class Configuration
      * Sets a boolean flag that indicates whether proxy classes should always be regenerated
      * during each script execution.
      *
-     * @param boolean|int $bool Possible values are constants of Doctrine\Common\Proxy\AbstractProxyFactory
+     * @param bool|int $bool Possible values are constants of Doctrine\Common\Proxy\AbstractProxyFactory
      */
     public function setAutoGenerateProxyClasses($bool)
     {
@@ -264,7 +263,7 @@ class Configuration
      * Gets a boolean flag that indicates whether hydrator classes should always be regenerated
      * during each script execution.
      *
-     * @return boolean|integer Possible values are defined constants
+     * @return bool|int Possible values are defined constants
      */
     public function getAutoGenerateHydratorClasses()
     {
@@ -275,7 +274,7 @@ class Configuration
      * Sets a boolean flag that indicates whether hydrator classes should always be regenerated
      * during each script execution.
      *
-     * @param boolean|integer $bool
+     * @param bool|int $bool
      */
     public function setAutoGenerateHydratorClasses($bool)
     {
@@ -326,7 +325,7 @@ class Configuration
      * Gets a integer flag that indicates how and when persistent collection
      * classes should be generated.
      *
-     * @return integer Possible values are defined constants
+     * @return int Possible values are defined constants
      */
     public function getAutoGeneratePersistentCollectionClasses()
     {
@@ -337,7 +336,7 @@ class Configuration
      * Sets a integer flag that indicates how and when persistent collection
      * classes should be generated.
      *
-     * @param integer $mode Possible values are defined constants
+     * @param int $mode Possible values are defined constants
      */
     public function setAutoGeneratePersistentCollectionClasses($mode)
     {
@@ -402,7 +401,7 @@ class Configuration
      */
     public function getClassMetadataFactoryName()
     {
-        if ( ! isset($this->attributes['classMetadataFactoryName'])) {
+        if (! isset($this->attributes['classMetadataFactoryName'])) {
             $this->attributes['classMetadataFactoryName'] = ClassMetadataFactory::class;
         }
         return $this->attributes['classMetadataFactoryName'];
@@ -415,7 +414,7 @@ class Configuration
      */
     public function getDefaultCommitOptions()
     {
-        return $this->attributes['defaultCommitOptions'] ?? array('w' => 1);
+        return $this->attributes['defaultCommitOptions'] ?? ['w' => 1];
     }
 
     /**
@@ -435,12 +434,12 @@ class Configuration
      * @param string $className  The class name of the filter.
      * @param array  $parameters The parameters for the filter.
      */
-    public function addFilter($name, $className, array $parameters = array())
+    public function addFilter($name, $className, array $parameters = [])
     {
-        $this->attributes['filters'][$name] = array(
+        $this->attributes['filters'][$name] = [
             'class' => $className,
-            'parameters' => $parameters
-        );
+            'parameters' => $parameters,
+        ];
     }
 
     /**
@@ -476,7 +475,6 @@ class Configuration
      *
      * @param string $className
      *
-     * @return void
      *
      * @throws MongoDBException If not is a ObjectRepository
      */
@@ -484,7 +482,7 @@ class Configuration
     {
         $reflectionClass = new \ReflectionClass($className);
 
-        if ( ! $reflectionClass->implementsInterface(ObjectRepository::class)) {
+        if (! $reflectionClass->implementsInterface(ObjectRepository::class)) {
             throw MongoDBException::invalidDocumentRepository($className);
         }
 
@@ -504,7 +502,6 @@ class Configuration
     /**
      * Set the document repository factory.
      *
-     * @param RepositoryFactory $repositoryFactory
      */
     public function setRepositoryFactory(RepositoryFactory $repositoryFactory)
     {
@@ -524,7 +521,6 @@ class Configuration
     /**
      * Set the persistent collection factory.
      *
-     * @param PersistentCollectionFactory $persistentCollectionFactory
      */
     public function setPersistentCollectionFactory(PersistentCollectionFactory $persistentCollectionFactory)
     {
@@ -538,7 +534,7 @@ class Configuration
      */
     public function getPersistentCollectionFactory()
     {
-        if ( ! isset($this->attributes['persistentCollectionFactory'])) {
+        if (! isset($this->attributes['persistentCollectionFactory'])) {
             $this->attributes['persistentCollectionFactory'] = new DefaultPersistentCollectionFactory();
         }
         return $this->attributes['persistentCollectionFactory'];
@@ -547,7 +543,6 @@ class Configuration
     /**
      * Set the persistent collection generator.
      *
-     * @param PersistentCollectionGenerator $persistentCollectionGenerator
      */
     public function setPersistentCollectionGenerator(PersistentCollectionGenerator $persistentCollectionGenerator)
     {
@@ -561,7 +556,7 @@ class Configuration
      */
     public function getPersistentCollectionGenerator()
     {
-        if ( ! isset($this->attributes['persistentCollectionGenerator'])) {
+        if (! isset($this->attributes['persistentCollectionGenerator'])) {
             $this->attributes['persistentCollectionGenerator'] = new DefaultPersistentCollectionGenerator(
                 $this->getPersistentCollectionDir(),
                 $this->getPersistentCollectionNamespace()

--- a/lib/Doctrine/ODM/MongoDB/DocumentNotFoundException.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentNotFoundException.php
@@ -1,12 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB;
+
+use function json_encode;
+use function sprintf;
 
 /**
  * Class for exception when encountering proxy object that has
  * an identifier that does not exist in the database.
  *
- * @since       1.0
  */
 class DocumentNotFoundException extends MongoDBException
 {
@@ -14,7 +18,7 @@ class DocumentNotFoundException extends MongoDBException
     {
         return new self(sprintf(
             'The "%s" document with identifier %s could not be found.',
-            $className, 
+            $className,
             json_encode($identifier)
         ));
     }

--- a/lib/Doctrine/ODM/MongoDB/DocumentRepository.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentRepository.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
-use Doctrine\Common\Inflector\Inflector;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Query\QueryExpressionVisitor;
+use function is_array;
 
 /**
  * A DocumentRepository serves as a repository for documents with generic as well as
@@ -18,7 +20,6 @@ use Doctrine\ODM\MongoDB\Query\QueryExpressionVisitor;
  * This class is designed for inheritance and users can subclass this class to
  * write their own repositories with business-specific methods to locate documents.
  *
- * @since       1.0
  */
 class DocumentRepository implements ObjectRepository, Selectable
 {
@@ -46,9 +47,9 @@ class DocumentRepository implements ObjectRepository, Selectable
      * Initializes this instance with the specified document manager, unit of work and
      * class metadata.
      *
-     * @param DocumentManager $dm The DocumentManager to use.
-     * @param UnitOfWork $uow The UnitOfWork to use.
-     * @param ClassMetadata $classMetadata The class metadata.
+     * @param DocumentManager $dm            The DocumentManager to use.
+     * @param UnitOfWork      $uow           The UnitOfWork to use.
+     * @param ClassMetadata   $classMetadata The class metadata.
      */
     public function __construct(DocumentManager $dm, UnitOfWork $uow, ClassMetadata $classMetadata)
     {
@@ -90,9 +91,9 @@ class DocumentRepository implements ObjectRepository, Selectable
      * Finds a document matching the specified identifier. Optionally a lock mode and
      * expected version may be specified.
      *
-     * @param mixed $id Identifier.
-     * @param int $lockMode Optional. Lock mode; one of the LockMode constants.
-     * @param int $lockVersion Optional. Expected version.
+     * @param mixed $id          Identifier.
+     * @param int   $lockMode    Optional. Lock mode; one of the LockMode constants.
+     * @param int   $lockVersion Optional. Expected version.
      * @throws Mapping\MappingException
      * @throws LockException
      * @return object|null The document, if found, otherwise null.
@@ -123,14 +124,14 @@ class DocumentRepository implements ObjectRepository, Selectable
             return $document; // Hit!
         }
 
-        $criteria = array('_id' => $id);
+        $criteria = ['_id' => $id];
 
         if ($lockMode === LockMode::NONE) {
             return $this->getDocumentPersister()->load($criteria);
         }
 
         if ($lockMode === LockMode::OPTIMISTIC) {
-            if (!$this->class->isVersioned) {
+            if (! $this->class->isVersioned) {
                 throw LockException::notVersioned($this->documentName);
             }
             if ($document = $this->getDocumentPersister()->load($criteria)) {
@@ -140,7 +141,7 @@ class DocumentRepository implements ObjectRepository, Selectable
             return $document;
         }
 
-        return $this->getDocumentPersister()->load($criteria, null, array(), $lockMode);
+        return $this->getDocumentPersister()->load($criteria, null, [], $lockMode);
     }
 
     /**
@@ -150,20 +151,20 @@ class DocumentRepository implements ObjectRepository, Selectable
      */
     public function findAll()
     {
-        return $this->findBy(array());
+        return $this->findBy([]);
     }
 
     /**
      * Finds documents by a set of criteria.
      *
-     * @param array        $criteria Query criteria
-     * @param array        $sort     Sort array for Cursor::sort()
-     * @param integer|null $limit    Limit for Cursor::limit()
-     * @param integer|null $skip     Skip for Cursor::skip()
+     * @param array    $criteria Query criteria
+     * @param array    $sort     Sort array for Cursor::sort()
+     * @param int|null $limit    Limit for Cursor::limit()
+     * @param int|null $skip     Skip for Cursor::skip()
      *
      * @return array
      */
-    public function findBy(array $criteria, array $sort = null, $limit = null, $skip = null)
+    public function findBy(array $criteria, ?array $sort = null, $limit = null, $skip = null)
     {
         return $this->getDocumentPersister()->loadAll($criteria, $sort, $limit, $skip)->toArray(false);
     }
@@ -216,7 +217,6 @@ class DocumentRepository implements ObjectRepository, Selectable
      * returns a new collection containing these elements.
      *
      * @see Selectable::matching()
-     * @param Criteria $criteria
      * @return Collection
      */
     public function matching(Criteria $criteria)

--- a/lib/Doctrine/ODM/MongoDB/Event/DocumentNotFoundEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/DocumentNotFoundEventArgs.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /*
  *  $Id$
  *
@@ -26,7 +29,6 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 /**
  * Provides event arguments for the documentNotFound event.
  *
- * @since 1.1
  */
 class DocumentNotFoundEventArgs extends LifecycleEventArgs
 {
@@ -41,10 +43,9 @@ class DocumentNotFoundEventArgs extends LifecycleEventArgs
     private $disableException = false;
 
     /**
-     * Constructor.
+     *
      *
      * @param object $document
-     * @param DocumentManager $dm
      * @param string $identifier
      */
     public function __construct($document, DocumentManager $dm, $identifier)

--- a/lib/Doctrine/ODM/MongoDB/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/LifecycleEventArgs.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Event;
 
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs as BaseLifecycleEventArgs;
+use Doctrine\ODM\MongoDB\DocumentManager;
 
 /**
  * Lifecycle Events are triggered by the UnitOfWork during lifecycle transitions
  * of documents.
  *
- * @since 1.0
  */
 class LifecycleEventArgs extends BaseLifecycleEventArgs
 {
@@ -25,7 +27,7 @@ class LifecycleEventArgs extends BaseLifecycleEventArgs
     /**
      * Retrieves the associated DocumentManager.
      *
-     * @return \Doctrine\ODM\MongoDB\DocumentManager
+     * @return DocumentManager
      */
     public function getDocumentManager()
     {

--- a/lib/Doctrine/ODM/MongoDB/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/LoadClassMetadataEventArgs.php
@@ -1,20 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Event;
 
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs as BaseLoadClassMetadataEventArgs;
+use Doctrine\ODM\MongoDB\DocumentManager;
 
 /**
  * Class that holds event arguments for a loadMetadata event.
  *
- * @since 1.0
  */
 class LoadClassMetadataEventArgs extends BaseLoadClassMetadataEventArgs
 {
     /**
      * Retrieves the associated DocumentManager.
      *
-     * @return \Doctrine\ODM\MongoDB\DocumentManager
+     * @return DocumentManager
      */
     public function getDocumentManager()
     {

--- a/lib/Doctrine/ODM/MongoDB/Event/ManagerEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/ManagerEventArgs.php
@@ -1,20 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Event;
 
 use Doctrine\Common\Persistence\Event\ManagerEventArgs as BaseManagerEventArgs;
+use Doctrine\ODM\MongoDB\DocumentManager;
 
 /**
  * Provides event arguments for the flush events.
  *
- * @since 1.0
  */
 class ManagerEventArgs extends BaseManagerEventArgs
 {
     /**
      * Retrieves the associated DocumentManager.
      *
-     * @return \Doctrine\ODM\MongoDB\DocumentManager
+     * @return DocumentManager
      */
     public function getDocumentManager()
     {

--- a/lib/Doctrine/ODM/MongoDB/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/OnClearEventArgs.php
@@ -1,20 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Event;
 
 use Doctrine\Common\Persistence\Event\OnClearEventArgs as BaseOnClearEventArgs;
+use Doctrine\ODM\MongoDB\DocumentManager;
 
 /**
  * Provides event arguments for the onClear event.
  *
- * @since 1.0
  */
 class OnClearEventArgs extends BaseOnClearEventArgs
 {
     /**
      * Retrieves the associated DocumentManager.
      *
-     * @return \Doctrine\ODM\MongoDB\DocumentManager
+     * @return DocumentManager
      */
     public function getDocumentManager()
     {

--- a/lib/Doctrine/ODM/MongoDB/Event/OnFlushEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/OnFlushEventArgs.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Event;
 
 /**
  * Provides event arguments for the onFlush event.
  *
- * @since 1.0
  */
 class OnFlushEventArgs extends ManagerEventArgs
 {

--- a/lib/Doctrine/ODM/MongoDB/Event/PostCollectionLoadEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PostCollectionLoadEventArgs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Event;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
@@ -8,7 +10,6 @@ use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 /**
  * Class that holds arguments for postCollectionLoad event.
  *
- * @since 1.1
  */
 class PostCollectionLoadEventArgs extends ManagerEventArgs
 {
@@ -17,10 +18,6 @@ class PostCollectionLoadEventArgs extends ManagerEventArgs
      */
     private $collection;
 
-    /**
-     * @param PersistentCollectionInterface $collection
-     * @param DocumentManager $dm
-     */
     public function __construct(PersistentCollectionInterface $collection, DocumentManager $dm)
     {
         parent::__construct($dm);

--- a/lib/Doctrine/ODM/MongoDB/Event/PostFlushEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PostFlushEventArgs.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Event;
 
 /**
  * Provides event arguments for the postFlush event.
  *
- * @since 1.0
  */
 class PostFlushEventArgs extends ManagerEventArgs
 {

--- a/lib/Doctrine/ODM/MongoDB/Event/PreFlushEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PreFlushEventArgs.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Event;
 
 /**
  * Provides event arguments for the preFlush event.
  *
- * @since 1.0
  */
 class PreFlushEventArgs extends ManagerEventArgs
 {

--- a/lib/Doctrine/ODM/MongoDB/Event/PreLoadEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PreLoadEventArgs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Event;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
@@ -7,7 +9,6 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 /**
  * Class that holds event arguments for a preLoad event.
  *
- * @since 1.0
  */
 class PreLoadEventArgs extends LifecycleEventArgs
 {
@@ -17,11 +18,10 @@ class PreLoadEventArgs extends LifecycleEventArgs
     private $data;
 
     /**
-     * Constructor.
      *
-     * @param object          $document
-     * @param DocumentManager $dm
-     * @param array           $data     Array of data to be loaded and hydrated
+     *
+     * @param object $document
+     * @param array  $data     Array of data to be loaded and hydrated
      */
     public function __construct($document, DocumentManager $dm, array &$data)
     {

--- a/lib/Doctrine/ODM/MongoDB/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PreUpdateEventArgs.php
@@ -1,13 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Event;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use function get_class;
+use function sprintf;
 
 /**
  * Class that holds event arguments for a preUpdate event.
  *
- * @since 1.0
  */
 class PreUpdateEventArgs extends LifecycleEventArgs
 {
@@ -17,11 +20,10 @@ class PreUpdateEventArgs extends LifecycleEventArgs
     private $documentChangeSet;
 
     /**
-     * Constructor.
      *
-     * @param object          $document
-     * @param DocumentManager $dm
-     * @param array           $changeSet
+     *
+     * @param object $document
+     * @param array  $changeSet
      */
     public function __construct($document, DocumentManager $dm, array $changeSet)
     {
@@ -44,7 +46,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
      *
      * @param string $field
      *
-     * @return boolean
+     * @return bool
      */
     public function hasChangedField($field)
     {
@@ -99,7 +101,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
      */
     private function assertValidField($field)
     {
-        if ( ! isset($this->documentChangeSet[$field])) {
+        if (! isset($this->documentChangeSet[$field])) {
             throw new \InvalidArgumentException(sprintf(
                 'Field "%s" is not a valid field of the document "%s" in PreUpdateEventArgs.',
                 $field,

--- a/lib/Doctrine/ODM/MongoDB/Events.php
+++ b/lib/Doctrine/ODM/MongoDB/Events.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB;
 
 /**
@@ -7,72 +9,73 @@ namespace Doctrine\ODM\MongoDB;
  *
  * This class cannot be instantiated.
  *
- * @since       1.0
  */
 final class Events
 {
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 
     /**
      * The preRemove event occurs for a given document before the respective
      * DocumentManager remove operation for that document is executed.
-     * 
+     *
      * This is a document lifecycle event.
-     * 
+     *
      * @var string
      */
-    const preRemove = 'preRemove';
+    public const preRemove = 'preRemove';
 
     /**
-     * The postRemove event occurs for a document after the document has 
+     * The postRemove event occurs for a document after the document has
      * been deleted. It will be invoked after the database delete operations.
-     * 
+     *
      * This is a document lifecycle event.
-     * 
+     *
      * @var string
      */
-    const postRemove = 'postRemove';
+    public const postRemove = 'postRemove';
 
     /**
      * The prePersist event occurs for a given document before the respective
      * DocumentManager persist operation for that document is executed.
-     * 
+     *
      * This is a document lifecycle event.
-     * 
+     *
      * @var string
      */
-    const prePersist = 'prePersist';
+    public const prePersist = 'prePersist';
 
     /**
-     * The postPersist event occurs for a document after the document has 
+     * The postPersist event occurs for a document after the document has
      * been made persistent. It will be invoked after the database insert operations.
      * Generated primary key values are available in the postPersist event.
-     * 
+     *
      * This is a document lifecycle event.
-     * 
+     *
      * @var string
      */
-    const postPersist = 'postPersist';
+    public const postPersist = 'postPersist';
 
     /**
-     * The preUpdate event occurs before the database update operations to 
-     * document data. 
-     * 
+     * The preUpdate event occurs before the database update operations to
+     * document data.
+     *
      * This is a document lifecycle event.
-     * 
+     *
      * @var string
      */
-    const preUpdate = 'preUpdate';
+    public const preUpdate = 'preUpdate';
 
     /**
-     * The postUpdate event occurs after the database update operations to 
-     * document data. 
-     * 
+     * The postUpdate event occurs after the database update operations to
+     * document data.
+     *
      * This is a document lifecycle event.
-     * 
+     *
      * @var string
      */
-    const postUpdate = 'postUpdate';
+    public const postUpdate = 'postUpdate';
 
     /**
      * The preLoad event occurs for a document before the document has been loaded
@@ -83,37 +86,37 @@ final class Events
      *
      * @var string
      */
-    const preLoad = 'preLoad';
+    public const preLoad = 'preLoad';
 
     /**
      * The postLoad event occurs for a document after the document has been loaded
      * into the current DocumentManager from the database or after the refresh operation
      * has been applied to it.
-     * 
+     *
      * Note that the postLoad event occurs for a document before any associations have been
      * initialized. Therefore it is not safe to access associations in a postLoad callback
      * or event handler.
-     * 
+     *
      * This is a document lifecycle event.
-     * 
+     *
      * @var string
      */
-    const postLoad = 'postLoad';
+    public const postLoad = 'postLoad';
 
     /**
      * The loadClassMetadata event occurs after the mapping metadata for a class
      * has been loaded from a mapping source (annotations/xml).
-     * 
+     *
      * @var string
      */
-    const loadClassMetadata = 'loadClassMetadata';
+    public const loadClassMetadata = 'loadClassMetadata';
 
     /**
      * The preFlush event occurs when the DocumentManager#flush() operation is invoked,
      * but before any changes to managed documents have been calculated. This event is
      * always raised right after DocumentManager#flush() call.
      */
-    const preFlush = 'preFlush';
+    public const preFlush = 'preFlush';
 
     /**
      * The onFlush event occurs when the DocumentManager#flush() operation is invoked,
@@ -121,10 +124,10 @@ final class Events
      * actual database operations are executed. The event is only raised if there is
      * actually something to do for the underlying UnitOfWork. If nothing needs to be done,
      * the onFlush event is not raised.
-     * 
+     *
      * @var string
      */
-    const onFlush = 'onFlush';
+    public const onFlush = 'onFlush';
 
     /**
      * The postFlush event occurs when the DocumentManager#flush() operation is invoked and
@@ -135,7 +138,7 @@ final class Events
      *
      * @var string
      */
-    const postFlush = 'postFlush';
+    public const postFlush = 'postFlush';
 
     /**
      * The onClear event occurs when the DocumentManager#clear() operation is invoked,
@@ -143,7 +146,7 @@ final class Events
      *
      * @var string
      */
-    const onClear = 'onClear';
+    public const onClear = 'onClear';
 
     /**
      * The documentNotFound event occurs if a proxy object could not be found in
@@ -151,12 +154,12 @@ final class Events
      *
      * @var string
      */
-    const documentNotFound = 'documentNotFound';
+    public const documentNotFound = 'documentNotFound';
 
     /**
      * The postCollectionLoad event occurs after collection is initialized (loaded).
      *
      * @var string
      */
-    const postCollectionLoad = 'postCollectionLoad';
+    public const postCollectionLoad = 'postCollectionLoad';
 }

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorException.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Hydrator;
 
 use Doctrine\ODM\MongoDB\MongoDBException;
@@ -7,7 +9,6 @@ use Doctrine\ODM\MongoDB\MongoDBException;
 /**
  * MongoDB ODM Hydrator Exception
  *
- * @since  1.0
  */
 class HydratorException extends MongoDBException
 {

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorInterface.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorInterface.php
@@ -1,21 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Hydrator;
 
 /**
  * The HydratorInterface defines methods all hydrator need to implement
  *
- * @since       1.0
  */
 interface HydratorInterface
 {
     /**
      * Hydrate array of MongoDB document data into the given document object.
      *
-     * @param object $document  The document object to hydrate the data into.
-     * @param array $data The array of document data.
-     * @param array $hints Any hints to account for during reconstitution/lookup of the document.
+     * @param object $document The document object to hydrate the data into.
+     * @param array  $data     The array of document data.
+     * @param array  $hints    Any hints to account for during reconstitution/lookup of the document.
      * @return array $values The array of hydrated values.
      */
-    public function hydrate($document, $data, array $hints = array());
+    public function hydrate($document, $data, array $hints = []);
 }

--- a/lib/Doctrine/ODM/MongoDB/Id/AbstractIdGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Id/AbstractIdGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Id;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
@@ -7,14 +9,12 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 /**
  * AbstractIdGenerator
  *
- * @since       1.0
  */
 abstract class AbstractIdGenerator
 {
     /**
      * Generates an identifier for a document.
      *
-     * @param \Doctrine\ODM\MongoDB\DocumentManager $dm
      * @param object $document
      * @return mixed
      */

--- a/lib/Doctrine/ODM/MongoDB/Id/AlnumGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Id/AlnumGenerator.php
@@ -70,15 +70,15 @@ class AlnumGenerator extends IncrementGenerator
     /** @inheritDoc */
     public function generate(DocumentManager $dm, $document)
     {
-        $id = parent::generate($dm, $document);
+        $id = (string) parent::generate($dm, $document);
         $index = $this->awkwardSafeMode ? $this->awkwardSafeChars : $this->chars;
-        $base  = strlen($index);
+        $base  = (string) strlen($index);
 
         $out = '';
         do {
             $out = $index[bcmod($id, $base)] . $out;
             $id = bcdiv($id, $base);
-        } while (bccomp($id, 0) === 1);
+        } while (bccomp($id, '0') === 1);
 
         if (is_numeric($this->pad)) {
             $out = str_pad($out, $this->pad, '0', STR_PAD_LEFT);

--- a/lib/Doctrine/ODM/MongoDB/Id/AlnumGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Id/AlnumGenerator.php
@@ -1,8 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Id;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use const STR_PAD_LEFT;
+use function bccomp;
+use function bcdiv;
+use function bcmod;
+use function intval;
+use function is_numeric;
+use function str_pad;
+use function strlen;
 
 /**
  * AlnumGenerator is responsible for generating cased alpha-numeric unique identifiers.
@@ -16,11 +26,9 @@ use Doctrine\ODM\MongoDB\DocumentManager;
  *
  * The character set used for ID generation can be explicitly set with the "chars" option (e.g. base36, etc.)
  *
- * @since       1.0
  */
 class AlnumGenerator extends IncrementGenerator
 {
-
     protected $pad = null;
 
     protected $awkwardSafeMode = false;
@@ -70,7 +78,7 @@ class AlnumGenerator extends IncrementGenerator
         do {
             $out = $index[bcmod($id, $base)] . $out;
             $id = bcdiv($id, $base);
-        } while (bccomp($id, 0) == 1);
+        } while (bccomp($id, 0) === 1);
 
         if (is_numeric($this->pad)) {
             $out = str_pad($out, $this->pad, '0', STR_PAD_LEFT);

--- a/lib/Doctrine/ODM/MongoDB/Id/AutoGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Id/AutoGenerator.php
@@ -1,19 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Id;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use MongoDB\BSON\ObjectId;
 
 /**
  * AutoGenerator generates a native ObjectId
  *
- * @since       1.0
  */
 class AutoGenerator extends AbstractIdGenerator
 {
     /** @inheritDoc */
     public function generate(DocumentManager $dm, $document)
     {
-        return new \MongoDB\BSON\ObjectId();
+        return new ObjectId();
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Id/IncrementGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Id/IncrementGenerator.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Id;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
 use MongoDB\Operation\FindOneAndUpdate;
+use function get_class;
 
 /**
  * IncrementGenerator is responsible for generating auto increment identifiers. It uses
@@ -16,7 +19,6 @@ use MongoDB\Operation\FindOneAndUpdate;
  * collection. If not specified it defaults to the name of the collection for the
  * document.
  *
- * @since       1.0
  */
 class IncrementGenerator extends AbstractIdGenerator
 {

--- a/lib/Doctrine/ODM/MongoDB/Id/UuidGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Id/UuidGenerator.php
@@ -1,13 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Id;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use function chr;
+use function hexdec;
+use function mt_rand;
+use function php_uname;
+use function preg_match;
+use function sha1;
+use function sprintf;
+use function str_replace;
+use function strlen;
+use function substr;
 
 /**
  * Generates UUIDs.
  *
- * @since       1.0
  */
 class UuidGenerator extends AbstractIdGenerator
 {
@@ -42,7 +53,7 @@ class UuidGenerator extends AbstractIdGenerator
      * Checks that a given string is a valid uuid.
      *
      * @param string $uuid The string to check.
-     * @return boolean
+     * @return bool
      */
     public function isValid($uuid)
     {
@@ -53,8 +64,8 @@ class UuidGenerator extends AbstractIdGenerator
     /**
      * Generates a new UUID
      *
-     * @param DocumentManager $dm Not used.
-     * @param object $document Not used.
+     * @param DocumentManager $dm       Not used.
+     * @param object          $document Not used.
      * @return string UUID
      */
     public function generate(DocumentManager $dm, $document)
@@ -95,18 +106,18 @@ class UuidGenerator extends AbstractIdGenerator
      * Generates a v5 UUID
      *
      * @param string $namespace The UUID to seed with
-     * @param string $salt The string to salt this new UUID with
+     * @param string $salt      The string to salt this new UUID with
      * @throws \Exception when the provided namespace is invalid
      * @return string
      */
     public function generateV5($namespace, $salt)
     {
-        if ( ! $this->isValid($namespace)) {
+        if (! $this->isValid($namespace)) {
             throw new \Exception('Provided $namespace is invalid: ' . $namespace);
         }
 
         // Get hexadecimal components of namespace
-        $nhex = str_replace(array('-', '{', '}'), '', $namespace);
+        $nhex = str_replace(['-', '{', '}'], '', $namespace);
 
         // Binary Value
         $nstr = '';

--- a/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
@@ -1,6 +1,13 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Iterator;
+
+use function current;
+use function key;
+use function next;
+use function reset;
 
 /**
  * Iterator for wrapping a Traversable and caching its results.
@@ -19,7 +26,7 @@ final class CachingIterator implements Iterator
     private $iteratorExhausted = false;
 
     /**
-     * Constructor.
+     *
      *
      * Initialize the iterator and stores the first item in the cache. This
      * effectively rewinds the Traversable and the wrapping Generator, which
@@ -27,7 +34,6 @@ final class CachingIterator implements Iterator
      * behavior of the SPL iterators and allows users to omit an explicit call
      * to rewind() before using the other methods.
      *
-     * @param \Traversable $iterator
      */
     public function __construct(\Traversable $iterator)
     {
@@ -62,11 +68,10 @@ final class CachingIterator implements Iterator
 
     /**
      * @see http://php.net/iterator.next
-     * @return void
      */
     public function next()
     {
-        if ( ! $this->iteratorExhausted) {
+        if (! $this->iteratorExhausted) {
             $this->iterator->next();
             $this->storeCurrentItem();
         }
@@ -76,7 +81,6 @@ final class CachingIterator implements Iterator
 
     /**
      * @see http://php.net/iterator.rewind
-     * @return void
      */
     public function rewind()
     {
@@ -93,7 +97,7 @@ final class CachingIterator implements Iterator
     /**
      *
      * @see http://php.net/iterator.valid
-     * @return boolean
+     * @return bool
      */
     public function valid()
     {
@@ -105,7 +109,7 @@ final class CachingIterator implements Iterator
      */
     private function exhaustIterator()
     {
-        while ( ! $this->iteratorExhausted) {
+        while (! $this->iteratorExhausted) {
             $this->next();
         }
     }

--- a/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Iterator;
 
@@ -45,7 +47,6 @@ final class HydratingIterator implements \Iterator
 
     /**
      * @see http://php.net/iterator.next
-     * @return void
      */
     public function next()
     {
@@ -54,7 +55,6 @@ final class HydratingIterator implements \Iterator
 
     /**
      * @see http://php.net/iterator.rewind
-     * @return void
      */
     public function rewind()
     {
@@ -63,7 +63,7 @@ final class HydratingIterator implements \Iterator
 
     /**
      * @see http://php.net/iterator.valid
-     * @return boolean
+     * @return bool
      */
     public function valid()
     {

--- a/lib/Doctrine/ODM/MongoDB/Iterator/Iterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/Iterator.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Iterator;
 

--- a/lib/Doctrine/ODM/MongoDB/Iterator/PrimingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/PrimingIterator.php
@@ -1,9 +1,13 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Iterator;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Query\ReferencePrimer;
+use function is_callable;
+use function iterator_to_array;
 
 final class PrimingIterator implements Iterator
 {

--- a/lib/Doctrine/ODM/MongoDB/LockException.php
+++ b/lib/Doctrine/ODM/MongoDB/LockException.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB;
 
 /**
  * LockException
  *
- * @since 1.0
  */
 class LockException extends MongoDBException
 {
@@ -34,7 +35,7 @@ class LockException extends MongoDBException
 
     public static function lockFailedVersionMissmatch($document, $expectedLockVersion, $actualLockVersion)
     {
-        return new self('The optimistic lock failed, version ' . $expectedLockVersion . ' was expected, but is actually '.$actualLockVersion, $document);
+        return new self('The optimistic lock failed, version ' . $expectedLockVersion . ' was expected, but is actually ' . $actualLockVersion, $document);
     }
 
     public static function notVersioned($documentName)
@@ -44,11 +45,11 @@ class LockException extends MongoDBException
 
     public static function invalidLockFieldType($type)
     {
-        return new self('Invalid lock field type '.$type.'. Lock field must be int.');
+        return new self('Invalid lock field type ' . $type . '. Lock field must be int.');
     }
 
     public static function invalidVersionFieldType($type)
     {
-        return new self('Invalid version field type '.$type.'. Version field must be int or date.');
+        return new self('Invalid version field type ' . $type . '. Version field must be int or date.');
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/LockMode.php
+++ b/lib/Doctrine/ODM/MongoDB/LockMode.php
@@ -1,18 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB;
 
 /**
  * Contains all MongoDB ODM LockModes
  *
- * @since       1.0
  */
 class LockMode
 {
-    const NONE = 0;
-    const OPTIMISTIC = 1;
-    const PESSIMISTIC_READ = 2;
-    const PESSIMISTIC_WRITE = 4;
+    public const NONE = 0;
+    public const OPTIMISTIC = 1;
+    public const PESSIMISTIC_READ = 2;
+    public const PESSIMISTIC_WRITE = 4;
 
-    final private function __construct() { }
+    final private function __construct()
+    {
+    }
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractDocument.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractField.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractField.php
@@ -1,15 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
+use function get_class;
+use function sprintf;
 
 abstract class AbstractField extends Annotation
 {
     public $name;
     public $type = 'string';
     public $nullable = false;
-    public $options = array();
+    public $options = [];
     public $strategy;
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractIndex.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractIndex.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 
 abstract class AbstractIndex extends Annotation
 {
-    public $keys = array();
+    public $keys = [];
     public $name;
     public $dropDups;
     public $background;
@@ -14,6 +16,6 @@ abstract class AbstractIndex extends Annotation
     public $order;
     public $unique = false;
     public $sparse = false;
-    public $options = array();
-    public $partialFilterExpression = array();
+    public $options = [];
+    public $partialFilterExpression = [];
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AlsoLoad.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AlsoLoad.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ChangeTrackingPolicy.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ChangeTrackingPolicy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DefaultDiscriminatorValue.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DefaultDiscriminatorValue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DiscriminatorField.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DiscriminatorField.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DiscriminatorMap.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DiscriminatorMap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DiscriminatorValue.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DiscriminatorValue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Document.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Document.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
@@ -12,7 +14,7 @@ final class Document extends AbstractDocument
     public $db;
     public $collection;
     public $repositoryClass;
-    public $indexes = array();
+    public $indexes = [];
     public $readOnly = false;
     public $shardKey;
     public $writeConcern;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/EmbedMany.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/EmbedMany.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/EmbedOne.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/EmbedOne.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/EmbeddedDocument.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/EmbeddedDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**
@@ -9,5 +11,5 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
  */
 final class EmbeddedDocument extends AbstractDocument
 {
-    public $indexes = array();
+    public $indexes = [];
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Field.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Field.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/HasLifecycleCallbacks.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/HasLifecycleCallbacks.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Id.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Id.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Index.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Index.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Indexes.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Indexes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Inheritance.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Inheritance.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
@@ -12,7 +14,7 @@ use Doctrine\Common\Annotations\Annotation;
 final class Inheritance extends Annotation
 {
     public $type = 'NONE';
-    public $discriminatorMap = array();
+    public $discriminatorMap = [];
     public $discriminatorField;
     public $defaultDiscriminatorValue;
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/InheritanceType.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/InheritanceType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Lock.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Lock.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/MappedSuperclass.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/MappedSuperclass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/NotSaved.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/NotSaved.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PostLoad.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PostLoad.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PostPersist.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PostPersist.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PostRemove.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PostRemove.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PostUpdate.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PostUpdate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PreFlush.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PreFlush.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PreLoad.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PreLoad.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PrePersist.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PrePersist.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PreRemove.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PreRemove.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PreUpdate.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/PreUpdate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/QueryResultDocument.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/QueryResultDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /** @Annotation */

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReadPreference.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReadPreference.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceMany.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceMany.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceOne.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ReferenceOne.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
@@ -23,8 +25,8 @@ final class ReferenceOne extends AbstractField
     public $inversedBy;
     public $mappedBy;
     public $repositoryMethod;
-    public $sort = array();
-    public $criteria = array();
+    public $sort = [];
+    public $criteria = [];
     public $limit;
     public $skip;
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ShardKey.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/ShardKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
@@ -7,7 +9,7 @@ use Doctrine\Common\Annotations\Annotation;
 /** @Annotation */
 final class ShardKey extends Annotation
 {
-    public $keys = array();
+    public $keys = [];
     public $unique;
     public $numInitialChunks;
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/UniqueIndex.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/UniqueIndex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Version.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Version.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/SimplifiedXmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/SimplifiedXmlDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping\Driver;
 
 use Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator;
@@ -7,11 +9,10 @@ use Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator;
 /**
  * XmlDriver that additionally looks for mapping information in a global file.
  *
- * @license MIT
  */
 class SimplifiedXmlDriver extends XmlDriver
 {
-    const DEFAULT_FILE_EXTENSION = '.mongodb-odm.xml';
+    public const DEFAULT_FILE_EXTENSION = '.mongodb-odm.xml';
 
     /**
      * {@inheritDoc}

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Mapping;
 
 use Doctrine\Common\Persistence\Mapping\MappingException as BaseMappingException;
@@ -7,7 +9,6 @@ use Doctrine\Common\Persistence\Mapping\MappingException as BaseMappingException
 /**
  * Class for all exceptions related to the Doctrine MongoDB ODM
  *
- * @since       1.0
  */
 class MappingException extends BaseMappingException
 {
@@ -104,7 +105,7 @@ class MappingException extends BaseMappingException
      * Throws an exception that indicates that a class used in a discriminator map does not exist.
      * An example would be an outdated (maybe renamed) classname.
      *
-     * @param string $className The class that could not be found
+     * @param string $className   The class that could not be found
      * @param string $owningClass The class that declares the discriminator map.
      * @return MappingException
      */
@@ -119,7 +120,7 @@ class MappingException extends BaseMappingException
     /**
      * Throws an exception that indicates a discriminator value does not exist in a map
      *
-     * @param string $value The discriminator value that could not be found
+     * @param string $value       The discriminator value that could not be found
      * @param string $owningClass The class that declares the discriminator map
      * @return MappingException
      */
@@ -152,7 +153,6 @@ class MappingException extends BaseMappingException
      * within the stacktrace
      *
      * @param string $document The document's name
-     * @param \ReflectionException $previousException
      * @return \Doctrine\ODM\MongoDB\Mapping\MappingException
      */
     public static function reflectionFailure($document, \ReflectionException $previousException)

--- a/lib/Doctrine/ODM/MongoDB/MongoDBException.php
+++ b/lib/Doctrine/ODM/MongoDB/MongoDBException.php
@@ -1,11 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB;
+
+use function array_slice;
+use function end;
+use function get_class;
+use function is_array;
+use function is_object;
+use function join;
+use function sprintf;
 
 /**
  * Class for all exceptions related to the Doctrine MongoDB ODM
  *
- * @since       1.0
  */
 class MongoDBException extends \Exception
 {
@@ -67,19 +76,20 @@ class MongoDBException extends \Exception
      */
     public static function invalidDocumentRepository($className)
     {
-        return new self("Invalid repository class '".$className."'. It must be a Doctrine\Common\Persistence\ObjectRepository.");
+        return new self("Invalid repository class '" . $className . "'. It must be a Doctrine\Common\Persistence\ObjectRepository.");
     }
 
     /**
-     * @param string $type
+     * @param string       $type
      * @param string|array $expected
-     * @param mixed $got
+     * @param mixed        $got
      * @return MongoDBException
      */
     public static function invalidValueForType($type, $expected, $got)
     {
         if (is_array($expected)) {
-            $expected = sprintf('%s or %s',
+            $expected = sprintf(
+                '%s or %s',
                 join(', ', array_slice($expected, 0, -1)),
                 end($expected)
             );
@@ -121,7 +131,8 @@ class MongoDBException extends \Exception
      */
     public static function failedToEnableSharding($dbName, $errorMessage)
     {
-        return new self(sprintf('Failed to enable sharding for database "%s". Error from MongoDB: %s',
+        return new self(sprintf(
+            'Failed to enable sharding for database "%s". Error from MongoDB: %s',
             $dbName,
             $errorMessage
         ));
@@ -134,7 +145,8 @@ class MongoDBException extends \Exception
      */
     public static function failedToEnsureDocumentSharding($className, $errorMessage)
     {
-        return new self(sprintf('Failed to ensure sharding for document "%s". Error from MongoDB: %s',
+        return new self(sprintf(
+            'Failed to ensure sharding for document "%s". Error from MongoDB: %s',
             $className,
             $errorMessage
         ));

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -1,17 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB;
 
 use Doctrine\Common\Collections\Collection as BaseCollection;
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionTrait;
-use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 
 /**
  * A PersistentCollection represents a collection of elements that have persistent state.
  *
- * @since 1.0
  */
 class PersistentCollection implements PersistentCollectionInterface
 {
@@ -19,8 +18,6 @@ class PersistentCollection implements PersistentCollectionInterface
 
     /**
      * @param BaseCollection $coll
-     * @param DocumentManager $dm
-     * @param UnitOfWork $uow
      */
     public function __construct(BaseCollection $coll, DocumentManager $dm, UnitOfWork $uow)
     {

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/AbstractPersistentCollectionFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/AbstractPersistentCollectionFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\PersistentCollection;
 
 use Doctrine\Common\Collections\ArrayCollection;
@@ -10,14 +12,13 @@ use Doctrine\ODM\MongoDB\PersistentCollection;
 /**
  * Abstract factory for creating persistent collection classes.
  *
- * @since 1.1
  */
 abstract class AbstractPersistentCollectionFactory implements PersistentCollectionFactory
 {
     /**
      * {@inheritdoc}
      */
-    public function create(DocumentManager $dm, array $mapping, BaseCollection $coll = null)
+    public function create(DocumentManager $dm, array $mapping, ?BaseCollection $coll = null)
     {
         if ($coll === null) {
             $coll = ! empty($mapping['collectionClass'])

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/DefaultPersistentCollectionFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/DefaultPersistentCollectionFactory.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\PersistentCollection;
 
 /**
  * Default factory class for persistent collection classes.
  *
- * @since 1.1
  */
 final class DefaultPersistentCollectionFactory extends AbstractPersistentCollectionFactory
 {
@@ -14,6 +15,6 @@ final class DefaultPersistentCollectionFactory extends AbstractPersistentCollect
      */
     protected function createCollectionClass($collectionClass)
     {
-        return new $collectionClass;
+        return new $collectionClass();
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionException.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionException.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\PersistentCollection;
 
 use Doctrine\ODM\MongoDB\MongoDBException;
+use function sprintf;
 
 /**
  * MongoDB ODM PersistentCollection Exception.
  *
- * @since 1.1
  */
 class PersistentCollectionException extends MongoDBException
 {
@@ -27,10 +29,9 @@ class PersistentCollectionException extends MongoDBException
     }
 
     /**
-     * @param string          $className
-     * @param string          $methodName
-     * @param string          $parameterName
-     * @param \Exception|null $previous
+     * @param string $className
+     * @param string $methodName
+     * @param string $parameterName
      *
      * @return self
      */
@@ -38,7 +39,7 @@ class PersistentCollectionException extends MongoDBException
         $className,
         $methodName,
         $parameterName,
-        \Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         return new self(
             sprintf(
@@ -55,11 +56,10 @@ class PersistentCollectionException extends MongoDBException
     /**
      * @param string $className
      * @param string $methodName
-     * @param \Exception|null $previous
      *
      * @return self
      */
-    public static function invalidReturnTypeHint($className, $methodName, \Exception $previous = null)
+    public static function invalidReturnTypeHint($className, $methodName, ?\Throwable $previous = null)
     {
         return new self(
             sprintf(

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\PersistentCollection;
 
 use Doctrine\Common\Collections\Collection as BaseCollection;
@@ -8,17 +10,16 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 /**
  * Interface for persistent collection classes factory.
  *
- * @since 1.1
  */
 interface PersistentCollectionFactory
 {
     /**
      * Creates specified persistent collection to work with given collection class.
      *
-     * @param DocumentManager $dm DocumentManager with which collection is associated
-     * @param array $mapping Mapping of field holding collection
-     * @param BaseCollection $coll Collection to be decorated
+     * @param DocumentManager $dm      DocumentManager with which collection is associated
+     * @param array           $mapping Mapping of field holding collection
+     * @param BaseCollection  $coll    Collection to be decorated
      * @return PersistentCollectionInterface
      */
-    public function create(DocumentManager $dm, array $mapping, BaseCollection $coll = null);
+    public function create(DocumentManager $dm, array $mapping, ?BaseCollection $coll = null);
 }

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionGenerator.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\PersistentCollection;
 
 /**
  * Interface for PersistentCollection classes generator.
  *
- * @since 1.1
  */
 interface PersistentCollectionGenerator
 {
@@ -13,7 +14,7 @@ interface PersistentCollectionGenerator
      * Loads persistent collection class.
      *
      * @param string $collectionClass FQCN of base collection class
-     * @param int $autoGenerate
+     * @param int    $autoGenerate
      * @return string FQCN of generated class
      */
     public function loadClass($collectionClass, $autoGenerate);

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionInterface.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\PersistentCollection;
 
 use Doctrine\Common\Collections\Collection;
@@ -11,14 +13,12 @@ use Doctrine\ODM\MongoDB\MongoDBException;
  * Interface for persistent collection classes.
  *
  * @internal
- * @since 1.1
  */
 interface PersistentCollectionInterface extends Collection
 {
     /**
      * Sets the document manager and unit of work (used during merge operations).
      *
-     * @param DocumentManager $dm
      */
     public function setDocumentManager(DocumentManager $dm);
 
@@ -60,14 +60,14 @@ interface PersistentCollectionInterface extends Collection
      * Gets a boolean flag indicating whether this collection is dirty which means
      * its state needs to be synchronized with the database.
      *
-     * @return boolean TRUE if the collection is dirty, FALSE otherwise.
+     * @return bool TRUE if the collection is dirty, FALSE otherwise.
      */
     public function isDirty();
 
     /**
      * Sets a boolean flag, indicating whether this collection is dirty.
      *
-     * @param boolean $dirty Whether the collection should be marked dirty or not.
+     * @param bool $dirty Whether the collection should be marked dirty or not.
      */
     public function setDirty($dirty);
 
@@ -77,7 +77,7 @@ interface PersistentCollectionInterface extends Collection
      * describes the association between the owner and the elements of the collection.
      *
      * @param object $document
-     * @param array $mapping
+     * @param array  $mapping
      */
     public function setOwner($document, array $mapping);
 
@@ -157,14 +157,14 @@ interface PersistentCollectionInterface extends Collection
     /**
      * Sets the initialized flag of the collection, forcing it into that state.
      *
-     * @param boolean $bool
+     * @param bool $bool
      */
     public function setInitialized($bool);
 
     /**
      * Checks whether this collection has been initialized.
      *
-     * @return boolean
+     * @return bool
      */
     public function isInitialized();
 

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -711,7 +711,9 @@ class DocumentPersister
                 $this->uow->setParentAssociation($embeddedDocumentObject, $mapping, $owner, $mapping['name'] . '.' . $key);
 
                 $data = $this->hydratorFactory->hydrate($embeddedDocumentObject, $embeddedDocument, $collection->getHints());
-                $id = $embeddedMetadata->identifier && $data[$embeddedMetadata->identifier] ?? null;
+                $id = $embeddedMetadata->identifier && isset($data[$embeddedMetadata->identifier])
+                    ? $data[$embeddedMetadata->identifier]
+                    : null;
 
                 if (empty($collection->getHints()[Query::HINT_READ_ONLY])) {
                     $this->uow->registerManaged($embeddedDocumentObject, $id, $data);
@@ -912,7 +914,7 @@ class DocumentPersister
      */
     private function getSortDirection($sort)
     {
-        switch (strtolower($sort)) {
+        switch (strtolower((string) $sort)) {
             case 'desc':
                 return -1;
 
@@ -1033,7 +1035,7 @@ class DocumentPersister
                 continue;
             }
 
-            $preparedQueryElements = $this->prepareQueryElement($key, $value, null, true, $isNewObj);
+            $preparedQueryElements = $this->prepareQueryElement((string) $key, $value, null, true, $isNewObj);
             foreach ($preparedQueryElements as list($preparedKey, $preparedValue)) {
                 $preparedQuery[$preparedKey] = is_array($preparedValue)
                     ? array_map('\Doctrine\ODM\MongoDB\Types\Type::convertPHPToDatabaseValue', $preparedValue)

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -711,9 +711,7 @@ class DocumentPersister
                 $this->uow->setParentAssociation($embeddedDocumentObject, $mapping, $owner, $mapping['name'] . '.' . $key);
 
                 $data = $this->hydratorFactory->hydrate($embeddedDocumentObject, $embeddedDocument, $collection->getHints());
-                $id = $embeddedMetadata->identifier && isset($data[$embeddedMetadata->identifier])
-                    ? $data[$embeddedMetadata->identifier]
-                    : null;
+                $id = $data[$embeddedMetadata->identifier] ?? null;
 
                 if (empty($collection->getHints()[Query::HINT_READ_ONLY])) {
                     $this->uow->registerManaged($embeddedDocumentObject, $id, $data);

--- a/lib/Doctrine/ODM/MongoDB/Proxy/Proxy.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Proxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Proxy;
 
 use Doctrine\Common\Proxy\Proxy as BaseProxy;
@@ -7,6 +9,7 @@ use Doctrine\Common\Proxy\Proxy as BaseProxy;
 /**
  * Document Proxy interface.
  *
- * @since       1.0
  */
-interface Proxy extends BaseProxy {}
+interface Proxy extends BaseProxy
+{
+}

--- a/lib/Doctrine/ODM/MongoDB/Query/CriteriaMerger.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/CriteriaMerger.php
@@ -1,6 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Query;
+
+use function array_filter;
+use function array_values;
+use function count;
 
 /**
  * Utility class for merging query criteria.
@@ -21,7 +27,7 @@ class CriteriaMerger
     public function merge(...$criterias)
     {
         $nonEmptyCriterias = array_values(array_filter($criterias, function (array $criteria) {
-            return !empty($criteria);
+            return ! empty($criteria);
         }));
 
         switch (count($nonEmptyCriterias)) {

--- a/lib/Doctrine/ODM/MongoDB/Query/Filter/BsonFilter.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Filter/BsonFilter.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Query\Filter;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use function array_key_exists;
 
 /**
  * The base class that user defined filters should extend.
@@ -22,7 +25,7 @@ abstract class BsonFilter
      * Parameters for the filter.
      * @var array
      */
-    protected $parameters = array();
+    protected $parameters = [];
 
     /**
      * Constructs the BsonFilter object.
@@ -37,8 +40,8 @@ abstract class BsonFilter
     /**
      * Sets a parameter that can be used by the filter.
      *
-     * @param string $name Name of the parameter.
-     * @param mixed $value Value of the parameter.
+     * @param string $name  Name of the parameter.
+     * @param mixed  $value Value of the parameter.
      *
      * @return BsonFilter The current Bson filter.
      */
@@ -61,7 +64,7 @@ abstract class BsonFilter
      */
     final public function getParameter($name)
     {
-        if ( ! array_key_exists($name, $this->parameters)) {
+        if (! array_key_exists($name, $this->parameters)) {
             throw new \InvalidArgumentException("Filter parameter '" . $name . "' is not set.");
         }
         return $this->parameters[$name];
@@ -72,7 +75,6 @@ abstract class BsonFilter
      *
      * If there is no criteria for the class, an empty array should be returned.
      *
-     * @param ClassMetadata $class
      * @return array
      */
     abstract public function addFilterCriteria(ClassMetadata $class);

--- a/lib/Doctrine/ODM/MongoDB/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/QueryExpressionVisitor.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Query;
 
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\Expr\ExpressionVisitor;
 use Doctrine\Common\Collections\Expr\Value;
+use MongoDB\BSON\Regex;
 
 /**
  * Converts Collection expressions to query expressions.
  *
- * @since  1.0
  */
 class QueryExpressionVisitor extends ExpressionVisitor
 {
@@ -20,7 +22,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
      * @todo Implement support for Comparison::CONTAINS
      * @var array
      */
-    private static $operatorMethods = array(
+    private static $operatorMethods = [
         Comparison::EQ => 'equals',
         Comparison::GT => 'gt',
         Comparison::GTE => 'gte',
@@ -30,28 +32,23 @@ class QueryExpressionVisitor extends ExpressionVisitor
         Comparison::LTE => 'lte',
         Comparison::NEQ => 'notEqual',
         Comparison::NIN => 'notIn',
-    );
+    ];
 
     /**
      * Map Criteria API composite types to query builder methods
      *
      * @var array
      */
-    private static $compositeMethods = array(
+    private static $compositeMethods = [
         CompositeExpression::TYPE_AND => 'addAnd',
         CompositeExpression::TYPE_OR => 'addOr',
-    );
+    ];
 
     /**
      * @var Builder
      */
     protected $builder;
 
-    /**
-     * Constructor.
-     *
-     * @param Builder $builder
-     */
     public function __construct(Builder $builder)
     {
         $this->builder = $builder;
@@ -61,8 +58,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
      * Converts a comparison expression into the target query language output.
      *
      * @see ExpressionVisitor::walkComparison()
-     * @param Comparison $comparison
-     * @return \Doctrine\ODM\MongoDB\Query\Expr
+     * @return Expr
      */
     public function walkComparison(Comparison $comparison)
     {
@@ -87,7 +83,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
 
                 return $this->builder->expr()
                     ->field($comparison->getField())
-                    ->equals(new \MongoDB\BSON\Regex($value, ''));
+                    ->equals(new Regex($value, ''));
 
             default:
                 throw new \RuntimeException('Unknown comparison operator: ' . $comparison->getOperator());
@@ -98,12 +94,11 @@ class QueryExpressionVisitor extends ExpressionVisitor
      * Converts a composite expression into the target query language output.
      *
      * @see ExpressionVisitor::walkCompositeExpression()
-     * @param CompositeExpression $compositeExpr
-     * @return \Doctrine\ODM\MongoDB\Query\Expr
+     * @return Expr
      */
     public function walkCompositeExpression(CompositeExpression $compositeExpr)
     {
-        if ( ! isset(self::$compositeMethods[$compositeExpr->getType()])) {
+        if (! isset(self::$compositeMethods[$compositeExpr->getType()])) {
             throw new \RuntimeException('Unknown composite ' . $compositeExpr->getType());
         }
 
@@ -121,7 +116,6 @@ class QueryExpressionVisitor extends ExpressionVisitor
      * Converts a value expression into the target query language part.
      *
      * @see ExpressionVisitor::walkValue()
-     * @param Value $value
      * @return mixed
      */
     public function walkValue(Value $value)

--- a/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
@@ -1,14 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Query;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use Doctrine\ODM\MongoDB\PersistentCollection;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Proxy\Proxy;
 use Doctrine\ODM\MongoDB\UnitOfWork;
-use MongoDB\Driver\ReadPreference;
+use function array_push;
+use function array_shift;
+use function array_values;
+use function call_user_func;
+use function count;
+use function explode;
+use function get_class;
+use function implode;
+use function is_callable;
+use function is_object;
+use function serialize;
+use function sprintf;
 
 /**
  * The ReferencePrimer is responsible for priming reference relationships.
@@ -20,7 +32,6 @@ use MongoDB\Driver\ReadPreference;
  * Priming can only be used for the owning side side of a relationship, since
  * the referenced identifiers are not immediately available on an inverse side.
  *
- * @since  1.0
  */
 class ReferencePrimer
 {
@@ -48,19 +59,19 @@ class ReferencePrimer
     /**
      * Initializes this instance with the specified document manager and unit of work.
      *
-     * @param DocumentManager $dm Document manager.
-     * @param UnitOfWork $uow Unit of work.
+     * @param DocumentManager $dm  Document manager.
+     * @param UnitOfWork      $uow Unit of work.
      */
     public function __construct(DocumentManager $dm, UnitOfWork $uow)
     {
         $this->dm = $dm;
         $this->uow = $uow;
 
-        $this->defaultPrimer = function(DocumentManager $dm, ClassMetadata $class, array $ids, array $hints) {
+        $this->defaultPrimer = function (DocumentManager $dm, ClassMetadata $class, array $ids, array $hints) {
             $qb = $dm->createQueryBuilder($class->name)
                 ->field($class->identifier)->in($ids);
 
-            if ( ! empty($hints[Query::HINT_READ_PREFERENCE])) {
+            if (! empty($hints[Query::HINT_READ_PREFERENCE])) {
                 $qb->setReadPreference($hints[Query::HINT_READ_PREFERENCE]);
             }
 
@@ -87,7 +98,7 @@ class ReferencePrimer
      * @throws \LogicException If the mapped field is a simple reference and is
      *                         missing a target document class.
      */
-    public function primeReferences(ClassMetadata $class, $documents, $fieldName, array $hints = array(), $primer = null)
+    public function primeReferences(ClassMetadata $class, $documents, $fieldName, array $hints = [], $primer = null)
     {
         $data = $this->parseDotSyntaxForPrimer($fieldName, $class, $documents);
         $mapping = $data['mapping'];
@@ -98,7 +109,7 @@ class ReferencePrimer
         /* Inverse-side references would need to be populated before we can
          * collect references to be primed. This is not supported.
          */
-        if ( ! isset($mapping['reference']) || ! $mapping['isOwningSide']) {
+        if (! isset($mapping['reference']) || ! $mapping['isOwningSide']) {
             throw new \InvalidArgumentException(sprintf('Field "%s" is not the owning side of a reference relationship in class "%s"', $fieldName, $class->name));
         }
 
@@ -114,7 +125,7 @@ class ReferencePrimer
         }
 
         $primer = $primer ?: $this->defaultPrimer;
-        $groupedIds = array();
+        $groupedIds = [];
 
         /* @var $document PersistentCollectionInterface */
         foreach ($documents as $document) {
@@ -123,7 +134,7 @@ class ReferencePrimer
             /* The field will need to be either a Proxy (reference-one) or
              * PersistentCollection (reference-many) in order to prime anything.
              */
-            if ( ! is_object($fieldValue)) {
+            if (! is_object($fieldValue)) {
                 continue;
             }
 
@@ -131,7 +142,7 @@ class ReferencePrimer
                 $refClass = $this->dm->getClassMetadata(get_class($fieldValue));
                 $id = $this->uow->getDocumentIdentifier($fieldValue);
                 $groupedIds[$refClass->name][serialize($id)] = $id;
-            } elseif ($mapping['type'] == 'many' && $fieldValue instanceof PersistentCollectionInterface) {
+            } elseif ($mapping['type'] === 'many' && $fieldValue instanceof PersistentCollectionInterface) {
                 $this->addManyReferences($fieldValue, $groupedIds);
             }
         }
@@ -159,14 +170,14 @@ class ReferencePrimer
     private function parseDotSyntaxForPrimer($fieldName, $class, $documents, $mapping = null)
     {
         // Recursion passthrough:
-        if ($mapping != null) {
-            return array('fieldName' => $fieldName, 'class' => $class, 'documents' => $documents, 'mapping' => $mapping);
+        if ($mapping !== null) {
+            return ['fieldName' => $fieldName, 'class' => $class, 'documents' => $documents, 'mapping' => $mapping];
         }
 
         // Gather mapping data:
         $e = explode('.', $fieldName);
 
-        if ( ! isset($class->fieldMappings[$e[0]])) {
+        if (! isset($class->fieldMappings[$e[0]])) {
             throw new \InvalidArgumentException(sprintf('Field %s cannot be further parsed for priming because it is unmapped.', $fieldName));
         }
 
@@ -174,16 +185,16 @@ class ReferencePrimer
         $e[0] = $mapping['fieldName'];
 
         // Case of embedded document(s) to recurse through:
-        if ( ! isset($mapping['reference'])) {
+        if (! isset($mapping['reference'])) {
             if (empty($mapping['embedded'])) {
                 throw new \InvalidArgumentException(sprintf('Field "%s" of fieldName "%s" is not an embedded document, therefore no children can be primed. Aborting. This feature does not support traversing nested referenced documents at this time.', $e[0], $fieldName));
             }
 
-            if ( ! isset($mapping['targetDocument'])) {
+            if (! isset($mapping['targetDocument'])) {
                 throw new \InvalidArgumentException(sprintf('No target document class has been specified for this embedded document. However, targetDocument mapping must be specified in order for prime to work on fieldName "%s" for mapping of field "%s".', $fieldName, $mapping['fieldName']));
             }
 
-            $childDocuments = array();
+            $childDocuments = [];
 
             foreach ($documents as $document) {
                 $fieldValue = $class->getFieldValue($document, $e[0]);
@@ -193,7 +204,7 @@ class ReferencePrimer
                         array_push($childDocuments, $elemDocument);
                     }
                 } else {
-                    array_push($childDocuments,$fieldValue);
+                    array_push($childDocuments, $fieldValue);
                 }
             }
 
@@ -201,11 +212,11 @@ class ReferencePrimer
 
             $childClass = $this->dm->getClassMetadata($mapping['targetDocument']);
 
-            if ( ! $childClass->hasField($e[0])) {
+            if (! $childClass->hasField($e[0])) {
                 throw new \InvalidArgumentException(sprintf('Field to prime must exist in embedded target document. Reference fieldName "%s" for mapping of target document class "%s".', $fieldName, $mapping['targetDocument']));
             }
 
-            $childFieldName = implode('.',$e);
+            $childFieldName = implode('.', $e);
 
             return $this->parseDotSyntaxForPrimer($childFieldName, $childClass, $childDocuments);
         }
@@ -216,7 +227,7 @@ class ReferencePrimer
                 throw new \InvalidArgumentException(sprintf('Cannot prime more than one layer deep but field "%s" is a reference and has children in fieldName "%s".', $e[0], $fieldName));
             }
 
-            return array('fieldName' => $fieldName, 'class' => $class, 'documents' => $documents, 'mapping' => $mapping);
+            return ['fieldName' => $fieldName, 'class' => $class, 'documents' => $documents, 'mapping' => $mapping];
         }
     }
 
@@ -227,8 +238,7 @@ class ReferencePrimer
      * have a target document class defined. Without that, there is no way to
      * infer the class of the referenced documents.
      *
-     * @param PersistentCollectionInterface $persistentCollection
-     * @param array                $groupedIds
+     * @param array $groupedIds
      */
     private function addManyReferences(PersistentCollectionInterface $persistentCollection, array &$groupedIds)
     {
@@ -251,7 +261,7 @@ class ReferencePrimer
 
             $document = $this->uow->tryGetById($id, $class);
 
-            if ( ! $document || ($document instanceof Proxy && ! $document->__isInitialized())) {
+            if (! $document || ($document instanceof Proxy && ! $document->__isInitialized())) {
                 $id = $class->getPHPIdentifierValue($id);
                 $groupedIds[$className][serialize($id)] = $id;
             }

--- a/lib/Doctrine/ODM/MongoDB/Repository/AbstractRepositoryFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Repository/AbstractRepositoryFactory.php
@@ -1,15 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Repository;
 
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use function ltrim;
+use function spl_object_hash;
 
 /**
  * Abstract factory for creating document repositories.
  *
- * @since 1.2
  */
 abstract class AbstractRepositoryFactory implements RepositoryFactory
 {
@@ -18,7 +21,7 @@ abstract class AbstractRepositoryFactory implements RepositoryFactory
      *
      * @var ObjectRepository[]
      */
-    private $repositoryList = array();
+    private $repositoryList = [];
 
     /**
      * {@inheritdoc}
@@ -59,8 +62,6 @@ abstract class AbstractRepositoryFactory implements RepositoryFactory
      * Instantiates requested repository.
      *
      * @param string $repositoryClassName
-     * @param DocumentManager $documentManager
-     * @param ClassMetadata $metadata
      * @return ObjectRepository
      */
     abstract protected function instantiateRepository($repositoryClassName, DocumentManager $documentManager, ClassMetadata $metadata);

--- a/lib/Doctrine/ODM/MongoDB/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Repository/DefaultRepositoryFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Repository;
 
 use Doctrine\ODM\MongoDB\DocumentManager;

--- a/lib/Doctrine/ODM/MongoDB/Repository/RepositoryFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Repository/RepositoryFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Repository;
 
 use Doctrine\Common\Persistence\ObjectRepository;

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -1,12 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use MongoDB\Driver\Exception\RuntimeException;
-use MongoDB\Driver\WriteConcern;
 use MongoDB\Model\IndexInfo;
+use function array_filter;
+use function array_unique;
+use function iterator_to_array;
+use function strpos;
 
 class SchemaManager
 {
@@ -21,10 +26,6 @@ class SchemaManager
      */
     protected $metadataFactory;
 
-    /**
-     * @param DocumentManager $dm
-     * @param ClassMetadataFactory $cmf
-     */
     public function __construct(DocumentManager $dm, ClassMetadataFactory $cmf)
     {
         $this->dm = $dm;
@@ -35,7 +36,7 @@ class SchemaManager
      * Ensure indexes are created for all documents that can be loaded with the
      * metadata factory.
      *
-     * @param integer $timeout Timeout (ms) for acknowledged index creation
+     * @param int $timeout Timeout (ms) for acknowledged index creation
      */
     public function ensureIndexes($timeout = null)
     {
@@ -53,7 +54,7 @@ class SchemaManager
      * Indexes that exist in MongoDB but not the document metadata will be
      * deleted.
      *
-     * @param integer $timeout Timeout (ms) for acknowledged index creation
+     * @param int $timeout Timeout (ms) for acknowledged index creation
      */
     public function updateIndexes($timeout = null)
     {
@@ -72,7 +73,7 @@ class SchemaManager
      * deleted.
      *
      * @param string $documentName
-     * @param integer $timeout Timeout (ms) for acknowledged index creation
+     * @param int    $timeout      Timeout (ms) for acknowledged index creation
      * @throws \InvalidArgumentException
      */
     public function updateDocumentIndexes($documentName, $timeout = null)
@@ -92,7 +93,7 @@ class SchemaManager
          */
         $self = $this;
         $mongoIndexes = array_filter($mongoIndexes, function (IndexInfo $mongoIndex) use ($documentIndexes, $self) {
-            if ('_id_' === $mongoIndex['name']) {
+            if ($mongoIndex['name'] === '_id_') {
                 return false;
             }
 
@@ -123,32 +124,32 @@ class SchemaManager
      */
     public function getDocumentIndexes($documentName)
     {
-        $visited = array();
+        $visited = [];
         return $this->doGetDocumentIndexes($documentName, $visited);
     }
 
     /**
      * @param string $documentName
-     * @param array $visited
+     * @param array  $visited
      * @return array
      */
     private function doGetDocumentIndexes($documentName, array &$visited)
     {
         if (isset($visited[$documentName])) {
-            return array();
+            return [];
         }
 
         $visited[$documentName] = true;
 
         $class = $this->dm->getClassMetadata($documentName);
         $indexes = $this->prepareIndexes($class);
-        $embeddedDocumentIndexes = array();
+        $embeddedDocumentIndexes = [];
 
         // Add indexes from embedded & referenced documents
         foreach ($class->fieldMappings as $fieldMapping) {
             if (isset($fieldMapping['embedded'])) {
                 if (isset($fieldMapping['targetDocument'])) {
-                    $possibleEmbeds = array($fieldMapping['targetDocument']);
+                    $possibleEmbeds = [$fieldMapping['targetDocument']];
                 } elseif (isset($fieldMapping['discriminatorMap'])) {
                     $possibleEmbeds = array_unique($fieldMapping['discriminatorMap']);
                 } else {
@@ -171,9 +172,9 @@ class SchemaManager
                 }
             } elseif (isset($fieldMapping['reference']) && isset($fieldMapping['targetDocument'])) {
                 foreach ($indexes as $idx => $index) {
-                    $newKeys = array();
+                    $newKeys = [];
                     foreach ($index['keys'] as $key => $v) {
-                        if ($key == $fieldMapping['name']) {
+                        if ($key === $fieldMapping['name']) {
                             $key = ClassMetadata::getReferenceFieldName($fieldMapping['storeAs'], $key);
                         }
                         $newKeys[$key] = $v;
@@ -186,20 +187,19 @@ class SchemaManager
     }
 
     /**
-     * @param ClassMetadata $class
      * @return array
      */
     private function prepareIndexes(ClassMetadata $class)
     {
         $persister = $this->dm->getUnitOfWork()->getDocumentPersister($class->name);
         $indexes = $class->getIndexes();
-        $newIndexes = array();
+        $newIndexes = [];
 
         foreach ($indexes as $index) {
-            $newIndex = array(
-                'keys' => array(),
-                'options' => $index['options']
-            );
+            $newIndex = [
+                'keys' => [],
+                'options' => $index['options'],
+            ];
             foreach ($index['keys'] as $key => $value) {
                 $key = $persister->prepareFieldName($key);
                 if ($class->hasField($key)) {
@@ -220,7 +220,7 @@ class SchemaManager
      * Ensure the given document's indexes are created.
      *
      * @param string $documentName
-     * @param integer $timeout Timeout (ms) for acknowledged index creation
+     * @param int    $timeout      Timeout (ms) for acknowledged index creation
      * @throws \InvalidArgumentException
      */
     public function ensureDocumentIndexes($documentName, $timeout = null)
@@ -235,7 +235,7 @@ class SchemaManager
                 $keys = $index['keys'];
                 $options = $index['options'];
 
-                if ( ! isset($options['timeout']) && isset($timeout)) {
+                if (! isset($options['timeout']) && isset($timeout)) {
                     $options['timeout'] = $timeout;
                 }
 
@@ -384,15 +384,15 @@ class SchemaManager
      * the unique index. Additionally, the background option is only
      * relevant to index creation and is not considered.
      *
-     * @param array|IndexInfo $mongoIndex Mongo index data.
-     * @param array $documentIndex Document index data.
+     * @param array|IndexInfo $mongoIndex    Mongo index data.
+     * @param array           $documentIndex Document index data.
      * @return bool True if the indexes are equivalent, otherwise false.
      */
     public function isMongoIndexEquivalentToDocumentIndex($mongoIndex, $documentIndex)
     {
         $documentIndexOptions = $documentIndex['options'];
 
-        if ($mongoIndex['key'] != $documentIndex['keys']) {
+        if ($mongoIndex['key'] !== $documentIndex['keys']) {
             return false;
         }
 
@@ -404,20 +404,18 @@ class SchemaManager
             return false;
         }
 
-        if ( ! empty($mongoIndex['unique']) && empty($mongoIndex['dropDups']) &&
+        if (! empty($mongoIndex['unique']) && empty($mongoIndex['dropDups']) &&
             ! empty($documentIndexOptions['unique']) && ! empty($documentIndexOptions['dropDups'])) {
-
             return false;
         }
 
-        foreach (array('bits', 'max', 'min') as $option) {
+        foreach (['bits', 'max', 'min'] as $option) {
             if (isset($mongoIndex[$option]) xor isset($documentIndexOptions[$option])) {
                 return false;
             }
 
             if (isset($mongoIndex[$option]) && isset($documentIndexOptions[$option]) &&
                 $mongoIndex[$option] !== $documentIndexOptions[$option]) {
-
                 return false;
             }
         }
@@ -428,7 +426,6 @@ class SchemaManager
 
         if (isset($mongoIndex['partialFilterExpression']) && isset($documentIndexOptions['partialFilterExpression']) &&
             $mongoIndex['partialFilterExpression'] !== $documentIndexOptions['partialFilterExpression']) {
-
             return false;
         }
 
@@ -443,10 +440,10 @@ class SchemaManager
      *
      * @throws MongoDBException
      */
-    public function ensureSharding(array $indexOptions = array())
+    public function ensureSharding(array $indexOptions = [])
     {
         foreach ($this->metadataFactory->getAllMetadata() as $class) {
-            if ($class->isMappedSuperclass || !$class->isSharded()) {
+            if ($class->isMappedSuperclass || ! $class->isSharded()) {
                 continue;
             }
 
@@ -462,10 +459,10 @@ class SchemaManager
      *
      * @throws MongoDBException
      */
-    public function ensureDocumentSharding($documentName, array $indexOptions = array())
+    public function ensureDocumentSharding($documentName, array $indexOptions = [])
     {
         $class = $this->dm->getClassMetadata($documentName);
-        if ( ! $class->isSharded()) {
+        if (! $class->isSharded()) {
             return;
         }
 
@@ -478,7 +475,7 @@ class SchemaManager
                 $done = true;
 
                 // Need to check error message because MongoDB 3.0 does not return a code for this error
-                if ($result['ok'] != 1 && strpos($result['errmsg'], 'please create an index that starts') !== false) {
+                if ($result['ok'] !== 1 && strpos($result['errmsg'], 'please create an index that starts') !== false) {
                     // The proposed key is not returned when using mongo-php-adapter with ext-mongodb.
                     // See https://github.com/mongodb/mongo-php-driver/issues/296 for details
                     $key = $result['proposedKey'] ?? $this->dm->getClassMetadata($documentName)->getShardKey()['keys'];
@@ -487,7 +484,7 @@ class SchemaManager
                     $done = false;
                 }
             } catch (RuntimeException $e) {
-                if ($e->getCode() === 20 || $e->getMessage() == 'already sharded') {
+                if ($e->getCode() === 20 || $e->getMessage() === 'already sharded') {
                     return;
                 }
 
@@ -497,7 +494,7 @@ class SchemaManager
 
         // Starting with MongoDB 3.2, this command returns code 20 when a collection is already sharded.
         // For older MongoDB versions, check the error message
-        if ($result['ok'] == 1 || (isset($result['code']) && $result['code'] == 20) || $result['errmsg'] == 'already sharded') {
+        if ($result['ok'] === 1 || (isset($result['code']) && $result['code'] === 20) || $result['errmsg'] === 'already sharded') {
             return;
         }
 
@@ -517,7 +514,7 @@ class SchemaManager
         $adminDb = $this->dm->getClient()->selectDatabase('admin');
 
         try {
-            $adminDb->command(array('enableSharding' => $dbName));
+            $adminDb->command(['enableSharding' => $dbName]);
         } catch (RuntimeException $e) {
             if ($e->getCode() !== 23 || $e->getMessage() === 'already enabled') {
                 throw MongoDBException::failedToEnableSharding($dbName, $e->getMessage());
@@ -538,10 +535,10 @@ class SchemaManager
         $adminDb = $this->dm->getClient()->selectDatabase('admin');
 
         $result = $adminDb->command(
-            array(
+            [
                 'shardCollection' => $dbName . '.' . $class->getCollection(),
-                'key'             => $shardKey['keys']
-            )
+                'key'             => $shardKey['keys'],
+            ]
         )->toArray()[0];
 
         return $result;

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -475,7 +475,7 @@ class SchemaManager
                 $done = true;
 
                 // Need to check error message because MongoDB 3.0 does not return a code for this error
-                if ($result['ok'] !== 1 && strpos($result['errmsg'], 'please create an index that starts') !== false) {
+                if (! (bool) $result['ok'] && strpos($result['errmsg'], 'please create an index that starts') !== false) {
                     // The proposed key is not returned when using mongo-php-adapter with ext-mongodb.
                     // See https://github.com/mongodb/mongo-php-driver/issues/296 for details
                     $key = $result['proposedKey'] ?? $this->dm->getClassMetadata($documentName)->getShardKey()['keys'];
@@ -484,7 +484,7 @@ class SchemaManager
                     $done = false;
                 }
             } catch (RuntimeException $e) {
-                if ($e->getCode() === 20 || $e->getMessage() === 'already sharded') {
+                if ($e->getCode() === 20 || $e->getCode() === 23 || $e->getMessage() === 'already sharded') {
                     return;
                 }
 
@@ -494,7 +494,7 @@ class SchemaManager
 
         // Starting with MongoDB 3.2, this command returns code 20 when a collection is already sharded.
         // For older MongoDB versions, check the error message
-        if ($result['ok'] === 1 || (isset($result['code']) && $result['code'] === 20) || $result['errmsg'] === 'already sharded') {
+        if ((bool) $result['ok'] || (isset($result['code']) && $result['code'] === 20) || $result['errmsg'] === 'already sharded') {
             return;
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -1,17 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command\ClearCache;
 
 use Doctrine\Common\Cache\ApcCache;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use const PHP_EOL;
 
 /**
  * Command to clear the metadata cache of the various cache drivers.
  *
- * @since   1.0
- * @version $Revision$
  */
 class MetadataCommand extends Command
 {
@@ -23,7 +24,7 @@ class MetadataCommand extends Command
         $this
         ->setName('odm:clear-cache:metadata')
         ->setDescription('Clear all metadata cache of the various cache drivers.')
-        ->setDefinition(array())
+        ->setDefinition([])
         ->setHelp(<<<EOT
 Clear all metadata cache of the various cache drivers.
 EOT
@@ -38,12 +39,12 @@ EOT
         $dm = $this->getHelper('documentManager')->getDocumentManager();
         $cacheDriver = $dm->getConfiguration()->getMetadataCacheImpl();
 
-        if ( ! $cacheDriver) {
+        if (! $cacheDriver) {
             throw new \InvalidArgumentException('No Metadata cache driver is configured on given DocumentManager.');
         }
 
         if ($cacheDriver instanceof ApcCache) {
-            throw new \LogicException("Cannot clear APC Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
+            throw new \LogicException('Cannot clear APC Cache from Console, its shared in the Webserver memory and not accessible from the CLI.');
         }
 
         $output->write('Clearing ALL Metadata cache entries' . PHP_EOL);

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php
@@ -1,16 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command;
 
+use Doctrine\ODM\MongoDB\Tools\Console\MetadataFilter;
+use Symfony\Component\Console;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console;
-use Doctrine\ODM\MongoDB\Tools\Console\MetadataFilter;
+use const PHP_EOL;
+use function count;
+use function file_exists;
+use function is_dir;
+use function is_writable;
+use function mkdir;
+use function realpath;
+use function sprintf;
 
 /**
  * Command to (re)generate the hydrator classes used by doctrine.
  *
- * @since   1.0
  */
 class GenerateHydratorsCommand extends Console\Command\Command
 {
@@ -22,16 +31,19 @@ class GenerateHydratorsCommand extends Console\Command\Command
         $this
         ->setName('odm:generate:hydrators')
         ->setDescription('Generates hydrator classes for document classes.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
-                'filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'filter',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'A string pattern used to match documents that should be processed.'
             ),
             new InputArgument(
-                'dest-path', InputArgument::OPTIONAL,
+                'dest-path',
+                InputArgument::OPTIONAL,
                 'The path to generate your hydrator classes. If none is provided, it will attempt to grab from configuration.'
             ),
-        ))
+        ])
         ->setHelp(<<<EOT
 Generates hydrator classes for document classes.
 EOT
@@ -44,7 +56,7 @@ EOT
     protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output)
     {
         $dm = $this->getHelper('documentManager')->getDocumentManager();
-        
+
         $metadatas = $dm->getMetadataFactory()->getAllMetadata();
         $metadatas = MetadataFilter::filter($metadatas, $input->getOption('filter'));
 
@@ -53,17 +65,17 @@ EOT
             $destPath = $dm->getConfiguration()->getHydratorDir();
         }
 
-        if ( ! is_dir($destPath)) {
+        if (! is_dir($destPath)) {
             mkdir($destPath, 0775, true);
         }
 
         $destPath = realpath($destPath);
 
-        if ( ! file_exists($destPath)) {
+        if (! file_exists($destPath)) {
             throw new \InvalidArgumentException(
                 sprintf("Hydrators destination directory '<info>%s</info>' does not exist.", $destPath)
             );
-        } elseif ( ! is_writable($destPath)) {
+        } elseif (! is_writable($destPath)) {
             throw new \InvalidArgumentException(
                 sprintf("Hydrators destination directory '<info>%s</info>' does not have write permissions.", $destPath)
             );

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GeneratePersistentCollectionsCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GeneratePersistentCollectionsCommand.php
@@ -1,16 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command;
 
 use Doctrine\ODM\MongoDB\Tools\Console\MetadataFilter;
+use Symfony\Component\Console;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console;
+use const PHP_EOL;
+use function count;
+use function file_exists;
+use function is_dir;
+use function is_writable;
+use function mkdir;
+use function realpath;
+use function sprintf;
 
 /**
  * Command to (re)generate the persistent collection classes used by doctrine.
  *
- * @since 1.1
  */
 class GeneratePersistentCollectionsCommand extends Console\Command\Command
 {
@@ -22,16 +31,19 @@ class GeneratePersistentCollectionsCommand extends Console\Command\Command
         $this
             ->setName('odm:generate:persistent-collections')
             ->setDescription('Generates persistent collection classes for custom collections.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption(
-                    'filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                    'filter',
+                    null,
+                    InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                     'A string pattern used to match documents that should be processed.'
                 ),
                 new InputArgument(
-                    'dest-path', InputArgument::OPTIONAL,
+                    'dest-path',
+                    InputArgument::OPTIONAL,
                     'The path to generate your proxy classes. If none is provided, it will attempt to grab from configuration.'
                 ),
-            ))
+            ])
             ->setHelp(<<<EOT
 Generates persistent collection classes for custom collections.
 EOT
@@ -53,17 +65,17 @@ EOT
             $destPath = $dm->getConfiguration()->getPersistentCollectionDir();
         }
 
-        if ( ! is_dir($destPath)) {
+        if (! is_dir($destPath)) {
             mkdir($destPath, 0775, true);
         }
 
         $destPath = realpath($destPath);
 
-        if ( ! file_exists($destPath)) {
+        if (! file_exists($destPath)) {
             throw new \InvalidArgumentException(
                 sprintf("Persistent collections destination directory '<info>%s</info>' does not exist.", $destPath)
             );
-        } elseif ( ! is_writable($destPath)) {
+        } elseif (! is_writable($destPath)) {
             throw new \InvalidArgumentException(
                 sprintf("Persistent collections destination directory '<info>%s</info>' does not have write permissions.", $destPath)
             );

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
@@ -1,17 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Tools\Console\MetadataFilter;
+use Symfony\Component\Console;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console;
-use Doctrine\ODM\MongoDB\Tools\Console\MetadataFilter;
+use const PHP_EOL;
+use function array_filter;
+use function count;
+use function file_exists;
+use function is_dir;
+use function is_writable;
+use function mkdir;
+use function realpath;
+use function sprintf;
 
 /**
  * Command to (re)generate the proxy classes used by doctrine.
  *
- * @since   1.0
  */
 class GenerateProxiesCommand extends Console\Command\Command
 {
@@ -23,16 +33,19 @@ class GenerateProxiesCommand extends Console\Command\Command
         $this
         ->setName('odm:generate:proxies')
         ->setDescription('Generates proxy classes for document classes.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
-                'filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'filter',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'A string pattern used to match documents that should be processed.'
             ),
             new InputArgument(
-                'dest-path', InputArgument::OPTIONAL,
+                'dest-path',
+                InputArgument::OPTIONAL,
                 'The path to generate your proxy classes. If none is provided, it will attempt to grab from configuration.'
             ),
-        ))
+        ])
         ->setHelp(<<<EOT
 Generates proxy classes for document classes.
 EOT
@@ -45,9 +58,9 @@ EOT
     protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output)
     {
         $dm = $this->getHelper('documentManager')->getDocumentManager();
-        
+
         $metadatas = array_filter($dm->getMetadataFactory()->getAllMetadata(), function (ClassMetadata $classMetadata) {
-            return !$classMetadata->isEmbeddedDocument && !$classMetadata->isMappedSuperclass && !$classMetadata->isQueryResultDocument;
+            return ! $classMetadata->isEmbeddedDocument && ! $classMetadata->isMappedSuperclass && ! $classMetadata->isQueryResultDocument;
         });
         $metadatas = MetadataFilter::filter($metadatas, $input->getOption('filter'));
 
@@ -56,17 +69,17 @@ EOT
             $destPath = $dm->getConfiguration()->getProxyDir();
         }
 
-        if ( ! is_dir($destPath)) {
+        if (! is_dir($destPath)) {
             mkdir($destPath, 0775, true);
         }
 
         $destPath = realpath($destPath);
 
-        if ( ! file_exists($destPath)) {
+        if (! file_exists($destPath)) {
             throw new \InvalidArgumentException(
                 sprintf("Proxies destination directory '<info>%s</info>' does not exist.", $destPath)
             );
-        } elseif ( ! is_writable($destPath)) {
+        } elseif (! is_writable($destPath)) {
             throw new \InvalidArgumentException(
                 sprintf("Proxies destination directory '<info>%s</info>' does not have write permissions.", $destPath)
             );

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
@@ -1,16 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command;
 
 use Doctrine\Common\Util\Debug;
+use Symfony\Component\Console;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console;
+use function is_numeric;
+use function json_decode;
 
 /**
  * Command to query mongodb and inspect the outputted results from your document classes.
  *
- * @since   1.0
  */
 class QueryCommand extends Console\Command\Command
 {
@@ -22,32 +25,43 @@ class QueryCommand extends Console\Command\Command
         $this
         ->setName('odm:query')
         ->setDescription('Query mongodb and inspect the outputted results from your document classes.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputArgument(
-                'class', InputArgument::REQUIRED,
+                'class',
+                InputArgument::REQUIRED,
                 'The class to query.'
             ),
             new InputArgument(
-                'query', InputArgument::REQUIRED,
+                'query',
+                InputArgument::REQUIRED,
                 'The query to execute and output the results for.'
             ),
             new InputOption(
-                'hydrate', null, InputOption::VALUE_NONE,
+                'hydrate',
+                null,
+                InputOption::VALUE_NONE,
                 'Whether or not to hydrate the results in to document objects.'
             ),
             new InputOption(
-                'skip', null, InputOption::VALUE_REQUIRED,
+                'skip',
+                null,
+                InputOption::VALUE_REQUIRED,
                 'The number of documents to skip in the cursor.'
             ),
             new InputOption(
-                'limit', null, InputOption::VALUE_REQUIRED,
+                'limit',
+                null,
+                InputOption::VALUE_REQUIRED,
                 'The number of documents to return.'
             ),
             new InputOption(
-                'depth', null, InputOption::VALUE_REQUIRED,
-                'Dumping depth of Document graph.', 7
-            )
-        ))
+                'depth',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Dumping depth of Document graph.',
+                7
+            ),
+        ])
         ->setHelp(<<<EOT
 Execute a query and output the results.
 EOT
@@ -66,12 +80,12 @@ EOT
 
         $depth = $input->getOption('depth');
 
-        if ( ! is_numeric($depth)) {
+        if (! is_numeric($depth)) {
             throw new \LogicException("Option 'depth' must contain an integer value");
         }
 
         if (($skip = $input->getOption('skip')) !== null) {
-            if ( ! is_numeric($skip)) {
+            if (! is_numeric($skip)) {
                 throw new \LogicException("Option 'skip' must contain an integer value");
             }
 
@@ -79,7 +93,7 @@ EOT
         }
 
         if (($limit = $input->getOption('limit')) !== null) {
-            if ( ! is_numeric($limit)) {
+            if (! is_numeric($limit)) {
                 throw new \LogicException("Option 'limit' must contain an integer value");
             }
 

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/AbstractCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/AbstractCommand.php
@@ -1,15 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command\Schema;
 
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\MongoDB\SchemaManager;
 use Symfony\Component\Console\Command\Command;
 
 abstract class AbstractCommand extends Command
 {
-    const DB = 'db';
-    const COLLECTION = 'collection';
-    const INDEX = 'index';
+    public const DB = 'db';
+    public const COLLECTION = 'collection';
+    public const INDEX = 'index';
 
     abstract protected function processDocumentCollection(SchemaManager $sm, $document);
 
@@ -32,7 +36,7 @@ abstract class AbstractCommand extends Command
     }
 
     /**
-     * @return \Doctrine\ODM\MongoDB\DocumentManager
+     * @return DocumentManager
      */
     protected function getDocumentManager()
     {
@@ -40,7 +44,7 @@ abstract class AbstractCommand extends Command
     }
 
     /**
-     * @return \Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory
+     * @return ClassMetadataFactory
      */
     protected function getMetadataFactory()
     {

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command\Schema;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
@@ -7,10 +9,13 @@ use Doctrine\ODM\MongoDB\SchemaManager;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function array_filter;
+use function sprintf;
+use function ucfirst;
 
 class CreateCommand extends AbstractCommand
 {
-    private $createOrder = array(self::COLLECTION, self::INDEX);
+    private $createOrder = [self::COLLECTION, self::INDEX];
 
     private $timeout;
 
@@ -53,10 +58,10 @@ class CreateCommand extends AbstractCommand
                 $output->writeln(sprintf(
                     'Created <comment>%s%s</comment> for <info>%s</info>',
                     $option,
-                    (isset($class) ? (self::INDEX === $option ? '(es)' : '') : (self::INDEX === $option ? 'es' : 's')),
+                    (isset($class) ? ($option === self::INDEX ? '(es)' : '') : ($option === self::INDEX ? 'es' : 's')),
                     ($class ?? 'all classes')
                 ));
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $output->writeln('<error>' . $e->getMessage() . '</error>');
                 $isErrored = true;
             }
@@ -99,15 +104,15 @@ class CreateCommand extends AbstractCommand
     {
         $classMetadata = $this->getMetadataFactory()->getMetadataFor($document);
 
-        if (!$classMetadata->isEmbeddedDocument && !$classMetadata->isMappedSuperclass && !$classMetadata->isQueryResultDocument) {
-            $this->getDocumentManager()->getProxyFactory()->generateProxyClasses(array($classMetadata));
+        if (! $classMetadata->isEmbeddedDocument && ! $classMetadata->isMappedSuperclass && ! $classMetadata->isQueryResultDocument) {
+            $this->getDocumentManager()->getProxyFactory()->generateProxyClasses([$classMetadata]);
         }
     }
 
     protected function processProxy(SchemaManager $sm)
     {
         $classes = array_filter($this->getMetadataFactory()->getAllMetadata(), function (ClassMetadata $classMetadata) {
-            return !$classMetadata->isEmbeddedDocument && !$classMetadata->isMappedSuperclass && !$classMetadata->isQueryResultDocument;
+            return ! $classMetadata->isEmbeddedDocument && ! $classMetadata->isMappedSuperclass && ! $classMetadata->isQueryResultDocument;
         });
 
         $this->getDocumentManager()->getProxyFactory()->generateProxyClasses($classes);

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
@@ -1,15 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command\Schema;
 
 use Doctrine\ODM\MongoDB\SchemaManager;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function array_filter;
+use function sprintf;
+use function ucfirst;
 
 class DropCommand extends AbstractCommand
 {
-    private $dropOrder = array(self::INDEX, self::COLLECTION, self::DB);
+    private $dropOrder = [self::INDEX, self::COLLECTION, self::DB];
 
     protected function configure()
     {
@@ -46,10 +51,10 @@ class DropCommand extends AbstractCommand
                 $output->writeln(sprintf(
                     'Dropped <comment>%s%s</comment> for <info>%s</info>',
                     $option,
-                    (isset($class) ? (self::INDEX === $option ? '(es)' : '') : (self::INDEX === $option ? 'es' : 's')),
+                    (isset($class) ? ($option === self::INDEX ? '(es)' : '') : ($option === self::INDEX ? 'es' : 's')),
                     ($class ?? 'all classes')
                 ));
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $output->writeln('<error>' . $e->getMessage() . '</error>');
                 $isErrored = true;
             }

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ShardCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ShardCommand.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command\Schema;
 
 use Doctrine\ODM\MongoDB\SchemaManager;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function sprintf;
 
 class ShardCommand extends AbstractCommand
 {
@@ -19,8 +22,6 @@ class ShardCommand extends AbstractCommand
     }
 
     /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
      * @return int|null|void
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -38,7 +39,7 @@ class ShardCommand extends AbstractCommand
                 $this->processIndex($sm);
                 $output->writeln('Enabled sharding for <info>all classes</info>');
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             $isErrored = true;
         }
@@ -47,7 +48,6 @@ class ShardCommand extends AbstractCommand
     }
 
     /**
-     * @param SchemaManager $sm
      * @param object $document
      */
     protected function processDocumentIndex(SchemaManager $sm, $document)
@@ -55,16 +55,12 @@ class ShardCommand extends AbstractCommand
         $sm->ensureDocumentSharding($document);
     }
 
-    /**
-     * @param SchemaManager $sm
-     */
     protected function processIndex(SchemaManager $sm)
     {
         $sm->ensureSharding();
     }
 
     /**
-     * @param SchemaManager $sm
      * @param object $document
      * @throws \BadMethodCallException
      */
@@ -74,7 +70,6 @@ class ShardCommand extends AbstractCommand
     }
 
     /**
-     * @param SchemaManager $sm
      * @throws \BadMethodCallException
      */
     protected function processCollection(SchemaManager $sm)
@@ -83,7 +78,6 @@ class ShardCommand extends AbstractCommand
     }
 
     /**
-     * @param SchemaManager $sm
      * @param object $document
      * @throws \BadMethodCallException
      */
@@ -93,7 +87,6 @@ class ShardCommand extends AbstractCommand
     }
 
     /**
-     * @param SchemaManager $sm
      * @throws \BadMethodCallException
      */
     protected function processDb(SchemaManager $sm)

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command\Schema;
 
 use Doctrine\ODM\MongoDB\SchemaManager;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function sprintf;
 
 class UpdateCommand extends AbstractCommand
 {
@@ -22,8 +25,6 @@ class UpdateCommand extends AbstractCommand
     }
 
     /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
      * @return int|null|void
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -44,7 +45,7 @@ class UpdateCommand extends AbstractCommand
                 $this->processIndex($sm);
                 $output->writeln('Updated <comment>indexes</comment> for <info>all classes</info>');
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             $isErrored = true;
         }
@@ -53,7 +54,6 @@ class UpdateCommand extends AbstractCommand
     }
 
     /**
-     * @param SchemaManager $sm
      * @param object $document
      */
     protected function processDocumentIndex(SchemaManager $sm, $document)
@@ -61,16 +61,12 @@ class UpdateCommand extends AbstractCommand
         $sm->updateDocumentIndexes($document, $this->timeout);
     }
 
-    /**
-     * @param SchemaManager $sm
-     */
     protected function processIndex(SchemaManager $sm)
     {
         $sm->updateIndexes($this->timeout);
     }
 
     /**
-     * @param SchemaManager $sm
      * @param object $document
      * @throws \BadMethodCallException
      */
@@ -80,7 +76,6 @@ class UpdateCommand extends AbstractCommand
     }
 
     /**
-     * @param SchemaManager $sm
      * @throws \BadMethodCallException
      */
     protected function processCollection(SchemaManager $sm)
@@ -89,7 +84,6 @@ class UpdateCommand extends AbstractCommand
     }
 
     /**
-     * @param SchemaManager $sm
      * @param object $document
      * @throws \BadMethodCallException
      */
@@ -99,7 +93,6 @@ class UpdateCommand extends AbstractCommand
     }
 
     /**
-     * @param SchemaManager $sm
      * @throws \BadMethodCallException
      */
     protected function processDb(SchemaManager $sm)

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ValidateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ValidateCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command\Schema;
 
 use Doctrine\Common\Cache\VoidCache;
@@ -7,6 +9,9 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use function serialize;
+use function sprintf;
+use function unserialize;
 
 class ValidateCommand extends Command
 {
@@ -18,7 +23,7 @@ class ValidateCommand extends Command
         $this
             ->setName('odm:schema:validate')
             ->setDescription('Validates if document mapping stays the same after serializing into cache.')
-            ->setDefinition(array())
+            ->setDefinition([])
             ->setHelp(<<<EOT
 Validates if document mapping stays the same after serializing into cache.
 EOT
@@ -37,9 +42,9 @@ EOT
 
         $errors = 0;
         foreach ($metadataFactory->getAllMetadata() as $meta) {
-            if ($meta != unserialize(serialize($meta))) {
+            if ($meta !== unserialize(serialize($meta))) {
                 ++$errors;
-                $output->writeln(sprintf("%s has mapping issues.", $meta->name));
+                $output->writeln(sprintf('%s has mapping issues.', $meta->name));
             }
         }
         if ($errors) {

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Helper/DocumentManagerHelper.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Helper/DocumentManagerHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tools\Console\Helper;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
@@ -8,17 +10,11 @@ use Symfony\Component\Console\Helper\Helper;
 /**
  * Symfony console component helper for accessing a DocumentManager instance.
  *
- * @since  1.0
  */
 class DocumentManagerHelper extends Helper
 {
     protected $dm;
 
-    /**
-     * Constructor.
-     *
-     * @param DocumentManager $dm
-     */
     public function __construct(DocumentManager $dm)
     {
         $this->dm = $dm;

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/MetadataFilter.php
@@ -1,18 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tools\Console;
+
+use function count;
+use function iterator_to_array;
+use function strpos;
 
 /**
  * Used by CLI Tools to restrict entity-based commands to given patterns.
  *
- * @since       1.0
  */
 class MetadataFilter extends \FilterIterator implements \Countable
 {
     /**
      * Filter Metadatas by one or more filter options.
      *
-     * @param array $metadatas
+     * @param array        $metadatas
      * @param array|string $filter
      * @return array
      */
@@ -25,10 +30,9 @@ class MetadataFilter extends \FilterIterator implements \Countable
     /**
      * @var array
      */
-    private $_filter = array();
+    private $_filter = [];
 
     /**
-     * @param \ArrayIterator $metadata
      * @param array|string $filter
      */
     public function __construct(\ArrayIterator $metadata, $filter)
@@ -42,7 +46,7 @@ class MetadataFilter extends \FilterIterator implements \Countable
      */
     public function accept()
     {
-        if (count($this->_filter) == 0) {
+        if (count($this->_filter) === 0) {
             return true;
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Tools/ResolveTargetDocumentListener.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/ResolveTargetDocumentListener.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tools;
 
 use Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use function array_replace_recursive;
+use function ltrim;
 
 /**
  * ResolveTargetDocumentListener
@@ -15,27 +19,24 @@ class ResolveTargetDocumentListener
     /**
      * @var array
      */
-    private $resolveTargetDocuments = array();
+    private $resolveTargetDocuments = [];
 
     /**
      * Add a target-document class name to resolve to a new class name.
      *
      * @param string $originalDocument
      * @param string $newDocument
-     * @param array $mapping
-     * @return void
+     * @param array  $mapping
      */
     public function addResolveTargetDocument($originalDocument, $newDocument, array $mapping)
     {
-        $mapping['targetDocument'] = ltrim($newDocument, "\\");
-        $this->resolveTargetDocuments[ltrim($originalDocument, "\\")] = $mapping;
+        $mapping['targetDocument'] = ltrim($newDocument, '\\');
+        $this->resolveTargetDocuments[ltrim($originalDocument, '\\')] = $mapping;
     }
 
     /**
      * Process event and resolve new target document names.
      *
-     * @param LoadClassMetadataEventArgs $args
-     * @return void
      */
     public function loadClassMetadata(LoadClassMetadataEventArgs $args)
     {
@@ -49,7 +50,6 @@ class ResolveTargetDocumentListener
     }
 
     /**
-     * @param ClassMetadata $classMetadata
      * @param array $mapping
      */
     private function remapAssociation(ClassMetadata $classMetadata, array $mapping)

--- a/lib/Doctrine/ODM/MongoDB/Types/BinDataByteArrayType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/BinDataByteArrayType.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
+
+use MongoDB\BSON\Binary;
 
 /**
  * The BinData type for byte array data.
@@ -8,9 +12,8 @@ namespace Doctrine\ODM\MongoDB\Types;
  * Per the BSON specification, this sub-type is deprecated in favor of the
  * generic sub-type (BinDataType class).
  *
- * @since       1.0
  */
 class BinDataByteArrayType extends BinDataType
 {
-    protected $binDataType = \MongoDB\BSON\Binary::TYPE_OLD_BINARY;
+    protected $binDataType = Binary::TYPE_OLD_BINARY;
 }

--- a/lib/Doctrine/ODM/MongoDB/Types/BinDataCustomType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/BinDataCustomType.php
@@ -1,13 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
+
+use MongoDB\BSON\Binary;
 
 /**
  * The BinData type for custom binary data.
  *
- * @since       1.0
  */
 class BinDataCustomType extends BinDataType
 {
-    protected $binDataType = \MongoDB\BSON\Binary::TYPE_USER_DEFINED;
+    protected $binDataType = Binary::TYPE_USER_DEFINED;
 }

--- a/lib/Doctrine/ODM/MongoDB/Types/BinDataFuncType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/BinDataFuncType.php
@@ -1,13 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
+
+use MongoDB\BSON\Binary;
 
 /**
  * The BinData type for function data.
  *
- * @since       1.0
  */
 class BinDataFuncType extends BinDataType
 {
-    protected $binDataType = \MongoDB\BSON\Binary::TYPE_FUNCTION;
+    protected $binDataType = Binary::TYPE_FUNCTION;
 }

--- a/lib/Doctrine/ODM/MongoDB/Types/BinDataMD5Type.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/BinDataMD5Type.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
+
+use MongoDB\BSON\Binary;
 
 /**
  * The BinData type for binary MD5 data.
@@ -8,9 +12,8 @@ namespace Doctrine\ODM\MongoDB\Types;
  * Note: This sub-type is intended to store binary MD5 data. Considering using
  * the basic string field type for storing hexadecimal MD5 strings.
  *
- * @since       1.0
  */
 class BinDataMD5Type extends BinDataType
 {
-    protected $binDataType = \MongoDB\BSON\Binary::TYPE_MD5;
+    protected $binDataType = Binary::TYPE_MD5;
 }

--- a/lib/Doctrine/ODM/MongoDB/Types/BinDataType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/BinDataType.php
@@ -1,21 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
+
+use MongoDB\BSON\Binary;
+use function sprintf;
 
 /**
  * The BinData type for generic data.
  *
- * @since       1.0
  */
 class BinDataType extends Type
 {
     /**
      * Data type for binary data
      *
-     * @var integer
+     * @var int
      * @see http://bsonspec.org/#/specification
      */
-    protected $binDataType = \MongoDB\BSON\Binary::TYPE_GENERIC;
+    protected $binDataType = Binary::TYPE_GENERIC;
 
     public function convertToDatabaseValue($value)
     {
@@ -23,12 +27,12 @@ class BinDataType extends Type
             return null;
         }
 
-        if ( ! $value instanceof \MongoDB\BSON\Binary) {
-            return new \MongoDB\BSON\Binary($value, $this->binDataType);
+        if (! $value instanceof Binary) {
+            return new Binary($value, $this->binDataType);
         }
 
         if ($value->getType() !== $this->binDataType) {
-            return new \MongoDB\BSON\Binary($value->getData(), $this->binDataType);
+            return new Binary($value->getData(), $this->binDataType);
         }
 
         return $value;
@@ -36,7 +40,7 @@ class BinDataType extends Type
 
     public function convertToPHPValue($value)
     {
-        return $value !== null ? ($value instanceof \MongoDB\BSON\Binary ? $value->getData() : $value) : null;
+        return $value !== null ? ($value instanceof Binary ? $value->getData() : $value) : null;
     }
 
     public function closureToMongo()

--- a/lib/Doctrine/ODM/MongoDB/Types/BinDataUUIDRFC4122Type.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/BinDataUUIDRFC4122Type.php
@@ -1,13 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
+
+use MongoDB\BSON\Binary;
 
 /**
  * The BinData type for binary UUID data, which follows RFC 4122.
  *
- * @since       1.0
  */
 class BinDataUUIDRFC4122Type extends BinDataType
 {
-    protected $binDataType = \MongoDB\BSON\Binary::TYPE_UUID;
+    protected $binDataType = Binary::TYPE_UUID;
 }

--- a/lib/Doctrine/ODM/MongoDB/Types/BinDataUUIDType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/BinDataUUIDType.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
+
+use MongoDB\BSON\Binary;
 
 /**
  * The BinData type for binary UUID data.
@@ -8,9 +12,8 @@ namespace Doctrine\ODM\MongoDB\Types;
  * Per the BSON specification, this sub-type is deprecated in favor of the
  * RFC 4122 UUID sub-type (BinDataUUIDRFC4122Type class).
  *
- * @since       1.0
  */
 class BinDataUUIDType extends BinDataType
 {
-    protected $binDataType = \MongoDB\BSON\Binary::TYPE_OLD_UUID;
+    protected $binDataType = Binary::TYPE_OLD_UUID;
 }

--- a/lib/Doctrine/ODM/MongoDB/Types/BooleanType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/BooleanType.php
@@ -1,22 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
 
 /**
  * The Boolean type.
  *
- * @since       1.0
  */
 class BooleanType extends Type
 {
     public function convertToDatabaseValue($value)
     {
-        return $value !== null ? (boolean) $value : null;
+        return $value !== null ? (bool) $value : null;
     }
 
     public function convertToPHPValue($value)
     {
-        return $value !== null ? (boolean) $value : null;
+        return $value !== null ? (bool) $value : null;
     }
 
     public function closureToMongo()

--- a/lib/Doctrine/ODM/MongoDB/Types/ClosureToPHP.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/ClosureToPHP.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
+
+use function sprintf;
 
 trait ClosureToPHP
 {

--- a/lib/Doctrine/ODM/MongoDB/Types/CollectionType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/CollectionType.php
@@ -1,20 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
 
 use Doctrine\ODM\MongoDB\MongoDBException;
+use function array_values;
+use function is_array;
 
 /**
  * The Collection type.
  *
- * @since       1.0
  */
 class CollectionType extends Type
 {
     public function convertToDatabaseValue($value)
     {
         if ($value !== null && ! is_array($value)) {
-            throw MongoDBException::invalidValueForType('Collection', array('array', 'null'), $value);
+            throw MongoDBException::invalidValueForType('Collection', ['array', 'null'], $value);
         }
         return $value !== null ? array_values($value) : null;
     }

--- a/lib/Doctrine/ODM/MongoDB/Types/CustomIdType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/CustomIdType.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
 
 /**
  * The Id type.
  *
- * @since       1.0
  */
 class CustomIdType extends Type
 {

--- a/lib/Doctrine/ODM/MongoDB/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/DateType.php
@@ -1,11 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
+
+use MongoDB\BSON\UTCDateTime;
+use function date_default_timezone_get;
+use function explode;
+use function get_class;
+use function gettype;
+use function is_numeric;
+use function is_scalar;
+use function is_string;
+use function sprintf;
+use function str_pad;
+use function strpos;
 
 /**
  * The Date type.
  *
- * @since       1.0
  */
 class DateType extends Type
 {
@@ -24,14 +37,14 @@ class DateType extends Type
 
         if ($value instanceof \DateTimeInterface) {
             return $value;
-        } elseif ($value instanceof \MongoDB\BSON\UTCDateTime) {
+        } elseif ($value instanceof UTCDateTime) {
             $datetime = $value->toDateTime();
             $datetime->setTimezone(new \DateTimeZone(date_default_timezone_get()));
         } elseif (is_numeric($value)) {
             $seconds = $value;
             $microseconds = 0;
 
-            if (false !== strpos($value, '.')) {
+            if (strpos($value, '.') !== false) {
                 list($seconds, $microseconds) = explode('.', $value);
                 $microseconds = str_pad($microseconds, 6, '0'); // ensure microseconds
             }
@@ -40,13 +53,13 @@ class DateType extends Type
         } elseif (is_string($value)) {
             try {
                 $datetime = new \DateTime($value);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $exception = $e;
             }
         }
 
         if ($datetime === false) {
-            throw new \InvalidArgumentException(sprintf('Could not convert %s to a date value', is_scalar($value) ? '"'.$value.'"' : gettype($value)), 0, $exception);
+            throw new \InvalidArgumentException(sprintf('Could not convert %s to a date value', is_scalar($value) ? '"' . $value . '"' : gettype($value)), 0, $exception);
         }
 
         return $datetime;
@@ -65,13 +78,13 @@ class DateType extends Type
 
     public function convertToDatabaseValue($value)
     {
-        if ($value === null || $value instanceof \MongoDB\BSON\UTCDateTime) {
+        if ($value === null || $value instanceof UTCDateTime) {
             return $value;
         }
 
         $datetime = static::getDateTime($value);
 
-        return new \MongoDB\BSON\UTCDateTime((int) $datetime->format('Uv'));
+        return new UTCDateTime((int) $datetime->format('Uv'));
     }
 
     public function convertToPHPValue($value)
@@ -85,11 +98,11 @@ class DateType extends Type
 
     public function closureToMongo()
     {
-        return 'if ($value === null || $value instanceof \MongoDB\BSON\UTCDateTime) { $return = $value; } else { $datetime = \\'.get_class($this).'::getDateTime($value); $return = new \MongoDB\BSON\UTCDateTime((int) $datetime->format(\'Uv\')); }';
+        return 'if ($value === null || $value instanceof \MongoDB\BSON\UTCDateTime) { $return = $value; } else { $datetime = \\' . get_class($this) . '::getDateTime($value); $return = new \MongoDB\BSON\UTCDateTime((int) $datetime->format(\'Uv\')); }';
     }
 
     public function closureToPHP()
     {
-        return 'if ($value === null) { $return = null; } else { $return = \\'.get_class($this).'::getDateTime($value); }';
+        return 'if ($value === null) { $return = null; } else { $return = \\' . get_class($this) . '::getDateTime($value); }';
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/DateType.php
@@ -42,6 +42,7 @@ class DateType extends Type
             $datetime->setTimezone(new \DateTimeZone(date_default_timezone_get()));
         } elseif (is_numeric($value)) {
             $seconds = $value;
+            $value = (string) $value;
             $microseconds = 0;
 
             if (strpos($value, '.') !== false) {
@@ -49,7 +50,7 @@ class DateType extends Type
                 $microseconds = str_pad($microseconds, 6, '0'); // ensure microseconds
             }
 
-            $datetime = static::craftDateTime($seconds, $microseconds);
+            $datetime = static::craftDateTime((int) $seconds, $microseconds);
         } elseif (is_string($value)) {
             try {
                 $datetime = new \DateTime($value);
@@ -65,7 +66,8 @@ class DateType extends Type
         return $datetime;
     }
 
-    private static function craftDateTime($seconds, $microseconds = 0)
+    // @todo fix typing for $microseconds
+    private static function craftDateTime(int $seconds, $microseconds = 0)
     {
         $datetime = new \DateTime();
         $datetime->setTimestamp($seconds);

--- a/lib/Doctrine/ODM/MongoDB/Types/FileType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/FileType.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
 
 /**
  * The File type.
  *
- * @since       1.0
  */
 class FileType extends Type
 {

--- a/lib/Doctrine/ODM/MongoDB/Types/FloatType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/FloatType.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
 
 /**
  * The Float type.
  *
- * @since       1.0
  */
 class FloatType extends Type
 {

--- a/lib/Doctrine/ODM/MongoDB/Types/HashType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/HashType.php
@@ -1,20 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
 
 use Doctrine\ODM\MongoDB\MongoDBException;
+use function is_array;
 
 /**
  * The Hash type.
  *
- * @since       1.0
  */
 class HashType extends Type
 {
     public function convertToDatabaseValue($value)
     {
         if ($value !== null && ! is_array($value)) {
-            throw MongoDBException::invalidValueForType('Hash', array('array', 'null'), $value);
+            throw MongoDBException::invalidValueForType('Hash', ['array', 'null'], $value);
         }
         return $value !== null ? (object) $value : null;
     }

--- a/lib/Doctrine/ODM/MongoDB/Types/IdType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/IdType.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
 
+use MongoDB\BSON\ObjectId;
 use MongoDB\Driver\Exception\InvalidArgumentException;
 
 /**
  * The Id type.
  *
- * @since       1.0
  */
 class IdType extends Type
 {
@@ -16,11 +18,11 @@ class IdType extends Type
         if ($value === null) {
             return null;
         }
-        if ( ! $value instanceof \MongoDB\BSON\ObjectId) {
+        if (! $value instanceof ObjectId) {
             try {
-                $value = new \MongoDB\BSON\ObjectId($value);
+                $value = new ObjectId($value);
             } catch (InvalidArgumentException $e) {
-                $value = new \MongoDB\BSON\ObjectId();
+                $value = new ObjectId();
             }
         }
         return $value;
@@ -28,7 +30,7 @@ class IdType extends Type
 
     public function convertToPHPValue($value)
     {
-        return $value instanceof \MongoDB\BSON\ObjectId ? (string) $value : $value;
+        return $value instanceof ObjectId ? (string) $value : $value;
     }
 
     public function closureToMongo()

--- a/lib/Doctrine/ODM/MongoDB/Types/IdType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/IdType.php
@@ -20,7 +20,7 @@ class IdType extends Type
         }
         if (! $value instanceof ObjectId) {
             try {
-                $value = new ObjectId($value);
+                $value = new ObjectId((string) $value);
             } catch (InvalidArgumentException $e) {
                 $value = new ObjectId();
             }

--- a/lib/Doctrine/ODM/MongoDB/Types/IntIdType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/IntIdType.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
 
 /**
  * The Integer Id type.
  *
- * @since       1.0
  */
 class IntIdType extends IntType
 {

--- a/lib/Doctrine/ODM/MongoDB/Types/IntType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/IntType.php
@@ -1,22 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
 
 /**
  * The Int type.
  *
- * @since       1.0
  */
 class IntType extends Type
 {
     public function convertToDatabaseValue($value)
     {
-        return $value !== null ? (integer) $value : null;
+        return $value !== null ? (int) $value : null;
     }
 
     public function convertToPHPValue($value)
     {
-        return $value !== null ? (integer) $value : null;
+        return $value !== null ? (int) $value : null;
     }
 
     public function closureToMongo()

--- a/lib/Doctrine/ODM/MongoDB/Types/KeyType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/KeyType.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
+
+use MongoDB\BSON\MaxKey;
+use MongoDB\BSON\MinKey;
 
 /**
  * The Key type.
  *
- * @since       1.0
  */
 class KeyType extends Type
 {
@@ -14,7 +18,7 @@ class KeyType extends Type
         if ($value === null) {
             return null;
         }
-        return $value ? new \MongoDB\BSON\MaxKey : new \MongoDB\BSON\MinKey;
+        return $value ? new MaxKey() : new MinKey();
     }
 
     public function convertToPHPValue($value)
@@ -22,6 +26,6 @@ class KeyType extends Type
         if ($value === null) {
             return null;
         }
-        return $value instanceof \MongoDB\BSON\MaxKey ? 1 : 0;
+        return $value instanceof MaxKey ? 1 : 0;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Types/ObjectIdType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/ObjectIdType.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
+
+use MongoDB\BSON\ObjectId;
 
 /**
  * The ObjectId type.
  *
- * @since       1.0
  */
 class ObjectIdType extends Type
 {
@@ -14,8 +17,8 @@ class ObjectIdType extends Type
         if ($value === null) {
             return null;
         }
-        if ( ! $value instanceof \MongoDB\BSON\ObjectId) {
-            $value = new \MongoDB\BSON\ObjectId($value);
+        if (! $value instanceof ObjectId) {
+            $value = new ObjectId($value);
         }
         return $value;
     }

--- a/lib/Doctrine/ODM/MongoDB/Types/RawType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/RawType.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
 
 /**
  * Raw data type.
  *
- * @since       1.0
  */
 class RawType extends Type
 {

--- a/lib/Doctrine/ODM/MongoDB/Types/StringType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/StringType.php
@@ -1,17 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
+
+use MongoDB\BSON\Regex;
 
 /**
  * The String type.
  *
- * @since       1.0
  */
 class StringType extends Type
 {
     public function convertToDatabaseValue($value)
     {
-        return ($value === null || $value instanceof \MongoDB\BSON\Regex) ? $value : (string) $value;
+        return ($value === null || $value instanceof Regex) ? $value : (string) $value;
     }
 
     public function convertToPHPValue($value)

--- a/lib/Doctrine/ODM/MongoDB/Types/TimestampType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/TimestampType.php
@@ -1,13 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
 
 use MongoDB\BSON\Timestamp;
+use function explode;
+use function substr;
 
 /**
  * The Timestamp type.
  *
- * @since       1.0
  */
 class TimestampType extends Type
 {
@@ -26,7 +29,6 @@ class TimestampType extends Type
     }
 
     /**
-     * @param Timestamp $timestamp
      * @return int
      */
     private function extractSeconds(Timestamp $timestamp)

--- a/lib/Doctrine/ODM/MongoDB/Types/Type.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/Type.php
@@ -1,46 +1,55 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Types;
 
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Types;
+use MongoDB\BSON\ObjectId;
+use function end;
+use function explode;
+use function get_class;
+use function gettype;
+use function is_object;
+use function sprintf;
+use function str_replace;
 
 /**
  * The Type interface.
  *
- * @since       1.0
  */
 abstract class Type
 {
-    const ID = 'id';
-    const INTID = 'int_id';
-    const CUSTOMID = 'custom_id';
-    const BOOL = 'bool';
-    const BOOLEAN = 'boolean';
-    const INT = 'int';
-    const INTEGER = 'integer';
-    const FLOAT = 'float';
-    const STRING = 'string';
-    const DATE = 'date';
-    const KEY = 'key';
-    const TIMESTAMP = 'timestamp';
-    const BINDATA = 'bin';
-    const BINDATAFUNC = 'bin_func';
-    const BINDATABYTEARRAY = 'bin_bytearray';
-    const BINDATAUUID = 'bin_uuid';
-    const BINDATAUUIDRFC4122 = 'bin_uuid_rfc4122';
-    const BINDATAMD5 = 'bin_md5';
-    const BINDATACUSTOM = 'bin_custom';
-    const HASH = 'hash';
-    const COLLECTION = 'collection';
-    const OBJECTID = 'object_id';
-    const RAW = 'raw';
+    public const ID = 'id';
+    public const INTID = 'int_id';
+    public const CUSTOMID = 'custom_id';
+    public const BOOL = 'bool';
+    public const BOOLEAN = 'boolean';
+    public const INT = 'int';
+    public const INTEGER = 'integer';
+    public const FLOAT = 'float';
+    public const STRING = 'string';
+    public const DATE = 'date';
+    public const KEY = 'key';
+    public const TIMESTAMP = 'timestamp';
+    public const BINDATA = 'bin';
+    public const BINDATAFUNC = 'bin_func';
+    public const BINDATABYTEARRAY = 'bin_bytearray';
+    public const BINDATAUUID = 'bin_uuid';
+    public const BINDATAUUIDRFC4122 = 'bin_uuid_rfc4122';
+    public const BINDATAMD5 = 'bin_md5';
+    public const BINDATACUSTOM = 'bin_custom';
+    public const HASH = 'hash';
+    public const COLLECTION = 'collection';
+    public const OBJECTID = 'object_id';
+    public const RAW = 'raw';
 
     /** Map of already instantiated type objects. One instance per type (flyweight). */
-    private static $typeObjects = array();
+    private static $typeObjects = [];
 
     /** The map of supported doctrine mapping types. */
-    private static $typesMap = array(
+    private static $typesMap = [
         self::ID => Types\IdType::class,
         self::INTID => Types\IntIdType::class,
         self::CUSTOMID => Types\CustomIdType::class,
@@ -64,10 +73,12 @@ abstract class Type
         self::COLLECTION => Types\CollectionType::class,
         self::OBJECTID => Types\ObjectIdType::class,
         self::RAW => Types\RawType::class,
-    );
+    ];
 
     /* Prevent instantiation and force use of the factory method. */
-    final private function __construct() {}
+    final private function __construct()
+    {
+    }
 
     /**
      * Converts a value from its PHP representation to its database representation
@@ -106,7 +117,7 @@ abstract class Type
     /**
      * Register a new type in the type map.
      *
-     * @param string $name The name of the type.
+     * @param string $name  The name of the type.
      * @param string $class The class name.
      */
     public static function registerType($name, $class)
@@ -123,12 +134,12 @@ abstract class Type
      */
     public static function getType($type)
     {
-        if ( ! isset(self::$typesMap[$type])) {
+        if (! isset(self::$typesMap[$type])) {
             throw new \InvalidArgumentException(sprintf('Invalid type specified "%s".', $type));
         }
-        if ( ! isset(self::$typeObjects[$type])) {
+        if (! isset(self::$typeObjects[$type])) {
             $className = self::$typesMap[$type];
-            self::$typeObjects[$type] = new $className;
+            self::$typeObjects[$type] = new $className();
         }
         return self::$typeObjects[$type];
     }
@@ -145,7 +156,7 @@ abstract class Type
         if (is_object($variable)) {
             if ($variable instanceof \DateTimeInterface) {
                 return self::getType('date');
-            } elseif ($variable instanceof \MongoDB\BSON\ObjectId) {
+            } elseif ($variable instanceof ObjectId) {
                 return self::getType('id');
             }
         } else {
@@ -171,7 +182,7 @@ abstract class Type
      * Adds a custom type to the type map.
      *
      * @static
-     * @param string $name Name of the type. This should correspond to what getName() returns.
+     * @param string $name      Name of the type. This should correspond to what getName() returns.
      * @param string $className The class name of the custom type.
      * @throws MappingException
      */
@@ -189,7 +200,7 @@ abstract class Type
      *
      * @static
      * @param string $name Name of the type
-     * @return boolean TRUE if type is supported; FALSE otherwise
+     * @return bool TRUE if type is supported; FALSE otherwise
      */
     public static function hasType($name)
     {
@@ -206,7 +217,7 @@ abstract class Type
      */
     public static function overrideType($name, $className)
     {
-        if ( ! isset(self::$typesMap[$name])) {
+        if (! isset(self::$typesMap[$name])) {
             throw MappingException::typeNotFound($name);
         }
 

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1022,7 +1022,7 @@ class UnitOfWork implements PropertyChangedListener
                 ));
             }
 
-            if ($class->generatorType === ClassMetadata::GENERATOR_TYPE_AUTO && $idValue !== null && ! preg_match('#^[0-9a-f]{24}$#', $idValue)) {
+            if ($class->generatorType === ClassMetadata::GENERATOR_TYPE_AUTO && $idValue !== null && ! preg_match('#^[0-9a-f]{24}$#', (string) $idValue)) {
                 throw new \InvalidArgumentException(sprintf(
                     '%s uses AUTO identifier generation strategy but provided identifier is not a valid ObjectId.',
                     get_class($document)

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -16,6 +16,7 @@ use Doctrine\ODM\MongoDB\Persisters\CollectionPersister;
 use Doctrine\ODM\MongoDB\Persisters\PersistenceBuilder;
 use Doctrine\ODM\MongoDB\Proxy\Proxy;
 use Doctrine\ODM\MongoDB\Query\Query;
+use Doctrine\ODM\MongoDB\Types\DateType;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 use Doctrine\ODM\MongoDB\Utility\LifecycleEventManager;
@@ -735,11 +736,15 @@ class UnitOfWork implements PropertyChangedListener
 
                 // skip equivalent date values
                 if (isset($class->fieldMappings[$propName]['type']) && $class->fieldMappings[$propName]['type'] === 'date') {
+                    /** @var DateType $dateType */
                     $dateType = Type::getType('date');
                     $dbOrgValue = $dateType->convertToDatabaseValue($orgValue);
                     $dbActualValue = $dateType->convertToDatabaseValue($actualValue);
 
-                    if ($dbOrgValue instanceof UTCDateTime && $dbActualValue instanceof UTCDateTime && $dbOrgValue === $dbActualValue) {
+                    $orgTimestamp = $dbOrgValue instanceof UTCDateTime ? $dbOrgValue->toDateTime()->getTimestamp() : null;
+                    $actualTimestamp = $dbActualValue instanceof UTCDateTime ? $dbActualValue->toDateTime()->getTimestamp() : null;
+
+                    if ($orgTimestamp === $actualTimestamp) {
                         continue;
                     }
                 }

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB;
 
 use Doctrine\Common\Collections\ArrayCollection;
@@ -10,45 +12,57 @@ use Doctrine\Common\PropertyChangedListener;
 use Doctrine\ODM\MongoDB\Hydrator\HydratorFactory;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
+use Doctrine\ODM\MongoDB\Persisters\CollectionPersister;
 use Doctrine\ODM\MongoDB\Persisters\PersistenceBuilder;
 use Doctrine\ODM\MongoDB\Proxy\Proxy;
 use Doctrine\ODM\MongoDB\Query\Query;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 use Doctrine\ODM\MongoDB\Utility\LifecycleEventManager;
+use MongoDB\BSON\UTCDateTime;
+use function array_filter;
+use function count;
+use function get_class;
+use function in_array;
+use function is_array;
+use function is_object;
+use function method_exists;
+use function preg_match;
+use function serialize;
+use function spl_object_hash;
+use function sprintf;
 
 /**
  * The UnitOfWork is responsible for tracking changes to objects during an
  * "object-level" transaction and for writing out changes to the database
  * in the correct order.
  *
- * @since       1.0
  */
 class UnitOfWork implements PropertyChangedListener
 {
     /**
      * A document is in MANAGED state when its persistence is managed by a DocumentManager.
      */
-    const STATE_MANAGED = 1;
+    public const STATE_MANAGED = 1;
 
     /**
      * A document is new if it has just been instantiated (i.e. using the "new" operator)
      * and is not (yet) managed by a DocumentManager.
      */
-    const STATE_NEW = 2;
+    public const STATE_NEW = 2;
 
     /**
      * A detached document is an instance with a persistent identity that is not
      * (or no longer) associated with a DocumentManager (and a UnitOfWork).
      */
-    const STATE_DETACHED = 3;
+    public const STATE_DETACHED = 3;
 
     /**
      * A removed document instance is an instance with a persistent identity,
      * associated with a DocumentManager, whose persistent state has been
      * deleted (or is scheduled for deletion).
      */
-    const STATE_REMOVED = 4;
+    public const STATE_REMOVED = 4;
 
     /**
      * The identity map holds references to all managed documents.
@@ -64,7 +78,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $identityMap = array();
+    private $identityMap = [];
 
     /**
      * Map of all identifiers of managed documents.
@@ -72,7 +86,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $documentIdentifiers = array();
+    private $documentIdentifiers = [];
 
     /**
      * Map of the original document data of managed documents.
@@ -84,7 +98,7 @@ class UnitOfWork implements PropertyChangedListener
      *           A value will only really be copied if the value in the document is modified
      *           by the user.
      */
-    private $originalDocumentData = array();
+    private $originalDocumentData = [];
 
     /**
      * Map of document changes. Keys are object ids (spl_object_hash).
@@ -92,7 +106,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $documentChangeSets = array();
+    private $documentChangeSets = [];
 
     /**
      * The (cached) states of any known documents.
@@ -100,7 +114,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $documentStates = array();
+    private $documentStates = [];
 
     /**
      * Map of documents that are scheduled for dirty checking at commit time.
@@ -112,56 +126,56 @@ class UnitOfWork implements PropertyChangedListener
      * @var array
      * @todo rename: scheduledForSynchronization
      */
-    private $scheduledForDirtyCheck = array();
+    private $scheduledForDirtyCheck = [];
 
     /**
      * A list of all pending document insertions.
      *
      * @var array
      */
-    private $documentInsertions = array();
+    private $documentInsertions = [];
 
     /**
      * A list of all pending document updates.
      *
      * @var array
      */
-    private $documentUpdates = array();
+    private $documentUpdates = [];
 
     /**
      * A list of all pending document upserts.
      *
      * @var array
      */
-    private $documentUpserts = array();
+    private $documentUpserts = [];
 
     /**
      * A list of all pending document deletions.
      *
      * @var array
      */
-    private $documentDeletions = array();
+    private $documentDeletions = [];
 
     /**
      * All pending collection deletions.
      *
      * @var array
      */
-    private $collectionDeletions = array();
+    private $collectionDeletions = [];
 
     /**
      * All pending collection updates.
      *
      * @var array
      */
-    private $collectionUpdates = array();
+    private $collectionUpdates = [];
 
     /**
      * A list of documents related to collections scheduled for update or deletion
      *
      * @var array
      */
-    private $hasScheduledCollections = array();
+    private $hasScheduledCollections = [];
 
     /**
      * List of collections visited during changeset calculation on a commit-phase of a UnitOfWork.
@@ -170,7 +184,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $visitedCollections = array();
+    private $visitedCollections = [];
 
     /**
      * The DocumentManager that "owns" this UnitOfWork instance.
@@ -191,7 +205,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $orphanRemovals = array();
+    private $orphanRemovals = [];
 
     /**
      * The HydratorFactory used for hydrating array Mongo documents to Doctrine object documents.
@@ -205,7 +219,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $persisters = array();
+    private $persisters = [];
 
     /**
      * The collection persister instance used to persist changes to collections.
@@ -226,7 +240,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $parentAssociations = array();
+    private $parentAssociations = [];
 
     /**
      * @var LifecycleEventManager
@@ -240,7 +254,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $embeddedDocumentsRegistry = array();
+    private $embeddedDocumentsRegistry = [];
 
     /**
      * @var int
@@ -250,9 +264,6 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Initializes a new UnitOfWork instance, bound to the given DocumentManager.
      *
-     * @param DocumentManager $dm
-     * @param EventManager $evm
-     * @param HydratorFactory $hydratorFactory
      */
     public function __construct(DocumentManager $dm, EventManager $evm, HydratorFactory $hydratorFactory)
     {
@@ -270,7 +281,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function getPersistenceBuilder()
     {
-        if ( ! $this->persistenceBuilder) {
+        if (! $this->persistenceBuilder) {
             $this->persistenceBuilder = new PersistenceBuilder($this->dm, $this);
         }
         return $this->persistenceBuilder;
@@ -280,7 +291,7 @@ class UnitOfWork implements PropertyChangedListener
      * Sets the parent association for a given embedded document.
      *
      * @param object $document
-     * @param array $mapping
+     * @param array  $mapping
      * @param object $parent
      * @param string $propertyPath
      */
@@ -288,7 +299,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         $oid = spl_object_hash($document);
         $this->embeddedDocumentsRegistry[$oid] = $document;
-        $this->parentAssociations[$oid] = array($mapping, $parent, $propertyPath);
+        $this->parentAssociations[$oid] = [$mapping, $parent, $propertyPath];
     }
 
     /**
@@ -316,7 +327,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function getDocumentPersister($documentName)
     {
-        if ( ! isset($this->persisters[$documentName])) {
+        if (! isset($this->persisters[$documentName])) {
             $class = $this->dm->getClassMetadata($documentName);
             $pb = $this->getPersistenceBuilder();
             $this->persisters[$documentName] = new Persisters\DocumentPersister($pb, $this->dm, $this->evm, $this, $this->hydratorFactory, $class);
@@ -327,11 +338,11 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Get the collection persister instance.
      *
-     * @return \Doctrine\ODM\MongoDB\Persisters\CollectionPersister
+     * @return CollectionPersister
      */
     public function getCollectionPersister()
     {
-        if ( ! isset($this->collectionPersister)) {
+        if (! isset($this->collectionPersister)) {
             $pb = $this->getPersistenceBuilder();
             $this->collectionPersister = new Persisters\CollectionPersister($this->dm, $pb, $this);
         }
@@ -342,7 +353,6 @@ class UnitOfWork implements PropertyChangedListener
      * Set the document persister instance to use for the given document name
      *
      * @param string $documentName
-     * @param Persisters\DocumentPersister $persister
      */
     public function setDocumentPersister($documentName, Persisters\DocumentPersister $persister)
     {
@@ -362,7 +372,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param array $options Array of options to be used with batchInsert(), update() and remove()
      */
-    public function commit(array $options = array())
+    public function commit(array $options = [])
     {
         // Raise preFlush
         if ($this->evm->hasListeners(Events::preFlush)) {
@@ -372,7 +382,7 @@ class UnitOfWork implements PropertyChangedListener
         // Compute changes done since last commit.
         $this->computeChangeSets();
 
-        if ( ! ($this->documentInsertions ||
+        if (! ($this->documentInsertions ||
             $this->documentUpserts ||
             $this->documentDeletions ||
             $this->documentUpdates ||
@@ -435,7 +445,7 @@ class UnitOfWork implements PropertyChangedListener
             $this->visitedCollections =
             $this->scheduledForDirtyCheck =
             $this->orphanRemovals =
-            $this->hasScheduledCollections = array();
+            $this->hasScheduledCollections = [];
         } finally {
             $this->commitsInProgress--;
         }
@@ -444,17 +454,17 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Groups a list of scheduled documents by their class.
      *
-     * @param array $documents Scheduled documents (e.g. $this->documentInsertions)
-     * @param bool $includeEmbedded
+     * @param array $documents       Scheduled documents (e.g. $this->documentInsertions)
+     * @param bool  $includeEmbedded
      * @return array Tuples of ClassMetadata and a corresponding array of objects
      */
     private function getClassesForCommitAction($documents, $includeEmbedded = false)
     {
         if (empty($documents)) {
-            return array();
+            return [];
         }
-        $divided = array();
-        $embeds = array();
+        $divided = [];
+        $embeds = [];
         foreach ($documents as $oid => $d) {
             $className = get_class($d);
             if (isset($embeds[$className])) {
@@ -470,7 +480,7 @@ class UnitOfWork implements PropertyChangedListener
                 continue;
             }
             if (empty($divided[$class->name])) {
-                $divided[$class->name] = array($class, array($oid => $d));
+                $divided[$class->name] = [$class, [$oid => $d]];
             } else {
                 $divided[$class->name][1][$oid] = $d;
             }
@@ -487,7 +497,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         foreach ($this->documentInsertions as $document) {
             $class = $this->dm->getClassMetadata(get_class($document));
-            if ( ! $class->isEmbeddedDocument) {
+            if (! $class->isEmbeddedDocument) {
                 $this->computeChangeSet($class, $document);
             }
         }
@@ -502,7 +512,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         foreach ($this->documentUpserts as $document) {
             $class = $this->dm->getClassMetadata(get_class($document));
-            if ( ! $class->isEmbeddedDocument) {
+            if (! $class->isEmbeddedDocument) {
                 $this->computeChangeSet($class, $document);
             }
         }
@@ -518,7 +528,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         $oid = spl_object_hash($document);
 
-        return $this->documentChangeSets[$oid] ?? array();
+        return $this->documentChangeSets[$oid] ?? [];
     }
 
     /**
@@ -526,7 +536,7 @@ class UnitOfWork implements PropertyChangedListener
      * Sets the changeset for a document.
      *
      * @param object $document
-     * @param array $changeset
+     * @param array  $changeset
      */
     public function setDocumentChangeSet($document, $changeset)
     {
@@ -542,7 +552,7 @@ class UnitOfWork implements PropertyChangedListener
     public function getDocumentActualData($document)
     {
         $class = $this->dm->getClassMetadata(get_class($document));
-        $actualData = array();
+        $actualData = [];
         foreach ($class->reflFields as $name => $refProp) {
             $mapping = $class->fieldMappings[$name];
             // skip not saved fields
@@ -553,14 +563,14 @@ class UnitOfWork implements PropertyChangedListener
             if ((isset($mapping['association']) && $mapping['type'] === 'many')
                 && $value !== null && ! ($value instanceof PersistentCollectionInterface)) {
                 // If $actualData[$name] is not a Collection then use an ArrayCollection.
-                if ( ! $value instanceof Collection) {
+                if (! $value instanceof Collection) {
                     $value = new ArrayCollection($value);
                 }
 
                 // Inject PersistentCollection
                 $coll = $this->dm->getConfiguration()->getPersistentCollectionFactory()->create($this->dm, $mapping, $value);
                 $coll->setOwner($document, $mapping);
-                $coll->setDirty( ! $value->isEmpty());
+                $coll->setDirty(! $value->isEmpty());
                 $class->reflFields[$name]->setValue($document, $coll);
                 $actualData[$name] = $coll;
             } else {
@@ -591,18 +601,18 @@ class UnitOfWork implements PropertyChangedListener
      * and any changes to its properties are detected, then a reference to the document is stored
      * there to mark it for an update.
      *
-     * @param ClassMetadata $class The class descriptor of the document.
-     * @param object $document The document for which to compute the changes.
+     * @param ClassMetadata $class    The class descriptor of the document.
+     * @param object        $document The document for which to compute the changes.
      */
     public function computeChangeSet(ClassMetadata $class, $document)
     {
-        if ( ! $class->isInheritanceTypeNone()) {
+        if (! $class->isInheritanceTypeNone()) {
             $class = $this->dm->getClassMetadata(get_class($document));
         }
 
         // Fire PreFlush lifecycle callbacks
-        if ( ! empty($class->lifecycleCallbacks[Events::preFlush])) {
-            $class->invokeLifecycleCallbacks(Events::preFlush, $document, array(new Event\PreFlushEventArgs($this->dm)));
+        if (! empty($class->lifecycleCallbacks[Events::preFlush])) {
+            $class->invokeLifecycleCallbacks(Events::preFlush, $document, [new Event\PreFlushEventArgs($this->dm)]);
         }
 
         $this->computeOrRecomputeChangeSet($class, $document);
@@ -611,9 +621,8 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Used to do the common work of computeChangeSet and recomputeSingleDocumentChangeSet
      *
-     * @param \Doctrine\ODM\MongoDB\Mapping\ClassMetadata $class
      * @param object $document
-     * @param boolean $recompute
+     * @param bool   $recompute
      */
     private function computeOrRecomputeChangeSet(ClassMetadata $class, $document, $recompute = false)
     {
@@ -624,7 +633,7 @@ class UnitOfWork implements PropertyChangedListener
             // Document is either NEW or MANAGED but not yet fully persisted (only has an id).
             // These result in an INSERT.
             $this->originalDocumentData[$oid] = $actualData;
-            $changeSet = array();
+            $changeSet = [];
             foreach ($actualData as $propName => $actualValue) {
                 /* At this PersistentCollection shouldn't be here, probably it
                  * was cloned and its ownership must be fixed
@@ -637,7 +646,7 @@ class UnitOfWork implements PropertyChangedListener
                 if (isset($class->fieldMappings[$propName]['reference']) && $class->fieldMappings[$propName]['isInverseSide']) {
                     continue;
                 }
-                $changeSet[$propName] = array(null, $actualValue);
+                $changeSet[$propName] = [null, $actualValue];
             }
             $this->documentChangeSets[$oid] = $changeSet;
         } else {
@@ -651,7 +660,7 @@ class UnitOfWork implements PropertyChangedListener
             if ($isChangeTrackingNotify && ! $recompute && isset($this->documentChangeSets[$oid])) {
                 $changeSet = $this->documentChangeSets[$oid];
             } else {
-                $changeSet = array();
+                $changeSet = [];
             }
 
             foreach ($actualData as $propName => $actualValue) {
@@ -664,7 +673,7 @@ class UnitOfWork implements PropertyChangedListener
 
                 // skip if value has not changed
                 if ($orgValue === $actualValue) {
-                    if (!$actualValue instanceof PersistentCollectionInterface) {
+                    if (! $actualValue instanceof PersistentCollectionInterface) {
                         continue;
                     }
 
@@ -679,7 +688,7 @@ class UnitOfWork implements PropertyChangedListener
                     if ($orgValue !== null) {
                         $this->scheduleOrphanRemoval($orgValue);
                     }
-                    $changeSet[$propName] = array($orgValue, $actualValue);
+                    $changeSet[$propName] = [$orgValue, $actualValue];
                     continue;
                 }
 
@@ -689,7 +698,7 @@ class UnitOfWork implements PropertyChangedListener
                         $this->scheduleOrphanRemoval($orgValue);
                     }
 
-                    $changeSet[$propName] = array($orgValue, $actualValue);
+                    $changeSet[$propName] = [$orgValue, $actualValue];
                     continue;
                 }
 
@@ -711,7 +720,7 @@ class UnitOfWork implements PropertyChangedListener
 
                 // if embed-many or reference-many relationship
                 if (isset($class->fieldMappings[$propName]['type']) && $class->fieldMappings[$propName]['type'] === 'many') {
-                    $changeSet[$propName] = array($orgValue, $actualValue);
+                    $changeSet[$propName] = [$orgValue, $actualValue];
                     /* If original collection was exchanged with a non-empty value
                      * and $set will be issued, there is no need to $unset it first
                      */
@@ -730,13 +739,13 @@ class UnitOfWork implements PropertyChangedListener
                     $dbOrgValue = $dateType->convertToDatabaseValue($orgValue);
                     $dbActualValue = $dateType->convertToDatabaseValue($actualValue);
 
-                    if ($dbOrgValue instanceof \MongoDB\BSON\UTCDateTime && $dbActualValue instanceof \MongoDB\BSON\UTCDateTime && $dbOrgValue == $dbActualValue) {
+                    if ($dbOrgValue instanceof UTCDateTime && $dbActualValue instanceof UTCDateTime && $dbOrgValue === $dbActualValue) {
                         continue;
                     }
                 }
 
                 // regular field
-                $changeSet[$propName] = array($orgValue, $actualValue);
+                $changeSet[$propName] = [$orgValue, $actualValue];
             }
             if ($changeSet) {
                 $this->documentChangeSets[$oid] = isset($this->documentChangeSets[$oid])
@@ -751,7 +760,9 @@ class UnitOfWork implements PropertyChangedListener
         // Look for changes in associations of the document
         $associationMappings = array_filter(
             $class->associationMappings,
-            function ($assoc) { return empty($assoc['notSaved']); }
+            function ($assoc) {
+                return empty($assoc['notSaved']);
+            }
         );
 
         foreach ($associationMappings as $mapping) {
@@ -767,7 +778,7 @@ class UnitOfWork implements PropertyChangedListener
                 continue;
             }
 
-            $values = $mapping['type'] === ClassMetadata::ONE ? array($value) : $value->unwrap();
+            $values = $mapping['type'] === ClassMetadata::ONE ? [$value] : $value->unwrap();
 
             foreach ($values as $obj) {
                 $oid2 = spl_object_hash($obj);
@@ -776,10 +787,10 @@ class UnitOfWork implements PropertyChangedListener
                     if (empty($this->documentChangeSets[$oid][$mapping['fieldName']])) {
                         // instance of $value is the same as it was previously otherwise there would be
                         // change set already in place
-                        $this->documentChangeSets[$oid][$mapping['fieldName']] = array($value, $value);
+                        $this->documentChangeSets[$oid][$mapping['fieldName']] = [$value, $value];
                     }
 
-                    if ( ! $isNewDocument) {
+                    if (! $isNewDocument) {
                         $this->scheduleForUpdate($document);
                     }
 
@@ -823,8 +834,7 @@ class UnitOfWork implements PropertyChangedListener
                     break;
 
                 default:
-                    $documentsToProcess = array();
-
+                    $documentsToProcess = [];
             }
 
             foreach ($documentsToProcess as $document) {
@@ -834,7 +844,7 @@ class UnitOfWork implements PropertyChangedListener
                 }
                 // Only MANAGED documents that are NOT SCHEDULED FOR INSERTION, UPSERT OR DELETION are processed here.
                 $oid = spl_object_hash($document);
-                if ( ! isset($this->documentInsertions[$oid])
+                if (! isset($this->documentInsertions[$oid])
                     && ! isset($this->documentUpserts[$oid])
                     && ! isset($this->documentDeletions[$oid])
                     && isset($this->documentStates[$oid])
@@ -849,8 +859,8 @@ class UnitOfWork implements PropertyChangedListener
      * Computes the changes of an association.
      *
      * @param object $parentDocument
-     * @param array $assoc
-     * @param mixed $value The value of the association.
+     * @param array  $assoc
+     * @param mixed  $value          The value of the association.
      * @throws \InvalidArgumentException
      */
     private function computeAssociationChanges($parentDocument, array $assoc, $value)
@@ -869,7 +879,7 @@ class UnitOfWork implements PropertyChangedListener
             }
             $topmostOwner = $this->getOwningDocument($value->getOwner());
             $this->visitedCollections[spl_object_hash($topmostOwner)][] = $value;
-            if ( ! empty($assoc['orphanRemoval']) || isset($assoc['embedded'])) {
+            if (! empty($assoc['orphanRemoval']) || isset($assoc['embedded'])) {
                 $value->initialize();
                 foreach ($value->getDeletedDocuments() as $orphan) {
                     $this->scheduleOrphanRemoval($orphan);
@@ -880,13 +890,13 @@ class UnitOfWork implements PropertyChangedListener
         // Look through the documents, and in any of their associations,
         // for transient (new) documents, recursively. ("Persistence by reachability")
         // Unwrap. Uninitialized collections will simply be empty.
-        $unwrappedValue = ($assoc['type'] === ClassMetadata::ONE) ? array($value) : $value->unwrap();
+        $unwrappedValue = ($assoc['type'] === ClassMetadata::ONE) ? [$value] : $value->unwrap();
 
         $count = 0;
         foreach ($unwrappedValue as $key => $entry) {
-            if ( ! is_object($entry)) {
+            if (! is_object($entry)) {
                 throw new \InvalidArgumentException(
-                        sprintf('Expected object, found "%s" in %s::%s', $entry, get_class($parentDocument), $assoc['name'])
+                    sprintf('Expected object, found "%s" in %s::%s', $entry, get_class($parentDocument), $assoc['name'])
                 );
             }
 
@@ -902,7 +912,7 @@ class UnitOfWork implements PropertyChangedListener
 
             switch ($state) {
                 case self::STATE_NEW:
-                    if ( ! $assoc['isCascadePersist']) {
+                    if (! $assoc['isCascadePersist']) {
                         throw new \InvalidArgumentException('A new document was found through a relationship that was not'
                             . ' configured to cascade persist operations: ' . $this->objToStr($entry) . '.'
                             . ' Explicitly persist the new document or configure cascading persist operations'
@@ -954,7 +964,6 @@ class UnitOfWork implements PropertyChangedListener
                 default:
                     // MANAGED associated documents are already taken into account
                     // during changeset calculation anyway, since they are in the identity map.
-
             }
         }
     }
@@ -969,8 +978,8 @@ class UnitOfWork implements PropertyChangedListener
      * whereby changes detected in this method prevail.
      *
      * @ignore
-     * @param ClassMetadata $class The class descriptor of the document.
-     * @param object $document The document for which to (re)calculate the change set.
+     * @param ClassMetadata $class    The class descriptor of the document.
+     * @param object        $document The document for which to (re)calculate the change set.
      * @throws \InvalidArgumentException If the passed document is not MANAGED.
      */
     public function recomputeSingleDocumentChangeSet(ClassMetadata $class, $document)
@@ -982,11 +991,11 @@ class UnitOfWork implements PropertyChangedListener
 
         $oid = spl_object_hash($document);
 
-        if ( ! isset($this->documentStates[$oid]) || $this->documentStates[$oid] != self::STATE_MANAGED) {
+        if (! isset($this->documentStates[$oid]) || $this->documentStates[$oid] !== self::STATE_MANAGED) {
             throw new \InvalidArgumentException('Document must be managed.');
         }
 
-        if ( ! $class->isInheritanceTypeNone()) {
+        if (! $class->isInheritanceTypeNone()) {
             $class = $this->dm->getClassMetadata(get_class($document));
         }
 
@@ -994,7 +1003,6 @@ class UnitOfWork implements PropertyChangedListener
     }
 
     /**
-     * @param ClassMetadata $class
      * @param object $document
      * @throws \InvalidArgumentException If there is something wrong with document's identifier.
      */
@@ -1045,11 +1053,10 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Executes all document insertions for documents of the specified type.
      *
-     * @param ClassMetadata $class
      * @param array $documents Array of documents to insert
-     * @param array $options Array of options to be used with batchInsert()
+     * @param array $options   Array of options to be used with batchInsert()
      */
-    private function executeInserts(ClassMetadata $class, array $documents, array $options = array())
+    private function executeInserts(ClassMetadata $class, array $documents, array $options = [])
     {
         $persister = $this->getDocumentPersister($class->name);
 
@@ -1068,14 +1075,12 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Executes all document upserts for documents of the specified type.
      *
-     * @param ClassMetadata $class
      * @param array $documents Array of documents to upsert
-     * @param array $options Array of options to be used with batchInsert()
+     * @param array $options   Array of options to be used with batchInsert()
      */
-    private function executeUpserts(ClassMetadata $class, array $documents, array $options = array())
+    private function executeUpserts(ClassMetadata $class, array $documents, array $options = [])
     {
         $persister = $this->getDocumentPersister($class->name);
-
 
         foreach ($documents as $oid => $document) {
             $persister->addUpsert($document);
@@ -1092,11 +1097,10 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Executes all document updates for documents of the specified type.
      *
-     * @param Mapping\ClassMetadata $class
      * @param array $documents Array of documents to update
-     * @param array $options Array of options to be used with update()
+     * @param array $options   Array of options to be used with update()
      */
-    private function executeUpdates(ClassMetadata $class, array $documents, array $options = array())
+    private function executeUpdates(ClassMetadata $class, array $documents, array $options = [])
     {
         if ($class->isReadOnly) {
             return;
@@ -1108,7 +1112,7 @@ class UnitOfWork implements PropertyChangedListener
         foreach ($documents as $oid => $document) {
             $this->lifecycleEventManager->preUpdate($class, $document);
 
-            if ( ! empty($this->documentChangeSets[$oid]) || $this->hasScheduledCollections($document)) {
+            if (! empty($this->documentChangeSets[$oid]) || $this->hasScheduledCollections($document)) {
                 $persister->update($document, $options);
             }
 
@@ -1121,16 +1125,15 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Executes all document deletions for documents of the specified type.
      *
-     * @param ClassMetadata $class
      * @param array $documents Array of documents to delete
-     * @param array $options Array of options to be used with remove()
+     * @param array $options   Array of options to be used with remove()
      */
-    private function executeDeletions(ClassMetadata $class, array $documents, array $options = array())
+    private function executeDeletions(ClassMetadata $class, array $documents, array $options = [])
     {
         $persister = $this->getDocumentPersister($class->name);
 
         foreach ($documents as $oid => $document) {
-            if ( ! $class->isEmbeddedDocument) {
+            if (! $class->isEmbeddedDocument) {
                 $persister->delete($document, $options);
             }
             unset(
@@ -1163,7 +1166,6 @@ class UnitOfWork implements PropertyChangedListener
      * If the document already has an identifier, it will be added to the
      * identity map.
      *
-     * @param ClassMetadata $class
      * @param object $document The document to schedule for insertion.
      * @throws \InvalidArgumentException
      */
@@ -1192,7 +1194,6 @@ class UnitOfWork implements PropertyChangedListener
      * Schedules a document for upsert into the database and adds it to the
      * identity map
      *
-     * @param ClassMetadata $class
      * @param object $document The document to schedule for upsert.
      * @throws \InvalidArgumentException
      */
@@ -1222,7 +1223,7 @@ class UnitOfWork implements PropertyChangedListener
      * Checks whether a document is scheduled for insertion.
      *
      * @param object $document
-     * @return boolean
+     * @return bool
      */
     public function isScheduledForInsert($document)
     {
@@ -1233,7 +1234,7 @@ class UnitOfWork implements PropertyChangedListener
      * Checks whether a document is scheduled for upsert.
      *
      * @param object $document
-     * @return boolean
+     * @return bool
      */
     public function isScheduledForUpsert($document)
     {
@@ -1249,7 +1250,7 @@ class UnitOfWork implements PropertyChangedListener
     public function scheduleForUpdate($document)
     {
         $oid = spl_object_hash($document);
-        if ( ! isset($this->documentIdentifiers[$oid])) {
+        if (! isset($this->documentIdentifiers[$oid])) {
             throw new \InvalidArgumentException('Document has no identity.');
         }
 
@@ -1257,7 +1258,7 @@ class UnitOfWork implements PropertyChangedListener
             throw new \InvalidArgumentException('Document is removed.');
         }
 
-        if ( ! isset($this->documentUpdates[$oid])
+        if (! isset($this->documentUpdates[$oid])
             && ! isset($this->documentInsertions[$oid])
             && ! isset($this->documentUpserts[$oid])) {
             $this->documentUpdates[$oid] = $document;
@@ -1270,7 +1271,7 @@ class UnitOfWork implements PropertyChangedListener
      * at commit time.
      *
      * @param object $document
-     * @return boolean
+     * @return bool
      */
     public function isScheduledForUpdate($document)
     {
@@ -1301,7 +1302,7 @@ class UnitOfWork implements PropertyChangedListener
             return; // document has not been persisted yet, so nothing more to do.
         }
 
-        if ( ! $this->isInIdentityMap($document)) {
+        if (! $this->isInIdentityMap($document)) {
             return; // ignore
         }
 
@@ -1311,7 +1312,7 @@ class UnitOfWork implements PropertyChangedListener
         if (isset($this->documentUpdates[$oid])) {
             unset($this->documentUpdates[$oid]);
         }
-        if ( ! isset($this->documentDeletions[$oid])) {
+        if (! isset($this->documentDeletions[$oid])) {
             $this->documentDeletions[$oid] = $document;
         }
     }
@@ -1321,7 +1322,7 @@ class UnitOfWork implements PropertyChangedListener
      * of work.
      *
      * @param object $document
-     * @return boolean
+     * @return bool
      */
     public function isScheduledForDelete($document)
     {
@@ -1332,7 +1333,7 @@ class UnitOfWork implements PropertyChangedListener
      * Checks whether a document is scheduled for insertion, update or deletion.
      *
      * @param object $document
-     * @return boolean
+     * @return bool
      */
     public function isDocumentScheduled($document)
     {
@@ -1352,8 +1353,8 @@ class UnitOfWork implements PropertyChangedListener
      * keys to allow differentiation of equal, but not identical, values.
      *
      * @ignore
-     * @param object $document  The document to register.
-     * @return boolean  TRUE if the registration was successful, FALSE if the identity of
+     * @param object $document The document to register.
+     * @return bool  TRUE if the registration was successful, FALSE if the identity of
      *                  the document in question is already managed.
      */
     public function addToIdentityMap($document)
@@ -1379,10 +1380,10 @@ class UnitOfWork implements PropertyChangedListener
      * Gets the state of a document with regard to the current unit of work.
      *
      * @param object   $document
-     * @param int|null $assume The state to assume if the state is not yet known (not MANAGED or REMOVED).
-     *                         This parameter can be set to improve performance of document state detection
-     *                         by potentially avoiding a database lookup if the distinction between NEW and DETACHED
-     *                         is either known or does not matter for the caller of the method.
+     * @param int|null $assume   The state to assume if the state is not yet known (not MANAGED or REMOVED).
+     *                           This parameter can be set to improve performance of document state detection
+     *                           by potentially avoiding a database lookup if the distinction between NEW and DETACHED
+     *                           is either known or does not matter for the caller of the method.
      * @return int The document state.
      */
     public function getDocumentState($document, $assume = null)
@@ -1444,14 +1445,14 @@ class UnitOfWork implements PropertyChangedListener
      * @ignore
      * @param object $document
      * @throws \InvalidArgumentException
-     * @return boolean
+     * @return bool
      */
     public function removeFromIdentityMap($document)
     {
         $oid = spl_object_hash($document);
 
         // Check if id is registered first
-        if ( ! isset($this->documentIdentifiers[$oid])) {
+        if (! isset($this->documentIdentifiers[$oid])) {
             return false;
         }
 
@@ -1479,7 +1480,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function getById($id, ClassMetadata $class)
     {
-        if ( ! $class->identifier) {
+        if (! $class->identifier) {
             throw new \InvalidArgumentException(sprintf('Class "%s" does not have an identifier', $class->name));
         }
 
@@ -1501,7 +1502,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function tryGetById($id, ClassMetadata $class)
     {
-        if ( ! $class->identifier) {
+        if (! $class->identifier) {
             throw new \InvalidArgumentException(sprintf('Class "%s" does not have an identifier', $class->name));
         }
 
@@ -1526,13 +1527,13 @@ class UnitOfWork implements PropertyChangedListener
      * Checks whether a document is registered in the identity map.
      *
      * @param object $document
-     * @return boolean
+     * @return bool
      */
     public function isInIdentityMap($document)
     {
         $oid = spl_object_hash($document);
 
-        if ( ! isset($this->documentIdentifiers[$oid])) {
+        if (! isset($this->documentIdentifiers[$oid])) {
             return false;
         }
 
@@ -1550,7 +1551,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         $class = $this->dm->getClassMetadata(get_class($document));
 
-        if ( ! $class->identifier) {
+        if (! $class->identifier) {
             $id = spl_object_hash($document);
         } else {
             $id = $this->documentIdentifiers[spl_object_hash($document)];
@@ -1567,7 +1568,7 @@ class UnitOfWork implements PropertyChangedListener
      * @ignore
      * @param string $id
      * @param string $rootClassName
-     * @return boolean
+     * @return bool
      */
     public function containsId($id, $rootClassName)
     {
@@ -1587,7 +1588,7 @@ class UnitOfWork implements PropertyChangedListener
         if ($class->isMappedSuperclass || $class->isQueryResultDocument) {
             throw MongoDBException::cannotPersistMappedSuperclass($class->name);
         }
-        $visited = array();
+        $visited = [];
         $this->doPersist($document, $visited);
     }
 
@@ -1600,7 +1601,7 @@ class UnitOfWork implements PropertyChangedListener
      * this UnitOfWork as NEW.
      *
      * @param object $document The document to persist.
-     * @param array $visited The already visited documents.
+     * @param array  $visited  The already visited documents.
      * @throws \InvalidArgumentException
      * @throws MongoDBException
      */
@@ -1636,7 +1637,8 @@ class UnitOfWork implements PropertyChangedListener
 
             case self::STATE_DETACHED:
                 throw new \InvalidArgumentException(
-                    'Behavior of persist() for a detached document is not yet defined.');
+                    'Behavior of persist() for a detached document is not yet defined.'
+                );
 
             default:
                 throw MongoDBException::invalidDocumentState($documentState);
@@ -1652,7 +1654,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function remove($document)
     {
-        $visited = array();
+        $visited = [];
         $this->doRemove($document, $visited);
     }
 
@@ -1663,7 +1665,7 @@ class UnitOfWork implements PropertyChangedListener
      * the already visited documents to prevent infinite recursions.
      *
      * @param object $document The document to delete.
-     * @param array $visited The map of the already visited documents.
+     * @param array  $visited  The map of the already visited documents.
      * @throws MongoDBException
      */
     private function doRemove($document, array &$visited)
@@ -1707,7 +1709,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function merge($document)
     {
-        $visited = array();
+        $visited = [];
 
         return $this->doMerge($document, $visited);
     }
@@ -1784,7 +1786,7 @@ class UnitOfWork implements PropertyChangedListener
                 $documentVersion = $class->reflFields[$class->versionField]->getValue($document);
 
                 // Throw exception if versions don't match
-                if ($managedCopyVersion != $documentVersion) {
+                if ($managedCopyVersion !== $documentVersion) {
                     throw LockException::lockFailedVersionMissmatch($document, $documentVersion, $managedCopyVersion);
                 }
             }
@@ -1793,8 +1795,8 @@ class UnitOfWork implements PropertyChangedListener
             foreach ($class->reflClass->getProperties() as $prop) {
                 $name = $prop->name;
                 $prop->setAccessible(true);
-                if ( ! isset($class->associationMappings[$name])) {
-                    if ( ! $class->isIdentifier($name)) {
+                if (! isset($class->associationMappings[$name])) {
+                    if (! $class->isIdentifier($name)) {
                         $prop->setValue($managedCopy, $prop->getValue($document));
                     }
                 } else {
@@ -1808,7 +1810,7 @@ class UnitOfWork implements PropertyChangedListener
                         } elseif ($other instanceof Proxy && ! $other->__isInitialized__) {
                             // Do not merge fields marked lazy that have not been fetched
                             continue;
-                        } elseif ( ! $assoc2['isCascadeMerge']) {
+                        } elseif (! $assoc2['isCascadeMerge']) {
                             if ($this->getDocumentState($other) === self::STATE_DETACHED) {
                                 $targetDocument = $assoc2['targetDocument'] ?? get_class($other);
                                 /* @var $targetClass \Doctrine\ODM\MongoDB\Mapping\ClassMetadata */
@@ -1821,8 +1823,8 @@ class UnitOfWork implements PropertyChangedListener
                                     $other = $this
                                         ->dm
                                         ->getProxyFactory()
-                                        ->getProxy($assoc2['targetDocument'], array($targetClass->identifier => $relatedId));
-                                    $this->registerManaged($other, $relatedId, array());
+                                        ->getProxy($assoc2['targetDocument'], [$targetClass->identifier => $relatedId]);
+                                    $this->registerManaged($other, $relatedId, []);
                                 }
                             }
 
@@ -1841,7 +1843,7 @@ class UnitOfWork implements PropertyChangedListener
 
                         $managedCol = $prop->getValue($managedCopy);
 
-                        if ( ! $managedCol) {
+                        if (! $managedCol) {
                             $managedCol = $this->dm->getConfiguration()->getPersistentCollectionFactory()->create($this->dm, $assoc2, null);
                             $managedCol->setOwner($managedCopy, $assoc2);
                             $prop->setValue($managedCopy, $managedCol);
@@ -1856,7 +1858,7 @@ class UnitOfWork implements PropertyChangedListener
                             $managedCol->initialize();
 
                             // If $managedCol differs from the merged collection, clear and set dirty
-                            if ( ! $managedCol->isEmpty() && $managedCol !== $mergeCol) {
+                            if (! $managedCol->isEmpty() && $managedCol !== $mergeCol) {
                                 $managedCol->unwrap()->clear();
                                 $managedCol->setDirty(true);
 
@@ -1910,7 +1912,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function detach($document)
     {
-        $visited = array();
+        $visited = [];
         $this->doDetach($document, $visited);
     }
 
@@ -1918,7 +1920,7 @@ class UnitOfWork implements PropertyChangedListener
      * Executes a detach operation on the given document.
      *
      * @param object $document
-     * @param array $visited
+     * @param array  $visited
      * @internal This method always considers documents with an assigned identifier as DETACHED.
      */
     private function doDetach($document, array &$visited)
@@ -1933,11 +1935,18 @@ class UnitOfWork implements PropertyChangedListener
         switch ($this->getDocumentState($document, self::STATE_DETACHED)) {
             case self::STATE_MANAGED:
                 $this->removeFromIdentityMap($document);
-                unset($this->documentInsertions[$oid], $this->documentUpdates[$oid],
-                    $this->documentDeletions[$oid], $this->documentIdentifiers[$oid],
-                    $this->documentStates[$oid], $this->originalDocumentData[$oid],
-                    $this->parentAssociations[$oid], $this->documentUpserts[$oid],
-                    $this->hasScheduledCollections[$oid], $this->embeddedDocumentsRegistry[$oid]);
+                unset(
+                    $this->documentInsertions[$oid],
+                    $this->documentUpdates[$oid],
+                    $this->documentDeletions[$oid],
+                    $this->documentIdentifiers[$oid],
+                    $this->documentStates[$oid],
+                    $this->originalDocumentData[$oid],
+                    $this->parentAssociations[$oid],
+                    $this->documentUpserts[$oid],
+                    $this->hasScheduledCollections[$oid],
+                    $this->embeddedDocumentsRegistry[$oid]
+                );
                 break;
             case self::STATE_NEW:
             case self::STATE_DETACHED:
@@ -1956,7 +1965,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function refresh($document)
     {
-        $visited = array();
+        $visited = [];
         $this->doRefresh($document, $visited);
     }
 
@@ -1964,7 +1973,7 @@ class UnitOfWork implements PropertyChangedListener
      * Executes a refresh operation on a document.
      *
      * @param object $document The document to refresh.
-     * @param array $visited The already visited documents during cascades.
+     * @param array  $visited  The already visited documents during cascades.
      * @throws \InvalidArgumentException If the document is not MANAGED.
      */
     private function doRefresh($document, array &$visited)
@@ -1978,8 +1987,8 @@ class UnitOfWork implements PropertyChangedListener
 
         $class = $this->dm->getClassMetadata(get_class($document));
 
-        if ( ! $class->isEmbeddedDocument) {
-            if ($this->getDocumentState($document) == self::STATE_MANAGED) {
+        if (! $class->isEmbeddedDocument) {
+            if ($this->getDocumentState($document) === self::STATE_MANAGED) {
                 $this->getDocumentPersister($class->name)->refresh($document);
             } else {
                 throw new \InvalidArgumentException('Document is not MANAGED.');
@@ -1993,7 +2002,7 @@ class UnitOfWork implements PropertyChangedListener
      * Cascades a refresh operation to associated documents.
      *
      * @param object $document
-     * @param array $visited
+     * @param array  $visited
      */
     private function cascadeRefresh($document, array &$visited)
     {
@@ -2001,7 +2010,9 @@ class UnitOfWork implements PropertyChangedListener
 
         $associationMappings = array_filter(
             $class->associationMappings,
-            function ($assoc) { return $assoc['isCascadeRefresh']; }
+            function ($assoc) {
+                return $assoc['isCascadeRefresh'];
+            }
         );
 
         foreach ($associationMappings as $mapping) {
@@ -2024,13 +2035,13 @@ class UnitOfWork implements PropertyChangedListener
      * Cascades a detach operation to associated documents.
      *
      * @param object $document
-     * @param array $visited
+     * @param array  $visited
      */
     private function cascadeDetach($document, array &$visited)
     {
         $class = $this->dm->getClassMetadata(get_class($document));
         foreach ($class->fieldMappings as $mapping) {
-            if ( ! $mapping['isCascadeDetach']) {
+            if (! $mapping['isCascadeDetach']) {
                 continue;
             }
             $relatedDocuments = $class->reflFields[$mapping['fieldName']]->getValue($document);
@@ -2052,7 +2063,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param object $document
      * @param object $managedCopy
-     * @param array $visited
+     * @param array  $visited
      */
     private function cascadeMerge($document, $managedCopy, array &$visited)
     {
@@ -2060,7 +2071,9 @@ class UnitOfWork implements PropertyChangedListener
 
         $associationMappings = array_filter(
             $class->associationMappings,
-            function ($assoc) { return $assoc['isCascadeMerge']; }
+            function ($assoc) {
+                return $assoc['isCascadeMerge'];
+            }
         );
 
         foreach ($associationMappings as $assoc) {
@@ -2085,7 +2098,7 @@ class UnitOfWork implements PropertyChangedListener
      * Cascades the save operation to associated documents.
      *
      * @param object $document
-     * @param array $visited
+     * @param array  $visited
      */
     private function cascadePersist($document, array &$visited)
     {
@@ -2093,7 +2106,9 @@ class UnitOfWork implements PropertyChangedListener
 
         $associationMappings = array_filter(
             $class->associationMappings,
-            function ($assoc) { return $assoc['isCascadePersist']; }
+            function ($assoc) {
+                return $assoc['isCascadePersist'];
+            }
         );
 
         foreach ($associationMappings as $fieldName => $mapping) {
@@ -2110,7 +2125,7 @@ class UnitOfWork implements PropertyChangedListener
 
                 $count = 0;
                 foreach ($relatedDocuments as $relatedKey => $relatedDocument) {
-                    if ( ! empty($mapping['embedded'])) {
+                    if (! empty($mapping['embedded'])) {
                         list(, $knownParent, ) = $this->getParentAssociation($relatedDocument);
                         if ($knownParent && $knownParent !== $document) {
                             $relatedDocument = clone $relatedDocument;
@@ -2122,7 +2137,7 @@ class UnitOfWork implements PropertyChangedListener
                     $this->doPersist($relatedDocument, $visited);
                 }
             } elseif ($relatedDocuments !== null) {
-                if ( ! empty($mapping['embedded'])) {
+                if (! empty($mapping['embedded'])) {
                     list(, $knownParent, ) = $this->getParentAssociation($relatedDocuments);
                     if ($knownParent && $knownParent !== $document) {
                         $relatedDocuments = clone $relatedDocuments;
@@ -2139,13 +2154,13 @@ class UnitOfWork implements PropertyChangedListener
      * Cascades the delete operation to associated documents.
      *
      * @param object $document
-     * @param array $visited
+     * @param array  $visited
      */
     private function cascadeRemove($document, array &$visited)
     {
         $class = $this->dm->getClassMetadata(get_class($document));
         foreach ($class->fieldMappings as $mapping) {
-            if ( ! $mapping['isCascadeRemove']) {
+            if (! $mapping['isCascadeRemove']) {
                 continue;
             }
             if ($document instanceof Proxy && ! $document->__isInitialized__) {
@@ -2168,32 +2183,32 @@ class UnitOfWork implements PropertyChangedListener
      * Acquire a lock on the given document.
      *
      * @param object $document
-     * @param int $lockMode
-     * @param int $lockVersion
+     * @param int    $lockMode
+     * @param int    $lockVersion
      * @throws LockException
      * @throws \InvalidArgumentException
      */
     public function lock($document, $lockMode, $lockVersion = null)
     {
-        if ($this->getDocumentState($document) != self::STATE_MANAGED) {
+        if ($this->getDocumentState($document) !== self::STATE_MANAGED) {
             throw new \InvalidArgumentException('Document is not MANAGED.');
         }
 
         $documentName = get_class($document);
         $class = $this->dm->getClassMetadata($documentName);
 
-        if ($lockMode == LockMode::OPTIMISTIC) {
-            if ( ! $class->isVersioned) {
+        if ($lockMode === LockMode::OPTIMISTIC) {
+            if (! $class->isVersioned) {
                 throw LockException::notVersioned($documentName);
             }
 
-            if ($lockVersion != null) {
+            if ($lockVersion !== null) {
                 $documentVersion = $class->reflFields[$class->versionField]->getValue($document);
-                if ($documentVersion != $lockVersion) {
+                if ($documentVersion !== $lockVersion) {
                     throw LockException::lockFailedVersionMissmatch($document, $lockVersion, $documentVersion);
                 }
             }
-        } elseif (in_array($lockMode, array(LockMode::PESSIMISTIC_READ, LockMode::PESSIMISTIC_WRITE))) {
+        } elseif (in_array($lockMode, [LockMode::PESSIMISTIC_READ, LockMode::PESSIMISTIC_WRITE])) {
             $this->getDocumentPersister($class->name)->lock($document, $lockMode);
         }
     }
@@ -2206,8 +2221,8 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function unlock($document)
     {
-        if ($this->getDocumentState($document) != self::STATE_MANAGED) {
-            throw new \InvalidArgumentException("Document is not MANAGED.");
+        if ($this->getDocumentState($document) !== self::STATE_MANAGED) {
+            throw new \InvalidArgumentException('Document is not MANAGED.');
         }
         $documentName = get_class($document);
         $this->getDocumentPersister($documentName)->unlock($document);
@@ -2236,9 +2251,9 @@ class UnitOfWork implements PropertyChangedListener
             $this->parentAssociations =
             $this->embeddedDocumentsRegistry =
             $this->orphanRemovals =
-            $this->hasScheduledCollections = array();
+            $this->hasScheduledCollections = [];
         } else {
-            $visited = array();
+            $visited = [];
             foreach ($this->identityMap as $className => $documents) {
                 if ($className === $documentName) {
                     foreach ($documents as $document) {
@@ -2289,9 +2304,7 @@ class UnitOfWork implements PropertyChangedListener
      *  3) NOP if state is OK
      * Returned collection should be used from now on (only important with 2nd point)
      *
-     * @param PersistentCollectionInterface $coll
      * @param object $document
-     * @param ClassMetadata $class
      * @param string $propName
      * @return PersistentCollectionInterface
      */
@@ -2301,7 +2314,7 @@ class UnitOfWork implements PropertyChangedListener
         if ($owner === null) { // cloned
             $coll->setOwner($document, $class->fieldMappings[$propName]);
         } elseif ($owner !== $document) { // no clone, we have to fix
-            if ( ! $coll->isInitialized()) {
+            if (! $coll->isInitialized()) {
                 $coll->initialize(); // we have to do this otherwise the cols share state
             }
             $newValue = clone $coll;
@@ -2320,13 +2333,12 @@ class UnitOfWork implements PropertyChangedListener
      * INTERNAL:
      * Schedules a complete collection for removal when this UnitOfWork commits.
      *
-     * @param PersistentCollectionInterface $coll
      */
     public function scheduleCollectionDeletion(PersistentCollectionInterface $coll)
     {
         $oid = spl_object_hash($coll);
         unset($this->collectionUpdates[$oid]);
-        if ( ! isset($this->collectionDeletions[$oid])) {
+        if (! isset($this->collectionDeletions[$oid])) {
             $this->collectionDeletions[$oid] = $coll;
             $this->scheduleCollectionOwner($coll);
         }
@@ -2335,8 +2347,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Checks whether a PersistentCollection is scheduled for deletion.
      *
-     * @param PersistentCollectionInterface $coll
-     * @return boolean
+     * @return bool
      */
     public function isCollectionScheduledForDeletion(PersistentCollectionInterface $coll)
     {
@@ -2347,7 +2358,6 @@ class UnitOfWork implements PropertyChangedListener
      * INTERNAL:
      * Unschedules a collection from being deleted when this UnitOfWork commits.
      *
-     * @param PersistentCollectionInterface $coll
      */
     public function unscheduleCollectionDeletion(PersistentCollectionInterface $coll)
     {
@@ -2363,7 +2373,6 @@ class UnitOfWork implements PropertyChangedListener
      * INTERNAL:
      * Schedules a collection for update when this UnitOfWork commits.
      *
-     * @param PersistentCollectionInterface $coll
      */
     public function scheduleCollectionUpdate(PersistentCollectionInterface $coll)
     {
@@ -2375,7 +2384,7 @@ class UnitOfWork implements PropertyChangedListener
             $this->unscheduleCollectionDeletion($coll);
         }
         $oid = spl_object_hash($coll);
-        if ( ! isset($this->collectionUpdates[$oid])) {
+        if (! isset($this->collectionUpdates[$oid])) {
             $this->collectionUpdates[$oid] = $coll;
             $this->scheduleCollectionOwner($coll);
         }
@@ -2385,7 +2394,6 @@ class UnitOfWork implements PropertyChangedListener
      * INTERNAL:
      * Unschedules a collection from being updated when this UnitOfWork commits.
      *
-     * @param PersistentCollectionInterface $coll
      */
     public function unscheduleCollectionUpdate(PersistentCollectionInterface $coll)
     {
@@ -2400,8 +2408,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Checks whether a PersistentCollection is scheduled for update.
      *
-     * @param PersistentCollectionInterface $coll
-     * @return boolean
+     * @return bool
      */
     public function isCollectionScheduledForUpdate(PersistentCollectionInterface $coll)
     {
@@ -2420,7 +2427,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         $oid = spl_object_hash($document);
 
-        return $this->visitedCollections[$oid] ?? array();
+        return $this->visitedCollections[$oid] ?? [];
     }
 
     /**
@@ -2434,7 +2441,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         $oid = spl_object_hash($document);
 
-        return $this->hasScheduledCollections[$oid] ?? array();
+        return $this->hasScheduledCollections[$oid] ?? [];
     }
 
     /**
@@ -2442,7 +2449,7 @@ class UnitOfWork implements PropertyChangedListener
      * scheduled for update or deletion.
      *
      * @param object $document
-     * @return boolean
+     * @return bool
      */
     public function hasScheduledCollections($document)
     {
@@ -2460,7 +2467,6 @@ class UnitOfWork implements PropertyChangedListener
      * unscheduled and atomic one is scheduled for update instead. This makes
      * calculating update data way easier.
      *
-     * @param PersistentCollectionInterface $coll
      */
     private function scheduleCollectionOwner(PersistentCollectionInterface $coll)
     {
@@ -2470,7 +2476,7 @@ class UnitOfWork implements PropertyChangedListener
         if ($document !== $coll->getOwner()) {
             $parent = $coll->getOwner();
             $mapping = [];
-            while (null !== ($parentAssoc = $this->getParentAssociation($parent))) {
+            while (($parentAssoc = $this->getParentAssociation($parent)) !== null) {
                 list($mapping, $parent, ) = $parentAssoc;
             }
             if (CollectionHelper::isAtomic($mapping['strategy'])) {
@@ -2482,7 +2488,7 @@ class UnitOfWork implements PropertyChangedListener
             }
         }
 
-        if ( ! $this->isDocumentScheduled($document)) {
+        if (! $this->isDocumentScheduled($document)) {
             $this->scheduleForUpdate($document);
         }
     }
@@ -2504,7 +2510,7 @@ class UnitOfWork implements PropertyChangedListener
         while ($class->isEmbeddedDocument) {
             $parentAssociation = $this->getParentAssociation($document);
 
-            if ( ! $parentAssociation) {
+            if (! $parentAssociation) {
                 throw new \UnexpectedValueException('Could not determine parent association for ' . get_class($document));
             }
 
@@ -2560,13 +2566,13 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @ignore
      * @param string $className The name of the document class.
-     * @param array $data The data for the document.
-     * @param array $hints Any hints to account for during reconstitution/lookup of the document.
-     * @param object $document The document to be hydrated into in case of creation
+     * @param array  $data      The data for the document.
+     * @param array  $hints     Any hints to account for during reconstitution/lookup of the document.
+     * @param object $document  The document to be hydrated into in case of creation
      * @return object The document instance.
      * @internal Highly performance-sensitive method.
      */
-    public function getOrCreateDocument($className, $data, &$hints = array(), $document = null)
+    public function getOrCreateDocument($className, $data, &$hints = [], $document = null)
     {
         $class = $this->dm->getClassMetadata($className);
 
@@ -2672,12 +2678,9 @@ class UnitOfWork implements PropertyChangedListener
     {
         $oid = spl_object_hash($document);
 
-        return $this->originalDocumentData[$oid] ?? array();
+        return $this->originalDocumentData[$oid] ?? [];
     }
 
-    /**
-     * @ignore
-     */
     public function setOriginalDocumentData($document, array $data)
     {
         $oid = spl_object_hash($document);
@@ -2692,7 +2695,7 @@ class UnitOfWork implements PropertyChangedListener
      * @ignore
      * @param string $oid
      * @param string $property
-     * @param mixed $value
+     * @param mixed  $value
      */
     public function setOriginalDocumentProperty($oid, $property, $value)
     {
@@ -2713,7 +2716,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Checks whether the UnitOfWork has any pending insertions.
      *
-     * @return boolean TRUE if this UnitOfWork has pending insertions, FALSE otherwise.
+     * @return bool TRUE if this UnitOfWork has pending insertions, FALSE otherwise.
      */
     public function hasPendingInsertions()
     {
@@ -2724,7 +2727,7 @@ class UnitOfWork implements PropertyChangedListener
      * Calculates the size of the UnitOfWork. The size of the UnitOfWork is the
      * number of documents in the identity map.
      *
-     * @return integer
+     * @return int
      */
     public function size()
     {
@@ -2747,15 +2750,15 @@ class UnitOfWork implements PropertyChangedListener
      * conversion and throw an exception if it's inconsistent.
      *
      * @param object $document The document.
-     * @param array $id The identifier values.
-     * @param array $data The original document data.
+     * @param array  $id       The identifier values.
+     * @param array  $data     The original document data.
      */
     public function registerManaged($document, $id, $data)
     {
         $oid = spl_object_hash($document);
         $class = $this->dm->getClassMetadata(get_class($document));
 
-        if ( ! $class->identifier || $id === null) {
+        if (! $class->identifier || $id === null) {
             $this->documentIdentifiers[$oid] = $oid;
         } else {
             $this->documentIdentifiers[$oid] = $class->getPHPIdentifierValue($id);
@@ -2774,7 +2777,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function clearDocumentChangeSet($oid)
     {
-        $this->documentChangeSets[$oid] = array();
+        $this->documentChangeSets[$oid] = [];
     }
 
     /* PropertyChangedListener implementation */
@@ -2782,23 +2785,23 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Notifies this UnitOfWork of a property change in a document.
      *
-     * @param object $document The document that owns the property.
+     * @param object $document     The document that owns the property.
      * @param string $propertyName The name of the property that changed.
-     * @param mixed $oldValue The old value of the property.
-     * @param mixed $newValue The new value of the property.
+     * @param mixed  $oldValue     The old value of the property.
+     * @param mixed  $newValue     The new value of the property.
      */
     public function propertyChanged($document, $propertyName, $oldValue, $newValue)
     {
         $oid = spl_object_hash($document);
         $class = $this->dm->getClassMetadata(get_class($document));
 
-        if ( ! isset($class->fieldMappings[$propertyName])) {
+        if (! isset($class->fieldMappings[$propertyName])) {
             return; // ignore non-persistent fields
         }
 
         // Update changeset and mark document for synchronization
-        $this->documentChangeSets[$oid][$propertyName] = array($oldValue, $newValue);
-        if ( ! isset($this->scheduledForDirtyCheck[$class->name][$oid])) {
+        $this->documentChangeSets[$oid][$propertyName] = [$oldValue, $newValue];
+        if (! isset($this->scheduledForDirtyCheck[$class->name][$oid])) {
             $this->scheduleForDirtyCheck($document);
         }
     }
@@ -2867,7 +2870,6 @@ class UnitOfWork implements PropertyChangedListener
      * Helper method to initialize a lazy loading proxy or persistent collection.
      *
      * @param object $obj
-     * @return void
      */
     public function initializeObject($obj)
     {
@@ -2880,6 +2882,6 @@ class UnitOfWork implements PropertyChangedListener
 
     private function objToStr($obj)
     {
-        return method_exists($obj, '__toString') ? (string)$obj : get_class($obj) . '@' . spl_object_hash($obj);
+        return method_exists($obj, '__toString') ? (string) $obj : get_class($obj) . '@' . spl_object_hash($obj);
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Utility/CollectionHelper.php
+++ b/lib/Doctrine/ODM/MongoDB/Utility/CollectionHelper.php
@@ -1,17 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Utility;
+
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use function in_array;
 
 /**
  * Utility class used to unify checks on how collection strategies should behave.
  *
- * @since   1.0
  * @internal
  */
 class CollectionHelper
 {
-    const DEFAULT_STRATEGY = ClassMetadata::STORAGE_STRATEGY_PUSH_ALL;
+    public const DEFAULT_STRATEGY = ClassMetadata::STORAGE_STRATEGY_PUSH_ALL;
 
     /**
      * Returns whether update query must be included in query updating owning document.
@@ -60,7 +63,7 @@ class CollectionHelper
                 ClassMetadata::STORAGE_STRATEGY_SET,
                 ClassMetadata::STORAGE_STRATEGY_SET_ARRAY,
                 ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET,
-                ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET_ARRAY
+                ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET_ARRAY,
             ]
         );
     }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<ruleset>
+    <arg name="basepath" value="."/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors" />
+
+    <!-- Ignore warnings and show progress of the run -->
+    <arg value="np"/>
+
+    <file>lib</file>
+    <file>tests</file>
+    <file>tools</file>
+
+    <exclude-pattern>tests/Proxies*</exclude-pattern>
+    <exclude-pattern>tests/Hydrators*</exclude-pattern>
+    <exclude-pattern>tests/PersistentCollections*</exclude-pattern>
+
+    <rule ref="Doctrine">
+        <!-- Traversable type hints often end up as mixed[], so we skip them for now -->
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversablePropertyTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification" />
+
+        <!-- Will cause BC breaks to method signatures - disabled for now -->
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint" />
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint" />
+
+        <exclude name="Generic.Formatting.MultipleStatementAlignment" />
+
+        <!-- Disabled due to the large number of false positives in 4.4.4 -->
+        <exclude name="SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity" />
+
+        <!-- Disabled to avoid class renaming - to be handled in a separate PR -->
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming" />
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming" />
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming" />
+
+        <!-- The following rules are intended to be enabled one-by-one to have reviewable diffs -->
+
+        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedFOREACH" />
+        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedIF" />
+        <exclude name="Generic.NamingConventions.UpperCaseConstantName.ConstantNotUpperCase" />
+        <exclude name="Generic.PHP.ForbiddenFunctions.Found" />
+        <exclude name="Generic.PHP.ForbiddenFunctions.FoundWithAlternative" />
+        <exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace" />
+        <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenercase" />
+        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment" />
+        <exclude name="SlevomatCodingStandard.ControlStructures.AssignmentInCondition.AssignmentInCondition" />
+        <exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit" />
+        <exclude name="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod" />
+        <exclude name="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedProperty" />
+        <exclude name="SlevomatCodingStandard.Classes.UnusedPrivateElements.WriteOnlyProperty" />
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingPropertyTypeHint" />
+        <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
+        <exclude name="Squiz.Commenting.FunctionComment.ThrowsNotCapital" />
+        <exclude name="Squiz.Commenting.FunctionComment.ThrowsNoFullStop" />
+        <exclude name="Squiz.Commenting.FunctionComment.WrongStyle" />
+        <exclude name="Squiz.Classes.ClassFileName.NoMatch" />
+        <exclude name="Squiz.Scope.MethodScope.Missing" />
+        <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar" />
+    </rule>
+
+    <!-- Require no space around colon in return types -->
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing">
+        <properties>
+            <property name="spacesCountBeforeColon" value="0"/>
+        </properties>
+    </rule>
+
+    <rule ref="Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase">
+        <exclude-pattern>lib/Doctrine/ODM/MongoDB/Events.php</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+</ruleset>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationOperatorsProviderTrait.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationOperatorsProviderTrait.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation;
 
 use Doctrine\ODM\MongoDB\Aggregation\Expr;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Documents\User;
+use function is_array;
 
 trait AggregationOperatorsProviderTrait
 {
@@ -149,7 +152,7 @@ trait AggregationOperatorsProviderTrait
                     return [
                         $expr->gte('$field', 5),
                         '$field',
-                        '$otherField'
+                        '$otherField',
                     ];
                 },
             ],
@@ -308,10 +311,10 @@ trait AggregationOperatorsProviderTrait
                     '$let' => [
                         'vars' => [
                             'total' => ['$add' => ['$price', '$tax']],
-                            'discounted' => ['$cond' => ['if' => '$applyDiscount', 'then' => 0.9, 'else' => 1]]
+                            'discounted' => ['$cond' => ['if' => '$applyDiscount', 'then' => 0.9, 'else' => 1]],
                         ],
-                        'in' => ['$multiply' => ['$$total', '$$discounted']]
-                    ]
+                        'in' => ['$multiply' => ['$$total', '$$discounted']],
+                    ],
                 ],
                 'operator' => 'let',
                 'args' => function (Expr $expr) {
@@ -363,7 +366,7 @@ trait AggregationOperatorsProviderTrait
                     return [
                         '$quizzes',
                         'grade',
-                        $expr->add('$$grade', 2)
+                        $expr->add('$$grade', 2),
                     ];
                 },
             ],
@@ -440,7 +443,7 @@ trait AggregationOperatorsProviderTrait
                         ['sum' => 0, 'product' => 1],
                         $expr
                             ->add('$$value.sum', '$$this')
-                            ->multiply('$$value.product', '$$this')
+                            ->multiply('$$value.product', '$$this'),
                     ];
                 },
             ],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationTestTrait.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationTestTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
@@ -24,7 +26,7 @@ trait AggregationTestTrait
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\Doctrine\ODM\MongoDB\Aggregation\Expr
+     * @return \PHPUnit_Framework_MockObject_MockObject|AggregationExpr
      */
     protected function getMockAggregationExpr()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/ExprTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation;
 
 use Doctrine\ODM\MongoDB\Aggregation\Expr;
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
-use Documents\User;
 
 class ExprTest extends BaseTest
 {
@@ -60,8 +60,8 @@ class ExprTest extends BaseTest
             [
                 'nested' => [
                     'dayOfMonth' => ['$dayOfMonth' => '$dateField'],
-                    'dayOfWeek' => ['$dayOfWeek' => '$dateField']
-                ]
+                    'dayOfWeek' => ['$dayOfWeek' => '$dateField'],
+                ],
             ],
             $expr->getExpression()
         );
@@ -103,7 +103,7 @@ class ExprTest extends BaseTest
                         ['case' => ['$eq' => ['$numElements', 1]], 'then' => 'One element given'],
                     ],
                     'default' => ['$concat' => ['$numElements', ' elements given']],
-                ]
+                ],
             ],
             $expr->getExpression()
         );

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/AddFieldsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/AddFieldsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\AddFields;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketAutoTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketAutoTest.php
@@ -1,14 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\BucketAuto;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\CmsComment;
 use Documents\User;
 
-class BucketTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class BucketTest extends BaseTest
 {
     use AggregationTestTrait;
 
@@ -23,12 +26,14 @@ class BucketTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->field('averageValue')
             ->avg('$value');
 
-        $this->assertSame(['$bucketAuto' => [
+        $this->assertSame([
+        '$bucketAuto' => [
             'groupBy' => '$someField',
             'buckets' => 3,
             'granularity' => 'R10',
-            'output' => ['averageValue' => ['$avg' => '$value']]
-        ]], $bucketStage->getExpression());
+            'output' => ['averageValue' => ['$avg' => '$value']],
+        ],
+        ], $bucketStage->getExpression());
     }
 
     public function testBucketAutoFromBuilder()
@@ -42,12 +47,15 @@ class BucketTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->field('averageValue')
             ->avg('$value');
 
-        $this->assertSame([['$bucketAuto' => [
+        $this->assertSame([[
+        '$bucketAuto' => [
             'groupBy' => '$someField',
             'buckets' => 3,
             'granularity' => 'R10',
-            'output' => ['averageValue' => ['$avg' => '$value']]
-        ]]], $builder->getPipeline());
+            'output' => ['averageValue' => ['$avg' => '$value']],
+        ],
+        ],
+        ], $builder->getPipeline());
     }
 
     public function testBucketAutoSkipsUndefinedProperties()
@@ -57,10 +65,12 @@ class BucketTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->groupBy('$someField')
             ->buckets(3);
 
-        $this->assertSame(['$bucketAuto' => [
+        $this->assertSame([
+        '$bucketAuto' => [
             'groupBy' => '$someField',
             'buckets' => 3,
-        ]], $bucketStage->getExpression());
+        ],
+        ], $bucketStage->getExpression());
     }
 
     public function testFieldNameConversion()
@@ -76,12 +86,15 @@ class BucketTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                 ->avg('$value');
 
         $this->assertEquals(
-            [['$bucketAuto' => [
+            [[
+            '$bucketAuto' => [
                 'groupBy' => '$ip',
                 'buckets' => 3,
                 'granularity' => 'R10',
-                'output' => ['averageValue' => ['$avg' => '$value']]
-            ]]],
+                'output' => ['averageValue' => ['$avg' => '$value']],
+            ],
+            ],
+            ],
             $builder->getPipeline()
         );
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketTest.php
@@ -1,14 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Bucket;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\CmsComment;
 use Documents\User;
 
-class BucketAutoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class BucketAutoTest extends BaseTest
 {
     use AggregationTestTrait;
 
@@ -23,12 +26,14 @@ class BucketAutoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->field('averageValue')
             ->avg('$value');
 
-        $this->assertSame(['$bucket' => [
+        $this->assertSame([
+        '$bucket' => [
             'groupBy' => '$someField',
             'boundaries' => [1, 2, 3],
             'default' => 0,
-            'output' => ['averageValue' => ['$avg' => '$value']]
-        ]], $bucketStage->getExpression());
+            'output' => ['averageValue' => ['$avg' => '$value']],
+        ],
+        ], $bucketStage->getExpression());
     }
 
     public function testBucketFromBuilder()
@@ -42,12 +47,15 @@ class BucketAutoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->field('averageValue')
             ->avg('$value');
 
-        $this->assertSame([['$bucket' => [
+        $this->assertSame([[
+        '$bucket' => [
             'groupBy' => '$someField',
             'boundaries' => [1, 2, 3],
             'default' => 0,
-            'output' => ['averageValue' => ['$avg' => '$value']]
-        ]]], $builder->getPipeline());
+            'output' => ['averageValue' => ['$avg' => '$value']],
+        ],
+        ],
+        ], $builder->getPipeline());
     }
 
     public function testBucketSkipsUndefinedProperties()
@@ -57,10 +65,12 @@ class BucketAutoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->groupBy('$someField')
             ->boundaries(1, 2, 3);
 
-        $this->assertSame(['$bucket' => [
+        $this->assertSame([
+        '$bucket' => [
             'groupBy' => '$someField',
             'boundaries' => [1, 2, 3],
-        ]], $bucketStage->getExpression());
+        ],
+        ], $bucketStage->getExpression());
     }
 
     public function testFieldNameConversion()
@@ -76,12 +86,15 @@ class BucketAutoTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                 ->avg('$value');
 
         $this->assertEquals(
-            [['$bucket' => [
+            [[
+            '$bucket' => [
                 'groupBy' => '$ip',
                 'boundaries' => [1, 2, 3],
                 'default' => 0,
-                'output' => ['averageValue' => ['$avg' => '$value']]
-            ]]],
+                'output' => ['averageValue' => ['$avg' => '$value']],
+            ],
+            ],
+            ],
             $builder->getPipeline()
         );
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/CollStatsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/CollStatsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\CollStats;
@@ -51,8 +53,9 @@ class CollStatsTest extends BaseTest
         $this->assertSame([[
             '$collStats' => [
                 'latencyStats' => ['histograms' => true],
-                'storageStats' => []
-            ]
-        ]], $builder->getPipeline());
+                'storageStats' => [],
+            ],
+        ],
+        ], $builder->getPipeline());
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/CountTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/CountTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Count;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FacetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FacetTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Facet;
@@ -26,7 +28,7 @@ class FacetTest extends BaseTest
             '$facet' => [
                 'someField' => [['$sortByCount' => '$tags']],
                 'otherField' => [['$sortByCount' => '$comments']],
-            ]
+            ],
         ], $facetStage->getExpression());
     }
 
@@ -46,8 +48,9 @@ class FacetTest extends BaseTest
             '$facet' => [
                 'someField' => [['$sortByCount' => '$tags']],
                 'otherField' => [['$sortByCount' => '$comments']],
-            ]
-        ]], $builder->getPipeline());
+            ],
+        ],
+        ], $builder->getPipeline());
     }
 
     public function testFacetThrowsExceptionWithoutFieldName()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GeoNearTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GeoNearTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\GeoNear;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
@@ -7,14 +9,17 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\GraphLookup;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\GraphLookup\Airport;
 use Documents\GraphLookup\Employee;
 use Documents\GraphLookup\ReportingHierarchy;
 use Documents\GraphLookup\Traveller;
 use Documents\Sharded\ShardedOne;
 use Documents\User;
+use function array_merge;
+use function count;
 
-class GraphLookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GraphLookupTest extends BaseTest
 {
     use AggregationTestTrait;
 
@@ -34,14 +39,16 @@ class GraphLookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->alias('reportingHierarchy');
 
         $this->assertEquals(
-            ['$graphLookup' => [
+            [
+            '$graphLookup' => [
                 'from' => 'employees',
                 'startWith' => '$reportsTo',
                 'connectFromField' => 'reportsTo',
                 'connectToField' => 'name',
                 'as' => 'reportingHierarchy',
                 'restrictSearchWithMatch' => (object) [],
-            ]],
+            ],
+            ],
             $graphLookupStage->getExpression()
         );
     }
@@ -56,14 +63,17 @@ class GraphLookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->alias('reportingHierarchy');
 
         $this->assertEquals(
-            [['$graphLookup' => [
+            [[
+            '$graphLookup' => [
                 'from' => 'employees',
                 'startWith' => '$reportsTo',
                 'connectFromField' => 'reportsTo',
                 'connectToField' => 'name',
                 'as' => 'reportingHierarchy',
                 'restrictSearchWithMatch' => (object) [],
-            ]]],
+            ],
+            ],
+            ],
             $builder->getPipeline()
         );
     }
@@ -83,7 +93,8 @@ class GraphLookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->depthField('depth');
 
         $this->assertSame(
-            [['$graphLookup' => [
+            [[
+            '$graphLookup' => [
                 'from' => 'employees',
                 'startWith' => '$reportsTo',
                 'connectFromField' => 'reportsTo',
@@ -92,7 +103,9 @@ class GraphLookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                 'restrictSearchWithMatch' => ['hobbies' => 'golf'],
                 'maxDepth' => 1,
                 'depthField' => 'depth',
-            ]]],
+            ],
+            ],
+            ],
             $builder->getPipeline()
         );
     }
@@ -109,7 +122,7 @@ class GraphLookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'startWith' => '$reportsTo.id',
                     'connectFromField' => 'reportsTo.id',
                     'connectToField' => '_id',
-                ]
+                ],
             ],
             'owningSideId' => [
                 'addGraphLookupStage' => function (Builder $builder) {
@@ -120,7 +133,7 @@ class GraphLookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'startWith' => '$reportsToId',
                     'connectFromField' => 'reportsToId',
                     'connectToField' => '_id',
-                ]
+                ],
             ],
             'inverseSide' => [
                 'addGraphLookupStage' => function (Builder $builder) {
@@ -131,7 +144,7 @@ class GraphLookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'startWith' => '$reportsTo.id',
                     'connectFromField' => 'reportsTo.id',
                     'connectToField' => '_id',
-                ]
+                ],
             ],
         ];
     }
@@ -153,8 +166,8 @@ class GraphLookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'from' => 'Employee',
                     'as' => 'reportingHierarchy',
                     'restrictSearchWithMatch' => (object) [],
-                ], $expectedFields)
-            ]
+                ], $expectedFields),
+            ],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -187,7 +200,7 @@ class GraphLookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'startWith' => '$nearestAirport.id',
                     'connectFromField' => 'connections.id',
                     'connectToField' => '_id',
-                ]
+                ],
             ],
             'owningSideId' => [
                 'addGraphLookupStage' => function (Builder $builder) {
@@ -201,7 +214,7 @@ class GraphLookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'startWith' => '$nearestAirportId',
                     'connectFromField' => 'connectionIds',
                     'connectToField' => '_id',
-                ]
+                ],
             ],
         ];
     }
@@ -224,8 +237,8 @@ class GraphLookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'maxDepth' => 2,
                     'depthField' => 'numConnections',
                     'restrictSearchWithMatch' => (object) [],
-                ], $expectedFields)
-            ]
+                ], $expectedFields),
+            ],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -265,8 +278,8 @@ class GraphLookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'connectToField' => 'target',
                     'as' => 'targets',
                     'restrictSearchWithMatch' => (object) [],
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GroupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GroupTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Expr;
@@ -41,7 +43,9 @@ class GroupTest extends BaseTest
         return [
             'addToSet()' => ['addToSet', ['$field']],
             'avg()' => ['avg', ['$field']],
-            'expression()' => ['expression', function (Expr $expr) {
+            'expression()' => [
+        'expression',
+        function (Expr $expr) {
                 $expr
                     ->field('dayOfMonth')
                     ->dayOfMonth('$dateField')
@@ -49,7 +53,8 @@ class GroupTest extends BaseTest
                     ->dayOfWeek('$dateField');
 
                 return [$expr];
-            }],
+        },
+            ],
             'first()' => ['first', ['$field']],
             'last()' => ['last', ['$field']],
             'max()' => ['max', ['$field']],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/IndexStatsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/IndexStatsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\IndexStats;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LimitTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LimitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Limit;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LookupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LookupTest.php
@@ -1,12 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\CmsComment;
+use Documents\ReferenceUser;
 use Documents\Sharded\ShardedOne;
+use Documents\SimpleReferenceUser;
+use Documents\User;
 
-class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class LookupTest extends BaseTest
 {
     public function setUp()
     {
@@ -17,7 +23,7 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStage()
     {
-        $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
+        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
             ->lookup('user')
                 ->alias('user');
@@ -29,8 +35,8 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'localField' => 'userId',
                     'foreignField' => '_id',
                     'as' => 'user',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -44,7 +50,7 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageWithFieldNameTranslation()
     {
-        $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
+        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
             ->lookup(CmsComment::class)
                 ->localField('id')
@@ -58,8 +64,8 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'localField' => '_id',
                     'foreignField' => 'ip',
                     'as' => 'user',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -67,9 +73,9 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageWithClassName()
     {
-        $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
+        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
-            ->lookup(\Documents\User::class)
+            ->lookup(User::class)
                 ->localField('userId')
                 ->foreignField('_id')
                 ->alias('user');
@@ -81,8 +87,8 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'localField' => 'userId',
                     'foreignField' => '_id',
                     'as' => 'user',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -96,7 +102,7 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageWithCollectionName()
     {
-        $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
+        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
             ->lookup('randomCollectionName')
                 ->localField('userId')
@@ -110,8 +116,8 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'localField' => 'userId',
                     'foreignField' => '_id',
                     'as' => 'user',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -124,24 +130,22 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageReferenceMany()
     {
-        $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
+        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
             ->unwind('$users')
             ->lookup('users')
                 ->alias('users');
 
         $expectedPipeline = [
-            [
-                '$unwind' => '$users',
-            ],
+            ['$unwind' => '$users'],
             [
                 '$lookup' => [
                     'from' => 'users',
                     'localField' => 'users',
                     'foreignField' => '_id',
                     'as' => 'users',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -157,24 +161,22 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageReferenceManyStoreAsRef()
     {
-        $builder = $this->dm->createAggregationBuilder(\Documents\ReferenceUser::class);
+        $builder = $this->dm->createAggregationBuilder(ReferenceUser::class);
         $builder
             ->unwind('$referencedUsers')
             ->lookup('referencedUsers')
                 ->alias('users');
 
         $expectedPipeline = [
-            [
-                '$unwind' => '$referencedUsers',
-            ],
+            ['$unwind' => '$referencedUsers'],
             [
                 '$lookup' => [
                     'from' => 'users',
                     'localField' => 'referencedUsers.id',
                     'foreignField' => '_id',
                     'as' => 'users',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -192,7 +194,7 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $this->skipOnMongoDB34('$lookup tests without unwind will not work on MongoDB 3.4.0');
 
-        $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
+        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
             ->lookup('users')
                 ->alias('users');
@@ -204,8 +206,8 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'localField' => 'users',
                     'foreignField' => '_id',
                     'as' => 'users',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -220,7 +222,7 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $this->requireMongoDB34('$lookup tests with unwind require at least MongoDB 3.4.0');
 
-        $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
+        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
             ->lookup('users')
                 ->alias('users');
@@ -232,8 +234,8 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'localField' => 'users',
                     'foreignField' => '_id',
                     'as' => 'users',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -248,7 +250,7 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageReferenceOneInverse()
     {
-        $builder = $this->dm->createAggregationBuilder(\Documents\User::class);
+        $builder = $this->dm->createAggregationBuilder(User::class);
         $builder
             ->match()
                 ->field('username')
@@ -258,7 +260,7 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $expectedPipeline = [
             [
-                '$match' => ['username' => 'alcaeus']
+                '$match' => ['username' => 'alcaeus'],
             ],
             [
                 '$lookup' => [
@@ -266,8 +268,8 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'localField' => '_id',
                     'foreignField' => 'userId',
                     'as' => 'simpleReferenceOneInverse',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -280,7 +282,7 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageReferenceManyInverse()
     {
-        $builder = $this->dm->createAggregationBuilder(\Documents\User::class);
+        $builder = $this->dm->createAggregationBuilder(User::class);
         $builder
             ->match()
                 ->field('username')
@@ -290,7 +292,7 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $expectedPipeline = [
             [
-                '$match' => ['username' => 'alcaeus']
+                '$match' => ['username' => 'alcaeus'],
             ],
             [
                 '$lookup' => [
@@ -298,8 +300,8 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'localField' => '_id',
                     'foreignField' => 'users',
                     'as' => 'simpleReferenceManyInverse',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -312,7 +314,7 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageReferenceOneInverseStoreAsRef()
     {
-        $builder = $this->dm->createAggregationBuilder(\Documents\User::class);
+        $builder = $this->dm->createAggregationBuilder(User::class);
         $builder
             ->match()
                 ->field('username')
@@ -322,7 +324,7 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $expectedPipeline = [
             [
-                '$match' => ['username' => 'alcaeus']
+                '$match' => ['username' => 'alcaeus'],
             ],
             [
                 '$lookup' => [
@@ -330,8 +332,8 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'localField' => '_id',
                     'foreignField' => 'referencedUser.id',
                     'as' => 'embeddedReferenceOneInverse',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -344,7 +346,7 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupStageReferenceManyInverseStoreAsRef()
     {
-        $builder = $this->dm->createAggregationBuilder(\Documents\User::class);
+        $builder = $this->dm->createAggregationBuilder(User::class);
         $builder
             ->match()
                 ->field('username')
@@ -354,7 +356,7 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $expectedPipeline = [
             [
-                '$match' => ['username' => 'alcaeus']
+                '$match' => ['username' => 'alcaeus'],
             ],
             [
                 '$lookup' => [
@@ -362,8 +364,8 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     'localField' => '_id',
                     'foreignField' => 'referencedUsers.id',
                     'as' => 'embeddedReferenceManyInverse',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -376,7 +378,7 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLookupToShardedCollectionThrowsException()
     {
-        $builder = $this->dm->createAggregationBuilder(\Documents\User::class);
+        $builder = $this->dm->createAggregationBuilder(User::class);
 
         $this->expectException(MappingException::class);
         $builder
@@ -396,22 +398,22 @@ class LookupTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     private function insertTestData()
     {
-        $user1 = new \Documents\User();
+        $user1 = new User();
         $user1->setUsername('alcaeus');
-        $user2 = new \Documents\User();
+        $user2 = new User();
         $user2->setUsername('malarzm');
-        $user3 = new \Documents\User();
+        $user3 = new User();
         $user3->setUsername('jmikola');
 
         $this->dm->persist($user1);
         $this->dm->persist($user2);
 
-        $simpleReferenceUser = new \Documents\SimpleReferenceUser();
+        $simpleReferenceUser = new SimpleReferenceUser();
         $simpleReferenceUser->user = $user1;
         $simpleReferenceUser->addUser($user1);
         $simpleReferenceUser->addUser($user2);
 
-        $referenceUser = new \Documents\ReferenceUser();
+        $referenceUser = new ReferenceUser();
         $referenceUser->setReferencedUser($user1);
         $referenceUser->addReferencedUser($user1);
         $referenceUser->addReferencedUser($user2);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchTest.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Match;
 use Doctrine\ODM\MongoDB\Query\Expr;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\UTCDateTime;
 
 class MatchTest extends BaseTest
 {
@@ -95,16 +98,18 @@ class MatchTest extends BaseTest
         $builder = $this->dm->createAggregationBuilder('Documents\User');
 
         $date = new \DateTime();
-        $mongoDate = new \MongoDB\BSON\UTCDateTime((int) $date->format('Uv'));
+        $mongoDate = new UTCDateTime((int) $date->format('Uv'));
         $stage = $builder
             ->match()
                 ->field('createdAt')
                 ->lte($date);
 
         $this->assertEquals(
-            ['$match' => [
-                'createdAt' => ['$lte' => $mongoDate]
-            ]],
+            [
+            '$match' => [
+                'createdAt' => ['$lte' => $mongoDate],
+            ],
+            ],
             $stage->getExpression()
         );
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OperatorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OperatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Operator;
@@ -39,8 +41,8 @@ class OperatorTest extends BaseTest
             [
                 'nested' => [
                     'dayOfMonth' => ['$dayOfMonth' => '$dateField'],
-                    'dayOfWeek' => ['$dayOfWeek' => '$dateField']
-                ]
+                    'dayOfWeek' => ['$dayOfWeek' => '$dateField'],
+                ],
             ],
             $stage->getExpression()
         );
@@ -65,7 +67,7 @@ class OperatorTest extends BaseTest
                         ['case' => ['$eq' => ['$numElements', 1]], 'then' => 'One element given'],
                     ],
                     'default' => ['$concat' => ['$numElements', ' elements given']],
-                ]
+                ],
             ],
             $stage->getExpression()
         );

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OutTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OutTest.php
@@ -1,19 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
-class OutTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\Sharded\ShardedUser;
+use Documents\SimpleReferenceUser;
+use Documents\User;
+
+class OutTest extends BaseTest
 {
     public function testOutStageWithClassName()
     {
-        $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
+        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
-            ->out(\Documents\User::class);
+            ->out(User::class);
 
         $expectedPipeline = [
-            [
-                '$out' => 'users'
-            ]
+            ['$out' => 'users'],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -21,14 +26,12 @@ class OutTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testOutStageWithCollectionName()
     {
-        $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
+        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
             ->out('someRandomCollectionName');
 
         $expectedPipeline = [
-            [
-                '$out' => 'someRandomCollectionName'
-            ]
+            ['$out' => 'someRandomCollectionName'],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -40,16 +43,16 @@ class OutTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
      */
     public function testOutStageWithShardedClassName()
     {
-        $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
+        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
-            ->out(\Documents\Sharded\ShardedUser::class);
+            ->out(ShardedUser::class);
 
         $builder->getPipeline();
     }
 
     public function testSubsequentOutStagesAreOverwritten()
     {
-        $builder = $this->dm->createAggregationBuilder(\Documents\SimpleReferenceUser::class);
+        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
             ->out('someCollection')
             ->out('otherCollection');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
@@ -1,12 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Expr;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Project;
-use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationOperatorsProviderTrait;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function array_combine;
+use function array_map;
 
 class ProjectTest extends BaseTest
 {
@@ -54,7 +57,9 @@ class ProjectTest extends BaseTest
     {
         $operators = ['avg', 'max', 'min', 'stdDevPop', 'stdDevSamp', 'sum'];
 
-        return array_combine($operators, array_map(function ($operator) { return [$operator]; }, $operators));
+        return array_combine($operators, array_map(function ($operator) {
+            return [$operator];
+        }, $operators));
     }
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/RedactTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/RedactTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Redact;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
@@ -1,27 +1,33 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\CmsComment;
 use Documents\User;
+use MongoDB\BSON\UTCDateTime;
 
-class ReplaceRootTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class ReplaceRootTest extends BaseTest
 {
     public function testTypeConversion()
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
 
         $dateTime = new \DateTimeImmutable('2000-01-01T00:00Z');
-        $mongoDate = new \MongoDB\BSON\UTCDateTime((int) $dateTime->format('Uv'));
+        $mongoDate = new UTCDateTime((int) $dateTime->format('Uv'));
         $stage = $builder
             ->replaceRoot()
                 ->field('isToday')
                 ->eq('$createdAt', $dateTime);
 
         $this->assertEquals(
-            ['$replaceRoot' => [
+            [
+            '$replaceRoot' => [
                 'isToday' => ['$eq' => ['$createdAt', $mongoDate]],
-            ]],
+            ],
+            ],
             $stage->getExpression()
         );
     }
@@ -31,7 +37,7 @@ class ReplaceRootTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $builder = $this->dm->createAggregationBuilder(User::class);
 
         $dateTime = new \DateTimeImmutable('2000-01-01T00:00Z');
-        $mongoDate = new \MongoDB\BSON\UTCDateTime((int) $dateTime->format('Uv'));
+        $mongoDate = new UTCDateTime((int) $dateTime->format('Uv'));
         $stage = $builder
             ->replaceRoot(
                 $builder->expr()
@@ -40,9 +46,11 @@ class ReplaceRootTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             );
 
         $this->assertEquals(
-            ['$replaceRoot' => [
+            [
+            '$replaceRoot' => [
                 'isToday' => ['$eq' => ['$createdAt', $mongoDate]],
-            ]],
+            ],
+            ],
             $stage->getExpression()
         );
     }
@@ -57,9 +65,11 @@ class ReplaceRootTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                 ->concat('$authorIp', 'foo');
 
         $this->assertEquals(
-            ['$replaceRoot' => [
+            [
+            '$replaceRoot' => [
                 'someField' => ['$concat' => ['$ip', 'foo']],
-            ]],
+            ],
+            ],
             $stage->getExpression()
         );
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SampleTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SampleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Sample;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SkipTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SkipTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Skip;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortByCountTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortByCountTest.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\CmsComment;
 
-class SortByCountTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class SortByCountTest extends BaseTest
 {
     public function testFieldNameConversion()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
@@ -37,20 +39,20 @@ class SortTest extends BaseTest
             'singleFieldSeparated' => [
                 ['field' => -1],
                 'field',
-                'desc'
+                'desc',
             ],
             'singleFieldCombined' => [
                 ['field' => -1],
-                ['field' => 'desc']
+                ['field' => 'desc'],
             ],
             'multipleFields' => [
                 ['field' => -1, 'otherField' => 1],
-                ['field' => 'desc', 'otherField' => 'asc']
+                ['field' => 'desc', 'otherField' => 'asc'],
             ],
             'sortMeta' => [
                 ['field' => ['$meta' => 'textScore'], 'invalidField' => -1],
-                ['field' => 'textScore', 'invalidField' => 'nonExistingMetaField']
-            ]
+                ['field' => 'textScore', 'invalidField' => 'nonExistingMetaField'],
+            ],
         ];
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnwindTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnwindTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Unwind;

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\ODM\MongoDB\Configuration;
@@ -9,6 +11,14 @@ use Doctrine\ODM\MongoDB\UnitOfWork;
 use MongoDB\Client;
 use MongoDB\Model\DatabaseInfo;
 use PHPUnit\Framework\TestCase;
+use const DOCTRINE_MONGODB_DATABASE;
+use const DOCTRINE_MONGODB_SERVER;
+use function array_key_exists;
+use function array_map;
+use function getenv;
+use function in_array;
+use function iterator_to_array;
+use function version_compare;
 
 abstract class BaseTest extends TestCase
 {
@@ -25,7 +35,7 @@ abstract class BaseTest extends TestCase
 
     public function tearDown()
     {
-        if ( ! $this->dm) {
+        if (! $this->dm) {
             return;
         }
 
@@ -75,14 +85,14 @@ abstract class BaseTest extends TestCase
     protected function createTestDocumentManager()
     {
         $config = $this->getConfiguration();
-        $client = new Client(getenv("DOCTRINE_MONGODB_SERVER") ?: DOCTRINE_MONGODB_SERVER, [], ['typeMap' => ['root' => 'array', 'document' => 'array']]);
+        $client = new Client(getenv('DOCTRINE_MONGODB_SERVER') ?: DOCTRINE_MONGODB_SERVER, [], ['typeMap' => ['root' => 'array', 'document' => 'array']]);
 
         return DocumentManager::create($client, $config);
     }
 
     protected function getServerVersion()
     {
-        $result = $this->dm->getClient()->selectDatabase(DOCTRINE_MONGODB_DATABASE)->command(array('buildInfo' => 1))->toArray()[0];
+        $result = $this->dm->getClient()->selectDatabase(DOCTRINE_MONGODB_DATABASE)->command(['buildInfo' => 1])->toArray()[0];
 
         return $result['version'];
     }
@@ -90,11 +100,11 @@ abstract class BaseTest extends TestCase
     protected function skipTestIfNotSharded($className)
     {
         $result = $this->dm->getDocumentDatabase($className)->command(['listCommands' => true])->toArray()[0];
-        if (!$result['ok']) {
+        if (! $result['ok']) {
             $this->markTestSkipped('Could not check whether server supports sharding');
         }
 
-        if (!array_key_exists('shardCollection', $result['commands'])) {
+        if (! array_key_exists('shardCollection', $result['commands'])) {
             $this->markTestSkipped('Test skipped because server does not support sharding');
         }
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\ODM\MongoDB\Configuration;

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -1,14 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
 
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\Mocks\DocumentManagerMock;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\MongoDBException;
 use Documents\CmsPhonenumber;
+use Documents\Tournament\ParticipantSolo;
+use Documents\User;
+use MongoDB\BSON\ObjectId;
 use MongoDB\Client;
+use function get_class;
 
-class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class DocumentManagerTest extends BaseTest
 {
     public function testCustomRepository()
     {
@@ -77,7 +83,7 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testGetPartialReference()
     {
-        $id = new \MongoDB\BSON\ObjectId();
+        $id = new ObjectId();
         $user = $this->dm->getPartialReference('Documents\CmsUser', $id);
         $this->assertTrue($this->dm->contains($user));
         $this->assertEquals($id, $user->id);
@@ -93,13 +99,13 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function dataMethodsAffectedByNoObjectArguments()
     {
-        return array(
-            array('persist'),
-            array('remove'),
-            array('merge'),
-            array('refresh'),
-            array('detach')
-        );
+        return [
+            ['persist'],
+            ['remove'],
+            ['merge'],
+            ['refresh'],
+            ['detach'],
+        ];
     }
 
     /**
@@ -114,13 +120,13 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function dataAffectedByErrorIfClosedException()
     {
-        return array(
-            array('flush'),
-            array('persist'),
-            array('remove'),
-            array('merge'),
-            array('refresh'),
-        );
+        return [
+            ['flush'],
+            ['persist'],
+            ['remove'],
+            ['merge'],
+            ['refresh'],
+        ];
     }
 
     /**
@@ -129,7 +135,7 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
      */
     public function testAffectedByErrorIfClosedException($methodName)
     {
-        $this->expectException(\Doctrine\ODM\MongoDB\MongoDBException::class);
+        $this->expectException(MongoDBException::class);
         $this->expectExceptionMessage('closed');
 
         $this->dm->close();
@@ -146,7 +152,7 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
      */
     public function testCannotCreateDbRefWithoutId()
     {
-        $d = new \Documents\User();
+        $d = new User();
         $this->dm->createReference($d, ['storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF]);
     }
 
@@ -158,7 +164,7 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $dbRef = $this->dm->createReference($phonenumber, ['storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF, 'targetDocument' => CmsPhonenumber::class]);
 
-        $this->assertSame(array('$ref' => 'CmsPhonenumber', '$id' => 0), $dbRef);
+        $this->assertSame(['$ref' => 'CmsPhonenumber', '$id' => 0], $dbRef);
     }
 
     /**
@@ -168,7 +174,7 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testDisriminatedSimpleReferenceFails()
     {
         $d = new WrongSimpleRefDocument();
-        $r = new \Documents\Tournament\ParticipantSolo('Maciej');
+        $r = new ParticipantSolo('Maciej');
         $this->dm->persist($r);
         $class = $this->dm->getClassMetadata(get_class($d));
         $this->dm->createReference($r, $class->associationMappings['ref']);
@@ -176,13 +182,13 @@ class DocumentManagerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testDifferentStoreAsDbReferences()
     {
-        $r = new \Documents\User();
+        $r = new User();
         $this->dm->persist($r);
         $d = new ReferenceStoreAsDocument();
         $class = $this->dm->getClassMetadata(get_class($d));
 
         $dbRef = $this->dm->createReference($r, $class->associationMappings['ref1']);
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $dbRef);
+        $this->assertInstanceOf(ObjectId::class, $dbRef);
 
         $dbRef = $this->dm->createReference($r, $class->associationMappings['ref2']);
         $this->assertCount(2, $dbRef);

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
-use Doctrine\ODM\MongoDB\LockMode;
 use Documents\Account;
 use Documents\Address;
 use Documents\Developer;
@@ -13,6 +14,7 @@ use Documents\Phonenumber;
 use Documents\SubProject;
 use Documents\User;
 use MongoDB\BSON\ObjectId;
+use const DOCTRINE_MONGODB_DATABASE;
 
 class DocumentRepositoryTest extends BaseTest
 {
@@ -38,7 +40,7 @@ class DocumentRepositoryTest extends BaseTest
             ->getUnitOfWork()
             ->getDocumentPersister(User::class)
             ->prepareQueryOrNewObj(['account' => $account]);
-        $expectedQuery = ['account.$id' => new \MongoDB\BSON\ObjectId($account->getId())];
+        $expectedQuery = ['account.$id' => new ObjectId($account->getId())];
         $this->assertEquals($expectedQuery, $query);
 
         $this->assertSame($user, $this->dm->getRepository(User::class)->findOneBy(['account' => $account]));
@@ -59,8 +61,8 @@ class DocumentRepositoryTest extends BaseTest
             ->prepareQueryOrNewObj(['user' => $user]);
         $expectedQuery = [
             'user.$ref' => 'users',
-            'user.$id' => new \MongoDB\BSON\ObjectId($user->getId()),
-            'user.$db' => DOCTRINE_MONGODB_DATABASE
+            'user.$id' => new ObjectId($user->getId()),
+            'user.$db' => DOCTRINE_MONGODB_DATABASE,
         ];
         $this->assertEquals($expectedQuery, $query);
 
@@ -82,7 +84,7 @@ class DocumentRepositoryTest extends BaseTest
             ->prepareQueryOrNewObj(['userDbRef' => $user]);
         $expectedQuery = [
             'userDbRef.$ref' => 'users',
-            'userDbRef.$id' => new ObjectId($user->getId())
+            'userDbRef.$id' => new ObjectId($user->getId()),
         ];
         $this->assertEquals($expectedQuery, $query);
 
@@ -101,7 +103,7 @@ class DocumentRepositoryTest extends BaseTest
             ->getUnitOfWork()
             ->getDocumentPersister(Developer::class)
             ->prepareQueryOrNewObj(['projects' => $project]);
-        $expectedQuery = ['projects' => ['$elemMatch' => ['$id' => new \MongoDB\BSON\ObjectId($project->getId())]]];
+        $expectedQuery = ['projects' => ['$elemMatch' => ['$id' => new ObjectId($project->getId())]]];
         $this->assertEquals($expectedQuery, $query);
 
         $this->assertSame($developer, $this->dm->getRepository(Developer::class)->findOneBy(['projects' => $project]));
@@ -146,7 +148,7 @@ class DocumentRepositoryTest extends BaseTest
         $expectedQuery = [
             'groups' => [
                 '$elemMatch' => [
-                    '$id' => new \MongoDB\BSON\ObjectId($group->getId()),
+                    '$id' => new ObjectId($group->getId()),
                 ],
             ],
         ];

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleCallbacksTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleCallbacksTest.php
@@ -1,12 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Events;
 
 use Doctrine\ODM\MongoDB\Event;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 
-class LifecycleCallbacksTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class LifecycleCallbacksTest extends BaseTest
 {
     private function createUser($name = 'jon', $fullName = 'Jonathan H. Wage')
     {
@@ -24,7 +27,7 @@ class LifecycleCallbacksTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user = $this->createUser();
         $this->dm->clear();
 
-        $user = $this->dm->find(__NAMESPACE__.'\User', $user->id);
+        $user = $this->dm->find(__NAMESPACE__ . '\User', $user->id);
         $this->assertInstanceOf('DateTime', $user->createdAt);
         $this->assertInstanceOf('DateTime', $user->profile->createdAt);
 
@@ -33,7 +36,7 @@ class LifecycleCallbacksTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $user = $this->dm->find(__NAMESPACE__.'\User', $user->id);
+        $user = $this->dm->find(__NAMESPACE__ . '\User', $user->id);
         $this->assertInstanceOf('DateTime', $user->updatedAt);
         $this->assertInstanceOf('DateTime', $user->profile->updatedAt);
     }
@@ -61,7 +64,7 @@ class LifecycleCallbacksTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue($user->postUpdate);
         $this->assertTrue($user->profile->postUpdate);
     }
-    
+
     public function testPreFlush()
     {
         $user = $this->createUser();
@@ -78,7 +81,7 @@ class LifecycleCallbacksTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user = $this->createUser();
         $this->dm->clear();
 
-        $user = $this->dm->find(__NAMESPACE__.'\User', $user->id);
+        $user = $this->dm->find(__NAMESPACE__ . '\User', $user->id);
 
         $this->assertTrue($user->preLoad);
         $this->assertTrue($user->profile->preLoad);
@@ -126,7 +129,7 @@ class LifecycleCallbacksTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue($profile->postUpdate);
 
         $this->dm->clear();
-        $user = $this->dm->find(__NAMESPACE__.'\User', $user->id);
+        $user = $this->dm->find(__NAMESPACE__ . '\User', $user->id);
         $profile = $user->profiles[0];
 
         $this->assertTrue($profile->preLoad);
@@ -172,10 +175,10 @@ class LifecycleCallbacksTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue($profile->postUpdate);
 
         $this->dm->clear();
-        $user = $this->dm->find(__NAMESPACE__.'\User', $user->id);
+        $user = $this->dm->find(__NAMESPACE__ . '\User', $user->id);
         $profile = $user->profile->profile;
         $profile->name = '2nd level changed again';
-        
+
         $profile2 = new Profile();
         $profile2->name = 'test';
         $user->profiles[] = $profile2;
@@ -206,12 +209,12 @@ class LifecycleCallbacksTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue($user->profiles[0]->preRemove);
         $this->assertTrue($user->profiles[0]->postRemove);
     }
-    
+
     public function testReferences()
     {
         $user = $this->createUser();
         $user2 = $this->createUser('maciej', 'Maciej Malarz');
-        
+
         $user->friends[] = $user2;
         $this->dm->flush();
 
@@ -250,10 +253,10 @@ class User extends BaseDocument
     public $profile;
 
     /** @ODM\EmbedMany(targetDocument="Profile") */
-    public $profiles = array();
-    
+    public $profiles = [];
+
     /** @ODM\ReferenceMany(targetDocument="User") */
-    public $friends = array();
+    public $friends = [];
 }
 
 /** @ODM\Document */
@@ -358,7 +361,7 @@ abstract class BaseDocument
     {
         $this->postLoad = true;
     }
-    
+
     /** @ODM\PreFlush */
     public function preFlush(Event\PreFlushEventArgs $e)
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleListenersTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleListenersTest.php
@@ -1,18 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Events;
 
 use Doctrine\ODM\MongoDB\Event\PostCollectionLoadEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function get_class;
 
-class LifecycleListenersTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class LifecycleListenersTest extends BaseTest
 {
     private function getDocumentManager()
     {
         $this->listener = new MyEventListener();
         $evm = $this->dm->getEventManager();
-        $events = array(
+        $events = [
             Events::prePersist,
             Events::postPersist,
             Events::preUpdate,
@@ -21,7 +25,7 @@ class LifecycleListenersTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             Events::postLoad,
             Events::preRemove,
             Events::postRemove,
-        );
+        ];
         $evm->addEventListener($events, $this->listener);
         return $this->dm;
     }
@@ -35,55 +39,55 @@ class LifecycleListenersTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $dm->persist($test);
         $dm->flush();
 
-        $called = array(
-            Events::prePersist => array('Doctrine\ODM\MongoDB\Tests\Events\TestDocument'),
-            Events::postPersist => array('Doctrine\ODM\MongoDB\Tests\Events\TestDocument')
-        );
+        $called = [
+            Events::prePersist => ['Doctrine\ODM\MongoDB\Tests\Events\TestDocument'],
+            Events::postPersist => ['Doctrine\ODM\MongoDB\Tests\Events\TestDocument'],
+        ];
         $this->assertEquals($called, $this->listener->called);
-        $this->listener->called = array();
+        $this->listener->called = [];
 
         $test->embedded[0] = new TestEmbeddedDocument();
         $test->embedded[0]->name = 'cool';
         $dm->flush();
         $dm->clear();
 
-        $called = array(
-            Events::prePersist => array('Doctrine\ODM\MongoDB\Tests\Events\TestEmbeddedDocument'),
-            Events::preUpdate => array('Doctrine\ODM\MongoDB\Tests\Events\TestDocument'),
-            Events::postUpdate => array('Doctrine\ODM\MongoDB\Tests\Events\TestDocument'),
-            Events::postPersist => array('Doctrine\ODM\MongoDB\Tests\Events\TestEmbeddedDocument')
-        );
+        $called = [
+            Events::prePersist => ['Doctrine\ODM\MongoDB\Tests\Events\TestEmbeddedDocument'],
+            Events::preUpdate => ['Doctrine\ODM\MongoDB\Tests\Events\TestDocument'],
+            Events::postUpdate => ['Doctrine\ODM\MongoDB\Tests\Events\TestDocument'],
+            Events::postPersist => ['Doctrine\ODM\MongoDB\Tests\Events\TestEmbeddedDocument'],
+        ];
         $this->assertEquals($called, $this->listener->called);
-        $this->listener->called = array();
+        $this->listener->called = [];
 
-        $document = $dm->find(__NAMESPACE__.'\TestDocument', $test->id);
+        $document = $dm->find(__NAMESPACE__ . '\TestDocument', $test->id);
         $document->embedded->initialize();
-        $called = array(
-            Events::preLoad => array('Doctrine\ODM\MongoDB\Tests\Events\TestDocument', 'Doctrine\ODM\MongoDB\Tests\Events\TestEmbeddedDocument'),
-            Events::postLoad => array('Doctrine\ODM\MongoDB\Tests\Events\TestDocument', 'Doctrine\ODM\MongoDB\Tests\Events\TestEmbeddedDocument')
-        );
+        $called = [
+            Events::preLoad => ['Doctrine\ODM\MongoDB\Tests\Events\TestDocument', 'Doctrine\ODM\MongoDB\Tests\Events\TestEmbeddedDocument'],
+            Events::postLoad => ['Doctrine\ODM\MongoDB\Tests\Events\TestDocument', 'Doctrine\ODM\MongoDB\Tests\Events\TestEmbeddedDocument'],
+        ];
         $this->assertEquals($called, $this->listener->called);
-        $this->listener->called = array();
+        $this->listener->called = [];
 
         $document->embedded[0]->name = 'changed';
         $dm->flush();
 
-        $called = array(
-            Events::preUpdate => array('Doctrine\ODM\MongoDB\Tests\Events\TestDocument', 'Doctrine\ODM\MongoDB\Tests\Events\TestEmbeddedDocument'),
-            Events::postUpdate => array('Doctrine\ODM\MongoDB\Tests\Events\TestDocument', 'Doctrine\ODM\MongoDB\Tests\Events\TestEmbeddedDocument')
-        );
+        $called = [
+            Events::preUpdate => ['Doctrine\ODM\MongoDB\Tests\Events\TestDocument', 'Doctrine\ODM\MongoDB\Tests\Events\TestEmbeddedDocument'],
+            Events::postUpdate => ['Doctrine\ODM\MongoDB\Tests\Events\TestDocument', 'Doctrine\ODM\MongoDB\Tests\Events\TestEmbeddedDocument'],
+        ];
         $this->assertEquals($called, $this->listener->called);
-        $this->listener->called = array();
+        $this->listener->called = [];
 
         $dm->remove($document);
         $dm->flush();
 
-        $called = array(
-            Events::preRemove => array('Doctrine\ODM\MongoDB\Tests\Events\TestEmbeddedDocument', 'Doctrine\ODM\MongoDB\Tests\Events\TestDocument'),
-            Events::postRemove => array('Doctrine\ODM\MongoDB\Tests\Events\TestEmbeddedDocument', 'Doctrine\ODM\MongoDB\Tests\Events\TestDocument')
-        );
+        $called = [
+            Events::preRemove => ['Doctrine\ODM\MongoDB\Tests\Events\TestEmbeddedDocument', 'Doctrine\ODM\MongoDB\Tests\Events\TestDocument'],
+            Events::postRemove => ['Doctrine\ODM\MongoDB\Tests\Events\TestEmbeddedDocument', 'Doctrine\ODM\MongoDB\Tests\Events\TestDocument'],
+        ];
         $this->assertEquals($called, $this->listener->called);
-        $this->listener->called = array();
+        $this->listener->called = [];
 
         $test = new TestDocument();
         $test->name = 'test';
@@ -91,19 +95,19 @@ class LifecycleListenersTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $test->embedded[0]->name = 'cool';
         $dm->persist($test);
         $dm->flush();
-        $this->listener->called = array();
+        $this->listener->called = [];
 
         $test->name = 'cool';
         $dm->flush();
 
         $dm->clear();
 
-        $called = array(
-            Events::preUpdate => array('Doctrine\ODM\MongoDB\Tests\Events\TestDocument'),
-            Events::postUpdate => array('Doctrine\ODM\MongoDB\Tests\Events\TestDocument')
-        );
+        $called = [
+            Events::preUpdate => ['Doctrine\ODM\MongoDB\Tests\Events\TestDocument'],
+            Events::postUpdate => ['Doctrine\ODM\MongoDB\Tests\Events\TestDocument'],
+        ];
         $this->assertEquals($called, $this->listener->called);
-        $this->listener->called = array();
+        $this->listener->called = [];
     }
 
     public function testMultipleLevelsOfEmbeddedDocsPrePersist()
@@ -117,29 +121,29 @@ class LifecycleListenersTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $dm->flush();
         $dm->clear();
 
-        $test = $dm->find(__NAMESPACE__.'\TestProfile', $test->id);
-        $this->listener->called = array();
+        $test = $dm->find(__NAMESPACE__ . '\TestProfile', $test->id);
+        $this->listener->called = [];
 
         $test->image->thumbnails[] = new Thumbnail('Thumbnail #1');
 
         $dm->flush();
-        $called = array(
-            Events::prePersist => array('Doctrine\ODM\MongoDB\Tests\Events\Thumbnail'),
-            Events::preUpdate => array('Doctrine\ODM\MongoDB\Tests\Events\TestProfile', 'Doctrine\ODM\MongoDB\Tests\Events\Image'),
-            Events::postUpdate => array('Doctrine\ODM\MongoDB\Tests\Events\TestProfile', 'Doctrine\ODM\MongoDB\Tests\Events\Image'),
-            Events::postPersist => array('Doctrine\ODM\MongoDB\Tests\Events\Thumbnail')
-        );
+        $called = [
+            Events::prePersist => ['Doctrine\ODM\MongoDB\Tests\Events\Thumbnail'],
+            Events::preUpdate => ['Doctrine\ODM\MongoDB\Tests\Events\TestProfile', 'Doctrine\ODM\MongoDB\Tests\Events\Image'],
+            Events::postUpdate => ['Doctrine\ODM\MongoDB\Tests\Events\TestProfile', 'Doctrine\ODM\MongoDB\Tests\Events\Image'],
+            Events::postPersist => ['Doctrine\ODM\MongoDB\Tests\Events\Thumbnail'],
+        ];
         $this->assertEquals($called, $this->listener->called);
-        $this->listener->called = array();
+        $this->listener->called = [];
 
         $test->image->thumbnails[0]->name = 'ok';
         $dm->flush();
-        $called = array(
-            Events::preUpdate => array('Doctrine\ODM\MongoDB\Tests\Events\TestProfile', 'Doctrine\ODM\MongoDB\Tests\Events\Image', 'Doctrine\ODM\MongoDB\Tests\Events\Thumbnail'),
-            Events::postUpdate => array('Doctrine\ODM\MongoDB\Tests\Events\TestProfile', 'Doctrine\ODM\MongoDB\Tests\Events\Image', 'Doctrine\ODM\MongoDB\Tests\Events\Thumbnail'),
-        );
+        $called = [
+            Events::preUpdate => ['Doctrine\ODM\MongoDB\Tests\Events\TestProfile', 'Doctrine\ODM\MongoDB\Tests\Events\Image', 'Doctrine\ODM\MongoDB\Tests\Events\Thumbnail'],
+            Events::postUpdate => ['Doctrine\ODM\MongoDB\Tests\Events\TestProfile', 'Doctrine\ODM\MongoDB\Tests\Events\Image', 'Doctrine\ODM\MongoDB\Tests\Events\Thumbnail'],
+        ];
         $this->assertEquals($called, $this->listener->called);
-        $this->listener->called = array();
+        $this->listener->called = [];
     }
 
     public function testChangeToReferenceFieldTriggersEvents()
@@ -153,29 +157,29 @@ class LifecycleListenersTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $dm->persist($profile);
         $dm->flush();
         $dm->clear();
-        $this->listener->called = array();
+        $this->listener->called = [];
 
-        $called = array(
-            Events::preUpdate => array('Doctrine\ODM\MongoDB\Tests\Events\TestDocument'),
-            Events::postUpdate => array('Doctrine\ODM\MongoDB\Tests\Events\TestDocument'),
-        );
+        $called = [
+            Events::preUpdate => ['Doctrine\ODM\MongoDB\Tests\Events\TestDocument'],
+            Events::postUpdate => ['Doctrine\ODM\MongoDB\Tests\Events\TestDocument'],
+        ];
 
         $document = $dm->getRepository(get_class($document))->find($document->id);
         $profile = $dm->getRepository(get_class($profile))->find($profile->id);
-        $this->listener->called = array();
+        $this->listener->called = [];
         $document->profile = $profile;
         $dm->flush();
         $dm->clear();
         $this->assertEquals($called, $this->listener->called, 'Changing ReferenceOne field did not dispatched proper events.');
-        $this->listener->called = array();
+        $this->listener->called = [];
 
         $document = $dm->getRepository(get_class($document))->find($document->id);
         $profile = $dm->getRepository(get_class($profile))->find($profile->id);
-        $this->listener->called = array();
+        $this->listener->called = [];
         $document->profiles[] = $profile;
         $dm->flush();
         $this->assertEquals($called, $this->listener->called, 'Changing ReferenceMany field did not dispatched proper events.');
-        $this->listener->called = array();
+        $this->listener->called = [];
     }
 
     public function testPostCollectionLoad()
@@ -205,7 +209,7 @@ class LifecycleListenersTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
 class MyEventListener
 {
-    public $called = array();
+    public $called = [];
 
     public function __call($method, $args)
     {
@@ -302,7 +306,7 @@ class Image
     public $name;
 
     /** @ODM\EmbedMany(targetDocument="Thumbnail") */
-    public $thumbnails = array();
+    public $thumbnails = [];
 
     public function __construct($name)
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/PreLoadEventArgsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/PreLoadEventArgsTest.php
@@ -1,17 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Events;
 
 use Doctrine\ODM\MongoDB\Event\PreLoadEventArgs;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Group;
 
-class PreLoadEventArgsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class PreLoadEventArgsTest extends BaseTest
 {
     public function testGetData()
     {
         $document = new Group('test');
         $dm = $this->dm;
-        $data = array('id' => '1234', 'name' => 'test');
+        $data = ['id' => '1234', 'name' => 'test'];
 
         $eventArgs = new PreLoadEventArgs($document, $dm, $data);
         $eventArgsData =& $eventArgs->getData();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/PreUpdateEventArgsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/PreUpdateEventArgsTest.php
@@ -1,15 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Events;
 
 use Doctrine\ODM\MongoDB\Event\PreUpdateEventArgs;
 use Doctrine\ODM\MongoDB\Events;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Article;
 use Documents\Book;
 use Documents\Chapter;
 use Documents\Page;
+use function get_class;
+use function in_array;
 
-class PreUpdateEventArgsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class PreUpdateEventArgsTest extends BaseTest
 {
     public function testChangeSetIsUpdated()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AlsoLoadTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AlsoLoadTest.php
@@ -1,24 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Documents\Functional\AlsoLoad;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function explode;
 
-class AlsoLoadTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class AlsoLoadTest extends BaseTest
 {
     public function testPropertyAlsoLoadDoesNotInterfereWithBasicHydration()
     {
-        $document = array(
+        $document = [
             'foo' => 'foo',
             'bar' => 'bar',
             'baz' => null,
             'zip' => 'zip',
-        );
+        ];
 
         $this->dm->getDocumentCollection(__NAMESPACE__ . '\AlsoLoadDocument')->insertOne($document);
 
-        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy(array());
+        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy([]);
 
         $this->assertEquals('foo', $document->foo, '"foo" gets its own value and ignores "bar" and "zip"');
         $this->assertEquals('bar', $document->bar, '"bar" is hydrated normally');
@@ -27,11 +30,11 @@ class AlsoLoadTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testPropertyAlsoLoadMayOverwriteDefaultPropertyValue()
     {
-        $document = array('zip' => 'zip');
+        $document = ['zip' => 'zip'];
 
         $this->dm->getDocumentCollection(__NAMESPACE__ . '\AlsoLoadDocument')->insertOne($document);
 
-        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy(array());
+        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy([]);
 
         $this->assertEquals('zip', $document->zap, '"zap" gets value from "zip", overwriting its default value');
         $this->assertEquals('zip', $document->zip, '"zip" is hydrated normally');
@@ -39,14 +42,14 @@ class AlsoLoadTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testPropertyAlsoLoadShortCircuitsAfterFirstFieldIsFound()
     {
-        $document = array(
+        $document = [
             'bar' => null,
             'zip' => 'zip',
-        );
+        ];
 
         $this->dm->getDocumentCollection(__NAMESPACE__ . '\AlsoLoadDocument')->insertOne($document);
 
-        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy(array());
+        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy([]);
 
         $this->assertEquals(null, $document->foo, '"foo" gets null value from "bar" and ignores "zip"');
         $this->assertEquals('zip', $document->baz, '"baz" gets value from "zip" and ignores "bar"');
@@ -56,11 +59,11 @@ class AlsoLoadTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testPropertyAlsoLoadChecksMultipleFields()
     {
-        $document = array('zip' => 'zip');
+        $document = ['zip' => 'zip'];
 
         $this->dm->getDocumentCollection(__NAMESPACE__ . '\AlsoLoadDocument')->insertOne($document);
 
-        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy(array());
+        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy([]);
 
         $this->assertEquals('zip', $document->foo, '"foo" gets value from "zip" since "bar" was missing');
         $this->assertNull($document->bar, '"bar" is not hydrated');
@@ -69,14 +72,14 @@ class AlsoLoadTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testPropertyAlsoLoadBeatsMethodAlsoLoad()
     {
-        $document = array(
+        $document = [
             'testNew' => 'testNew',
             'testOld' => 'testOld',
-        );
+        ];
 
         $this->dm->getDocumentCollection(__NAMESPACE__ . '\AlsoLoadDocument')->insertOne($document);
 
-        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy(array());
+        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy([]);
 
         $this->assertEquals('testNew', $document->test, '"test" gets value from "testNew"');
         $this->assertEquals('testNew', $document->testNew, '"testNew" is hydrated normally');
@@ -85,14 +88,14 @@ class AlsoLoadTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testMethodAlsoLoadDoesNotInterfereWithBasicHydration()
     {
-        $document = array(
+        $document = [
             'firstName' => 'Jonathan',
             'name' => 'Kris Wallsmith',
-        );
+        ];
 
         $this->dm->getDocumentCollection(__NAMESPACE__ . '\AlsoLoadDocument')->insertOne($document);
 
-        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy(array());
+        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy([]);
 
         $this->assertEquals('Jonathan', $document->firstName, '"firstName" gets value from exploded "name" but is overwritten with normal hydration');
         $this->assertEquals('Wallsmith', $document->lastName, '"lastName" gets value from exploded "name"');
@@ -101,11 +104,11 @@ class AlsoLoadTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testMethodAlsoLoadMayOverwriteDefaultPropertyValue()
     {
-        $document = array('testOld' => null);
+        $document = ['testOld' => null];
 
         $this->dm->getDocumentCollection(__NAMESPACE__ . '\AlsoLoadDocument')->insertOne($document);
 
-        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy(array());
+        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy([]);
 
         $this->assertNull($document->test, '"test" gets value from "testOld", overwriting its default value');
         $this->assertNull($document->testOld, '"testOld" is hydrated normally"');
@@ -113,16 +116,16 @@ class AlsoLoadTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testMethodAlsoLoadShortCircuitsAfterFirstFieldIsFound()
     {
-        $document = array(
+        $document = [
             'name' => 'Jonathan Wage',
             'fullName' => 'Kris Wallsmith',
             'testOld' => 'testOld',
             'testOlder' => 'testOlder',
-        );
+        ];
 
         $this->dm->getDocumentCollection(__NAMESPACE__ . '\AlsoLoadDocument')->insertOne($document);
 
-        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy(array());
+        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy([]);
 
         $this->assertEquals('Jonathan Wage', $document->name, '"name" is hydrated normally');
         $this->assertEquals('Kris Wallsmith', $document->fullName, '"fullName" is hydrated normally');
@@ -136,14 +139,14 @@ class AlsoLoadTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testMethodAlsoLoadChecksMultipleFields()
     {
-        $document = array(
+        $document = [
             'fullName' => 'Kris Wallsmith',
             'testOlder' => 'testOlder',
-        );
+        ];
 
         $this->dm->getDocumentCollection(__NAMESPACE__ . '\AlsoLoadDocument')->insertOne($document);
 
-        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy(array());
+        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadDocument')->findOneBy([]);
 
         $this->assertNull($document->name, '"name" is not hydrated');
         $this->assertEquals('Kris Wallsmith', $document->fullName, '"fullName" is hydrated normally');
@@ -176,16 +179,16 @@ class AlsoLoadTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testMethodAlsoLoadParentInheritance()
     {
-        $document = array(
+        $document = [
             'buzz' => 'buzz',
             'test' => 'test',
             'testOld' => 'testOld',
             'testOlder' => 'testOlder',
-        );
+        ];
 
         $this->dm->getDocumentCollection(__NAMESPACE__ . '\AlsoLoadChild')->insertOne($document);
 
-        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadChild')->findOneBy(array());
+        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadChild')->findOneBy([]);
 
         $this->assertEquals('buzz', $document->fizz, '"fizz" gets value from "buzz"');
         $this->assertEquals('test', $document->test, '"test" is hydrated normally, since "testOldest" was missing and parent method was overridden');
@@ -193,14 +196,14 @@ class AlsoLoadTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testMethodAlsoLoadGrandparentInheritance()
     {
-        $document = array(
+        $document = [
             'buzz' => 'buzz',
             'testReallyOldest' => 'testReallyOldest',
-        );
+        ];
 
         $this->dm->getDocumentCollection(__NAMESPACE__ . '\AlsoLoadGrandchild')->insertOne($document);
 
-        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadGrandchild')->findOneBy(array());
+        $document = $this->dm->getRepository(__NAMESPACE__ . '\AlsoLoadGrandchild')->findOneBy([]);
 
         $this->assertEquals('buzz', $document->fizz, '"fizz" gets value from "buzz"');
         $this->assertEquals('testReallyOldest', $document->test, '"test" gets value from "testReallyOldest"');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/BidirectionalInheritanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/BidirectionalInheritanceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Tests\BaseTest;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\Binary;
+use function get_class;
 
 class BinDataTest extends BaseTest
 {
@@ -17,23 +21,23 @@ class BinDataTest extends BaseTest
         $this->dm->persist($test);
         $this->dm->flush();
 
-        $check = $this->dm->getDocumentCollection(get_class($test))->findOne(array());
-        $this->assertInstanceOf(\MongoDB\BSON\Binary::class, $check[$field]);
+        $check = $this->dm->getDocumentCollection(get_class($test))->findOne([]);
+        $this->assertInstanceOf(Binary::class, $check[$field]);
         $this->assertEquals($type, $check[$field]->getType());
         $this->assertEquals($data, $check[$field]->getData());
     }
 
     public function provideData()
     {
-        return array(
-            array('bin', 'test', \MongoDB\BSON\Binary::TYPE_GENERIC),
-            array('binFunc', 'test', \MongoDB\BSON\Binary::TYPE_FUNCTION),
-            array('binByteArray', 'test', \MongoDB\BSON\Binary::TYPE_OLD_BINARY),
-            array('binUUID', 'testtesttesttest', \MongoDB\BSON\Binary::TYPE_OLD_UUID),
-            array('binUUIDRFC4122', '1234567890ABCDEF', \MongoDB\BSON\Binary::TYPE_UUID),
-            array('binMD5', 'test', \MongoDB\BSON\Binary::TYPE_MD5),
-            array('binCustom', 'test', \MongoDB\BSON\Binary::TYPE_USER_DEFINED),
-        );
+        return [
+            ['bin', 'test', Binary::TYPE_GENERIC],
+            ['binFunc', 'test', Binary::TYPE_FUNCTION],
+            ['binByteArray', 'test', Binary::TYPE_OLD_BINARY],
+            ['binUUID', 'testtesttesttest', Binary::TYPE_OLD_UUID],
+            ['binUUIDRFC4122', '1234567890ABCDEF', Binary::TYPE_UUID],
+            ['binMD5', 'test', Binary::TYPE_MD5],
+            ['binCustom', 'test', Binary::TYPE_USER_DEFINED],
+        ];
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Persisters\CollectionPersister;
 use Doctrine\ODM\MongoDB\Persisters\PersistenceBuilder;
-use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function get_class;
 
 class CollectionPersisterTest extends BaseTest
 {
@@ -13,9 +17,9 @@ class CollectionPersisterTest extends BaseTest
     {
         $persister = $this->getCollectionPersister();
         $user = $this->getTestUser('jwage');
-        $persister->delete($user->phonenumbers, array());
+        $persister->delete($user->phonenumbers, []);
 
-        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
         $this->assertArrayNotHasKey('phonenumbers', $user, 'Test that the phonenumbers field was deleted');
     }
 
@@ -23,9 +27,9 @@ class CollectionPersisterTest extends BaseTest
     {
         $persister = $this->getCollectionPersister();
         $user = $this->getTestUser('jwage');
-        $persister->delete($user->categories, array());
+        $persister->delete($user->categories, []);
 
-        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
         $this->assertArrayNotHasKey('categories', $user, 'Test that the categories field was deleted');
     }
 
@@ -34,18 +38,18 @@ class CollectionPersisterTest extends BaseTest
         $persister = $this->getCollectionPersister();
         $user = $this->getTestUser('jwage');
 
-        $persister->delete($user->categories[0]->children[0]->children, array());
-        $persister->delete($user->categories[0]->children[1]->children, array());
+        $persister->delete($user->categories[0]->children[0]->children, []);
+        $persister->delete($user->categories[0]->children[1]->children, []);
 
-        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
 
         $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
         $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
 
-        $persister->delete($user->categories[0]->children, array());
-        $persister->delete($user->categories[1]->children, array());
+        $persister->delete($user->categories[0]->children, []);
+        $persister->delete($user->categories[1]->children, []);
 
-        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
 
         $this->assertFalse(isset($check['categories'][0]['children']), 'Test that the nested children categories field was deleted');
         $this->assertTrue(isset($check['categories'][0]), 'Test that the category with the children still exists');
@@ -70,7 +74,7 @@ class CollectionPersisterTest extends BaseTest
 
         $this->dm->flush();
 
-        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
 
         $this->assertFalse(isset($check['phonenumbers'][0]));
         $this->assertFalse(isset($check['phonenumbers'][1]));
@@ -85,7 +89,7 @@ class CollectionPersisterTest extends BaseTest
         unset($user->categories[1]);
         $this->dm->flush();
 
-        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
         $this->assertFalse(isset($check['categories'][0]));
         $this->assertFalse(isset($check['categories'][1]));
     }
@@ -97,7 +101,7 @@ class CollectionPersisterTest extends BaseTest
         $user->phonenumbers[] = new CollectionPersisterPhonenumber('6155139185');
         $this->dm->flush();
 
-        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
         $this->assertCount(4, $check['phonenumbers']);
         $this->assertEquals((string) $check['phonenumbers'][2]['$id'], $user->phonenumbers[2]->id);
         $this->assertEquals((string) $check['phonenumbers'][3]['$id'], $user->phonenumbers[3]->id);
@@ -106,7 +110,7 @@ class CollectionPersisterTest extends BaseTest
         $user->categories[] = new CollectionPersisterCategory('Test');
         $this->dm->flush();
 
-        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
         $this->assertCount(4, $check['categories']);
 
         $user->categories[3]->children[0] = new CollectionPersisterCategory('Test');
@@ -115,7 +119,7 @@ class CollectionPersisterTest extends BaseTest
         $user->categories[3]->children[1]->children[1] = new CollectionPersisterCategory('Test');
         $this->dm->flush();
 
-        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
         $this->assertCount(2, $check['categories'][3]['children']);
         $this->assertCount(2, $check['categories'][3]['children']['1']['children']);
     }
@@ -168,7 +172,7 @@ class CollectionPersisterTest extends BaseTest
         $this->dm->persist($post);
         $this->dm->flush();
 
-        $doc = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterPost')->findOne(array('post' => 'postA'));
+        $doc = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterPost')->findOne(['post' => 'postA']);
 
         $this->assertCount(1, $doc['comments']);
         $this->assertEquals($commentA->comment, $doc['comments']['a']['comment']);
@@ -189,7 +193,7 @@ class CollectionPersisterTest extends BaseTest
         $this->dm->persist($post);
         $this->dm->flush();
 
-        $doc = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterPost')->findOne(array('post' => 'postA'));
+        $doc = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterPost')->findOne(['post' => 'postA']);
 
         $this->assertCount(2, $doc['comments']);
         $this->assertEquals($commentA->comment, $doc['comments']['a']['comment']);
@@ -209,7 +213,7 @@ class CollectionPersisterTest extends BaseTest
         $this->dm->persist($post);
         $this->dm->flush();
 
-        $doc = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterPost')->findOne(array('post' => 'postA'));
+        $doc = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterPost')->findOne(['post' => 'postA']);
 
         $this->assertCount(2, $doc['comments']);
         $this->assertEquals($commentA->comment, $doc['comments']['a']['comment']);
@@ -226,7 +230,7 @@ class CollectionPersisterTest extends BaseTest
         $this->dm->persist($post);
         $this->dm->flush();
 
-        $doc = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterPost')->findOne(array('post' => 'postA'));
+        $doc = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterPost')->findOne(['post' => 'postA']);
 
         $this->assertCount(1, $doc['comments']);
         $this->assertEquals($commentA->comment, $doc['comments']['a']['comment']);
@@ -248,8 +252,8 @@ class CollectionPersisterTest extends BaseTest
         $this->dm->persist($post);
         $this->dm->flush();
 
-        $this->assertSame($post, $this->dm->getRepository(get_class($post))->findOneBy(array('comments.a.by' => 'userA')));
-        $this->assertSame($post, $this->dm->getRepository(get_class($post))->findOneBy(array('comments.a.comments.b.by' => 'userB')));
+        $this->assertSame($post, $this->dm->getRepository(get_class($post))->findOneBy(['comments.a.by' => 'userA']));
+        $this->assertSame($post, $this->dm->getRepository(get_class($post))->findOneBy(['comments.a.comments.b.by' => 'userB']));
     }
 }
 
@@ -263,10 +267,10 @@ class CollectionPersisterUser
     public $username;
 
     /** @ODM\EmbedMany(targetDocument="CollectionPersisterCategory") */
-    public $categories = array();
+    public $categories = [];
 
     /** @ODM\ReferenceMany(targetDocument="CollectionPersisterPhonenumber", cascade={"persist"}) */
-    public $phonenumbers = array();
+    public $phonenumbers = [];
 }
 
 /** @ODM\EmbeddedDocument */
@@ -276,7 +280,7 @@ class CollectionPersisterCategory
     public $name;
 
     /** @ODM\EmbedMany(targetDocument="CollectionPersisterCategory") */
-    public $children = array();
+    public $children = [];
 
     public function __construct($name)
     {
@@ -303,42 +307,40 @@ class CollectionPersisterPhonenumber
 class CollectionPersisterPost
 {
   /** @ODM\Id */
-  public $id;
+    public $id;
 
   /** @ODM\Field(type="string") */
-  public $post;
+    public $post;
 
   /** @ODM\EmbedMany(targetDocument="CollectionPersisterComment", strategy="set") */
-  public $comments = array();
+    public $comments = [];
 
-  function __construct($post)
-  {
-    $this->comments = new \Doctrine\Common\Collections\ArrayCollection();
-    $this->post = $post;
-  }
-
-
+    function __construct($post)
+    {
+        $this->comments = new ArrayCollection();
+        $this->post = $post;
+    }
 }
 
 /** @ODM\EmbeddedDocument */
 class CollectionPersisterComment
 {
   /** @ODM\Id */
-  public $id;
+    public $id;
 
   /** @ODM\Field(type="string") */
-  public $comment;
+    public $comment;
 
   /** @ODM\Field(type="string") */
-  public $by;
+    public $by;
 
   /** @ODM\EmbedMany(targetDocument="CollectionPersisterComment", strategy="set") */
-  public $comments = array();
+    public $comments = [];
 
-  function __construct($comment, $by)
-  {
-    $this->comments = new \Doctrine\Common\Collections\ArrayCollection();
-    $this->comment = $comment;
-    $this->by = $by;
-  }
+    function __construct($comment, $by)
+    {
+        $this->comments = new ArrayCollection();
+        $this->comment = $comment;
+        $this->by = $by;
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionsTest.php
@@ -1,13 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Bars\Bar;
 use Documents\Bars\Location;
-use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-class CollectionsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class CollectionsTest extends BaseTest
 {
     public function testCollections()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
@@ -1,16 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\Events;
+use Doctrine\ODM\MongoDB\LockException;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Tests\QueryLogger;
 use Documents\Phonebook;
 use Documents\Phonenumber;
 use Documents\User;
 use Documents\VersionedUser;
+use function get_class;
 
-class CommitImprovementTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class CommitImprovementTest extends BaseTest
 {
     /**
      * @var Doctrine\ODM\MongoDB\Tests\QueryLogger
@@ -20,7 +25,7 @@ class CommitImprovementTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     protected function getConfiguration()
     {
         $this->markTestSkipped('mongodb-driver: query logging does not exist');
-        if ( ! isset($this->ql)) {
+        if (! isset($this->ql)) {
             $this->ql = new QueryLogger();
         }
 
@@ -68,8 +73,7 @@ class CommitImprovementTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $troll->setVersion(3);
         try {
             $this->dm->flush();
-        } catch (\Doctrine\ODM\MongoDB\LockException $ex) {
-
+        } catch (LockException $ex) {
         }
 
         $this->dm->clear();
@@ -137,22 +141,22 @@ class CommitImprovementTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
 class PhonenumberMachine implements EventSubscriber
 {
-    private $numbers = array('12345678', '87654321');
+    private $numbers = ['12345678', '87654321'];
 
     private $numberId = 0;
 
     public function getSubscribedEvents()
     {
-        return array(
+        return [
             Events::postPersist,
             Events::postUpdate,
-        );
+        ];
     }
 
     public function __call($eventName, $args)
     {
         $document = $args[0]->getDocument();
-        if ( ! ($document instanceof User)) {
+        if (! ($document instanceof User)) {
             return;
         }
         // hey I just met you, and this is crazy!
@@ -165,8 +169,8 @@ class PhonenumberMachine implements EventSubscriber
             // prove that even this won't break our flow
             $dm = $args[0]->getDocumentManager();
             $dm->getUnitOfWork()->recomputeSingleDocumentChangeSet(
-                    $dm->getClassMetadata(get_class($document)),
-                    $document
+                $dm->getClassMetadata(get_class($document)),
+                $document
             );
         }
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php
@@ -1,17 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\PersistentCollection;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\File;
 use Documents\ProfileNotify;
+use function get_class;
 
-class CustomCollectionsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class CustomCollectionsTest extends BaseTest
 {
     public function testMappingNamespaceIsAdded()
     {
@@ -35,12 +38,12 @@ class CustomCollectionsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $cm = new ClassMetadata('stdClass');
 
-        $cm->mapField(array(
+        $cm->mapField([
             'fieldName' => 'assoc',
             'reference' => true,
             'type' => 'many',
             'collectionClass' => 'stdClass',
-        ));
+        ]);
     }
 
     public function testGeneratedClassExtendsBaseCollection()
@@ -234,14 +237,14 @@ class MyEmbedsCollection extends ArrayCollection
 {
     public function getByName($name)
     {
-        return $this->filter(function($item) use ($name) {
+        return $this->filter(function ($item) use ($name) {
             return $item->name === $name;
         });
     }
 
     public function getEnabled()
     {
-        return $this->filter(function($item) {
+        return $this->filter(function ($item) {
             return $item->enabled;
         });
     }
@@ -258,7 +261,7 @@ class MyDocumentsCollection extends ArrayCollection
 {
     public function havingEmbeds()
     {
-        return $this->filter(function($item) {
+        return $this->filter(function ($item) {
             return $item->coll->count();
         });
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomFieldNameTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomFieldNameTest.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class CustomFieldNameTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class CustomFieldNameTest extends BaseTest
 {
     public function testInsertSetsLoginInsteadOfUsername()
     {
@@ -14,7 +17,7 @@ class CustomFieldNameTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->persist($test);
         $this->dm->flush();
 
-        $test = $this->dm->getDocumentCollection(__NAMESPACE__.'\CustomFieldName')->findOne();
+        $test = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CustomFieldName')->findOne();
         $this->assertArrayHasKey('login', $test);
         $this->assertEquals('test', $test['login']);
     }
@@ -28,7 +31,7 @@ class CustomFieldNameTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $test = $this->dm->find(__NAMESPACE__.'\CustomFieldName', $test->id);
+        $test = $this->dm->find(__NAMESPACE__ . '\CustomFieldName', $test->id);
         $this->assertNotNull($test);
         $this->assertEquals('test', $test->username);
     }
@@ -42,12 +45,12 @@ class CustomFieldNameTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $test = $this->dm->find(__NAMESPACE__.'\CustomFieldName', $test->id);
+        $test = $this->dm->find(__NAMESPACE__ . '\CustomFieldName', $test->id);
 
         $test->username = 'ok';
         $this->dm->flush();
 
-        $test = $this->dm->getDocumentCollection(__NAMESPACE__.'\CustomFieldName')->findOne();
+        $test = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CustomFieldName')->findOne();
         $this->assertArrayHasKey('login', $test);
         $this->assertEquals('ok', $test['login']);
     }
@@ -61,7 +64,7 @@ class CustomFieldNameTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $test = $this->dm->getRepository(__NAMESPACE__.'\CustomFieldName')->findOneBy(array('username' => 'test'));
+        $test = $this->dm->getRepository(__NAMESPACE__ . '\CustomFieldName')->findOneBy(['username' => 'test']);
         $this->assertNotNull($test);
         $this->assertEquals('test', $test->username);
     }
@@ -75,7 +78,7 @@ class CustomFieldNameTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $test = $this->dm->getRepository(__NAMESPACE__.'\CustomFieldName')->findOneBy(array('username' => 'test'));
+        $test = $this->dm->getRepository(__NAMESPACE__ . '\CustomFieldName')->findOneBy(['username' => 'test']);
         $this->assertNotNull($test);
         $this->assertEquals('test', $test->username);
     }
@@ -89,7 +92,7 @@ class CustomFieldNameTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $qb = $this->dm->createQueryBuilder(__NAMESPACE__.'\CustomFieldName')->field('username')->equals('test');
+        $qb = $this->dm->createQueryBuilder(__NAMESPACE__ . '\CustomFieldName')->field('username')->equals('test');
         $query = $qb->getQuery();
         $test = $query->getSingleResult();
         $this->assertNotNull($test);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomIdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomIdTest.php
@@ -1,12 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Account;
 use Documents\CustomUser;
 use Documents\User;
+use function count;
 
-class CustomIdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class CustomIdTest extends BaseTest
 {
     public function testSetId()
     {
@@ -74,11 +78,11 @@ class CustomIdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         unset($user1, $user2, $user3);
 
-        $users = $this->dm->getRepository("Documents\User")->findAll();
+        $users = $this->dm->getRepository('Documents\User')->findAll();
 
         $this->assertCount(2, $users);
 
-        $results = array();
+        $results = [];
         foreach ($users as $user) {
             if ($user->getId() === 'userId') {
                 $results['userId'] = true;
@@ -87,7 +91,7 @@ class CustomIdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             $results['ids'][] = $user->getId();
         }
 
-        $users = $this->dm->getRepository("Documents\CustomUser")->findAll();
+        $users = $this->dm->getRepository('Documents\CustomUser')->findAll();
 
         $this->assertCount(1, $users);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
@@ -1,12 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\Type;
+use function array_map;
+use function array_values;
+use function is_array;
 
-class CustomTypeTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class CustomTypeTest extends BaseTest
 {
     public static function setUpBeforeClass()
     {
@@ -16,7 +22,7 @@ class CustomTypeTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testCustomTypeValueConversions()
     {
         $country = new Country();
-        $country->nationalHolidays = array(new \DateTime(), new \DateTime());
+        $country->nationalHolidays = [new \DateTime(), new \DateTime()];
 
         $this->dm->persist($country);
         $this->dm->flush();
@@ -52,13 +58,13 @@ class DateCollectionType
             return null;
         }
 
-        if (!is_array($value)) {
+        if (! is_array($value)) {
             throw new CustomTypeException('Array expected.');
         }
 
         $converter = Type::getType('date');
 
-        $value = array_map(function($date) use ($converter) {
+        $value = array_map(function ($date) use ($converter) {
             return $converter->convertToDatabaseValue($date);
         }, array_values($value));
 
@@ -71,13 +77,13 @@ class DateCollectionType
             return null;
         }
 
-        if (!is_array($value)) {
+        if (! is_array($value)) {
             throw new CustomTypeException('Array expected.');
         }
 
         $converter = Type::getType('date');
 
-        $value = array_map(function($date) use ($converter) {
+        $value = array_map(function ($date) use ($converter) {
             return $converter->convertToPHPValue($date);
         }, array_values($value));
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DatabasesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DatabasesTest.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class DatabasesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class DatabasesTest extends BaseTest
 {
     public function testCustomDatabase()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
@@ -1,13 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Documents\Account;
-use Documents\Address;
-use Documents\Phonenumber;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\User;
+use MongoDB\BSON\UTCDateTime;
+use const PHP_INT_SIZE;
+use function get_class;
+use function time;
 
-class DateTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class DateTest extends BaseTest
 {
     public function testDates()
     {
@@ -40,7 +44,7 @@ class DateTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $user = $this->dm->getRepository(get_class($user))->findOneBy(array());
+        $user = $this->dm->getRepository(get_class($user))->findOneBy([]);
         $user->setCreatedAt($newValue);
         $this->dm->getUnitOfWork()->computeChangeSets();
         $changeset = $this->dm->getUnitOfWork()->getDocumentChangeset($user);
@@ -49,14 +53,14 @@ class DateTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function provideEquivalentDates()
     {
-        return array(
-            array(new \DateTime('1985-09-01 00:00:00'), new \DateTime('1985-09-01 00:00:00')),
-            array(new \DateTime('2012-07-11T14:55:14-04:00'), new \DateTime('2012-07-11T19:55:14+01:00')),
-            array(new \DateTime('@1342033881'), new \MongoDB\BSON\UTCDateTime(1342033881000)),
-            array(\DateTime::createFromFormat('U.u', '100000000.123'), new \MongoDB\BSON\UTCDateTime(100000000123)),
-            array(\DateTime::createFromFormat('U.u', '100000000.123000'), new \MongoDB\BSON\UTCDateTime(100000000123)),
-            array(new \MongoDB\BSON\UTCDateTime(100000000123), \DateTime::createFromFormat('U.u', '100000000.123')),
-        );
+        return [
+            [new \DateTime('1985-09-01 00:00:00'), new \DateTime('1985-09-01 00:00:00')],
+            [new \DateTime('2012-07-11T14:55:14-04:00'), new \DateTime('2012-07-11T19:55:14+01:00')],
+            [new \DateTime('@1342033881'), new UTCDateTime(1342033881000)],
+            [\DateTime::createFromFormat('U.u', '100000000.123'), new UTCDateTime(100000000123)],
+            [\DateTime::createFromFormat('U.u', '100000000.123000'), new UTCDateTime(100000000123)],
+            [new UTCDateTime(100000000123), \DateTime::createFromFormat('U.u', '100000000.123')],
+        ];
     }
 
     public function testDateInstanceValueChangeDoesCauseUpdateIfValueIsTheSame()
@@ -67,7 +71,7 @@ class DateTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $user = $this->dm->getRepository(get_class($user))->findOneBy(array());
+        $user = $this->dm->getRepository(get_class($user))->findOneBy([]);
         $user->getCreatedAt()->setTimestamp(time() - 3600);
 
         $this->dm->getUnitOfWork()->computeChangeSets();
@@ -92,10 +96,10 @@ class DateTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->dm->clear();
 
-        $test = $this->dm->getDocumentCollection('Documents\User')->findOne(array('username' => 'datetest2'));
+        $test = $this->dm->getDocumentCollection('Documents\User')->findOne(['username' => 'datetest2']);
         $this->assertArrayHasKey('createdAt', $test);
 
-        $user = $this->dm->getRepository('Documents\User')->findOneBy(array('username' => 'datetest2'));
+        $user = $this->dm->getRepository('Documents\User')->findOneBy(['username' => 'datetest2']);
         $this->assertInstanceOf(\DateTime::class, $user->getCreatedAt());
         $this->assertEquals('1900-01-01', $user->getCreatedAt()->format('Y-m-d'));
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DetachedDocumentTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DetachedDocumentTest.php
@@ -1,17 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional;
 
-use Documents\CmsUser;
-use Documents\CmsPhonenumber;
-use Documents\CmsAddress;
 use Doctrine\ODM\MongoDB\Proxy\Proxy;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\CmsAddress;
+use Documents\CmsPhonenumber;
+use Documents\CmsUser;
+use function get_class;
+use function serialize;
+use function unserialize;
 
-class DetachedDocumentTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class DetachedDocumentTest extends BaseTest
 {
     public function testSimpleDetachMerge()
     {
-        $user = new CmsUser;
+        $user = new CmsUser();
         $user->name = 'Roman';
         $user->username = 'romanb';
         $user->status = 'dev';
@@ -36,12 +42,12 @@ class DetachedDocumentTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testSerializeUnserializeModifyMerge()
     {
-        $user = new CmsUser;
+        $user = new CmsUser();
         $user->name = 'Guilherme';
         $user->username = 'gblanco';
         $user->status = 'developer';
 
-        $ph1 = new CmsPhonenumber;
+        $ph1 = new CmsPhonenumber();
         $ph1->phonenumber = '1234';
         $user->addPhonenumber($ph1);
 
@@ -58,7 +64,7 @@ class DetachedDocumentTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $user = unserialize($serialized);
 
-        $ph2 = new CmsPhonenumber;
+        $ph2 = new CmsPhonenumber();
         $ph2->phonenumber = '56789';
         $user->addPhonenumber($ph2);
         $this->assertCount(2, $user->getPhonenumbers());
@@ -98,17 +104,18 @@ class DetachedDocumentTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         try {
             $this->dm->flush();
             $this->fail();
-        } catch (\Exception $expected) {}
+        } catch (\Throwable $expected) {
+        }
     }
 
     public function testUninitializedLazyAssociationsAreIgnoredOnMerge()
     {
-        $user = new CmsUser;
+        $user = new CmsUser();
         $user->name = 'Guilherme';
         $user->username = 'gblanco';
         $user->status = 'developer';
 
-        $address = new CmsAddress;
+        $address = new CmsAddress();
         $address->city = 'Berlin';
         $address->country = 'Germany';
         $address->street = 'Sesamestreet';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DetachedDocumentTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DetachedDocumentTest.php
@@ -90,24 +90,6 @@ class DetachedDocumentTest extends BaseTest
         $this->assertTrue($this->dm->contains($phonenumbers[1]));
     }
 
-    /**
-     * @group DDC-203
-     */
-    public function testDetachedEntityThrowsExceptionOnFlush()
-    {
-        $ph = new CmsPhonenumber();
-        $ph->phonenumber = '12345';
-        $this->dm->persist($ph);
-        $this->dm->flush();
-        $this->dm->clear();
-        $this->dm->persist($ph);
-        try {
-            $this->dm->flush();
-            $this->fail();
-        } catch (\Throwable $expected) {
-        }
-    }
-
     public function testUninitializedLazyAssociationsAreIgnoredOnMerge()
     {
         $user = new CmsUser();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class ReferenceDiscriminatorsDefaultValueTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class ReferenceDiscriminatorsDefaultValueTest extends BaseTest
 {
     public function setUp()
     {
@@ -20,7 +23,7 @@ class ReferenceDiscriminatorsDefaultValueTest extends \Doctrine\ODM\MongoDB\Test
         $this->dm->persist($firstChildWithoutDiscriminator = new ChildDocumentWithoutDiscriminator('firstWithoutDiscriminator'));
         $this->dm->persist($secondChildWithoutDiscriminator = new ChildDocumentWithoutDiscriminator('firstWithoutDiscriminator'));
 
-        $children = array($firstChildWithoutDiscriminator, $secondChildWithoutDiscriminator);
+        $children = [$firstChildWithoutDiscriminator, $secondChildWithoutDiscriminator];
         $this->dm->persist($parentWithoutDiscriminator = new ParentDocumentWithoutDiscriminator($children));
 
         $this->dm->flush();
@@ -52,7 +55,7 @@ class ReferenceDiscriminatorsDefaultValueTest extends \Doctrine\ODM\MongoDB\Test
         $this->dm->persist($firstChildWithDiscriminator = new ChildDocumentWithDiscriminatorComplex('firstWithDiscriminator', 'veryComplex'));
         $this->dm->persist($secondChildWithDiscriminator = new ChildDocumentWithDiscriminatorSimple('secondWithDiscriminator'));
 
-        $children = array($firstChildWithDiscriminator, $secondChildWithDiscriminator);
+        $children = [$firstChildWithDiscriminator, $secondChildWithDiscriminator];
         $this->dm->persist($parentWithDiscriminator = new ParentDocumentWithDiscriminator($children));
 
         $this->dm->flush();
@@ -203,7 +206,6 @@ class ParentDocumentWithDiscriminator extends ParentDocument
  */
 class ChildDocumentWithDiscriminator extends ChildDocument
 {
-
 }
 
 /** @ODM\Document(collection="discriminator_child") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -1,12 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\ODM\MongoDB\LockException;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
 
-class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class DocumentPersisterTest extends BaseTest
 {
     private $class;
 
@@ -24,8 +29,8 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $collection = $this->dm->getDocumentCollection($this->class);
         $collection->drop();
 
-        foreach (array('a', 'b', 'c', 'd') as $name) {
-            $document = array('dbName' => $name);
+        foreach (['a', 'b', 'c', 'd'] as $name) {
+            $document = ['dbName' => $name];
             $collection->insertOne($document);
         }
 
@@ -42,15 +47,15 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->persist($document);
         $this->dm->flush();
 
-        $updatedData = $this->dm->getDocumentCollection($this->class)->findOne(array('_id' => $originalData['_id']));
+        $updatedData = $this->dm->getDocumentCollection($this->class)->findOne(['_id' => $originalData['_id']]);
 
         $this->assertEquals($originalData, $updatedData);
     }
 
     public function testExistsReturnsTrueForExistentDocuments()
     {
-        foreach (array('a', 'b', 'c', 'd') as $name) {
-            $document = $this->documentPersister->load(array('name' => $name));
+        foreach (['a', 'b', 'c', 'd'] as $name) {
+            $document = $this->documentPersister->load(['name' => $name]);
             $this->assertTrue($this->documentPersister->exists($document));
         }
     }
@@ -58,17 +63,17 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testExistsReturnsFalseForNonexistentDocuments()
     {
         $document = new DocumentPersisterTestDocument();
-        $document->id = new \MongoDB\BSON\ObjectId();
+        $document->id = new ObjectId();
 
         $this->assertFalse($this->documentPersister->exists($document));
     }
 
     public function testLoadPreparesCriteriaAndSort()
     {
-        $criteria = array('name' => array('$in' => array('a', 'b')));
-        $sort = array('name' => -1);
+        $criteria = ['name' => ['$in' => ['a', 'b']]];
+        $sort = ['name' => -1];
 
-        $document = $this->documentPersister->load($criteria, null, array(), 0, $sort);
+        $document = $this->documentPersister->load($criteria, null, [], 0, $sort);
 
         $this->assertInstanceOf($this->class, $document);
         $this->assertEquals('b', $document->name);
@@ -76,8 +81,8 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLoadAllPreparesCriteriaAndSort()
     {
-        $criteria = array('name' => array('$in' => array('a', 'b')));
-        $sort = array('name' => -1);
+        $criteria = ['name' => ['$in' => ['a', 'b']]];
+        $sort = ['name' => -1];
 
         $cursor = $this->documentPersister->loadAll($criteria, $sort);
         $documents = $cursor->toArray();
@@ -90,9 +95,9 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLoadAllWithSortLimitAndSkip()
     {
-        $sort = array('name' => -1);
+        $sort = ['name' => -1];
 
-        $cursor = $this->documentPersister->loadAll(array(), $sort, 1, 2);
+        $cursor = $this->documentPersister->loadAll([], $sort, 1, 2);
         $documents = $cursor->toArray();
 
         $this->assertInstanceOf($this->class, $documents[0]);
@@ -110,18 +115,18 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function getTestPrepareFieldNameData()
     {
-        return array(
-            array('name', 'dbName'),
-            array('association', 'associationName'),
-            array('association.id', 'associationName._id'),
-            array('association.nested', 'associationName.nestedName'),
-            array('association.nested.$id', 'associationName.nestedName.$id'),
-            array('association.nested._id', 'associationName.nestedName._id'),
-            array('association.nested.id', 'associationName.nestedName._id'),
-            array('association.nested.association.nested.$id', 'associationName.nestedName.associationName.nestedName.$id'),
-            array('association.nested.association.nested.id', 'associationName.nestedName.associationName.nestedName._id'),
-            array('association.nested.association.nested.firstName', 'associationName.nestedName.associationName.nestedName.firstName'),
-        );
+        return [
+            ['name', 'dbName'],
+            ['association', 'associationName'],
+            ['association.id', 'associationName._id'],
+            ['association.nested', 'associationName.nestedName'],
+            ['association.nested.$id', 'associationName.nestedName.$id'],
+            ['association.nested._id', 'associationName.nestedName._id'],
+            ['association.nested.id', 'associationName.nestedName._id'],
+            ['association.nested.association.nested.$id', 'associationName.nestedName.associationName.nestedName.$id'],
+            ['association.nested.association.nested.id', 'associationName.nestedName.associationName.nestedName._id'],
+            ['association.nested.association.nested.firstName', 'associationName.nestedName.associationName.nestedName.firstName'],
+        ];
     }
 
     /**
@@ -132,8 +137,8 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $class = DocumentPersisterTestHashIdDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $value = array('_id' => $hashId);
-        $expected = array('_id' => (object) $hashId);
+        $value = ['_id' => $hashId];
+        $expected = ['_id' => (object) $hashId];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
     }
@@ -146,39 +151,39 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $class = DocumentPersisterTestHashIdDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $value = array('_id' => array('$exists' => true));
-        $expected = array('_id' => array('$exists' => true));
+        $value = ['_id' => ['$exists' => true]];
+        $expected = ['_id' => ['$exists' => true]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('_id' => array('$elemMatch' => $hashId));
-        $expected = array('_id' => array('$elemMatch' => (object) $hashId));
+        $value = ['_id' => ['$elemMatch' => $hashId]];
+        $expected = ['_id' => ['$elemMatch' => (object) $hashId]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('_id' => array('$in' => array($hashId)));
-        $expected = array('_id' => array('$in' => array((object) $hashId)));
+        $value = ['_id' => ['$in' => [$hashId]]];
+        $expected = ['_id' => ['$in' => [(object) $hashId]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('_id' => array('$not' => array('$elemMatch' => $hashId)));
-        $expected = array('_id' => array('$not' => array('$elemMatch' => (object) $hashId)));
+        $value = ['_id' => ['$not' => ['$elemMatch' => $hashId]]];
+        $expected = ['_id' => ['$not' => ['$elemMatch' => (object) $hashId]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('_id' => array('$not' => array('$in' => array($hashId))));
-        $expected = array('_id' => array('$not' => array('$in' => array((object) $hashId))));
+        $value = ['_id' => ['$not' => ['$in' => [$hashId]]]];
+        $expected = ['_id' => ['$not' => ['$in' => [(object) $hashId]]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
     }
 
     public function provideHashIdentifiers()
     {
-        return array(
-            array(array('key' => 'value')),
-            array(array(0 => 'first', 1 => 'second')),
-            array(array('$ref' => 'ref', '$id' => 'id')),
-        );
+        return [
+            [['key' => 'value']],
+            [[0 => 'first', 1 => 'second']],
+            [['$ref' => 'ref', '$id' => 'id']],
+        ];
     }
 
     public function testPrepareQueryOrNewObjWithSimpleReferenceToTargetDocumentWithNormalIdType()
@@ -186,35 +191,35 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $class = DocumentPersisterTestHashIdDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $id = new \MongoDB\BSON\ObjectId();
+        $id = new ObjectId();
 
-        $value = array('simpleRef' => (string) $id);
-        $expected = array('simpleRef' => $id);
-
-        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
-
-        $value = array('simpleRef' => array('$exists' => true));
-        $expected = array('simpleRef' => array('$exists' => true));
+        $value = ['simpleRef' => (string) $id];
+        $expected = ['simpleRef' => $id];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('simpleRef' => array('$elemMatch' => (string) $id));
-        $expected = array('simpleRef' => array('$elemMatch' => $id));
+        $value = ['simpleRef' => ['$exists' => true]];
+        $expected = ['simpleRef' => ['$exists' => true]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('simpleRef' => array('$in' => array((string) $id)));
-        $expected = array('simpleRef' => array('$in' => array($id)));
+        $value = ['simpleRef' => ['$elemMatch' => (string) $id]];
+        $expected = ['simpleRef' => ['$elemMatch' => $id]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('simpleRef' => array('$not' => array('$elemMatch' => (string) $id)));
-        $expected = array('simpleRef' => array('$not' => array('$elemMatch' => $id)));
+        $value = ['simpleRef' => ['$in' => [(string) $id]]];
+        $expected = ['simpleRef' => ['$in' => [$id]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('simpleRef' => array('$not' => array('$in' => array((string) $id))));
-        $expected = array('simpleRef' => array('$not' => array('$in' => array($id))));
+        $value = ['simpleRef' => ['$not' => ['$elemMatch' => (string) $id]]];
+        $expected = ['simpleRef' => ['$not' => ['$elemMatch' => $id]]];
+
+        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
+
+        $value = ['simpleRef' => ['$not' => ['$in' => [(string) $id]]]];
+        $expected = ['simpleRef' => ['$not' => ['$in' => [$id]]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
     }
@@ -227,33 +232,33 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $class = DocumentPersisterTestDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $value = array('simpleRef' => $hashId);
-        $expected = array('simpleRef' => (object) $hashId);
+        $value = ['simpleRef' => $hashId];
+        $expected = ['simpleRef' => (object) $hashId];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('simpleRef' => array('$exists' => true));
-        $expected = array('simpleRef' => array('$exists' => true));
+        $value = ['simpleRef' => ['$exists' => true]];
+        $expected = ['simpleRef' => ['$exists' => true]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('simpleRef' => array('$elemMatch' => $hashId));
-        $expected = array('simpleRef' => array('$elemMatch' => (object) $hashId));
+        $value = ['simpleRef' => ['$elemMatch' => $hashId]];
+        $expected = ['simpleRef' => ['$elemMatch' => (object) $hashId]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('simpleRef' => array('$in' => array($hashId)));
-        $expected = array('simpleRef' => array('$in' => array((object) $hashId)));
+        $value = ['simpleRef' => ['$in' => [$hashId]]];
+        $expected = ['simpleRef' => ['$in' => [(object) $hashId]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('simpleRef' => array('$not' => array('$elemMatch' => $hashId)));
-        $expected = array('simpleRef' => array('$not' => array('$elemMatch' => (object) $hashId)));
+        $value = ['simpleRef' => ['$not' => ['$elemMatch' => $hashId]]];
+        $expected = ['simpleRef' => ['$not' => ['$elemMatch' => (object) $hashId]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('simpleRef' => array('$not' => array('$in' => array($hashId))));
-        $expected = array('simpleRef' => array('$not' => array('$in' => array((object) $hashId))));
+        $value = ['simpleRef' => ['$not' => ['$in' => [$hashId]]]];
+        $expected = ['simpleRef' => ['$not' => ['$in' => [(object) $hashId]]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
     }
@@ -263,35 +268,35 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $class = DocumentPersisterTestHashIdDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $id = new \MongoDB\BSON\ObjectId();
+        $id = new ObjectId();
 
-        $value = array('complexRef.id' => (string) $id);
-        $expected = array('complexRef.$id' => $id);
-
-        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
-
-        $value = array('complexRef.id' => array('$exists' => true));
-        $expected = array('complexRef.$id' => array('$exists' => true));
+        $value = ['complexRef.id' => (string) $id];
+        $expected = ['complexRef.$id' => $id];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('complexRef.id' => array('$elemMatch' => (string) $id));
-        $expected = array('complexRef.$id' => array('$elemMatch' => $id));
+        $value = ['complexRef.id' => ['$exists' => true]];
+        $expected = ['complexRef.$id' => ['$exists' => true]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('complexRef.id' => array('$in' => array((string) $id)));
-        $expected = array('complexRef.$id' => array('$in' => array($id)));
+        $value = ['complexRef.id' => ['$elemMatch' => (string) $id]];
+        $expected = ['complexRef.$id' => ['$elemMatch' => $id]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('complexRef.id' => array('$not' => array('$elemMatch' => (string) $id)));
-        $expected = array('complexRef.$id' => array('$not' => array('$elemMatch' => $id)));
+        $value = ['complexRef.id' => ['$in' => [(string) $id]]];
+        $expected = ['complexRef.$id' => ['$in' => [$id]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('complexRef.id' => array('$not' => array('$in' => array((string) $id))));
-        $expected = array('complexRef.$id' => array('$not' => array('$in' => array($id))));
+        $value = ['complexRef.id' => ['$not' => ['$elemMatch' => (string) $id]]];
+        $expected = ['complexRef.$id' => ['$not' => ['$elemMatch' => $id]]];
+
+        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
+
+        $value = ['complexRef.id' => ['$not' => ['$in' => [(string) $id]]]];
+        $expected = ['complexRef.$id' => ['$not' => ['$in' => [$id]]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
     }
@@ -304,33 +309,33 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $class = DocumentPersisterTestDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $value = array('complexRef.id' => $hashId);
-        $expected = array('complexRef.$id' => (object) $hashId);
+        $value = ['complexRef.id' => $hashId];
+        $expected = ['complexRef.$id' => (object) $hashId];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('complexRef.id' => array('$exists' => true));
-        $expected = array('complexRef.$id' => array('$exists' => true));
+        $value = ['complexRef.id' => ['$exists' => true]];
+        $expected = ['complexRef.$id' => ['$exists' => true]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('complexRef.id' => array('$elemMatch' => $hashId));
-        $expected = array('complexRef.$id' => array('$elemMatch' => (object) $hashId));
+        $value = ['complexRef.id' => ['$elemMatch' => $hashId]];
+        $expected = ['complexRef.$id' => ['$elemMatch' => (object) $hashId]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('complexRef.id' => array('$in' => array($hashId)));
-        $expected = array('complexRef.$id' => array('$in' => array((object) $hashId)));
+        $value = ['complexRef.id' => ['$in' => [$hashId]]];
+        $expected = ['complexRef.$id' => ['$in' => [(object) $hashId]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('complexRef.id' => array('$not' => array('$elemMatch' => $hashId)));
-        $expected = array('complexRef.$id' => array('$not' => array('$elemMatch' => (object) $hashId)));
+        $value = ['complexRef.id' => ['$not' => ['$elemMatch' => $hashId]]];
+        $expected = ['complexRef.$id' => ['$not' => ['$elemMatch' => (object) $hashId]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('complexRef.id' => array('$not' => array('$in' => array($hashId))));
-        $expected = array('complexRef.$id' => array('$not' => array('$in' => array((object) $hashId))));
+        $value = ['complexRef.id' => ['$not' => ['$in' => [$hashId]]]];
+        $expected = ['complexRef.$id' => ['$not' => ['$in' => [(object) $hashId]]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
     }
@@ -340,35 +345,35 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $class = DocumentPersisterTestHashIdDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $id = new \MongoDB\BSON\ObjectId();
+        $id = new ObjectId();
 
-        $value = array('embeddedRef.id' => (string) $id);
-        $expected = array('embeddedRef.id' => $id);
-
-        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
-
-        $value = array('embeddedRef.id' => array('$exists' => true));
-        $expected = array('embeddedRef.id' => array('$exists' => true));
+        $value = ['embeddedRef.id' => (string) $id];
+        $expected = ['embeddedRef.id' => $id];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('embeddedRef.id' => array('$elemMatch' => (string) $id));
-        $expected = array('embeddedRef.id' => array('$elemMatch' => $id));
+        $value = ['embeddedRef.id' => ['$exists' => true]];
+        $expected = ['embeddedRef.id' => ['$exists' => true]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('embeddedRef.id' => array('$in' => array((string) $id)));
-        $expected = array('embeddedRef.id' => array('$in' => array($id)));
+        $value = ['embeddedRef.id' => ['$elemMatch' => (string) $id]];
+        $expected = ['embeddedRef.id' => ['$elemMatch' => $id]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('embeddedRef.id' => array('$not' => array('$elemMatch' => (string) $id)));
-        $expected = array('embeddedRef.id' => array('$not' => array('$elemMatch' => $id)));
+        $value = ['embeddedRef.id' => ['$in' => [(string) $id]]];
+        $expected = ['embeddedRef.id' => ['$in' => [$id]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('embeddedRef.id' => array('$not' => array('$in' => array((string) $id))));
-        $expected = array('embeddedRef.id' => array('$not' => array('$in' => array($id))));
+        $value = ['embeddedRef.id' => ['$not' => ['$elemMatch' => (string) $id]]];
+        $expected = ['embeddedRef.id' => ['$not' => ['$elemMatch' => $id]]];
+
+        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
+
+        $value = ['embeddedRef.id' => ['$not' => ['$in' => [(string) $id]]]];
+        $expected = ['embeddedRef.id' => ['$not' => ['$in' => [$id]]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
     }
@@ -381,33 +386,33 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $class = DocumentPersisterTestDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $value = array('embeddedRef.id' => $hashId);
-        $expected = array('embeddedRef.id' => (object) $hashId);
+        $value = ['embeddedRef.id' => $hashId];
+        $expected = ['embeddedRef.id' => (object) $hashId];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('embeddedRef.id' => array('$exists' => true));
-        $expected = array('embeddedRef.id' => array('$exists' => true));
+        $value = ['embeddedRef.id' => ['$exists' => true]];
+        $expected = ['embeddedRef.id' => ['$exists' => true]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('embeddedRef.id' => array('$elemMatch' => $hashId));
-        $expected = array('embeddedRef.id' => array('$elemMatch' => (object) $hashId));
+        $value = ['embeddedRef.id' => ['$elemMatch' => $hashId]];
+        $expected = ['embeddedRef.id' => ['$elemMatch' => (object) $hashId]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('embeddedRef.id' => array('$in' => array($hashId)));
-        $expected = array('embeddedRef.id' => array('$in' => array((object) $hashId)));
+        $value = ['embeddedRef.id' => ['$in' => [$hashId]]];
+        $expected = ['embeddedRef.id' => ['$in' => [(object) $hashId]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('embeddedRef.id' => array('$not' => array('$elemMatch' => $hashId)));
-        $expected = array('embeddedRef.id' => array('$not' => array('$elemMatch' => (object) $hashId)));
+        $value = ['embeddedRef.id' => ['$not' => ['$elemMatch' => $hashId]]];
+        $expected = ['embeddedRef.id' => ['$not' => ['$elemMatch' => (object) $hashId]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
-        $value = array('embeddedRef.id' => array('$not' => array('$in' => array($hashId))));
-        $expected = array('embeddedRef.id' => array('$not' => array('$in' => array((object) $hashId))));
+        $value = ['embeddedRef.id' => ['$not' => ['$in' => [$hashId]]]];
+        $expected = ['embeddedRef.id' => ['$not' => ['$in' => [(object) $hashId]]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
     }
@@ -417,24 +422,24 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
      */
     public static function dataProviderTestWriteConcern()
     {
-        return array(
-            'default' => array(
+        return [
+            'default' => [
                 'className' => DocumentPersisterTestDocument::class,
                 'writeConcern' => 1,
-            ),
-            'acknowledged' => array(
+            ],
+            'acknowledged' => [
                 'className' => DocumentPersisterWriteConcernAcknowledged::class,
                 'writeConcern' => 1,
-            ),
-            'unacknowledged' => array(
+            ],
+            'unacknowledged' => [
                 'className' => DocumentPersisterWriteConcernUnacknowledged::class,
                 'writeConcern' => 0,
-            ),
-            'majority' => array(
+            ],
+            'majority' => [
                 'className' => DocumentPersisterWriteConcernMajority::class,
                 'writeConcern' => 'majority',
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -481,7 +486,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $reflectionProperty->setValue($documentPersister, $collection);
 
         $testDocument = new $class();
-        $testDocument->id = new \MongoDB\BSON\ObjectId();
+        $testDocument->id = new ObjectId();
         $this->dm->persist($testDocument);
         $this->dm->flush();
     }
@@ -521,13 +526,13 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $collection = $this->createMock(Collection::class);
         $collection->expects($this->once())
             ->method('insertMany')
-            ->with($this->isType('array'), $this->equalTo(array('w' => 0)));
+            ->with($this->isType('array'), $this->equalTo(['w' => 0]));
 
         $reflectionProperty = new \ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($documentPersister, $collection);
 
-        $this->dm->getConfiguration()->setDefaultCommitOptions(array('w' => 0));
+        $this->dm->getConfiguration()->setDefaultCommitOptions(['w' => 0]);
 
         $testDocument = new $class();
         $this->dm->persist($testDocument);
@@ -544,7 +549,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $collection = $this->createMock(Collection::class);
         $collection->expects($this->any())
             ->method('updateOne')
-            ->will($this->returnValue(array('n' => 1)));
+            ->will($this->returnValue(['n' => 1]));
 
         $reflectionProperty = new \ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setAccessible(true);
@@ -552,7 +557,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $testDocument = new $class();
         $testDocument->id = 12345;
-        $this->uow->registerManaged($testDocument, 12345, array('id' => 12345));
+        $this->uow->registerManaged($testDocument, 12345, ['id' => 12345]);
         $testDocument->name = 'test';
         $this->dm->persist($testDocument);
         $this->dm->flush();
@@ -570,7 +575,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $collection = $this->createMock(Collection::class);
         $collection->expects($this->any())
             ->method('updateOne')
-            ->will($this->returnValue(array('n' => 0)));
+            ->will($this->returnValue(['n' => 0]));
 
         $reflectionProperty = new \ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setAccessible(true);
@@ -578,8 +583,8 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $testDocument = new $class();
         $testDocument->id = 12345;
-        $this->uow->registerManaged($testDocument, 12345, array('id' => 12345));
-        $this->expectException(\Doctrine\ODM\MongoDB\LockException::class);
+        $this->uow->registerManaged($testDocument, 12345, ['id' => 12345]);
+        $this->expectException(LockException::class);
         $testDocument->name = 'test';
         $this->dm->persist($testDocument);
         $this->dm->flush();
@@ -634,7 +639,6 @@ class DocumentPersisterTestDocumentWithVersion
 
     /** @ODM\Version @ODM\Field(type="int") */
     public $revision = 1;
-
 }
 
 /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EcommerceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EcommerceTest.php
@@ -1,20 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Ecommerce\ConfigurableProduct;
-use Documents\Ecommerce\StockItem;
 use Documents\Ecommerce\Currency;
 use Documents\Ecommerce\Money;
 use Documents\Ecommerce\Option;
+use Documents\Ecommerce\StockItem;
 
-class EcommerceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class EcommerceTest extends BaseTest
 {
     public function setUp()
     {
         parent::setUp();
 
-        $currencies = array('USD' => 1, 'EURO' => 1.7, 'JPN' => 0.0125);
+        $currencies = ['USD' => 1, 'EURO' => 1.7, 'JPN' => 0.0125];
 
         foreach ($currencies as $name => &$multiplier) {
             $multiplier = new Currency($name, $multiplier);
@@ -45,11 +48,11 @@ class EcommerceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertCount(3, $product->getOptions());
         $this->assertEquals(12.99, $product->getOption('small')->getPrice());
 
-        $usdCurrency = $this->dm->getRepository('Documents\Ecommerce\Currency')->findOneBy(array('name' => 'USD'));
+        $usdCurrency = $this->dm->getRepository('Documents\Ecommerce\Currency')->findOneBy(['name' => 'USD']);
         $this->assertNotNull($usdCurrency);
         $usdCurrency->setMultiplier('2');
 
-        $this->assertInstanceOf(\Documents\Ecommerce\StockItem::class, $product->getOption('small')->getStockItem());
+        $this->assertInstanceOf(StockItem::class, $product->getOption('small')->getStockItem());
         $this->assertNotNull($product->getOption('small')->getStockItem()->getId());
         $this->assertEquals(12.99 * 2, $product->getOption('small')->getPrice());
     }
@@ -61,7 +64,7 @@ class EcommerceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $currency = $price->getCurrency();
         $this->assertInstanceOf(Currency::class, $currency);
         $this->assertNotNull($currency->getId());
-        $this->assertEquals($currency, $this->dm->getRepository('Documents\Ecommerce\Currency')->findOneBy(array('name' => Currency::USD)));
+        $this->assertEquals($currency, $this->dm->getRepository('Documents\Ecommerce\Currency')->findOneBy(['name' => Currency::USD]));
     }
 
     public function testRemoveOption()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedIdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedIdTest.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\ObjectId;
 
-class EmbeddedIdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class EmbeddedIdTest extends BaseTest
 {
     public function testEmbeddedIdsAreGenerated()
     {
@@ -17,7 +21,7 @@ class EmbeddedIdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testEmbeddedIdsAreNotOverwritten()
     {
-        $id = (string) new \MongoDB\BSON\ObjectId();
+        $id = (string) new ObjectId();
         $test = new DefaultIdEmbeddedDocument();
         $test->id = $id;
 
@@ -61,7 +65,7 @@ class EmbeddedIdTestUser
     public $embedOne;
 
     /** @ODM\EmbedMany(targetDocument="DefaultIdEmbeddedDocument") */
-    public $embedMany = array();
+    public $embedMany = [];
 }
 
 /** @ODM\Document */
@@ -74,7 +78,7 @@ class EmbeddedStrategyNoneIdTestUser
     public $embedOne;
 
     /** @ODM\EmbedMany(targetDocument="DefaultIdStrategyNoneEmbeddedDocument") */
-    public $embedMany = array();
+    public $embedMany = [];
 }
 
 /** @ODM\EmbeddedDocument */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedReferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedReferenceTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class EmbeddedReferenceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class EmbeddedReferenceTest extends BaseTest
 {
     public function testReferencedDocumentInsideEmbeddedDocument()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\Sharded\ShardedOne;
+use Documents\Sharded\ShardedOneWithDifferentKey;
+use function iterator_to_array;
 
 class EnsureShardingTest extends BaseTest
 {
@@ -11,73 +15,73 @@ class EnsureShardingTest extends BaseTest
     {
         parent::setUp();
 
-        $this->skipTestIfNotSharded(\Documents\Sharded\ShardedOne::class);
+        $this->skipTestIfNotSharded(ShardedOne::class);
     }
 
     public function testEnsureShardingForNewCollection()
     {
-        $class = \Documents\Sharded\ShardedOne::class;
+        $class = ShardedOne::class;
         $this->dm->getSchemaManager()->ensureDocumentSharding($class);
 
         $collection = $this->dm->getDocumentCollection($class);
         $indexes = iterator_to_array($collection->listIndexes());
-        $stats = $this->dm->getDocumentDatabase($class)->command(array('collstats' => $collection->getCollectionName()))->toArray()[0];
+        $stats = $this->dm->getDocumentDatabase($class)->command(['collstats' => $collection->getCollectionName()])->toArray()[0];
 
         $this->assertCount(2, $indexes);
-        $this->assertSame(array('k' => 1), $indexes[1]['key']);
+        $this->assertSame(['k' => 1], $indexes[1]['key']);
         $this->assertTrue($stats['sharded']);
     }
 
     public function testEnsureShardingForCollectionWithDocuments()
     {
         $this->markTestSkipped('Test does not pass due to https://github.com/mongodb/mongo-php-driver/issues/296');
-        $class = \Documents\Sharded\ShardedOne::class;
+        $class = ShardedOne::class;
         $collection = $this->dm->getDocumentCollection($class);
-        $doc = array('title' => 'hey', 'k' => 'hi');
+        $doc = ['title' => 'hey', 'k' => 'hi'];
         $collection->insertOne($doc);
 
         $this->dm->getSchemaManager()->ensureDocumentSharding($class);
 
         $indexes = iterator_to_array($collection->listIndexes());
-        $stats = $this->dm->getDocumentDatabase($class)->command(array('collstats' => $collection->getCollectionName()))->toArray()[0];
+        $stats = $this->dm->getDocumentDatabase($class)->command(['collstats' => $collection->getCollectionName()])->toArray()[0];
 
         $this->assertCount(2, $indexes);
-        $this->assertSame(array('k' => 1), $indexes[1]['key']);
+        $this->assertSame(['k' => 1], $indexes[1]['key']);
         $this->assertTrue($stats['sharded']);
     }
 
     public function testEnsureShardingForCollectionWithShardingEnabled()
     {
-        $class = \Documents\Sharded\ShardedOneWithDifferentKey::class;
+        $class = ShardedOneWithDifferentKey::class;
         $this->dm->getSchemaManager()->ensureDocumentSharding($class);
 
-        $this->dm->getSchemaManager()->ensureDocumentSharding(\Documents\Sharded\ShardedOne::class);
+        $this->dm->getSchemaManager()->ensureDocumentSharding(ShardedOne::class);
 
         $collection = $this->dm->getDocumentCollection($class);
         $indexes = iterator_to_array($collection->listIndexes());
-        $stats = $this->dm->getDocumentDatabase($class)->command(array('collstats' => $collection->getCollectionName()))->toArray()[0];
+        $stats = $this->dm->getDocumentDatabase($class)->command(['collstats' => $collection->getCollectionName()])->toArray()[0];
 
         $this->assertCount(2, $indexes);
-        $this->assertSame(array('v' => 1), $indexes[1]['key']);
+        $this->assertSame(['v' => 1], $indexes[1]['key']);
         $this->assertTrue($stats['sharded']);
     }
 
     public function testEnsureShardingForCollectionWithData()
     {
         $this->markTestSkipped('Test does not pass due to https://github.com/mongodb/mongo-php-driver/issues/296');
-        $document = new \Documents\Sharded\ShardedOne();
+        $document = new ShardedOne();
         $this->dm->persist($document);
         $this->dm->flush();
 
-        $class = \Documents\Sharded\ShardedOne::class;
+        $class = ShardedOne::class;
         $this->dm->getSchemaManager()->ensureDocumentSharding($class);
 
         $collection = $this->dm->getDocumentCollection($class);
         $indexes = iterator_to_array($collection->listIndexes());
-        $stats = $this->dm->getDocumentDatabase($class)->command(array('collstats' => $collection->getCollectionName()))->toArray()[0];
+        $stats = $this->dm->getDocumentDatabase($class)->command(['collstats' => $collection->getCollectionName()])->toArray()[0];
 
         $this->assertCount(2, $indexes);
-        $this->assertSame(array('k' => 1), $indexes[1]['key']);
+        $this->assertSame(['k' => 1], $indexes[1]['key']);
         $this->assertTrue($stats['sharded']);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilterTest.php
@@ -1,18 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Documents\User;
+use Doctrine\ODM\MongoDB\DocumentNotFoundException;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Group;
 use Documents\Profile;
+use Documents\User;
+use function sort;
 
-class FilterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class FilterTest extends BaseTest
 {
     public function setUp()
     {
         parent::setUp();
 
-        $this->ids = array();
+        $this->ids = [];
 
         $groupA = new Group('groupA');
         $groupB = new Group('groupB');
@@ -71,15 +76,15 @@ class FilterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testRepositoryFind()
     {
-        $this->assertEquals(array('John', 'Tim'), $this->getUsernamesWithFind());
+        $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithFind());
 
         $this->enableUserFilter();
         $this->dm->clear();
-        $this->assertEquals(array('Tim'), $this->getUsernamesWithFind());
+        $this->assertEquals(['Tim'], $this->getUsernamesWithFind());
 
         $this->fc->disable('testFilter');
         $this->dm->clear();
-        $this->assertEquals(array('John', 'Tim'), $this->getUsernamesWithFind());
+        $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithFind());
     }
 
     protected function getUsernamesWithFind()
@@ -89,12 +94,12 @@ class FilterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $tim = $repository->find($this->ids['tim']);
         $john = $repository->find($this->ids['john']);
 
-        $usernames = array();
+        $usernames = [];
 
-        if(isset($tim)) {
+        if (isset($tim)) {
             $usernames[] = $tim->getUsername();
         }
-        if(isset($john)) {
+        if (isset($john)) {
             $usernames[] = $john->getUsername();
         }
 
@@ -104,22 +109,22 @@ class FilterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testRepositoryFindBy()
     {
-        $this->assertEquals(array('John', 'Tim'), $this->getUsernamesWithFindBy());
+        $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithFindBy());
 
         $this->enableUserFilter();
         $this->dm->clear();
-        $this->assertEquals(array('Tim'), $this->getUsernamesWithFindBy());
+        $this->assertEquals(['Tim'], $this->getUsernamesWithFindBy());
 
         $this->fc->disable('testFilter');
         $this->dm->clear();
-        $this->assertEquals(array('John', 'Tim'), $this->getUsernamesWithFindBy());
+        $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithFindBy());
     }
 
     protected function getUsernamesWithFindBy()
     {
-        $all = $this->dm->getRepository('Documents\User')->findBy(array('hits' => 10));
+        $all = $this->dm->getRepository('Documents\User')->findBy(['hits' => 10]);
 
-        $usernames = array();
+        $usernames = [];
         foreach ($all as $user) {
             $usernames[] = $user->getUsername();
         }
@@ -142,29 +147,29 @@ class FilterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     protected function getJohnsUsernameWithFindOneBy()
     {
-        $john = $this->dm->getRepository('Documents\User')->findOneBy(array('id' => $this->ids['john']));
+        $john = $this->dm->getRepository('Documents\User')->findOneBy(['id' => $this->ids['john']]);
 
         return isset($john) ? $john->getUsername() : null;
     }
 
     public function testRepositoryFindAll()
     {
-        $this->assertEquals(array('John', 'Tim'), $this->getUsernamesWithFindAll());
+        $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithFindAll());
 
         $this->enableUserFilter();
         $this->dm->clear();
-        $this->assertEquals(array('Tim'), $this->getUsernamesWithFindAll());
+        $this->assertEquals(['Tim'], $this->getUsernamesWithFindAll());
 
         $this->fc->disable('testFilter');
         $this->dm->clear();
-        $this->assertEquals(array('John', 'Tim'), $this->getUsernamesWithFindAll());
+        $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithFindAll());
     }
 
     protected function getUsernamesWithFindAll()
     {
         $all = $this->dm->getRepository('Documents\User')->findAll();
 
-        $usernames = array();
+        $usernames = [];
         foreach ($all as $user) {
             $usernames[] = $user->getUsername();
         }
@@ -174,26 +179,26 @@ class FilterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testReferenceMany()
     {
-        $this->assertEquals(array('groupA', 'groupB'), $this->getGroupsByReference());
+        $this->assertEquals(['groupA', 'groupB'], $this->getGroupsByReference());
 
         $this->enableGroupFilter();
         $this->dm->clear();
-        $this->assertEquals(array('groupA'), $this->getGroupsByReference());
+        $this->assertEquals(['groupA'], $this->getGroupsByReference());
 
         $this->fc->disable('testFilter');
         $this->dm->clear();
-        $this->assertEquals(array('groupA', 'groupB'), $this->getGroupsByReference());
+        $this->assertEquals(['groupA', 'groupB'], $this->getGroupsByReference());
     }
 
     protected function getGroupsByReference()
     {
         $tim = $this->dm->getRepository('Documents\User')->find($this->ids['tim']);
 
-        $groupnames = array();
+        $groupnames = [];
         foreach ($tim->getGroups() as $group) {
             try {
                 $groupnames[] = $group->getName();
-            } catch (\Doctrine\ODM\MongoDB\DocumentNotFoundException $e) {
+            } catch (DocumentNotFoundException $e) {
                //Proxy object filtered
             }
         }
@@ -221,7 +226,7 @@ class FilterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $profile = $tim->getProfile();
         try {
             return $profile->getFirstname();
-        } catch (\Doctrine\ODM\MongoDB\DocumentNotFoundException $e) {
+        } catch (DocumentNotFoundException $e) {
             //Proxy object filtered
             return null;
         }
@@ -229,15 +234,15 @@ class FilterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testDocumentManagerRef()
     {
-        $this->assertEquals(array('John', 'Tim'), $this->getUsernamesWithDocumentManager());
+        $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithDocumentManager());
 
         $this->enableUserFilter();
         $this->dm->clear();
-        $this->assertEquals(array('Tim'), $this->getUsernamesWithDocumentManager());
+        $this->assertEquals(['Tim'], $this->getUsernamesWithDocumentManager());
 
         $this->fc->disable('testFilter');
         $this->dm->clear();
-        $this->assertEquals(array('John', 'Tim'), $this->getUsernamesWithDocumentManager());
+        $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithDocumentManager());
     }
 
     protected function getUsernamesWithDocumentManager()
@@ -245,17 +250,17 @@ class FilterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $tim = $this->dm->getReference('Documents\User', $this->ids['tim']);
         $john = $this->dm->getReference('Documents\User', $this->ids['john']);
 
-        $usernames = array();
+        $usernames = [];
 
         try {
             $usernames[] = $tim->getUsername();
-        } catch (\Doctrine\ODM\MongoDB\DocumentNotFoundException $e) {
+        } catch (DocumentNotFoundException $e) {
             //Proxy object filtered
         }
 
         try {
             $usernames[] = $john->getUsername();
-        } catch (\Doctrine\ODM\MongoDB\DocumentNotFoundException $e) {
+        } catch (DocumentNotFoundException $e) {
             //Proxy object filtered
         }
 
@@ -265,15 +270,15 @@ class FilterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testQuery()
     {
-        $this->assertEquals(array('John', 'Tim'), $this->getUsernamesWithQuery());
+        $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithQuery());
 
         $this->enableUserFilter();
         $this->dm->clear();
-        $this->assertEquals(array('Tim'), $this->getUsernamesWithQuery());
+        $this->assertEquals(['Tim'], $this->getUsernamesWithQuery());
 
         $this->fc->disable('testFilter');
         $this->dm->clear();
-        $this->assertEquals(array('John', 'Tim'), $this->getUsernamesWithQuery());
+        $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithQuery());
     }
 
     protected function getUsernamesWithQuery()
@@ -282,7 +287,7 @@ class FilterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $query = $qb->getQuery();
         $all = $query->execute();
 
-        $usernames = array();
+        $usernames = [];
         foreach ($all as $user) {
             $usernames[] = $user->getUsername();
         }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FindAndModifyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FindAndModifyTest.php
@@ -1,15 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\User;
 
-class FindAndModifyTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class FindAndModifyTest extends BaseTest
 {
     public function testFindAndModify()
     {
         $coll = $this->dm->getDocumentCollection('Documents\User');
-        $docs = array(array('count' => 0), array('count' => 0));
+        $docs = [['count' => 0], ['count' => 0]];
         $coll->insertMany($docs);
 
         // test update findAndModify

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FlushTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FlushTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Documents\CmsAddress;
-use Documents\CmsUser;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\FriendUser;
+use function get_class;
 
-class FlushTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class FlushTest extends BaseTest
 {
     /**
      * Given 3 users, userA userB userC
@@ -29,7 +31,9 @@ class FlushTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $userB->addFriend($userC);
 
         // persist all users, flush and clear
-        foreach (array($userA, $userB, $userC) as $user) $this->dm->persist($user);
+        foreach ([$userA, $userB, $userC] as $user) {
+            $this->dm->persist($user);
+        }
         $this->dm->flush();
         $this->dm->clear();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/HasLifecycleCallbacksTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/HasLifecycleCallbacksTest.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class HasLifecycleCallbacksTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class HasLifecycleCallbacksTest extends BaseTest
 {
     public function testHasLifecycleCallbacksSubExtendsSuper()
     {
@@ -110,7 +113,7 @@ abstract class HasLifecycleCallbacksSuper
     /** @ODM\Id */
     public $id;
 
-    public $invoked = array();
+    public $invoked = [];
 
     /** @ODM\PrePersist */
     public function prePersist()
@@ -125,7 +128,7 @@ abstract class HasLifecycleCallbacksSuperAnnotated
     /** @ODM\Id */
     public $id;
 
-    public $invoked = array();
+    public $invoked = [];
 
     /** @ODM\PrePersist */
     public function prePersist()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
@@ -1,10 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\Binary;
+use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\UTCDateTime;
+use function class_exists;
+use function date;
+use function get_class;
+use function gettype;
+use function is_object;
+use function md5;
+use function serialize;
+use function sprintf;
+use function ucfirst;
+use function unserialize;
 
-class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class IdTest extends BaseTest
 {
     public function testUuidId()
     {
@@ -14,15 +31,15 @@ class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $id = $user->id;
 
         $this->dm->clear();
-        $check1 = $this->dm->getRepository(__NAMESPACE__.'\UuidUser')->findOneBy(array('id' => $id));
+        $check1 = $this->dm->getRepository(__NAMESPACE__ . '\UuidUser')->findOneBy(['id' => $id]);
         $this->assertNotNull($check1);
 
-        $check2 = $this->dm->createQueryBuilder(__NAMESPACE__.'\UuidUser')
+        $check2 = $this->dm->createQueryBuilder(__NAMESPACE__ . '\UuidUser')
             ->field('id')->equals($id)->getQuery()->getSingleResult();
         $this->assertNotNull($check2);
         $this->assertSame($check1, $check2);
 
-        $check3 = $this->dm->createQueryBuilder(__NAMESPACE__.'\UuidUser')
+        $check3 = $this->dm->createQueryBuilder(__NAMESPACE__ . '\UuidUser')
             ->field('name')->equals('Jonathan H. Wage')->getQuery()->getSingleResult();
         $this->assertNotNull($check3);
         $this->assertSame($check2, $check3);
@@ -37,15 +54,15 @@ class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
 
         $this->dm->clear();
-        $check1 = $this->dm->getRepository(__NAMESPACE__.'\AlnumCharsUser')->findOneBy(array('id' => 'x'));
+        $check1 = $this->dm->getRepository(__NAMESPACE__ . '\AlnumCharsUser')->findOneBy(['id' => 'x']);
         $this->assertNotNull($check1);
 
-        $check2 = $this->dm->createQueryBuilder(__NAMESPACE__.'\AlnumCharsUser')
+        $check2 = $this->dm->createQueryBuilder(__NAMESPACE__ . '\AlnumCharsUser')
             ->field('id')->equals('x')->getQuery()->getSingleResult();
         $this->assertNotNull($check2);
         $this->assertSame($check1, $check2);
 
-        $check3 = $this->dm->createQueryBuilder(__NAMESPACE__.'\AlnumCharsUser')
+        $check3 = $this->dm->createQueryBuilder(__NAMESPACE__ . '\AlnumCharsUser')
             ->field('name')->equals('Kathrine R. Cage')->getQuery()->getSingleResult();
         $this->assertNotNull($check3);
         $this->assertSame($check2, $check3);
@@ -73,17 +90,16 @@ class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals($reference1->id, 1);
         $this->assertEquals($reference2->id, 2);
 
-        $check1 = $this->dm->getRepository(__NAMESPACE__.'\CollectionIdUser')->findOneBy(array('id' => $user1->id));
-        $check2 = $this->dm->getRepository(__NAMESPACE__.'\CollectionIdUser')->findOneBy(array('id' => $user2->id));
+        $check1 = $this->dm->getRepository(__NAMESPACE__ . '\CollectionIdUser')->findOneBy(['id' => $user1->id]);
+        $check2 = $this->dm->getRepository(__NAMESPACE__ . '\CollectionIdUser')->findOneBy(['id' => $user2->id]);
         $this->assertNotNull($check1);
         $this->assertNotNull($check2);
 
         $this->assertEquals('referenced 1', $check1->reference->getName());
         $this->assertEquals('referenced 2', $check2->reference->getName());
 
-        $check = $this->dm->getRepository(__NAMESPACE__.'\CollectionIdUser')->find($user1->id);
+        $check = $this->dm->getRepository(__NAMESPACE__ . '\CollectionIdUser')->find($user1->id);
         $this->assertNotNull($check);
-
     }
 
     public function testCollectionIdWithStartingId()
@@ -126,17 +142,17 @@ class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testIdGeneratorInstance()
     {
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\UuidUser');
-        $this->assertEquals(\Doctrine\ODM\MongoDB\Mapping\ClassMetadata::GENERATOR_TYPE_UUID, $class->generatorType);
-        $this->assertEquals(array('salt' => 'test'), $class->generatorOptions);
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\UuidUser');
+        $this->assertEquals(ClassMetadata::GENERATOR_TYPE_UUID, $class->generatorType);
+        $this->assertEquals(['salt' => 'test'], $class->generatorOptions);
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\Id\UuidGenerator', $class->idGenerator);
         $this->assertEquals('test', $class->idGenerator->getSalt());
 
         $serialized = serialize($class);
         $class = unserialize($serialized);
 
-        $this->assertEquals(\Doctrine\ODM\MongoDB\Mapping\ClassMetadata::GENERATOR_TYPE_UUID, $class->generatorType);
-        $this->assertEquals(array('salt' => 'test'), $class->generatorOptions);
+        $this->assertEquals(ClassMetadata::GENERATOR_TYPE_UUID, $class->generatorType);
+        $this->assertEquals(['salt' => 'test'], $class->generatorOptions);
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\Id\UuidGenerator', $class->idGenerator);
         $this->assertEquals('test', $class->idGenerator->getSalt());
     }
@@ -150,7 +166,7 @@ class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
          * scalars of different types to strings before comparison. We actually
          * want to check against PHP's loose equality logic here.
          */
-        $this->assertTrue($user1Id == $user2Id);
+        $this->assertTrue($user1Id === $user2Id);
         $this->assertNotSame($user1Id, $user2Id);
 
         $user1 = new CustomIdUser(sprintf('User1 with %s ID', gettype($user1Id)));
@@ -167,8 +183,8 @@ class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertSame($user1->id, $user1Id);
         $this->assertSame($user2->id, $user2Id);
 
-        $user1 = $this->dm->find(__NAMESPACE__.'\CustomIdUser', $user1Id);
-        $user2 = $this->dm->find(__NAMESPACE__.'\CustomIdUser', $user2Id);
+        $user1 = $this->dm->find(__NAMESPACE__ . '\CustomIdUser', $user1Id);
+        $user2 = $this->dm->find(__NAMESPACE__ . '\CustomIdUser', $user2Id);
 
         $this->assertNotSame($user1, $user2);
         $this->assertSame($user1->id, $user1Id);
@@ -182,12 +198,12 @@ class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
          *
          * See: http://docs.mongodb.org/manual/faq/developers/#what-is-the-compare-order-for-bson-types
          */
-        return array(
-            array('123', 123),
-            array('123', 123.0),
-            array('', 0),
-            array('0', 0),
-        );
+        return [
+            ['123', 123],
+            ['123', 123.0],
+            ['', 0],
+            ['0', 0],
+        ];
     }
 
     /**
@@ -207,7 +223,7 @@ class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertNotNull($object->id);
 
         if ($expectedMongoType !== null) {
-            $check = $this->dm->getDocumentCollection(get_class($object))->findOne(array());
+            $check = $this->dm->getDocumentCollection(get_class($object))->findOne([]);
             $this->assertEquals($expectedMongoType, is_object($check['_id']) ? get_class($check['_id']) : gettype($check['_id']));
         }
 
@@ -232,59 +248,59 @@ class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function getTestIdTypesAndStrategiesData()
     {
-        $identifier = new \MongoDB\BSON\ObjectId();
+        $identifier = new ObjectId();
 
-        return array(
+        return [
             // boolean
-            array('boolean', 'none', true,  true, 'boolean'),
-            array('boolean', 'none', 1,  true, 'boolean'),
-            array('boolean', 'none', false, false, 'boolean'),
+            ['boolean', 'none', true,  true, 'boolean'],
+            ['boolean', 'none', 1,  true, 'boolean'],
+            ['boolean', 'none', false, false, 'boolean'],
 
             // integer
-            array('int', 'none', 0, 0, 'integer'),
-            array('int', 'none', 1, 1, 'integer'),
-            array('int', 'none', '1', 1, 'integer'),
-            array('int', 'increment', null, 1, 'integer'),
+            ['int', 'none', 0, 0, 'integer'],
+            ['int', 'none', 1, 1, 'integer'],
+            ['int', 'none', '1', 1, 'integer'],
+            ['int', 'increment', null, 1, 'integer'],
 
             // raw
-            array('raw', 'none', 0, 0, 'integer'),
-            array('raw', 'none', '1', '1', 'string'),
-            array('raw', 'none', true, true, 'boolean'),
-            array('raw', 'increment', null, 1, 'integer'),
+            ['raw', 'none', 0, 0, 'integer'],
+            ['raw', 'none', '1', '1', 'string'],
+            ['raw', 'none', true, true, 'boolean'],
+            ['raw', 'increment', null, 1, 'integer'],
 
             // float
-            array('float', 'none', 1.1, 1.1, 'double'),
-            array('float', 'none', '1.1', 1.1, 'double'),
+            ['float', 'none', 1.1, 1.1, 'double'],
+            ['float', 'none', '1.1', 1.1, 'double'],
 
             // string
-            array('string', 'none', '', '', 'string'),
-            array('string', 'none', 1, '1', 'string'),
-            array('string', 'none', 'test', 'test', 'string'),
-            array('string', 'increment', null, '1', 'string'),
+            ['string', 'none', '', '', 'string'],
+            ['string', 'none', 1, '1', 'string'],
+            ['string', 'none', 'test', 'test', 'string'],
+            ['string', 'increment', null, '1', 'string'],
 
             // custom_id
-            array('custom_id', 'none', 0, 0, 'integer'),
-            array('custom_id', 'none', '1', '1', 'string'),
-            array('custom_id', 'increment', null, 1, 'integer'),
+            ['custom_id', 'none', 0, 0, 'integer'],
+            ['custom_id', 'none', '1', '1', 'string'],
+            ['custom_id', 'increment', null, 1, 'integer'],
 
             // object_id
-            array('object_id', 'none', (string) $identifier, (string) $identifier, \MongoDB\BSON\ObjectId::class),
+            ['object_id', 'none', (string) $identifier, (string) $identifier, ObjectId::class],
 
             // date
-            array('date', 'none', new \DateTime(date('Y-m-d')), new \DateTime(date('Y-m-d')), \MongoDB\BSON\UTCDateTime::class),
+            ['date', 'none', new \DateTime(date('Y-m-d')), new \DateTime(date('Y-m-d')), UTCDateTime::class],
 
             // bin
-            array('bin', 'none', 'test-data', 'test-data', \MongoDB\BSON\Binary::class),
-            array('bin', 'uuid', null, null, \MongoDB\BSON\Binary::class),
-            array('bin_func', 'none', 'test-data', 'test-data', \MongoDB\BSON\Binary::class),
-            array('bin_bytearray', 'none', 'test-data', 'test-data', \MongoDB\BSON\Binary::class),
-            array('bin_uuid', 'none', 'TestTestTestTest', 'TestTestTestTest', \MongoDB\BSON\Binary::class),
-            array('bin_md5', 'none', md5('test'), md5('test'), \MongoDB\BSON\Binary::class),
-            array('bin_custom', 'none', 'test-data', 'test-data', \MongoDB\BSON\Binary::class),
+            ['bin', 'none', 'test-data', 'test-data', Binary::class],
+            ['bin', 'uuid', null, null, Binary::class],
+            ['bin_func', 'none', 'test-data', 'test-data', Binary::class],
+            ['bin_bytearray', 'none', 'test-data', 'test-data', Binary::class],
+            ['bin_uuid', 'none', 'TestTestTestTest', 'TestTestTestTest', Binary::class],
+            ['bin_md5', 'none', md5('test'), md5('test'), Binary::class],
+            ['bin_custom', 'none', 'test-data', 'test-data', Binary::class],
 
             // hash
-            array('hash', 'none', array('key' => 'value'), array('key' => 'value'), 'array'),
-        );
+            ['hash', 'none', ['key' => 'value'], ['key' => 'value'], 'array'],
+        ];
     }
 
     /**
@@ -301,22 +317,22 @@ class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $check = $this->dm->getDocumentCollection(get_class($object))->findOne(array());
+        $check = $this->dm->getDocumentCollection(get_class($object))->findOne([]);
 
-        $this->assertEquals(\MongoDB\BSON\Binary::class, get_class($check['_id']));
+        $this->assertEquals(Binary::class, get_class($check['_id']));
         $this->assertEquals($expectedMongoBinDataType, $check['_id']->getType());
     }
 
     public function getTestBinIdsData()
     {
-        return array(
-            array('bin', 0, 'test-data'),
-            array('bin_func', \MongoDB\BSON\Binary::TYPE_FUNCTION, 'test-data'),
-            array('bin_bytearray', \MongoDB\BSON\Binary::TYPE_OLD_BINARY, 'test-data'),
-            array('bin_uuid', \MongoDB\BSON\Binary::TYPE_OLD_UUID, 'testtesttesttest'),
-            array('bin_md5', \MongoDB\BSON\Binary::TYPE_MD5, md5('test')),
-            array('bin_custom', \MongoDB\BSON\Binary::TYPE_USER_DEFINED, 'test-data'),
-        );
+        return [
+            ['bin', 0, 'test-data'],
+            ['bin_func', Binary::TYPE_FUNCTION, 'test-data'],
+            ['bin_bytearray', Binary::TYPE_OLD_BINARY, 'test-data'],
+            ['bin_uuid', Binary::TYPE_OLD_UUID, 'testtesttesttest'],
+            ['bin_md5', Binary::TYPE_MD5, md5('test')],
+            ['bin_custom', Binary::TYPE_USER_DEFINED, 'test-data'],
+        ];
     }
 
     /**
@@ -343,11 +359,11 @@ class IdTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     private function createIdTestClass($type, $strategy)
     {
         $shortClassName = sprintf('TestIdTypes%s%sUser', ucfirst($type), ucfirst($strategy));
-        $className = sprintf(__NAMESPACE__.'\\%s', $shortClassName);
+        $className = sprintf(__NAMESPACE__ . '\\%s', $shortClassName);
 
-        if (!class_exists($className)) {
+        if (! class_exists($className)) {
             $code = sprintf(
-'namespace Doctrine\ODM\MongoDB\Tests\Functional;
+                'namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
@@ -359,7 +375,11 @@ class %s
 
     /** @Doctrine\ODM\MongoDB\Mapping\Annotations\Field("type=string") **/
     public $test = "test";
-}', $shortClassName, $strategy, $type);
+}',
+                $shortClassName,
+                $strategy,
+                $type
+            );
 
             eval($code);
         }
@@ -396,7 +416,7 @@ class CollectionIdUser
     public $reference;
 
     /** @ODM\EmbedMany(targetDocument="EmbeddedCollectionId") */
-    public $embedded = array();
+    public $embedded = [];
 
     public function __construct($name)
     {
@@ -417,7 +437,7 @@ class CollectionIdUserWithStartingId
     public $reference;
 
     /** @ODM\EmbedMany(targetDocument="EmbeddedCollectionId") */
-    public $embedded = array();
+    public $embedded = [];
 
     public function __construct($name)
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
@@ -162,11 +162,6 @@ class IdTest extends BaseTest
      */
     public function testEqualButNotIdenticalIds($user1Id, $user2Id)
     {
-        /* Do not use assertEquals(), since the Scalar comparator tends to cast
-         * scalars of different types to strings before comparison. We actually
-         * want to check against PHP's loose equality logic here.
-         */
-        $this->assertTrue($user1Id === $user2Id);
         $this->assertNotSame($user1Id, $user2Id);
 
         $user1 = new CustomIdUser(sprintf('User1 with %s ID', gettype($user1Id)));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdentifiersTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdentifiersTest.php
@@ -1,14 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-class IdentifiersTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\Event;
+use Documents\User;
+use function get_class;
+
+class IdentifiersTest extends BaseTest
 {
     public function testGetIdentifierValue()
     {
-        $user = new \Documents\User();
+        $user = new User();
         $user->setUsername('jwage');
-        $event = new \Documents\Event();
+        $event = new Event();
         $event->setTitle('test event title');
         $event->setUser($user);
         $this->dm->persist($user);
@@ -36,7 +43,7 @@ class IdentifiersTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testIdentifiersAreSet()
     {
-        $user = new \Documents\User();
+        $user = new User();
         $user->setUsername('jwage');
         $user->setPassword('test');
 
@@ -48,7 +55,7 @@ class IdentifiersTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testIdentityMap()
     {
-        $user = new \Documents\User();
+        $user = new User();
         $user->setUsername('jwage');
 
         $this->dm->persist($user);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
@@ -1,14 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class IndexesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class IndexesTest extends BaseTest
 {
     private function uniqueTest($class)
     {
-        $class = __NAMESPACE__.'\\'.$class;
+        $class = __NAMESPACE__ . '\\' . $class;
         $this->dm->getSchemaManager()->ensureDocumentIndexes($class);
 
         $test = new $class();
@@ -33,7 +36,7 @@ class IndexesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testEmbeddedIndexes()
     {
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\DocumentWithEmbeddedIndexes');
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\DocumentWithEmbeddedIndexes');
         $sm = $this->dm->getSchemaManager();
         $indexes = $sm->getDocumentIndexes($class->name);
 
@@ -52,7 +55,7 @@ class IndexesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testDiscriminatedEmbeddedIndexes()
     {
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\DocumentWithIndexInDiscriminatedEmbeds');
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\DocumentWithIndexInDiscriminatedEmbeds');
         $sm = $this->dm->getSchemaManager();
         $indexes = $sm->getDocumentIndexes($class->name);
 
@@ -68,7 +71,7 @@ class IndexesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testDiscriminatorIndexes()
     {
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\DocumentWithDiscriminatorIndex');
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\DocumentWithDiscriminatorIndex');
         $sm = $this->dm->getSchemaManager();
         $indexes = $sm->getDocumentIndexes($class->name);
 
@@ -78,35 +81,35 @@ class IndexesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testIndexDefinitions()
     {
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\UniqueOnFieldTest');
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\UniqueOnFieldTest');
         $indexes = $class->getIndexes();
         $this->assertTrue(isset($indexes[0]['keys']['username']));
         $this->assertEquals(1, $indexes[0]['keys']['username']);
         $this->assertTrue(isset($indexes[0]['options']['unique']));
         $this->assertEquals(true, $indexes[0]['options']['unique']);
 
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\UniqueOnDocumentTest');
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\UniqueOnDocumentTest');
         $indexes = $class->getIndexes();
         $this->assertTrue(isset($indexes[0]['keys']['username']));
         $this->assertEquals(1, $indexes[0]['keys']['username']);
         $this->assertTrue(isset($indexes[0]['options']['unique']));
         $this->assertEquals(true, $indexes[0]['options']['unique']);
 
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\IndexesOnDocumentTest');
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\IndexesOnDocumentTest');
         $indexes = $class->getIndexes();
         $this->assertTrue(isset($indexes[0]['keys']['username']));
         $this->assertEquals(1, $indexes[0]['keys']['username']);
         $this->assertTrue(isset($indexes[0]['options']['unique']));
         $this->assertEquals(true, $indexes[0]['options']['unique']);
 
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\PartialIndexOnDocumentTest');
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\PartialIndexOnDocumentTest');
         $indexes = $class->getIndexes();
         $this->assertTrue(isset($indexes[0]['keys']['username']));
         $this->assertEquals(1, $indexes[0]['keys']['username']);
         $this->assertTrue(isset($indexes[0]['options']['partialFilterExpression']));
-        $this->assertSame(array('counter' => array('$gt' => 5)), $indexes[0]['options']['partialFilterExpression']);
+        $this->assertSame(['counter' => ['$gt' => 5]], $indexes[0]['options']['partialFilterExpression']);
 
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\UniqueSparseOnFieldTest');
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\UniqueSparseOnFieldTest');
         $indexes = $class->getIndexes();
         $this->assertTrue(isset($indexes[0]['keys']['username']));
         $this->assertEquals(1, $indexes[0]['keys']['username']);
@@ -115,7 +118,7 @@ class IndexesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue(isset($indexes[0]['options']['sparse']));
         $this->assertEquals(true, $indexes[0]['options']['sparse']);
 
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\UniqueSparseOnDocumentTest');
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\UniqueSparseOnDocumentTest');
         $indexes = $class->getIndexes();
         $this->assertTrue(isset($indexes[0]['keys']['username']));
         $this->assertEquals(1, $indexes[0]['keys']['username']);
@@ -124,7 +127,7 @@ class IndexesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue(isset($indexes[0]['options']['sparse']));
         $this->assertEquals(true, $indexes[0]['options']['sparse']);
 
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\SparseIndexesOnDocumentTest');
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\SparseIndexesOnDocumentTest');
         $indexes = $class->getIndexes();
         $this->assertTrue(isset($indexes[0]['keys']['username']));
         $this->assertEquals(1, $indexes[0]['keys']['username']);
@@ -133,7 +136,7 @@ class IndexesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue(isset($indexes[0]['options']['sparse']));
         $this->assertEquals(true, $indexes[0]['options']['sparse']);
 
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\MultipleFieldsUniqueIndexTest');
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\MultipleFieldsUniqueIndexTest');
         $indexes = $class->getIndexes();
         $this->assertTrue(isset($indexes[0]['keys']['username']));
         $this->assertEquals(1, $indexes[0]['keys']['username']);
@@ -142,7 +145,7 @@ class IndexesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue(isset($indexes[0]['options']['unique']));
         $this->assertEquals(true, $indexes[0]['options']['unique']);
 
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\MultipleFieldsUniqueSparseIndexTest');
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\MultipleFieldsUniqueSparseIndexTest');
         $indexes = $class->getIndexes();
         $this->assertTrue(isset($indexes[0]['keys']['username']));
         $this->assertEquals(1, $indexes[0]['keys']['username']);
@@ -153,7 +156,7 @@ class IndexesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue(isset($indexes[0]['options']['sparse']));
         $this->assertEquals(true, $indexes[0]['options']['sparse']);
 
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\MultipleFieldIndexes');
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\MultipleFieldIndexes');
         $indexes = $class->getIndexes();
         $this->assertTrue(isset($indexes[0]['keys']['username']));
         $this->assertEquals(1, $indexes[0]['keys']['username']);
@@ -221,7 +224,7 @@ class IndexesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $indexes = $this->dm->getSchemaManager()->getDocumentIndexes($className);
         $this->assertNotEmpty($indexes[0]['options']['partialFilterExpression']);
-        $this->assertSame(array('counter' => array('$gt' => 5)), $indexes[0]['options']['partialFilterExpression']);
+        $this->assertSame(['counter' => ['$gt' => 5]], $indexes[0]['options']['partialFilterExpression']);
         $this->assertTrue($indexes[0]['options']['unique']);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/InheritanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/InheritanceTest.php
@@ -1,15 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-class InheritanceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\Developer;
+use Documents\OtherSubProject;
+use Documents\Profile;
+use Documents\Project;
+use Documents\SpecialUser;
+use Documents\SubProject;
+use Documents\User;
+
+class InheritanceTest extends BaseTest
 {
     public function testCollectionPerClassInheritance()
     {
-        $profile = new \Documents\Profile();
+        $profile = new Profile();
         $profile->setFirstName('Jon');
 
-        $user = new \Documents\SpecialUser();
+        $user = new SpecialUser();
         $user->setUsername('specialuser');
         $user->setProfile($profile);
 
@@ -33,36 +44,36 @@ class InheritanceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $query = $qb->getQuery();
         $user = $query->getSingleResult();
         $this->assertEquals('Wage', $user->getProfile()->getLastName());
-        $this->assertInstanceOf(\Documents\SpecialUser::class, $user);
+        $this->assertInstanceOf(SpecialUser::class, $user);
     }
 
     public function testSingleCollectionInhertiance()
     {
-        $subProject = new \Documents\SubProject('Sub Project');
+        $subProject = new SubProject('Sub Project');
         $this->dm->persist($subProject);
         $this->dm->flush();
 
         $coll = $this->dm->getDocumentCollection('Documents\SubProject');
-        $document = $coll->findOne(array('name' => 'Sub Project'));
+        $document = $coll->findOne(['name' => 'Sub Project']);
         $this->assertEquals('sub-project', $document['type']);
 
-        $project = new \Documents\OtherSubProject('Other Sub Project');
+        $project = new OtherSubProject('Other Sub Project');
         $this->dm->persist($project);
         $this->dm->flush();
 
         $coll = $this->dm->getDocumentCollection('Documents\OtherSubProject');
-        $document = $coll->findOne(array('name' => 'Other Sub Project'));
+        $document = $coll->findOne(['name' => 'Other Sub Project']);
         $this->assertEquals('other-sub-project', $document['type']);
 
         $this->dm->clear();
 
-        $document = $this->dm->getRepository('Documents\SubProject')->findOneBy(array('name' => 'Sub Project'));
+        $document = $this->dm->getRepository('Documents\SubProject')->findOneBy(['name' => 'Sub Project']);
         $this->assertInstanceOf('Documents\SubProject', $document);
 
-        $document = $this->dm->getRepository('Documents\SubProject')->findOneBy(array('name' => 'Sub Project'));
+        $document = $this->dm->getRepository('Documents\SubProject')->findOneBy(['name' => 'Sub Project']);
         $this->assertInstanceOf('Documents\SubProject', $document);
 
-        $document = $this->dm->getRepository('Documents\Project')->findOneBy(array('name' => 'Sub Project'));
+        $document = $this->dm->getRepository('Documents\Project')->findOneBy(['name' => 'Sub Project']);
         $this->assertInstanceOf('Documents\SubProject', $document);
         $this->dm->clear();
 
@@ -70,13 +81,13 @@ class InheritanceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $document = $this->dm->find('Documents\Project', $id);
         $this->assertInstanceOf('Documents\SubProject', $document);
 
-        $document = $this->dm->getRepository('Documents\Project')->findOneBy(array('name' => 'Other Sub Project'));
+        $document = $this->dm->getRepository('Documents\Project')->findOneBy(['name' => 'Other Sub Project']);
         $this->assertInstanceOf('Documents\OtherSubProject', $document);
     }
 
     public function testPrePersistIsCalledFromMappedSuperClass()
     {
-        $user = new \Documents\User();
+        $user = new User();
         $user->setUsername('test');
         $this->dm->persist($user);
         $this->dm->flush();
@@ -85,13 +96,13 @@ class InheritanceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testInheritanceProxy()
     {
-        $developer = new \Documents\Developer('avalanche123');
+        $developer = new Developer('avalanche123');
 
         $projects = $developer->getProjects();
 
-        $projects->add(new \Documents\Project('Main Project'));
-        $projects->add(new \Documents\SubProject('Sub Project'));
-        $projects->add(new \Documents\OtherSubProject('Another Sub Project'));
+        $projects->add(new Project('Main Project'));
+        $projects->add(new SubProject('Sub Project'));
+        $projects->add(new OtherSubProject('Another Sub Project'));
 
         $this->dm->persist($developer);
         $this->dm->flush();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/CachingIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/CachingIteratorTest.php
@@ -1,9 +1,12 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Iterator;
 
 use Doctrine\ODM\MongoDB\Iterator\CachingIterator;
 use PHPUnit\Framework\TestCase;
+use function iterator_to_array;
 
 class CachingIteratorTest extends TestCase
 {
@@ -54,7 +57,7 @@ class CachingIteratorTest extends TestCase
 
     public function testPartialIterationDoesNotExhaust()
     {
-        $traversable = $this->getTraversableThatThrows([1, 2, new \Exception]);
+        $traversable = $this->getTraversableThatThrows([1, 2, new \Exception()]);
         $iterator = new CachingIterator($traversable);
 
         $expectedKey = 0;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/HydratingIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/HydratingIteratorTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Iterator;
 
@@ -6,6 +8,7 @@ use Doctrine\ODM\MongoDB\Iterator\HydratingIterator;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\User;
 use MongoDB\BSON\ObjectId;
+use function is_array;
 
 final class HydratingIteratorTest extends BaseTest
 {
@@ -45,7 +48,7 @@ final class HydratingIteratorTest extends BaseTest
 
     private function getTraversable($items = null)
     {
-        if (!is_array($items)) {
+        if (! is_array($items)) {
             $items = [
                 ['_id' => new ObjectId(), 'username' => 'foo', 'hits' => 1],
                 ['_id' => new ObjectId(), 'username' => 'bar', 'hits' => 2],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/PrimingIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/PrimingIteratorTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Iterator;
 
@@ -7,6 +9,7 @@ use Doctrine\ODM\MongoDB\Query\ReferencePrimer;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\User;
 use MongoDB\BSON\ObjectId;
+use function is_array;
 
 final class PrimingIteratorTest extends BaseTest
 {
@@ -31,7 +34,7 @@ final class PrimingIteratorTest extends BaseTest
 
     private function getIterator($items = null): \Iterator
     {
-        if (!is_array($items)) {
+        if (! is_array($items)) {
             $items = [
                 ['_id' => new ObjectId(), 'username' => 'foo', 'hits' => 1],
                 ['_id' => new ObjectId(), 'username' => 'bar', 'hits' => 2],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LifecycleTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LifecycleTest.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class LifecycleTest extends BaseTest
 {
@@ -24,7 +26,7 @@ class LifecycleTest extends BaseTest
 
         $this->dm->clear();
 
-        $parent = $this->dm->getRepository(__NAMESPACE__.'\ParentObject')->find($parent->getId());
+        $parent = $this->dm->getRepository(__NAMESPACE__ . '\ParentObject')->find($parent->getId());
         $this->assertNotNull($parent);
         $this->assertEquals('parent #changed', $parent->getName());
         $this->assertCount(1, $parent->getChildren());
@@ -43,7 +45,7 @@ class LifecycleTest extends BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $parent = $this->dm->getRepository(__NAMESPACE__.'\ParentObject')->find($parent->getId());
+        $parent = $this->dm->getRepository(__NAMESPACE__ . '\ParentObject')->find($parent->getId());
         $this->assertNotNull($parent);
         $this->assertCount(1, $parent->getChildren());
     }
@@ -86,7 +88,7 @@ class ParentObject
     /** @ODM\PrePersist @ODM\PreUpdate */
     public function prePersistPreUpdate()
     {
-        $this->children = array($this->child);
+        $this->children = [$this->child];
     }
 
     /** @ODM\PreUpdate */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
@@ -1,13 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\LockException;
 use Doctrine\ODM\MongoDB\LockMode;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\MongoDBException;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Issue;
+use Documents\User;
+use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\UTCDateTime;
+use function get_class;
+use function time;
 
-class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class LockTest extends BaseTest
 {
     public function testOptimisticLockIntSetInitialVersion()
     {
@@ -25,7 +35,7 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testOptimisticLockIntSetInitialVersionOnUpsert()
     {
-        $id = new \MongoDB\BSON\ObjectId();
+        $id = new ObjectId();
 
         $article = new LockInt('Test LockInt');
         $article->id = $id;
@@ -49,12 +59,12 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
 
         // Manually change the version so the next code will cause an exception
-        $this->dm->getDocumentCollection(get_class($article))->updateOne(array('_id' => new \MongoDB\BSON\ObjectId($article->id)), array('$set' => array('version' => 5)));
+        $this->dm->getDocumentCollection(get_class($article))->updateOne(['_id' => new ObjectId($article->id)], ['$set' => ['version' => 5]]);
 
         // Now lets change a property and try and save it again
         $article->title = 'ok';
 
-        $this->expectException(\Doctrine\ODM\MongoDB\LockException::class);
+        $this->expectException(LockException::class);
 
         $this->dm->flush();
     }
@@ -78,7 +88,7 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $test = new LockTimestamp();
         $test->title = 'Testing';
 
-        $this->assertNull($test->version, "Pre-Condition");
+        $this->assertNull($test->version, 'Pre-Condition');
 
         $this->dm->persist($test);
         $this->dm->flush();
@@ -97,13 +107,13 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testLockTimestampSetsDefaultValueOnUpsert()
     {
-        $id = new \MongoDB\BSON\ObjectId();
+        $id = new ObjectId();
 
         $test = new LockTimestamp();
         $test->title = 'Testing';
         $test->id = $id;
 
-        $this->assertNull($test->version, "Pre-Condition");
+        $this->assertNull($test->version, 'Pre-Condition');
 
         $this->dm->persist($test);
         $this->dm->flush();
@@ -128,23 +138,20 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
 
         // Manually change the version so the next code will cause an exception
-        $this->dm->getDocumentCollection(get_class($article))->updateOne(array('_id' => new \MongoDB\BSON\ObjectId($article->id)), array('$set' => array('version' => new \MongoDB\BSON\UTCDateTime(time() * 1000 + 600))));
+        $this->dm->getDocumentCollection(get_class($article))->updateOne(['_id' => new ObjectId($article->id)], ['$set' => ['version' => new UTCDateTime(time() * 1000 + 600)]]);
 
         // Now lets change a property and try and save it again
         $article->title = 'ok';
 
-        $this->expectException(\Doctrine\ODM\MongoDB\LockException::class);
+        $this->expectException(LockException::class);
 
         $this->dm->flush();
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testLockVersionedDocument()
     {
         $article = new LockInt();
-        $article->title = "my article";
+        $article->title = 'my article';
 
         $this->dm->persist($article);
         $this->dm->flush();
@@ -155,25 +162,25 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testLockVersionedDocumentMissmatchThrowsException()
     {
         $article = new LockInt();
-        $article->title = "my article";
+        $article->title = 'my article';
 
         $this->dm->persist($article);
         $this->dm->flush();
 
-        $this->expectException(\Doctrine\ODM\MongoDB\LockException::class);
+        $this->expectException(LockException::class);
 
         $this->dm->lock($article, LockMode::OPTIMISTIC, $article->version + 1);
     }
 
     public function testLockUnversionedDocumentThrowsException()
     {
-        $user = new \Documents\User();
+        $user = new User();
         $user->setUsername('test');
 
         $this->dm->persist($user);
         $this->dm->flush();
 
-        $this->expectException(\Doctrine\ODM\MongoDB\LockException::class);
+        $this->expectException(LockException::class);
         $this->expectExceptionMessage('Document Documents\User is not versioned.');
 
         $this->dm->lock($user, LockMode::OPTIMISTIC);
@@ -192,7 +199,7 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testLockPessimisticWrite()
     {
         $article = new LockInt();
-        $article->title = "my article";
+        $article->title = 'my article';
 
         $this->dm->persist($article);
         $this->dm->flush();
@@ -206,7 +213,7 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testLockPessimisticRead()
     {
         $article = new LockInt();
-        $article->title = "my article";
+        $article->title = 'my article';
 
         $this->dm->persist($article);
         $this->dm->flush();
@@ -220,7 +227,7 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testUnlock()
     {
         $article = new LockInt();
-        $article->title = "my article";
+        $article->title = 'my article';
 
         $this->dm->persist($article);
         $this->dm->flush();
@@ -241,15 +248,15 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testPessimisticReadLockThrowsExceptionOnRemove()
     {
         $article = new LockInt();
-        $article->title = "my article";
+        $article->title = 'my article';
 
         $this->dm->persist($article);
         $this->dm->flush();
 
-        $coll = $this->dm->getDocumentCollection(__NAMESPACE__.'\LockInt');
-        $coll->replaceOne(array('_id' => new \MongoDB\BSON\ObjectId($article->id)), array('locked' => LockMode::PESSIMISTIC_READ));
+        $coll = $this->dm->getDocumentCollection(__NAMESPACE__ . '\LockInt');
+        $coll->replaceOne(['_id' => new ObjectId($article->id)], ['locked' => LockMode::PESSIMISTIC_READ]);
 
-        $this->expectException(\Doctrine\ODM\MongoDB\LockException::class);
+        $this->expectException(LockException::class);
 
         $this->dm->remove($article);
         $this->dm->flush();
@@ -258,15 +265,15 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testPessimisticReadLockThrowsExceptionOnUpdate()
     {
         $article = new LockInt();
-        $article->title = "my article";
+        $article->title = 'my article';
 
         $this->dm->persist($article);
         $this->dm->flush();
 
-        $coll = $this->dm->getDocumentCollection(__NAMESPACE__.'\LockInt');
-        $coll->replaceOne(array('_id' => new \MongoDB\BSON\ObjectId($article->id)), array('locked' => LockMode::PESSIMISTIC_READ));
+        $coll = $this->dm->getDocumentCollection(__NAMESPACE__ . '\LockInt');
+        $coll->replaceOne(['_id' => new ObjectId($article->id)], ['locked' => LockMode::PESSIMISTIC_READ]);
 
-        $this->expectException(\Doctrine\ODM\MongoDB\LockException::class);
+        $this->expectException(LockException::class);
 
         $article->title = 'changed';
         $this->dm->flush();
@@ -275,15 +282,15 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testPessimisticWriteLockThrowExceptionOnRemove()
     {
         $article = new LockInt();
-        $article->title = "my article";
+        $article->title = 'my article';
 
         $this->dm->persist($article);
         $this->dm->flush();
 
-        $coll = $this->dm->getDocumentCollection(__NAMESPACE__.'\LockInt');
-        $coll->replaceOne(array('_id' => new \MongoDB\BSON\ObjectId($article->id)), array('locked' => LockMode::PESSIMISTIC_WRITE));
+        $coll = $this->dm->getDocumentCollection(__NAMESPACE__ . '\LockInt');
+        $coll->replaceOne(['_id' => new ObjectId($article->id)], ['locked' => LockMode::PESSIMISTIC_WRITE]);
 
-        $this->expectException(\Doctrine\ODM\MongoDB\LockException::class);
+        $this->expectException(LockException::class);
 
         $this->dm->remove($article);
         $this->dm->flush();
@@ -292,15 +299,15 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testPessimisticWriteLockThrowExceptionOnUpdate()
     {
         $article = new LockInt();
-        $article->title = "my article";
+        $article->title = 'my article';
 
         $this->dm->persist($article);
         $this->dm->flush();
 
-        $coll = $this->dm->getDocumentCollection(__NAMESPACE__.'\LockInt');
-        $coll->replaceOne(array('_id' => new \MongoDB\BSON\ObjectId($article->id)), array('locked' => LockMode::PESSIMISTIC_WRITE));
+        $coll = $this->dm->getDocumentCollection(__NAMESPACE__ . '\LockInt');
+        $coll->replaceOne(['_id' => new ObjectId($article->id)], ['locked' => LockMode::PESSIMISTIC_WRITE]);
 
-        $this->expectException(\Doctrine\ODM\MongoDB\LockException::class);
+        $this->expectException(LockException::class);
 
         $article->title = 'changed';
         $this->dm->flush();
@@ -309,24 +316,24 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testPessimisticWriteLockThrowExceptionOnRead()
     {
         $article = new LockInt();
-        $article->title = "my article";
+        $article->title = 'my article';
 
         $this->dm->persist($article);
         $this->dm->flush();
 
-        $coll = $this->dm->getDocumentCollection(__NAMESPACE__.'\LockInt');
-        $coll->replaceOne(array('_id' => new \MongoDB\BSON\ObjectId($article->id)), array('locked' => LockMode::PESSIMISTIC_WRITE));
+        $coll = $this->dm->getDocumentCollection(__NAMESPACE__ . '\LockInt');
+        $coll->replaceOne(['_id' => new ObjectId($article->id)], ['locked' => LockMode::PESSIMISTIC_WRITE]);
 
-        $this->expectException(\Doctrine\ODM\MongoDB\LockException::class);
+        $this->expectException(LockException::class);
 
         $this->dm->clear();
-        $article = $this->dm->find(__NAMESPACE__.'\LockInt', $article->id);
+        $article = $this->dm->find(__NAMESPACE__ . '\LockInt', $article->id);
     }
 
     public function testPessimisticReadLockFunctional()
     {
         $article = new LockInt();
-        $article->title = "my article";
+        $article->title = 'my article';
 
         $this->dm->persist($article);
         $this->dm->flush();
@@ -336,7 +343,7 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $article->title = 'test';
         $this->dm->flush();
 
-        $check = $this->dm->getDocumentCollection(__NAMESPACE__.'\LockInt')->findOne();
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\LockInt')->findOne();
         $this->assertEquals(2, $check['version']);
         $this->assertArrayNotHasKey('locked', $check);
         $this->assertEquals('test', $check['title']);
@@ -345,7 +352,7 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testPessimisticWriteLockFunctional()
     {
         $article = new LockInt();
-        $article->title = "my article";
+        $article->title = 'my article';
 
         $this->dm->persist($article);
         $this->dm->flush();
@@ -355,7 +362,7 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $article->title = 'test';
         $this->dm->flush();
 
-        $check = $this->dm->getDocumentCollection(__NAMESPACE__.'\LockInt')->findOne();
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\LockInt')->findOne();
         $this->assertEquals(2, $check['version']);
         $this->assertArrayNotHasKey('locked', $check);
         $this->assertEquals('test', $check['title']);
@@ -363,16 +370,16 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testInvalidLockDocument()
     {
-        $this->expectException(\Doctrine\ODM\MongoDB\MongoDBException::class);
+        $this->expectException(MongoDBException::class);
         $this->expectExceptionMessage('Invalid lock field type string. Lock field must be int.');
-        $this->dm->getClassMetadata(__NAMESPACE__.'\InvalidLockDocument');
+        $this->dm->getClassMetadata(__NAMESPACE__ . '\InvalidLockDocument');
     }
 
     public function testInvalidVersionDocument()
     {
-        $this->expectException(\Doctrine\ODM\MongoDB\MongoDBException::class);
+        $this->expectException(MongoDBException::class);
         $this->expectExceptionMessage('Invalid version field type string. Version field must be int or date.');
-        $this->dm->getClassMetadata(__NAMESPACE__.'\InvalidVersionDocument');
+        $this->dm->getClassMetadata(__NAMESPACE__ . '\InvalidVersionDocument');
     }
 
     /**
@@ -386,13 +393,13 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
 
         // simulate another request updating document in the meantime
-        $this->dm->getDocumentCollection(__NAMESPACE__.'\LockInt')->updateOne(
-            array('_id' => new \MongoDB\BSON\ObjectId($d->id)),
-            array('$set' => array('version' => 2))
+        $this->dm->getDocumentCollection(__NAMESPACE__ . '\LockInt')->updateOne(
+            ['_id' => new ObjectId($d->id)],
+            ['$set' => ['version' => 2]]
         );
 
         $d->issues->add(new Issue('oops', 'version mismatch'));
-        $this->uow->getCollectionPersister()->update($d->issues, array());
+        $this->uow->getCollectionPersister()->update($d->issues, []);
     }
 
     /**
@@ -406,12 +413,12 @@ class LockTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
 
         // simulate another request updating document in the meantime
-        $this->dm->getDocumentCollection(__NAMESPACE__.'\LockInt')->updateOne(
-            array('_id' => new \MongoDB\BSON\ObjectId($d->id)),
-            array('$set' => array('version' => 2))
+        $this->dm->getDocumentCollection(__NAMESPACE__ . '\LockInt')->updateOne(
+            ['_id' => new ObjectId($d->id)],
+            ['$set' => ['version' => 2]]
         );
 
-        $this->uow->getCollectionPersister()->delete($d->issues, array());
+        $this->uow->getCollectionPersister()->delete($d->issues, []);
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
@@ -148,6 +148,9 @@ class LockTest extends BaseTest
         $this->dm->flush();
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testLockVersionedDocument()
     {
         $article = new LockInt();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/MappedSuperclassTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/MappedSuperclassTest.php
@@ -1,19 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class MappedSuperclassTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MappedSuperclassTest extends BaseTest
 {
     public function testCRUD()
     {
-        $e = new DocumentSubClass;
+        $e = new DocumentSubClass();
         $e->setId(1);
         $e->setName('Roman');
         $e->setMapped1(42);
         $e->setMapped2('bar');
-        
+
         $related = new MappedSuperclassRelated1();
         $related->setId(1);
         $related->setName('Related');
@@ -29,7 +32,7 @@ class MappedSuperclassTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals(1, $e2->getId());
         $this->assertEquals('Roman', $e2->getName());
         $this->assertNotNull($e2->getMappedRelated1());
-        $this->assertInstanceOf(__NAMESPACE__.'\MappedSuperclassRelated1', $e2->getMappedRelated1());
+        $this->assertInstanceOf(__NAMESPACE__ . '\MappedSuperclassRelated1', $e2->getMappedRelated1());
         $this->assertEquals(42, $e2->getMapped1());
         $this->assertEquals('bar', $e2->getMapped2());
     }
@@ -95,17 +98,17 @@ class MappedSuperclassRelated1
     {
         $this->name = $name;
     }
-    
+
     public function getName()
     {
         return $this->name;
     }
-    
+
     public function setId($id)
     {
         $this->id = $id;
     }
-    
+
     public function getId()
     {
         return $this->id;
@@ -120,22 +123,22 @@ class DocumentSubClass extends MappedSuperclassBase
 
     /** @ODM\Field(type="string") */
     private $name;
-    
+
     public function setName($name)
     {
         $this->name = $name;
     }
-    
+
     public function getName()
     {
         return $this->name;
     }
-    
+
     public function setId($id)
     {
         $this->id = $id;
     }
-    
+
     public function getId()
     {
         return $this->id;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/MemoryUsageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/MemoryUsageTest.php
@@ -1,21 +1,33 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\CmsPhonenumber;
 use Documents\CmsUser;
+use function current;
+use function end;
+use function floor;
+use function gc_collect_cycles;
+use function log;
+use function memory_get_usage;
+use function pow;
+use function round;
+use function sprintf;
 
 /**
  * @group performance
  */
-class MemoryUsageTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MemoryUsageTest extends BaseTest
 {
     /**
      * Output for jwage "Memory increased by 14.09 kb"
      */
     public function testMemoryUsage()
     {
-        $memoryUsage = array();
+        $memoryUsage = [];
         for ($i = 0; $i < 100; $i++) {
             $ph1 = new CmsPhonenumber();
             $ph1->phonenumber = '12345';
@@ -46,7 +58,7 @@ class MemoryUsageTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     private function formatMemory($size)
     {
-        $unit = array('b', 'kb', 'mb', 'gb', 'tb', 'pb');
+        $unit = ['b', 'kb', 'mb', 'gb', 'tb', 'pb'];
         return round($size / pow(1024, ($i = floor(log($size, 1024)))), 2) . ' ' . $unit[$i];
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedCollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedCollectionsTest.php
@@ -1,13 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Phonebook;
 use Documents\Phonenumber;
+use function get_class;
 
-class NestedCollectionsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class NestedCollectionsTest extends BaseTest
 {
     /**
      * @dataProvider provideStrategy
@@ -63,14 +67,14 @@ class NestedCollectionsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function provideStrategy()
     {
-        return array(
-            array(ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET),
-            array(ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET_ARRAY),
-            array(ClassMetadata::STORAGE_STRATEGY_SET),
-            array(ClassMetadata::STORAGE_STRATEGY_SET_ARRAY),
-            array(ClassMetadata::STORAGE_STRATEGY_PUSH_ALL),
-            array(ClassMetadata::STORAGE_STRATEGY_ADD_TO_SET),
-        );
+        return [
+            [ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET],
+            [ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET_ARRAY],
+            [ClassMetadata::STORAGE_STRATEGY_SET],
+            [ClassMetadata::STORAGE_STRATEGY_SET_ARRAY],
+            [ClassMetadata::STORAGE_STRATEGY_PUSH_ALL],
+            [ClassMetadata::STORAGE_STRATEGY_ADD_TO_SET],
+        ];
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
@@ -1,11 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\ObjectId;
+use function is_numeric;
+use function is_string;
 
-class NestedDocumentsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class NestedDocumentsTest extends BaseTest
 {
     public function testSimple()
     {
@@ -27,14 +33,14 @@ class NestedDocumentsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $test = $this->dm->getDocumentCollection(__NAMESPACE__.'\Order')->findOne();
+        $test = $this->dm->getDocumentCollection(__NAMESPACE__ . '\Order')->findOne();
 
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $test['product']['_id']);
+        $this->assertInstanceOf(ObjectId::class, $test['product']['_id']);
         $this->assertEquals('Order', $test['title']);
         $this->assertEquals('Product', $test['product']['title']);
 
-        $doc = $this->dm->find(__NAMESPACE__.'\Order', $order->id);
-        $this->assertInstanceOf(__NAMESPACE__.'\Order', $order);
+        $doc = $this->dm->find(__NAMESPACE__ . '\Order', $order->id);
+        $this->assertInstanceOf(__NAMESPACE__ . '\Order', $order);
         $this->assertInternalType('string', $doc->product->id);
         $this->assertEquals((string) $test['product']['_id'], $doc->product->id);
         $this->assertEquals('Order', $doc->title);
@@ -42,22 +48,22 @@ class NestedDocumentsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->dm->clear();
 
-        $order = $this->dm->find(__NAMESPACE__.'\Order', $order->id);
-        $this->assertInstanceOf(__NAMESPACE__.'\Order', $order);
+        $order = $this->dm->find(__NAMESPACE__ . '\Order', $order->id);
+        $this->assertInstanceOf(__NAMESPACE__ . '\Order', $order);
 
-        $product = $this->dm->find(__NAMESPACE__.'\Product', $product->id);
-        $this->assertInstanceOf(__NAMESPACE__.'\Product', $product);
+        $product = $this->dm->find(__NAMESPACE__ . '\Product', $product->id);
+        $this->assertInstanceOf(__NAMESPACE__ . '\Product', $product);
 
         $order->product->title = 'tesgttttt';
         $this->dm->flush();
         $this->dm->clear();
 
-        $test1 = $this->dm->getDocumentCollection(__NAMESPACE__.'\Product')->findOne();
-        $test2 = $this->dm->getDocumentCollection(__NAMESPACE__.'\Order')->findOne();
+        $test1 = $this->dm->getDocumentCollection(__NAMESPACE__ . '\Product')->findOne();
+        $test2 = $this->dm->getDocumentCollection(__NAMESPACE__ . '\Order')->findOne();
         $this->assertNotEquals($test1['title'], $test2['product']['title']);
 
-        $order = $this->dm->find(__NAMESPACE__.'\Order', $order->id);
-        $product = $this->dm->find(__NAMESPACE__.'\Product', $product->id);
+        $order = $this->dm->find(__NAMESPACE__ . '\Order', $order->id);
+        $product = $this->dm->find(__NAMESPACE__ . '\Product', $product->id);
         $this->assertNotEquals($product->title, $order->product->title);
     }
 
@@ -70,7 +76,7 @@ class NestedDocumentsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $category = $this->dm->find(__NAMESPACE__.'\Category', $category->getId());
+        $category = $this->dm->find(__NAMESPACE__ . '\Category', $category->getId());
         $this->assertNotNull($category);
         $category->setName('Root Changed');
         $children = $category->getChildren();
@@ -81,7 +87,7 @@ class NestedDocumentsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $category = $this->dm->find(__NAMESPACE__.'\Category', $category->getId());
+        $category = $this->dm->find(__NAMESPACE__ . '\Category', $category->getId());
 
         $children = $category->getChildren();
         $this->assertEquals('Child 1 Changed', $children[0]->getName());
@@ -101,7 +107,7 @@ class NestedDocumentsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $test = $this->dm->getRepository(__NAMESPACE__.'\Hierarchy')->findOneBy(array('name' => 'Root'));
+        $test = $this->dm->getRepository(__NAMESPACE__ . '\Hierarchy')->findOneBy(['name' => 'Root']);
 
         $this->assertNotNull($test);
         $child1 = $test->getChild('Child 1')->setName('Child 1 Changed');
@@ -112,22 +118,22 @@ class NestedDocumentsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $test = $this->dm->find(__NAMESPACE__.'\Hierarchy', $test->getId());
+        $test = $this->dm->find(__NAMESPACE__ . '\Hierarchy', $test->getId());
         $this->assertNotNull($test);
         $this->assertEquals('Root Changed', $test->getName());
         $this->assertEquals('Child 1 Changed', $test->getChild(0)->getName());
         $this->assertEquals('Child 2 Changed', $test->getChild(1)->getName());
 
-        $child3 = $this->dm->getRepository(__NAMESPACE__.'\Hierarchy')->findOneBy(array('name' => 'Child 3'));
+        $child3 = $this->dm->getRepository(__NAMESPACE__ . '\Hierarchy')->findOneBy(['name' => 'Child 3']);
         $this->assertNotNull($child3);
         $child3->setName('Child 3 Changed');
         $this->dm->flush();
 
-        $child3 = $this->dm->getRepository(__NAMESPACE__.'\Hierarchy')->findOneBy(array('name' => 'Child 3 Changed'));
+        $child3 = $this->dm->getRepository(__NAMESPACE__ . '\Hierarchy')->findOneBy(['name' => 'Child 3 Changed']);
         $this->assertNotNull($child3);
         $this->assertEquals('Child 3 Changed', $child3->getName());
 
-        $test = $this->dm->getDocumentCollection(__NAMESPACE__.'\Hierarchy')->findOne(array('name' => 'Child 1 Changed'));
+        $test = $this->dm->getDocumentCollection(__NAMESPACE__ . '\Hierarchy')->findOne(['name' => 'Child 1 Changed']);
         $this->assertArrayNotHasKey('children', $test, 'Test empty array is not stored');
     }
 }
@@ -142,7 +148,7 @@ class Hierarchy
     private $name;
 
     /** @ODM\ReferenceMany(targetDocument="Hierarchy") */
-    private $children = array();
+    private $children = [];
 
     public function __construct($name)
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalEmbedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalEmbedTest.php
@@ -1,13 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\ODM\MongoDB\DocumentRepository;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 /**
  * Test the orphan removal on embedded documents that contain references with cascade operations.
  */
-class OrphanRemovalEmbedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class OrphanRemovalEmbedTest extends BaseTest
 {
     /**
      * Test unsetting an embedOne relationship
@@ -137,7 +141,7 @@ class OrphanRemovalEmbedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     }
 
     /**
-     * @return \Doctrine\ODM\MongoDB\DocumentRepository
+     * @return DocumentRepository
      */
     private function getUserRepository()
     {
@@ -145,7 +149,7 @@ class OrphanRemovalEmbedTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     }
 
     /**
-     * @return \Doctrine\ODM\MongoDB\DocumentRepository
+     * @return DocumentRepository
      */
     private function getAddressRepository()
     {
@@ -163,7 +167,7 @@ class OrphanRemovalCascadeUser
     public $profile;
 
     /** @ODM\EmbedMany(targetDocument="OrphanRemovalCascadeProfile") */
-    public $profileMany = array();
+    public $profileMany = [];
 }
 
 /** @ODM\EmbeddedDocument */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\ODM\MongoDB\DocumentRepository;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class OrphanRemovalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class OrphanRemovalTest extends BaseTest
 {
     public function testOrphanRemoval()
     {
@@ -241,7 +245,7 @@ class OrphanRemovalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     }
 
     /**
-     * @return \Doctrine\ODM\MongoDB\DocumentRepository
+     * @return DocumentRepository
      */
     private function getUserRepository()
     {
@@ -249,7 +253,7 @@ class OrphanRemovalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     }
 
     /**
-     * @return \Doctrine\ODM\MongoDB\DocumentRepository
+     * @return DocumentRepository
      */
     private function getProfileRepository()
     {
@@ -270,10 +274,10 @@ class OrphanRemovalUser
     public $profileNoOrphanRemoval;
 
     /** @ODM\ReferenceMany(targetDocument="OrphanRemovalProfile", orphanRemoval=true) */
-    public $profileMany = array();
+    public $profileMany = [];
 
     /** @ODM\ReferenceMany(targetDocument="OrphanRemovalProfile", orphanRemoval=false) */
-    public $profileManyNoOrphanRemoval = array();
+    public $profileManyNoOrphanRemoval = [];
 }
 
 /** @ODM\Document */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OwningAndInverseReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OwningAndInverseReferencesTest.php
@@ -1,10 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use DateTime;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\BlogPost;
+use Documents\BrowseNode;
+use Documents\Cart;
+use Documents\Comment;
+use Documents\Customer;
+use Documents\Feature;
+use Documents\FriendUser;
+use Documents\Product;
+use Documents\Tag;
+use function get_class;
+use function strtotime;
 
-class OwningAndInverseReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class OwningAndInverseReferencesTest extends BaseTest
 {
     public function testOneToOne()
     {
@@ -16,9 +30,9 @@ class OwningAndInverseReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
         // if inversedBy then isOwningSide
         // if mappedBy then isInverseSide
 
-        $customer = new \Documents\Customer;
+        $customer = new Customer();
         $customer->name = 'Jon Wage';
-        $customer->cart = new \Documents\Cart;
+        $customer->cart = new Cart();
         $customer->cart->numItems = 5;
         $customer->cart->customer = $customer;
         $customer->cartTest = 'test';
@@ -51,9 +65,9 @@ class OwningAndInverseReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
 
     public function testOneToManyBiDirectional()
     {
-        $product = new \Documents\Product('Book');
-        $product->addFeature(new \Documents\Feature('Pages'));
-        $product->addFeature(new \Documents\Feature('Cover'));
+        $product = new Product('Book');
+        $product->addFeature(new Feature('Pages'));
+        $product->addFeature(new Feature('Cover'));
         $this->dm->persist($product);
         $this->dm->flush();
         $this->dm->clear();
@@ -75,15 +89,15 @@ class OwningAndInverseReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
 
     public function testOneToManySelfReferencing()
     {
-        $node = new \Documents\BrowseNode('Root');
-        $node->addChild(new \Documents\BrowseNode('Child 1'));
-        $node->addChild(new \Documents\BrowseNode('Child 2'));
+        $node = new BrowseNode('Root');
+        $node->addChild(new BrowseNode('Child 1'));
+        $node->addChild(new BrowseNode('Child 2'));
 
         $this->dm->persist($node);
         $this->dm->flush();
         $this->dm->clear();
 
-        $check = $this->dm->getDocumentCollection(get_class($node))->findOne(array('parent' => array('$exists' => false)));
+        $check = $this->dm->getDocumentCollection(get_class($node))->findOne(['parent' => ['$exists' => false]]);
         $this->assertNotNull($check);
         $this->assertArrayNotHasKey('children', $check);
 
@@ -105,8 +119,8 @@ class OwningAndInverseReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
 
     public function testManyToMany()
     {
-        $baseballTag = new \Documents\Tag('baseball');
-        $blogPost = new \Documents\BlogPost();
+        $baseballTag = new Tag('baseball');
+        $blogPost = new BlogPost();
         $blogPost->name = 'Test';
         $blogPost->addTag($baseballTag);
 
@@ -137,10 +151,10 @@ class OwningAndInverseReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
 
     public function testManyToManySelfReferencing()
     {
-        $jwage = new \Documents\FriendUser('jwage');
-        $fabpot = new \Documents\FriendUser('fabpot');
+        $jwage = new FriendUser('jwage');
+        $fabpot = new FriendUser('fabpot');
         $fabpot->addFriend($jwage);
-        $romanb = new \Documents\FriendUser('romanb');
+        $romanb = new FriendUser('romanb');
         $romanb->addFriend($jwage);
         $jwage->addFriend($fabpot);
         $jwage->addFriend($romanb);
@@ -202,9 +216,9 @@ class OwningAndInverseReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
         $date2 = new DateTime();
         $date2->setTimestamp(strtotime('-10 seconds'));
 
-        $blogPost = new \Documents\BlogPost('Test');
-        $blogPost->addComment(new \Documents\Comment('Comment 1', $date1));
-        $blogPost->addComment(new \Documents\Comment('Comment 2', $date2));
+        $blogPost = new BlogPost('Test');
+        $blogPost->addComment(new Comment('Comment 1', $date1));
+        $blogPost->addComment(new Comment('Comment 2', $date2));
 
         $this->dm->persist($blogPost);
         $this->dm->flush();
@@ -243,8 +257,8 @@ class OwningAndInverseReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
             ->getQuery()
             ->getSingleResult();
 
-        $blogPost->addComment(new \Documents\Comment('Comment 3 by admin', $date1, true));
-        $blogPost->addComment(new \Documents\Comment('Comment 4 by admin', $date2, true));
+        $blogPost->addComment(new Comment('Comment 3 by admin', $date1, true));
+        $blogPost->addComment(new Comment('Comment 4 by admin', $date2, true));
         $this->dm->flush();
         $this->dm->clear();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionCloneTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionCloneTest.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Documents\CmsUser;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\CmsGroup;
+use Documents\CmsUser;
+use function get_class;
 
-class PersistentCollectionCloneTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class PersistentCollectionCloneTest extends BaseTest
 {
     private $user1;
     private $user2;
@@ -15,19 +19,19 @@ class PersistentCollectionCloneTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         parent::setUp();
 
         $user1 = new CmsUser();
-        $user1->username = "beberlei";
-        $user1->name = "Benjamin";
-        $user1->status = "active";
+        $user1->username = 'beberlei';
+        $user1->name = 'Benjamin';
+        $user1->status = 'active';
         $group1 = new CmsGroup();
-        $group1->name = "test";
+        $group1->name = 'test';
         $group2 = new CmsGroup();
-        $group2->name = "test";
+        $group2->name = 'test';
         $user1->addGroup($group1);
         $user1->addGroup($group2);
         $user2 = new CmsUser();
-        $user2->username = "romanb";
-        $user2->name = "Roman";
-        $user2->status = "active";
+        $user2->username = 'romanb';
+        $user2->name = 'Roman';
+        $user2->status = 'active';
 
         $this->dm->persist($user1);
         $this->dm->persist($user2);
@@ -77,7 +81,7 @@ class PersistentCollectionCloneTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user2 = $this->user2;
 
         $group3 = new CmsGroup();
-        $group3->name = "test";
+        $group3->name = 'test';
         $user2->groups = clone $user1->groups;
         $user2->groups->add($group3);
 
@@ -98,7 +102,7 @@ class PersistentCollectionCloneTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user2 = $this->user2;
 
         $group3 = new CmsGroup();
-        $group3->name = "test";
+        $group3->name = 'test';
         $user2->groups = $user1->groups;
         $user2->groups->add($group3);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistingTest.php
@@ -1,14 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\Mongo;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Account;
-use Documents\Address;
-use Documents\Phonenumber;
 use Documents\User;
 
-class PersistingTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class PersistingTest extends BaseTest
 {
     public function testCascadeInsertUpdateAndRemove()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PrePersistTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PrePersistTest.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class PrePersistTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class PrePersistTest extends BaseTest
 {
     public function testPrePersist()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RawTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RawTypeTest.php
@@ -1,47 +1,53 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\UTCDateTime;
+use function get_class;
 
-class RawTypeTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class RawTypeTest extends BaseTest
 {
-	/**
-	 * @dataProvider getTestRawTypeData
-	 */
-	public function testRawType($value)
-	{
-		$test = new RawType();
-		$test->raw = $value;
+    /**
+     * @dataProvider getTestRawTypeData
+     */
+    public function testRawType($value)
+    {
+        $test = new RawType();
+        $test->raw = $value;
 
-		$this->dm->persist($test);
-		$this->dm->flush();
+        $this->dm->persist($test);
+        $this->dm->flush();
 
-		$result = $this->dm->getDocumentCollection(get_class($test))->findOne(array('_id' => new \MongoDB\BSON\ObjectId($test->id)));
-		$this->assertEquals($value, $result['raw']);
-	}
+        $result = $this->dm->getDocumentCollection(get_class($test))->findOne(['_id' => new ObjectId($test->id)]);
+        $this->assertEquals($value, $result['raw']);
+    }
 
-	public function getTestRawTypeData()
-	{
-		return array(
-			array('test'),
-			array(1),
-			array(0),
-			array(array('test' => 'test')),
-			array(new \MongoDB\BSON\UTCDateTime()),
-			array(true),
-			array(array('date' => new \MongoDB\BSON\UTCDateTime())),
-			array(new \MongoDB\BSON\ObjectId())
-		);
-	}
+    public function getTestRawTypeData()
+    {
+        return [
+            ['test'],
+            [1],
+            [0],
+            [['test' => 'test']],
+            [new UTCDateTime()],
+            [true],
+            [['date' => new UTCDateTime()]],
+            [new ObjectId()],
+        ];
+    }
 }
 
 /** @ODM\Document */
 class RawType
 {
-	/** @ODM\Id */
-	public $id;
+    /** @ODM\Id */
+    public $id;
 
-	/** @ODM\Field(type="raw") */
-	public $raw;
+    /** @ODM\Field(type="raw") */
+    public $raw;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadOnlyDocumentTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadOnlyDocumentTest.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use MongoDB\BSON\ObjectId;
 
-class ReadOnlyDocumentTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class ReadOnlyDocumentTest extends BaseTest
 {
     public function testCanBeInserted()
     {
@@ -53,7 +56,7 @@ class ReadOnlyDocumentTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $rod = new ReadOnlyDocument('yay');
         $this->dm->persist($rod);
         $this->dm->flush();
-        $rod->value = "o.O";
+        $rod->value = 'o.O';
         $this->uow->recomputeSingleDocumentChangeSet($this->dm->getClassMetadata(ReadOnlyDocument::class), $rod);
         $this->assertEmpty($this->uow->getDocumentChangeSet($rod));
     }
@@ -66,7 +69,7 @@ class ReadOnlyDocumentTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $rod = $this->dm->find(ReadOnlyDocument::class, $rod->id);
-        $rod->value = "o.O";
+        $rod->value = 'o.O';
         $this->dm->flush();
         $this->dm->clear();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
@@ -1,15 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Query\Query;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Group;
 use Documents\User;
 use MongoDB\Driver\ReadPreference;
 
-class ReadPreferenceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class ReadPreferenceTest extends BaseTest
 {
     public function setUp()
     {
@@ -85,7 +88,7 @@ class ReadPreferenceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $query = $this->dm->getRepository(DocumentWithReadPreference::class)
             ->createQueryBuilder()
-            ->setReadPreference(new ReadPreference("secondary", []))
+            ->setReadPreference(new ReadPreference('secondary', []))
             ->getQuery();
 
         $this->assertReadPreferenceHint(ReadPreference::RP_SECONDARY, $query->getQuery()['readPreference']);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class ReferenceDiscriminatorsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class ReferenceDiscriminatorsTest extends BaseTest
 {
     public function setUp()
     {
@@ -88,11 +91,11 @@ class ReferenceDiscriminatorsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 }
 
 /**
-* @ODM\Document(collection="rdt_action")
-* @ODM\InheritanceType("SINGLE_COLLECTION")
-* @ODM\DiscriminatorField("discriminator")
-* @ODM\DiscriminatorMap({"action"="Action", "commentable_action"="CommentableAction"})
-*/
+ * @ODM\Document(collection="rdt_action")
+ * @ODM\InheritanceType("SINGLE_COLLECTION")
+ * @ODM\DiscriminatorField("discriminator")
+ * @ODM\DiscriminatorMap({"action"="Action", "commentable_action"="CommentableAction"})
+ */
 class Action
 {
     /** @ODM\Id */
@@ -123,9 +126,9 @@ class CommentableAction extends Action
     /**
      * @ODM\Field(type="collection")
      **/
-    protected $comments = array();
+    protected $comments = [];
 
-    public function __construct($type, array $comments = array())
+    public function __construct($type, array $comments = [])
     {
         parent::__construct($type);
         $this->comments = $comments;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceEmbeddedDocumentsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceEmbeddedDocumentsTest.php
@@ -1,13 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Documents\SubProject;
-use Documents\Project;
-use Documents\Issue;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\Issue;
+use Documents\Project;
+use Documents\SubProject;
 
-class ReferenceEmbeddedDocumentsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class ReferenceEmbeddedDocumentsTest extends BaseTest
 {
     public function testSavesEmbeddedDocumentsInReferencedDocument()
     {
@@ -23,15 +26,15 @@ class ReferenceEmbeddedDocumentsTest extends \Doctrine\ODM\MongoDB\Tests\BaseTes
         $subProject1 = new SubProject('Sub Project #1');
         $subProject2 = new SubProject('Sub Project #2');
 
-        $subProject1->setIssues(new ArrayCollection(array(
+        $subProject1->setIssues(new ArrayCollection([
             new Issue('Issue #1', 'Issue #1 on Sub Project #1'),
-            new Issue('Issue #2', 'Issue #2 on Sub Project #1')
-        )));
+            new Issue('Issue #2', 'Issue #2 on Sub Project #1'),
+        ]));
 
-        $subProject2->setIssues(new ArrayCollection(array(
+        $subProject2->setIssues(new ArrayCollection([
             new Issue('Issue #1', 'Issue #1 on Sub Project #2'),
-            new Issue('Issue #2', 'Issue #2 on Sub Project #2')
-        )));
+            new Issue('Issue #2', 'Issue #2 on Sub Project #2'),
+        ]));
 
         $subProjects->add($subProject1);
         $subProjects->add($subProject2);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
@@ -1,15 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Proxy\Proxy;
 use Doctrine\ODM\MongoDB\Query\Query;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Account;
 use Documents\Agent;
 use Documents\BlogPost;
 use Documents\Comment;
+use Documents\Ecommerce\ConfigurableProduct;
+use Documents\Ecommerce\Currency;
+use Documents\Ecommerce\Money;
+use Documents\Ecommerce\Option;
+use Documents\Ecommerce\StockItem;
 use Documents\Functional\EmbeddedWhichReferences;
 use Documents\Functional\EmbedNamed;
 use Documents\Functional\FavoritesUser;
@@ -21,14 +29,10 @@ use Documents\Project;
 use Documents\ReferenceUser;
 use Documents\SimpleReferenceUser;
 use Documents\User;
-use Documents\Ecommerce\ConfigurableProduct;
-use Documents\Ecommerce\Currency;
-use Documents\Ecommerce\Money;
-use Documents\Ecommerce\Option;
-use Documents\Ecommerce\StockItem;
 use MongoDB\Driver\ReadPreference;
+use function func_get_args;
 
-class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class ReferencePrimerTest extends BaseTest
 {
     /**
      * @expectedException InvalidArgumentException
@@ -87,9 +91,6 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->eagerCursor(false);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testFieldPrimingCanBeToggled()
     {
         $this->dm->createQueryBuilder(User::class)
@@ -381,7 +382,7 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->createQueryBuilder(Group::class)->getQuery()->toArray();
 
         $invoked = 0;
-        $primer = function(DocumentManager $dm, ClassMetadata $class, array $ids, array $hints) use (&$invoked) {
+        $primer = function (DocumentManager $dm, ClassMetadata $class, array $ids, array $hints) use (&$invoked) {
             $invoked++;
         };
 
@@ -418,8 +419,8 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $invokedArgs = array();
-        $primer = function(DocumentManager $dm, ClassMetadata $class, array $ids, array $hints) use (&$invokedArgs) {
+        $invokedArgs = [];
+        $primer = function (DocumentManager $dm, ClassMetadata $class, array $ids, array $hints) use (&$invokedArgs) {
             $invokedArgs[] = func_get_args();
         };
 
@@ -435,8 +436,8 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertArrayHasKey(Query::HINT_READ_PREFERENCE, $invokedArgs[0][3], 'Primer was invoked with UnitOfWork hints from original query.');
         $this->assertSame($readPreference, $invokedArgs[0][3][Query::HINT_READ_PREFERENCE], 'Primer was invoked with UnitOfWork hints from original query.');
 
-        $accountIds = array($account->getId());
-        $groupIds = array($group1->getId(), $group2->getId());
+        $accountIds = [$account->getId()];
+        $groupIds = [$group1->getId(), $group2->getId()];
 
         $this->assertEquals($accountIds, $invokedArgs[0][2]);
         $this->assertEquals($groupIds, $invokedArgs[1][2]);
@@ -474,7 +475,7 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $user1 = new User();
         $user2 = new User();
-        $phone = new Phonenumber('555-GET-THIS',$user2);
+        $phone = new Phonenumber('555-GET-THIS', $user2);
 
         $user1->addPhonenumber($phone);
         $user1->setUsername('SomeName');
@@ -505,16 +506,25 @@ class ReferencePrimerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $product = new ConfigurableProduct('Bundle');
 
         $product->addOption(
-            new Option('Lens1', new Money(75.00, new Currency('USD',1)),
-            new StockItem('Filter1', new Money(50.00, new Currency('USD',1)), 1))
+            new Option(
+                'Lens1',
+                new Money(75.00, new Currency('USD', 1)),
+                new StockItem('Filter1', new Money(50.00, new Currency('USD', 1)), 1)
+            )
         );
         $product->addOption(
-            new Option('Lens2', new Money(120.00, new Currency('USD',1)),
-            new StockItem('Filter2', new Money(100.00, new Currency('USD',1)), 1))
+            new Option(
+                'Lens2',
+                new Money(120.00, new Currency('USD', 1)),
+                new StockItem('Filter2', new Money(100.00, new Currency('USD', 1)), 1)
+            )
         );
         $product->addOption(
-            new Option('Lens3', new Money(180.00, new Currency('USD',1)),
-            new StockItem('Filter3', new Money(0.01, new Currency('USD',1)), 1))
+            new Option(
+                'Lens3',
+                new Money(180.00, new Currency('USD', 1)),
+                new StockItem('Filter3', new Money(0.01, new Currency('USD', 1)), 1)
+            )
         );
 
         $this->dm->persist($product);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
@@ -91,6 +91,9 @@ class ReferencePrimerTest extends BaseTest
             ->eagerCursor(false);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testFieldPrimingCanBeToggled()
     {
         $this->dm->createQueryBuilder(User::class)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceRepositoryMethodTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceRepositoryMethodTest.php
@@ -1,11 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\BlogPost;
+use Documents\Comment;
 use Documents\User;
+use function strtotime;
 
-class ReferenceRepositoryMethodTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class ReferenceRepositoryMethodTest extends BaseTest
 {
     public function testOneToOne()
     {
@@ -15,9 +20,9 @@ class ReferenceRepositoryMethodTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $date2 = new \DateTime();
         $date2->setTimestamp(strtotime('-10 seconds'));
 
-        $blogPost = new \Documents\BlogPost('Test');
-        $blogPost->addComment(new \Documents\Comment('Comment 1', $date1));
-        $blogPost->addComment(new \Documents\Comment('Comment 2', $date2));
+        $blogPost = new BlogPost('Test');
+        $blogPost->addComment(new Comment('Comment 1', $date1));
+        $blogPost->addComment(new Comment('Comment 2', $date2));
         $this->dm->persist($blogPost);
         $this->dm->flush();
         $this->dm->clear();
@@ -70,9 +75,9 @@ class ReferenceRepositoryMethodTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $repo = $this->dm->getRepository('Documents\BlogPost');
 
-        $blogPost = new \Documents\BlogPost('Test');
+        $blogPost = new BlogPost('Test');
 
-        $blogPost->addComment(new \Documents\Comment('Comment', new \DateTime()));
+        $blogPost->addComment(new Comment('Comment', new \DateTime()));
         $this->dm->persist($blogPost);
         $this->dm->flush();
         $this->dm->clear();
@@ -85,9 +90,9 @@ class ReferenceRepositoryMethodTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testRepositoryMethodWithoutMappedBy()
     {
-        $blogPost = new \Documents\BlogPost('Test');
+        $blogPost = new BlogPost('Test');
 
-        $blogPost->addComment(new \Documents\Comment('Comment', new \DateTime()));
+        $blogPost->addComment(new Comment('Comment', new \DateTime()));
         $this->dm->persist($blogPost);
         $this->dm->flush();
         $this->dm->clear();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
@@ -1,24 +1,31 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\Common\Persistence\Proxy;
 use Doctrine\ODM\MongoDB\Event\DocumentNotFoundEventArgs;
 use Doctrine\ODM\MongoDB\Events;
-use Documents\Address;
-use Documents\Profile;
-use Documents\ProfileNotify;
-use Documents\Phonenumber;
-use Documents\Account;
-use Documents\Group;
-use Documents\User;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\Account;
+use Documents\Address;
+use Documents\Group;
+use Documents\Phonenumber;
+use Documents\Profile;
+use Documents\ProfileNotify;
+use Documents\User;
+use MongoDB\BSON\Binary;
+use MongoDB\BSON\ObjectId;
+use function get_class;
 
-class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class ReferencesTest extends BaseTest
 {
     public function testManyDeleteReference()
     {
-        $user = new \Documents\User();
+        $user = new User();
 
         $user->addGroup(new Group('Group 1'));
         $user->addGroup(new Group('Group 2'));
@@ -86,7 +93,7 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $user = $this->dm->find(get_class($user), $user->getId());
-        $this->assertInstanceOf(\Doctrine\Common\Persistence\Proxy::class, $user->getProfileNotify());
+        $this->assertInstanceOf(Proxy::class, $user->getProfileNotify());
         $this->assertFalse($user->getProfileNotify()->__isInitialized());
 
         $user->getProfileNotify()->setLastName('Malarz');
@@ -126,7 +133,7 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testManyEmbedded()
     {
-        $user = new \Documents\User();
+        $user = new User();
         $user->addPhonenumber(new Phonenumber('6155139185'));
         $user->addPhonenumber(new Phonenumber('6153303769'));
 
@@ -166,7 +173,7 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testManyReference()
     {
-        $user = new \Documents\User();
+        $user = new User();
         $user->addGroup(new Group('Group 1'));
         $user->addGroup(new Group('Group 2'));
 
@@ -263,7 +270,7 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testManyReferenceWithAddToSetStrategy()
     {
-        $user = new \Documents\User();
+        $user = new User();
         $user->addUniqueGroup($group1 = new Group('Group 1'));
         $user->addUniqueGroup($group1);
         $user->addUniqueGroup(new Group('Group 2'));
@@ -319,7 +326,7 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testSortReferenceManyOwningSide()
     {
-        $user = new \Documents\User();
+        $user = new User();
         $user->addGroup(new Group('Group 1'));
         $user->addGroup(new Group('Group 2'));
 
@@ -350,7 +357,7 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $test = new DocumentWithArrayReference();
         $test->referenceOne = new DocumentWithArrayId();
-        $test->referenceOne->id = array('identifier' => 1);
+        $test->referenceOne->id = ['identifier' => 1];
 
         $this->dm->persist($test);
         $this->dm->persist($test->referenceOne);
@@ -360,10 +367,12 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $collection = $this->dm->getDocumentCollection(get_class($test));
 
         $collection->updateOne(
-            array('_id' => new \MongoDB\BSON\ObjectId($test->id)),
-            array('$set' => array(
-                'referenceOne.$id' => array('identifier' => 2),
-            ))
+            ['_id' => new ObjectId($test->id)],
+            [
+            '$set' => [
+                'referenceOne.$id' => ['identifier' => 2],
+            ],
+            ]
         );
 
         $test = $this->dm->find(get_class($test), $test->id);
@@ -387,13 +396,13 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $collection = $this->dm->getDocumentCollection(get_class($user));
 
-        $invalidId = new \MongoDB\BSON\ObjectId('abcdefabcdefabcdefabcdef');
+        $invalidId = new ObjectId('abcdefabcdefabcdefabcdef');
 
         $collection->updateOne(
-            array('_id' => new \MongoDB\BSON\ObjectId($user->getId())),
-            array('$set' => array(
-                'profile.$id' => $invalidId,
-            ))
+            ['_id' => new ObjectId($user->getId())],
+            [
+            '$set' => ['profile.$id' => $invalidId],
+            ]
         );
 
         $user = $this->dm->find(get_class($user), $user->getId());
@@ -418,13 +427,13 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $collection = $this->dm->getDocumentCollection(get_class($test));
 
-        $invalidBinData = new \MongoDB\BSON\Binary('testbindata', \MongoDB\BSON\Binary::TYPE_OLD_BINARY);
+        $invalidBinData = new Binary('testbindata', Binary::TYPE_OLD_BINARY);
 
         $collection->updateOne(
-            array('_id' => new \MongoDB\BSON\ObjectId($test->id)),
-            array('$set' => array(
-                'referenceOne.$id' => $invalidBinData,
-            ))
+            ['_id' => new ObjectId($test->id)],
+            [
+            '$set' => ['referenceOne.$id' => $invalidBinData],
+            ]
         );
 
         $test = $this->dm->find(get_class($test), $test->id);
@@ -444,13 +453,13 @@ class ReferencesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $collection = $this->dm->getDocumentCollection(get_class($user));
 
-        $invalidId = new \MongoDB\BSON\ObjectId('abcdefabcdefabcdefabcdef');
+        $invalidId = new ObjectId('abcdefabcdefabcdefabcdef');
 
         $collection->updateOne(
-            array('_id' => new \MongoDB\BSON\ObjectId($user->getId())),
-            array('$set' => array(
-                'profile.$id' => $invalidId,
-            ))
+            ['_id' => new ObjectId($user->getId())],
+            [
+            '$set' => ['profile.$id' => $invalidId],
+            ]
         );
 
         $user = $this->dm->find(get_class($user), $user->getId());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RemoveTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RemoveTest.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Account;
 use Documents\BlogPost;
 use Documents\CmsArticle;
@@ -12,7 +15,7 @@ use Documents\Group;
 use Documents\Project;
 use Documents\User;
 
-class RemoveTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class RemoveTest extends BaseTest
 {
     public function testRemove()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RepositoriesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RepositoriesTest.php
@@ -1,14 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\Criteria;
-use Documents\Account;
-use Documents\Address;
-use Documents\Phonenumber;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\User;
 
-class RepositoriesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class RepositoriesTest extends BaseTest
 {
     public function setUp()
     {
@@ -36,7 +36,7 @@ class RepositoriesTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user2 = $this->repository->find($this->user->getId());
         $this->assertSame($this->user, $user2);
 
-        $user3 = $this->repository->findOneBy(array('username' => 'w00ting'));
+        $user3 = $this->repository->findOneBy(['username' => 'w00ting']);
         $this->assertSame($user2, $user3);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
@@ -1,11 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Tests\QueryLogger;
 use Documents\Sharded\ShardedOne;
+use MongoDB\BSON\ObjectId;
+use function array_keys;
+use function end;
+use function get_class;
 
 class ShardKeyTest extends BaseTest
 {
@@ -17,7 +22,7 @@ class ShardKeyTest extends BaseTest
     protected function getConfiguration()
     {
         $this->markTestSkipped('mongodb-driver: query logging does not exist');
-        if ( ! isset($this->ql)) {
+        if (! isset($this->ql)) {
             $this->ql = new QueryLogger();
         }
 
@@ -31,7 +36,7 @@ class ShardKeyTest extends BaseTest
     {
         parent::setUp();
 
-        $class = \Documents\Sharded\ShardedOne::class;
+        $class = ShardedOne::class;
         $this->skipTestIfNotSharded($class);
         $schemaManager = $this->dm->getSchemaManager();
         $schemaManager->ensureDocumentSharding($class);
@@ -43,7 +48,7 @@ class ShardKeyTest extends BaseTest
         $this->dm->persist($o);
         $this->dm->flush();
 
-        /** @var \Documents\Sharded\ShardedOne $o */
+        /** @var ShardedOne $o */
         $o = $this->dm->find(get_class($o), $o->id);
         $o->title = 'test2';
         $this->dm->flush();
@@ -58,7 +63,7 @@ class ShardKeyTest extends BaseTest
     public function testUpsert()
     {
         $o = new ShardedOne();
-        $o->id = new \MongoDB\BSON\ObjectId();
+        $o->id = new ObjectId();
         $this->dm->persist($o);
         $this->dm->flush();
 
@@ -121,6 +126,6 @@ class ShardKeyTest extends BaseTest
         $this->dm->flush();
 
         $o->key = 'testing2';
-        $this->dm->flush(null, array('upsert' => true));
+        $this->dm->flush(null, ['upsert' => true]);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SimpleTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SimpleTest.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Bars\Bar;
 use Documents\Bars\Location;
 
-class SimpleTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class SimpleTest extends BaseTest
 {
     public function testSimple()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function get_class;
 
 class SplObjectHashCollisionsTest extends BaseTest
 {
@@ -48,11 +51,23 @@ class SplObjectHashCollisionsTest extends BaseTest
 
     public function provideParentAssociationsIsCleared()
     {
-        return array(
-            array( function (DocumentManager $dm) { $dm->clear(); }, 0 ),
-            array( function (DocumentManager $dm, $doc) { $dm->clear(get_class($doc)); }, 1 ),
-            array( function (DocumentManager $dm, $doc) { $dm->detach($doc); }, 1 ),
-        );
+        return [
+            [
+        function (DocumentManager $dm) {
+                $dm->clear();
+        }, 0,
+            ],
+            [
+            function (DocumentManager $dm, $doc) {
+                $dm->clear(get_class($doc));
+            }, 1,
+            ],
+            [
+            function (DocumentManager $dm, $doc) {
+                $dm->detach($doc);
+            }, 1,
+            ],
+        ];
     }
 
     private function expectCount($prop, $expected)
@@ -77,7 +92,7 @@ class SplColDoc
     public $one;
 
     /** @ODM\EmbedMany */
-    public $many = array();
+    public $many = [];
 }
 
 /** @ODM\EmbeddedDocument */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TestTargetDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TestTargetDocument.php
@@ -1,34 +1,37 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class TargetDocumentTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class TargetDocumentTest extends BaseTest
 {
     public function testMappedSuperClassAsTargetDocument()
     {
-    	$test = new TargetDocumentTestDocument();
-    	$test->reference = new TargetDocumentTestReference();
-    	$this->dm->persist($test);
-    	$this->dm->persist($test->reference);
-    	$this->dm->flush();
+        $test = new TargetDocumentTestDocument();
+        $test->reference = new TargetDocumentTestReference();
+        $this->dm->persist($test);
+        $this->dm->persist($test->reference);
+        $this->dm->flush();
     }
 }
 
 /** @ODM\Document */
 class TargetDocumentTestDocument
 {
-	/** @ODM\Id */
-	public $id;
+    /** @ODM\Id */
+    public $id;
 
-	/** @ODM\ReferenceOne(targetDocument="Doctrine\ODM\MongoDB\Tests\Functional\TargetDocumentTestReference") */
-	public $reference;
+    /** @ODM\ReferenceOne(targetDocument="Doctrine\ODM\MongoDB\Tests\Functional\TargetDocumentTestReference") */
+    public $reference;
 }
 
 /** @ODM\MappedSuperclass */
 abstract class TargetDocumentTestReference
 {
-	/** @ODM\Id */
-	public $id;
+    /** @ODM\Id */
+    public $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH1011Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1011Test extends BaseTest
 {
     public function testClearCollection()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1017Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1017Test.php
@@ -1,16 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\UnitOfWork;
+use function in_array;
+use function spl_object_hash;
 
 class GH1017Test extends BaseTest
 {
     public function testSPLObjectHashCollisionOnReplacingEmbeddedDoc()
     {
-        $usedHashes = array();
+        $usedHashes = [];
         $owner = new GH1017Document();
         $this->dm->persist($owner);
         $this->dm->flush();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
@@ -1,32 +1,31 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
 use Doctrine\ODM\MongoDB\Events;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\ObjectId;
+use function array_merge;
+use function get_class;
 
 class GH1058Test extends BaseTest
 {
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testModifyingDuringOnFlushEventNewDocument()
     {
-        $this->dm->getEventManager()->addEventListener(array(Events::onFlush), new GH1058Listener());
+        $this->dm->getEventManager()->addEventListener([Events::onFlush], new GH1058Listener());
         $document = new GH1058PersistDocument();
         $document->setValue('value 1');
         $this->dm->persist($document);
         $this->dm->flush();
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testModifyingDuringOnFlushEventNewDocumentWithId()
     {
-        $this->dm->getEventManager()->addEventListener(array(Events::onFlush), new GH1058Listener());
+        $this->dm->getEventManager()->addEventListener([Events::onFlush], new GH1058Listener());
         $document = new GH1058UpsertDocument();
         $document->generateId();
         $document->setValue('value 1');
@@ -37,7 +36,8 @@ class GH1058Test extends BaseTest
 
 class GH1058Listener
 {
-    public function onFlush(OnFlushEventArgs $args) {
+    public function onFlush(OnFlushEventArgs $args)
+    {
         $dm = $args->getDocumentManager();
         $uow = $dm->getUnitOfWork();
 
@@ -87,10 +87,10 @@ class GH1058UpsertDocument
         return $this->id;
     }
 
-    public final function generateId()
+    final public function generateId()
     {
-        if (!isset($this->id)) {
-            $this->id = (string) new \MongoDB\BSON\ObjectId();
+        if (! isset($this->id)) {
+            $this->id = (string) new ObjectId();
         }
     }
 
@@ -99,4 +99,3 @@ class GH1058UpsertDocument
         $this->value = $value;
     }
 }
-

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
@@ -14,6 +14,9 @@ use function get_class;
 
 class GH1058Test extends BaseTest
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testModifyingDuringOnFlushEventNewDocument()
     {
         $this->dm->getEventManager()->addEventListener([Events::onFlush], new GH1058Listener());
@@ -23,6 +26,9 @@ class GH1058Test extends BaseTest
         $this->dm->flush();
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testModifyingDuringOnFlushEventNewDocumentWithId()
     {
         $this->dm->getEventManager()->addEventListener([Events::onFlush], new GH1058Listener());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1107Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1107Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Persisters;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function get_class;
 
-class GH1117Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1117Test extends BaseTest
 {
     public function testAddOnUninitializedCollection()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1132Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1132Test.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Phonenumber;
 use Documents\User;
+use function get_class;
 
-class GH1132Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1132Test extends BaseTest
 {
     public function testClonedPersistentCollectionCanBeClearedAndUsedInNewDocument()
     {
@@ -36,7 +40,7 @@ class GH1132Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->persist($u);
         $this->dm->persist($u2);
         $this->dm->flush();
-        
+
         $u2->setPhonenumbers(clone $u->getPhonenumbers());
         $u2->getPhonenumbers()->clear();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1138Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1138Test.php
@@ -1,13 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
+use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Tests\QueryLogger;
 
-class GH1138Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1138Test extends BaseTest
 {
     /**
      * @var Doctrine\ODM\MongoDB\Tests\QueryLogger
@@ -17,7 +20,7 @@ class GH1138Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     protected function getConfiguration()
     {
         $this->markTestSkipped('mongodb-driver: query logging does not exist');
-        if ( ! isset($this->ql)) {
+        if (! isset($this->ql)) {
             $this->ql = new QueryLogger();
         }
 
@@ -48,7 +51,7 @@ class GH1138Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 /** @ODM\Document */
 class GH1138Document
 {
-    const CLASSNAME = __CLASS__;
+    public const CLASSNAME = __CLASS__;
 
     /** @ODM\Id */
     public $id;
@@ -81,4 +84,3 @@ class GH1138Listener
         }
     }
 }
-

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1152Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1152Test.php
@@ -1,12 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH1152Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1152Test extends BaseTest
 {
     public function testParentAssociationsInPostLoad()
     {
@@ -34,7 +37,7 @@ class GH1152Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 /** @ODM\Document */
 class GH1152Parent
 {
-    const CLASSNAME = __CLASS__;
+    public const CLASSNAME = __CLASS__;
 
     /** @ODM\Id */
     public $id;
@@ -56,7 +59,7 @@ class GH1152Listener
         $dm = $args->getDocumentManager();
         $document = $args->getDocument();
 
-        if (!$document instanceof GH1152Child) {
+        if (! $document instanceof GH1152Child) {
             return;
         }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function get_class;
 
-class GH1225Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1225Test extends BaseTest
 {
     public function testRemoveAddEmbeddedDocToExistingDocumentWithPreUpdateHook()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
@@ -1,11 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function count;
+use function end;
 
-class GH1229Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1229Test extends BaseTest
 {
     /**
      * @var string
@@ -134,7 +139,7 @@ class GH1229Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 /** @ODM\Document */
 class GH1229Parent
 {
-    const CLASSNAME = __CLASS__;
+    public const CLASSNAME = __CLASS__;
 
     /** @ODM\Id */
     public $id;
@@ -155,18 +160,12 @@ class GH1229Parent
         return $this->children->toArray();
     }
 
-    /**
-     * @param GH1229Child $child
-     */
     public function addChild(GH1229Child $child)
     {
         $child->setOrder(count($this->children));
         $this->children->add($child);
     }
 
-    /**
-     * @param GH1229Child $child
-     */
     public function removeChild(GH1229Child $child)
     {
         $this->children->removeElement($child);
@@ -190,7 +189,7 @@ class GH1229Parent
 /** @ODM\EmbeddedDocument */
 class GH1229Child
 {
-    const CLASSNAME = __CLASS__;
+    public const CLASSNAME = __CLASS__;
 
     /** @ODM\Field(type="string") */
     public $name;
@@ -230,5 +229,5 @@ class GH1229Child
 /** @ODM\EmbeddedDocument */
 class GH1229ChildTypeB extends GH1229Child
 {
-    const CLASSNAME = __CLASS__;
+    public const CLASSNAME = __CLASS__;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
@@ -1,16 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\DocumentRepository;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH1232Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1232Test extends BaseTest
 {
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testRemoveDoesNotCauseErrors()
     {
         $post = new GH1232Post();
@@ -32,7 +32,7 @@ class GH1232Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 /** @ODM\Document */
 class GH1232Post
 {
-    const CLASSNAME = __CLASS__;
+    public const CLASSNAME = __CLASS__;
 
     /** @ODM\Id */
     public $id;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
@@ -11,6 +11,9 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH1232Test extends BaseTest
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testRemoveDoesNotCauseErrors()
     {
         $post = new GH1232Post();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
@@ -1,12 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function array_map;
 
-class GH1275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1275Test extends BaseTest
 {
     public function testResortAtomicCollectionsFlipItems()
     {
@@ -32,7 +36,7 @@ class GH1275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $container->add($itemThree);
 
         $this->assertSame(
-            array('Number One', 'Number Two', 'Number Three'),
+            ['Number One', 'Number Two', 'Number Three'],
             array_map($getNameCallback, $container->items->toArray())
         );
 
@@ -44,7 +48,7 @@ class GH1275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->refresh($container);
 
         $this->assertSame(
-            array('Number One','Number Three', 'Number Two'),
+            ['Number One','Number Three', 'Number Two'],
             array_map($getNameCallback, $container->items->toArray())
         );
     }
@@ -73,7 +77,7 @@ class GH1275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $container->add($itemThree);
 
         $this->assertSame(
-            array('Number One', 'Number Two', 'Number Three'),
+            ['Number One', 'Number Two', 'Number Three'],
             array_map($getNameCallback, $container->items->toArray())
         );
 
@@ -83,7 +87,7 @@ class GH1275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->refresh($container);
 
         $this->assertSame(
-            array('Number One', 'Number Two', 'Number Three'),
+            ['Number One', 'Number Two', 'Number Three'],
             array_map($getNameCallback, $container->items->toArray())
         );
 
@@ -93,7 +97,7 @@ class GH1275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->refresh($container);
 
         $this->assertSame(
-            array('Number Two', 'Number One', 'Number Three'),
+            ['Number Two', 'Number One', 'Number Three'],
             array_map($getNameCallback, $container->items->toArray())
         );
 
@@ -103,7 +107,7 @@ class GH1275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->refresh($container);
 
         $this->assertSame(
-            array('Number One', 'Number Three', 'Number Two'),
+            ['Number One', 'Number Three', 'Number Two'],
             array_map($getNameCallback, $container->items->toArray())
         );
 
@@ -113,7 +117,7 @@ class GH1275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->refresh($container);
 
         $this->assertSame(
-            array('Number One', 'Number Three', 'Number Two'),
+            ['Number One', 'Number Three', 'Number Two'],
             array_map($getNameCallback, $container->items->toArray())
         );
 
@@ -123,7 +127,7 @@ class GH1275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->refresh($container);
 
         $this->assertSame(
-            array('Number Three', 'Number One', 'Number Two'),
+            ['Number Three', 'Number One', 'Number Two'],
             array_map($getNameCallback, $container->items->toArray())
         );
 
@@ -132,14 +136,14 @@ class GH1275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public static function getCollectionStrategies()
     {
-        return array(
-            'testResortWithStrategyAddToSet' => array(ClassMetadata::STORAGE_STRATEGY_ADD_TO_SET),
-            'testResortWithStrategySet' => array(ClassMetadata::STORAGE_STRATEGY_SET),
-            'testResortWithStrategySetArray' => array(ClassMetadata::STORAGE_STRATEGY_SET_ARRAY),
-            'testResortWithStrategyPushAll' => array(ClassMetadata::STORAGE_STRATEGY_PUSH_ALL),
-            'testResortWithStrategyAtomicSet' => array(ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET),
-            'testResortWithStrategyAtomicSetArray' => array(ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET_ARRAY),
-        );
+        return [
+            'testResortWithStrategyAddToSet' => [ClassMetadata::STORAGE_STRATEGY_ADD_TO_SET],
+            'testResortWithStrategySet' => [ClassMetadata::STORAGE_STRATEGY_SET],
+            'testResortWithStrategySetArray' => [ClassMetadata::STORAGE_STRATEGY_SET_ARRAY],
+            'testResortWithStrategyPushAll' => [ClassMetadata::STORAGE_STRATEGY_PUSH_ALL],
+            'testResortWithStrategyAtomicSet' => [ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET],
+            'testResortWithStrategyAtomicSetArray' => [ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET_ARRAY],
+        ];
     }
 
     /**
@@ -161,7 +165,7 @@ class GH1275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->refresh($container);
 
         $this->assertSame(
-            array('one', 'two', 'three'),
+            ['one', 'two', 'three'],
             array_map($getNameCallback, $container->$strategy->toArray())
         );
 
@@ -175,7 +179,7 @@ class GH1275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->refresh($container);
 
         $this->assertSame(
-            array('one', 'three', 'two'),
+            ['one', 'three', 'two'],
             array_map($getNameCallback, $container->$strategy->toArray())
         );
     }
@@ -184,7 +188,8 @@ class GH1275Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 /**
  * @ODM\Document(collection="item")
  */
-class Item {
+class Item
+{
     /** @ODM\Id */
     public $id;
 
@@ -206,7 +211,8 @@ class Item {
 /**
  * @ODM\EmbeddedDocument
  */
-class Element {
+class Element
+{
     /** @ODM\Id */
     public $id;
 
@@ -222,17 +228,18 @@ class Element {
 /**
  * @ODM\Document(collection="container")
  */
-class Container {
+class Container
+{
     /** @ODM\Id */
     public $id;
 
     /** @ODM\ReferenceMany(
-    *     targetDocument="Item",
-    *     cascade={"refresh","persist"},
-    *     orphanRemoval="true",
-    *     strategy="atomicSet"
-    * )
-    */
+     *     targetDocument="Item",
+     *     cascade={"refresh","persist"},
+     *     orphanRemoval="true",
+     *     strategy="atomicSet"
+     * )
+     */
     public $items;
 
     /**
@@ -305,7 +312,7 @@ class Container {
     public function add(Item $item)
     {
         $this->items->add($item);
-        if ($this->items->count() == 1) {
+        if ($this->items->count() === 1) {
             $this->firstItem = $item;
         }
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1294Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1294Test.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\Regex;
 
-class GH1294Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1294Test extends BaseTest
 {
     public function testRegexSearchOnIdentifierWithUuidStrategy()
     {
@@ -26,10 +30,10 @@ class GH1294Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $qb = $this->dm->createQueryBuilder($userClass);
 
         $res = $qb->field('id')
-            ->equals(new \MongoDB\BSON\Regex("^bbb.*$", 'i'))
+            ->equals(new Regex('^bbb.*$', 'i'))
             ->getQueryArray();
 
-        $this->assertInstanceOf(\MongoDB\BSON\Regex::class, $res['_id']);
+        $this->assertInstanceOf(Regex::class, $res['_id']);
         $this->assertEquals('^bbb.*$', $res['_id']->getPattern());
         $this->assertEquals('i', $res['_id']->getFlags());
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1346Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1346Test.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH1346Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1346Test extends BaseTest
 {
     /**
      * @group GH1346Test

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
@@ -1,23 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Query\Query;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH1418Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1418Test extends BaseTest
 {
     public function testManualHydrateAndMerge()
     {
-        $document = new GH1418Document;
-        $this->dm->getHydratorFactory()->hydrate($document, array(
+        $document = new GH1418Document();
+        $this->dm->getHydratorFactory()->hydrate($document, [
           '_id' => 1,
           'name' => 'maciej',
           'embedOne' => ['name' => 'maciej', 'sourceId' => 1],
           'embedMany' => [
-              ['name' => 'maciej', 'sourceId' => 2]
+              ['name' => 'maciej', 'sourceId' => 2],
           ],
-        ), [ Query::HINT_READ_ONLY => true ]);
+        ], [ Query::HINT_READ_ONLY => true ]);
 
         $this->assertEquals(1, $document->embedOne->id);
         $this->assertEquals(2, $document->embedMany->first()->id);
@@ -37,7 +40,7 @@ class GH1418Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testReadDocumentAndManage()
     {
-        $document = new GH1418Document;
+        $document = new GH1418Document();
         $document->id = 1;
 
         $embedded = new GH1418Embedded();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1428Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1428Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1435Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1435Test.php
@@ -1,14 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use MongoDB\BSON\ObjectId;
 
 class GH1435Test extends BaseTest
 {
     public function testUpsert()
     {
-        $id = (string) new \MongoDB\BSON\ObjectId();
+        $id = (string) new ObjectId();
 
         $document = new GH1435Document();
         $document->id = $id;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1525Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1525Test.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Id\UuidGenerator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH1525Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH1525Test extends BaseTest
 {
     public function testEmbedCloneTwoFlushesPerDocument()
     {
@@ -26,7 +30,7 @@ class GH1525Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         for ($i = 0; $i < 2; ++$i) {
-            $test = $this->dm->getRepository(GH1525Document::class)->findOneBy(array('name' => 'test' . $i));
+            $test = $this->dm->getRepository(GH1525Document::class)->findOneBy(['name' => 'test' . $i]);
 
             $this->assertInstanceOf(GH1525Document::class, $test);
 
@@ -41,7 +45,7 @@ class GH1525Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testEmbedCloneWithIdStrategyNoneOnParentAndEarlyPersist()
     {
-        $uuidGen = new \Doctrine\ODM\MongoDB\Id\UuidGenerator();
+        $uuidGen = new UuidGenerator();
         $embedded = new GH1525Embedded('embedded');
 
         $count = 2;
@@ -55,7 +59,7 @@ class GH1525Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         for ($i = 0; $i < $count; ++$i) {
-            $test = $this->dm->getRepository(GH1525DocumentIdStrategyNone::class)->findOneBy(array('name' => 'test' . $i));
+            $test = $this->dm->getRepository(GH1525DocumentIdStrategyNone::class)->findOneBy(['name' => 'test' . $i]);
 
             $this->assertInstanceOf(GH1525DocumentIdStrategyNone::class, $test);
 
@@ -66,7 +70,7 @@ class GH1525Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testEmbedCloneWithIdStrategyNoneOnParentAndLatePersist()
     {
-        $uuidGen = new \Doctrine\ODM\MongoDB\Id\UuidGenerator();
+        $uuidGen = new UuidGenerator();
         $embedded = new GH1525Embedded('embedded');
 
         $count = 2;
@@ -80,7 +84,7 @@ class GH1525Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         for ($i = 0; $i < $count; ++$i) {
-            $test = $this->dm->getRepository(GH1525DocumentIdStrategyNone::class)->findOneBy(array('name' => 'test' . $i));
+            $test = $this->dm->getRepository(GH1525DocumentIdStrategyNone::class)->findOneBy(['name' => 'test' . $i]);
 
             $this->assertInstanceOf(GH1525DocumentIdStrategyNone::class, $test);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1572Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1572Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\DocumentRepository;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH232Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH232Test.php
@@ -1,14 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-/**
- * @since 6/26/12
- */
-class GH232Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH232Test extends BaseTest
 {
     public function testReferencedDocumentInsideEmbeddedDocument()
     {
@@ -47,10 +47,10 @@ class Product
     public $name;
 
     /** @ODM\EmbedMany(targetDocument="Price") */
-    public $prices = array();
+    public $prices = [];
 
     /** @ODM\EmbedMany(targetDocument="SubProduct") */
-    public $subproducts = array();
+    public $subproducts = [];
 
     public function __construct($name)
     {
@@ -63,7 +63,7 @@ class Product
 class SubProduct
 {
     /** @ODM\EmbedMany(targetDocument="Price") */
-    public $prices = array();
+    public $prices = [];
 
     public function __construct()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH245Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH245Test.php
@@ -1,46 +1,50 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function get_class;
 
-class GH245Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH245Test extends BaseTest
 {
-	public function testTest()
-	{
-		$order = new GH245Order();
-		$order->id = 1;
+    public function testTest()
+    {
+        $order = new GH245Order();
+        $order->id = 1;
 
-		$orderLog = new GH245OrderLog();
-		$orderLog->order = $order;
+        $orderLog = new GH245OrderLog();
+        $orderLog->order = $order;
 
-		$this->dm->persist($orderLog);
-		$this->dm->persist($order);
-		$this->dm->flush();
-		$this->dm->clear();
+        $this->dm->persist($orderLog);
+        $this->dm->persist($order);
+        $this->dm->flush();
+        $this->dm->clear();
 
-		$user = $this->dm->find(get_class($order), $order->id);
+        $user = $this->dm->find(get_class($order), $order->id);
 
-		$this->assertInternalType('int', $order->id);
+        $this->assertInternalType('int', $order->id);
 
-		$check = $this->dm->getDocumentCollection(get_class($orderLog))->findOne();
-		$this->assertInternalType('int', $check['order']['$id']);
-	}
+        $check = $this->dm->getDocumentCollection(get_class($orderLog))->findOne();
+        $this->assertInternalType('int', $check['order']['$id']);
+    }
 }
 
 /** @ODM\Document */
 class GH245Order
 {
-	/** @ODM\Id(strategy="NONE") */
-	public $id;
+    /** @ODM\Id(strategy="NONE") */
+    public $id;
 }
 
 /** @ODM\Document */
 class GH245OrderLog
 {
-	/** @ODM\Id */
-	public $id;
+    /** @ODM\Id */
+    public $id;
 
-	/** @ODM\ReferenceOne(targetDocument="GH245Order") */
-	public $order;
+    /** @ODM\ReferenceOne(targetDocument="GH245Order") */
+    public $order;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -58,7 +60,7 @@ class GH267Test extends BaseTest
  * @ODM\Document(collection="users")
  */
 class GH267User
-{   
+{
     /** @ODM\Id */
     protected $id;
 
@@ -75,32 +77,32 @@ class GH267User
         $this->name = $name;
     }
 
-    public function setId($id) 
+    public function setId($id)
     {
         $this->id = $id;
     }
 
-    public function getId() 
+    public function getId()
     {
         return $this->id;
     }
 
-    public function setName($name) 
+    public function setName($name)
     {
         $this->name = $name;
     }
 
-    public function getName() 
+    public function getName()
     {
         return $this->name;
     }
 
-    public function setCompany($company) 
+    public function setCompany($company)
     {
         $this->company = $company;
     }
 
-    public function getCompany() 
+    public function getCompany()
     {
         return $this->company;
     }
@@ -113,7 +115,7 @@ class GH267User
  * @ODM\DiscriminatorMap({"seller"="GH267SellerCompany", "buyer"="GH267BuyerCompany"})
  */
 class GH267Company
-{   
+{
     /** @ODM\Id */
     protected $id;
 
@@ -122,22 +124,22 @@ class GH267Company
      */
     protected $users;
 
-    public function setId($id) 
+    public function setId($id)
     {
         $this->id = $id;
     }
 
-    public function getId() 
+    public function getId()
     {
         return $this->id;
     }
 
-    public function setUsers($users) 
+    public function setUsers($users)
     {
         $this->users = $users;
     }
 
-    public function getUsers() 
+    public function getUsers()
     {
         return $this->users;
     }
@@ -147,14 +149,12 @@ class GH267Company
  * @ODM\Document(collection="companies")
  */
 class GH267BuyerCompany extends GH267Company
-{   
-
+{
 }
 
 /**
  * @ODM\Document(collection="companies")
  */
 class GH267SellerCompany extends GH267Company
-{   
-
+{
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH385Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH385Test.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use MongoDB\BSON\ObjectId;
 
 class GH385Test extends BaseTest
 {
     public function testQueryBuilderShouldPrepareUnmappedFields()
     {
-        $identifier = new \MongoDB\BSON\ObjectId();
+        $identifier = new ObjectId();
 
         $qb = $this->dm->createQueryBuilder('Documents\User')
             ->upsert()
@@ -19,11 +21,11 @@ class GH385Test extends BaseTest
 
         $debug = $qb->getQuery()->getQuery();
 
-        $this->assertEquals(array('$inc' => array('foo.bar.level3a' => 1, 'foo.bar.level3b' => 1)), $debug['newObj']);
+        $this->assertEquals(['$inc' => ['foo.bar.level3a' => 1, 'foo.bar.level3b' => 1]], $debug['newObj']);
 
         $qb->getQuery()->execute();
 
-        $check = $this->dm->getDocumentCollection('Documents\User')->findOne(array('_id' => $identifier));
+        $check = $this->dm->getDocumentCollection('Documents\User')->findOne(['_id' => $identifier]);
         $this->assertNotNull($check);
         $this->assertTrue(isset($check['foo']['bar']['level3a']));
         $this->assertTrue(isset($check['foo']['bar']['level3b']));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH389Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH389Test.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH389Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH389Test extends BaseTest
 {
     public function testDiscriminatorEmptyEmbeddedDocument()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH426Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH426Test.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH426Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH426Test extends BaseTest
 {
     public function testTest()
     {
@@ -33,7 +36,7 @@ class GH426Form
     public $id;
 
     /** @ODM\ReferenceMany(targetDocument="GH426Field", mappedBy="form", cascade={"all"}) */
-    public $fields = array();
+    public $fields = [];
 
     /** @ODM\ReferenceOne(targetDocument="GH426Field", mappedBy="form", sort={"_id":1}) */
     public $firstField;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH435Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH435Test.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH435Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH435Test extends BaseTest
 {
     public function testOverridingFieldsType()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH453Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH453Test.php
@@ -1,15 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function array_values;
+use function get_class;
+use function sprintf;
 
-class GH453Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH453Test extends BaseTest
 {
     public function testHashWithStringKeys()
     {
-        $hash = array('a' => 'x', 'b' => 'y', 'c' => 'z');
+        $hash = ['a' => 'x', 'b' => 'y', 'c' => 'z'];
 
         $doc = new GH453Document();
         $doc->hash = $hash;
@@ -40,7 +46,7 @@ class GH453Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testHashWithNumericKeys()
     {
-        $hash = array(0 => 'x', 1 => 'y', 2 => 'z');
+        $hash = [0 => 'x', 1 => 'y', 2 => 'z'];
 
         $doc = new GH453Document();
         $doc->hash = $hash;
@@ -71,7 +77,7 @@ class GH453Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testCollection()
     {
-        $col = array('x', 'y', 'z');
+        $col = ['x', 'y', 'z'];
 
         $doc = new GH453Document();
         $doc->colPush = $col;
@@ -107,14 +113,20 @@ class GH453Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testEmbedMany()
     {
-        $colPush = new ArrayCollection(array(
+        $colPush = new ArrayCollection([
             new GH453EmbeddedDocument(),
             new GH453EmbeddedDocument(),
             new GH453EmbeddedDocument(),
-        ));
-        $colSet = $colPush->map(function($v) { return clone $v; });
-        $colSetArray = $colPush->map(function($v) { return clone $v; });
-        $colAddToSet = $colPush->map(function($v) { return clone $v; });
+        ]);
+        $colSet = $colPush->map(function ($v) {
+            return clone $v;
+        });
+        $colSetArray = $colPush->map(function ($v) {
+            return clone $v;
+        });
+        $colAddToSet = $colPush->map(function ($v) {
+            return clone $v;
+        });
 
         $doc = new GH453Document();
         $doc->embedManyPush = $colPush;
@@ -151,21 +163,39 @@ class GH453Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function testReferenceMany()
     {
-        $colPush = new ArrayCollection(array(
+        $colPush = new ArrayCollection([
             new GH453ReferencedDocument(),
             new GH453ReferencedDocument(),
             new GH453ReferencedDocument(),
-        ));
-        $colSet = $colPush->map(function($v) { return clone $v; });
-        $colSetArray = $colPush->map(function($v) { return clone $v; });
-        $colAddToSet = $colPush->map(function($v) { return clone $v; });
+        ]);
+        $colSet = $colPush->map(function ($v) {
+            return clone $v;
+        });
+        $colSetArray = $colPush->map(function ($v) {
+            return clone $v;
+        });
+        $colAddToSet = $colPush->map(function ($v) {
+            return clone $v;
+        });
 
         $dm = $this->dm;
 
-        $colPush->forAll(function($k, $v) use ($dm) { $dm->persist($v); return true; });
-        $colSet->forAll(function($k, $v) use ($dm) { $dm->persist($v); return true; });
-        $colSetArray->forAll(function($k, $v) use ($dm) { $dm->persist($v); return true; });
-        $colAddToSet->forAll(function($k, $v) use ($dm) { $dm->persist($v); return true; });
+        $colPush->forAll(function ($k, $v) use ($dm) {
+            $dm->persist($v);
+            return true;
+        });
+        $colSet->forAll(function ($k, $v) use ($dm) {
+            $dm->persist($v);
+            return true;
+        });
+        $colSetArray->forAll(function ($k, $v) use ($dm) {
+            $dm->persist($v);
+            return true;
+        });
+        $colAddToSet->forAll(function ($k, $v) use ($dm) {
+            $dm->persist($v);
+            return true;
+        });
 
         $doc = new GH453Document();
         $doc->referenceManyPush = $colPush;
@@ -216,13 +246,13 @@ class GH453Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     private function assertBsonType($bsonType, $documentId, $fieldName)
     {
-        $criteria = array('_id' => $documentId);
+        $criteria = ['_id' => $documentId];
 
-        if (4 === $bsonType) {
+        if ($bsonType === 4) {
             // See: https://jira.mongodb.org/browse/SERVER-1475
             $criteria['$where'] = sprintf('Array.isArray(this.%s)', $fieldName);
         } else {
-            $criteria[$fieldName] = array('$type' => $bsonType);
+            $criteria[$fieldName] = ['$type' => $bsonType];
         }
 
         $this->assertNotNull($this->dm->getRepository(__NAMESPACE__ . '\GH453Document')->findOneBy($criteria));
@@ -240,22 +270,22 @@ class GH453Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     private function assertBsonTypeAndValue($bsonType, $expectedValue, $documentId, $fieldName)
     {
-        if (4 === $bsonType) {
+        if ($bsonType === 4) {
             $expectedValue = array_values((array) $expectedValue);
-        } elseif (3 === $bsonType) {
+        } elseif ($bsonType === 3) {
             $expectedValue = (object) $expectedValue;
         }
 
-        $criteria = array(
+        $criteria = [
             '_id' => $documentId,
-            '$and' => array(array($fieldName => $expectedValue)),
-        );
+            '$and' => [[$fieldName => $expectedValue]],
+        ];
 
-        if (4 === $bsonType) {
+        if ($bsonType === 4) {
             // See: https://jira.mongodb.org/browse/SERVER-1475
-            $criteria['$and'][] = array('$where' => sprintf('Array.isArray(this.%s)', $fieldName));
+            $criteria['$and'][] = ['$where' => sprintf('Array.isArray(this.%s)', $fieldName)];
         } else {
-            $criteria['$and'][] = array($fieldName => array('$type' => $bsonType));
+            $criteria['$and'][] = [$fieldName => ['$type' => $bsonType]];
         }
 
         $this->assertNotNull($this->dm->getRepository(__NAMESPACE__ . '\GH453Document')->findOneBy($criteria));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH467Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH467Test.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH467Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH467Test extends BaseTest
 {
     public function testMergeDocumentWithUnsetCollectionFields()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH499Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH499Test.php
@@ -1,17 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\ObjectId;
 
-class GH499Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH499Test extends BaseTest
 {
     public function testSetRefMany()
     {
-        $a = new GH499Document(new \MongoDB\BSON\ObjectId());
-        $b = new GH499Document(new \MongoDB\BSON\ObjectId());
-        $c = new GH499Document(new \MongoDB\BSON\ObjectId());
+        $a = new GH499Document(new ObjectId());
+        $b = new GH499Document(new ObjectId());
+        $c = new GH499Document(new ObjectId());
 
         $a->addRef($b);
         $a->addRef($c);
@@ -24,10 +28,10 @@ class GH499Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $collection = $this->dm->getDocumentCollection(__NAMESPACE__ . '\GH499Document');
 
-        $a = $collection->findOne(array('_id' => new \MongoDB\BSON\ObjectId($a->getId())));
+        $a = $collection->findOne(['_id' => new ObjectId($a->getId())]);
 
-        $this->assertEquals(new \MongoDB\BSON\ObjectId($b->getId()), $a['refMany'][$b->getId()]);
-        $this->assertEquals(new \MongoDB\BSON\ObjectId($c->getId()), $a['refMany'][$c->getId()]);
+        $this->assertEquals(new ObjectId($b->getId()), $a['refMany'][$b->getId()]);
+        $this->assertEquals(new ObjectId($c->getId()), $a['refMany'][$c->getId()]);
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH520Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH520Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
@@ -44,7 +46,7 @@ class GH520Test extends BaseTest
         $this->dm->clear();
 
         $primedIds = null;
-        $primer = function(DocumentManager $dm, ClassMetadata $class, array $ids, array $hints) use (&$primedIds) {
+        $primer = function (DocumentManager $dm, ClassMetadata $class, array $ids, array $hints) use (&$primedIds) {
             $primedIds = $ids;
         };
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH529Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH529Test.php
@@ -1,14 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\ObjectId;
+use function get_class;
 
-class GH529Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH529Test extends BaseTest
 {
     public function testAutoIdWithConsistentValues()
     {
-        $identifier = new \MongoDB\BSON\ObjectId();
+        $identifier = new ObjectId();
         $doc = new GH529AutoIdDocument();
         $doc->id = $identifier;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
@@ -1,22 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function get_class;
 
-class GH560Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH560Test extends BaseTest
 {
     /**
      * @dataProvider provideDocumentIds
      */
     public function testPersistListenersAreCalled($id)
     {
-        $listener = new GH560EventSubscriber(array(
+        $listener = new GH560EventSubscriber([
             Events::prePersist,
             Events::postPersist,
-        ));
+        ]);
 
         $this->dm->getEventManager()->addEventSubscriber($listener);
 
@@ -25,10 +29,10 @@ class GH560Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $called = array(
-            array(Events::prePersist, __NAMESPACE__ . '\GH560Document'),
-            array(Events::postPersist, __NAMESPACE__ . '\GH560Document'),
-        );
+        $called = [
+            [Events::prePersist, __NAMESPACE__ . '\GH560Document'],
+            [Events::postPersist, __NAMESPACE__ . '\GH560Document'],
+        ];
 
         $this->assertEquals($called, $listener->called);
     }
@@ -52,10 +56,10 @@ class GH560Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
      */
     public function testUpdateListenersAreCalled($id)
     {
-        $listener = new GH560EventSubscriber(array(
+        $listener = new GH560EventSubscriber([
             Events::preUpdate,
             Events::postUpdate,
-        ));
+        ]);
 
         $this->dm->getEventManager()->addEventSubscriber($listener);
 
@@ -67,20 +71,20 @@ class GH560Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $called = array(
-            array(Events::preUpdate, __NAMESPACE__ . '\GH560Document'),
-            array(Events::postUpdate, __NAMESPACE__ . '\GH560Document'),
-        );
+        $called = [
+            [Events::preUpdate, __NAMESPACE__ . '\GH560Document'],
+            [Events::postUpdate, __NAMESPACE__ . '\GH560Document'],
+        ];
 
         $this->assertEquals($called, $listener->called);
     }
 
     public function provideDocumentIds()
     {
-        return array(
-            array(123456),
-            array('516ee7636803faea5600090a:path10421'),
-        );
+        return [
+            [123456],
+            ['516ee7636803faea5600090a:path10421'],
+        ];
     }
 }
 
@@ -91,7 +95,7 @@ class GH560EventSubscriber implements EventSubscriber
 
     public function __construct(array $events)
     {
-        $this->called = array();
+        $this->called = [];
         $this->events = $events;
     }
 
@@ -102,7 +106,7 @@ class GH560EventSubscriber implements EventSubscriber
 
     public function __call($eventName, $args)
     {
-        $this->called[] = array($eventName, get_class($args[0]->getDocument()));
+        $this->called[] = [$eventName, get_class($args[0]->getDocument())];
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH561Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH561Test.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH561Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH561Test extends BaseTest
 {
     public function testPersistMainDocument()
     {
@@ -19,16 +22,16 @@ class GH561Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $document = $this->dm->find(__NAMESPACE__.'\GH561Document', $document->id);
-        $this->assertInstanceOf(__NAMESPACE__.'\GH561Document', $document);
+        $document = $this->dm->find(__NAMESPACE__ . '\GH561Document', $document->id);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH561Document', $document);
         $this->assertCount(1, $document->embeddedDocuments);
 
         $embeddedDocument = $document->embeddedDocuments->first();
-        $this->assertInstanceOf(__NAMESPACE__.'\GH561EmbeddedDocument', $embeddedDocument);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH561EmbeddedDocument', $embeddedDocument);
         $this->assertCount(1, $embeddedDocument->embeddedDocuments);
 
         $anotherEmbeddedDocument = $embeddedDocument->embeddedDocuments->first();
-        $this->assertInstanceOf(__NAMESPACE__.'\GH561AnotherEmbeddedDocument', $anotherEmbeddedDocument);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH561AnotherEmbeddedDocument', $anotherEmbeddedDocument);
         $this->assertEquals('foo', $anotherEmbeddedDocument->name);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH566Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH566Test.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function iterator_to_array;
 
-class GH566Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH566Test extends BaseTest
 {
     public function testFoo()
     {
@@ -27,10 +31,10 @@ class GH566Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $embeddedDoc2->parent = $doc2;
 
         $doc3->version = $embeddedDoc2;
-        $doc3->versions = new ArrayCollection(array(
+        $doc3->versions = new ArrayCollection([
             $embeddedDoc1,
             $embeddedDoc2,
-        ));
+        ]);
 
         $this->dm->flush();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use MongoDB\Driver\Exception\BulkWriteException;
 
-class GH580Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH580Test extends BaseTest
 {
     public function testDocumentPersisterShouldClearQueuedInsertsOnMongoException()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH593Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH593Test.php
@@ -1,12 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\DocumentNotFoundException;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function iterator_to_array;
 
-class GH593Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH593Test extends BaseTest
 {
     public function setUp()
     {
@@ -59,11 +63,8 @@ class GH593Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertFalse($user1following[1]->__isInitialized());
         $this->assertEquals($user3->getId(), $user1following[1]->getId());
 
-        try {
-            $user1following[1]->__load();
-            $this->fail('Expected DocumentNotFoundException for filtered Proxy object');
-        } catch (DocumentNotFoundException $e) {
-        }
+        $this->expectException(DocumentNotFoundException::class);
+        $user1following[1]->__load();
     }
 
     public function testReferenceManyInverseSidePreparesFilterCriteria()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH596Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH596Test.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH596Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH596Test extends BaseTest
 {
     public function setUp()
     {
@@ -29,13 +32,17 @@ class GH596Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $query = $qb->getQuery();
         $query = $query->getQuery();
 
-        $expected = array('$and' => array(
-            array('$or' => array(
-                array('name' => 'foo'),
-                array('name' => 'bar'),
-            )),
-            array('deleted' => false),
-        ));
+        $expected = [
+        '$and' => [
+            [
+        '$or' => [
+                ['name' => 'foo'],
+                ['name' => 'bar'],
+            ],
+            ],
+            ['deleted' => false],
+        ],
+        ];
 
         $this->assertEquals($expected, $query['query']);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH597Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH597Test.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\ObjectId;
 
-class GH597Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH597Test extends BaseTest
 {
     public function testEmbedManyGetsUnset()
     {
@@ -15,28 +19,28 @@ class GH597Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         // default behavior on inserts already leaves out embedded documents
-        $expectedDocument = array('_id' => new \MongoDB\BSON\ObjectId($post->getId()));
+        $expectedDocument = ['_id' => new ObjectId($post->getId())];
         $this->assertPostDocument($expectedDocument, $post);
 
         // fill documents with comments
         $post = $this->dm->find(__NAMESPACE__ . '\GH597Post', $post->getId());
-        $post->comments = new ArrayCollection(array(
+        $post->comments = new ArrayCollection([
             new GH597Comment('Comment 1'),
             new GH597Comment('Comment 2'),
-            new GH597Comment('Comment 3')
-        ));
+            new GH597Comment('Comment 3'),
+        ]);
         $this->dm->persist($post);
         $this->dm->flush();
         $this->dm->clear();
 
-        $expectedDocument = array(
-            '_id' => new \MongoDB\BSON\ObjectId($post->getId()),
-            'comments' => array(
-                array('comment' => 'Comment 1'),
-                array('comment' => 'Comment 2'),
-                array('comment' => 'Comment 3')
-            )
-        );
+        $expectedDocument = [
+            '_id' => new ObjectId($post->getId()),
+            'comments' => [
+                ['comment' => 'Comment 1'],
+                ['comment' => 'Comment 2'],
+                ['comment' => 'Comment 3'],
+            ],
+        ];
         $this->assertPostDocument($expectedDocument, $post);
 
         // trigger update
@@ -50,7 +54,7 @@ class GH597Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertCount(0, $post->getComments());
 
         // make sure embedded documents got unset
-        $expectedDocument = array('_id' => new \MongoDB\BSON\ObjectId($post->getId()));
+        $expectedDocument = ['_id' => new ObjectId($post->getId())];
         $this->assertPostDocument($expectedDocument, $post);
     }
 
@@ -62,7 +66,7 @@ class GH597Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         // default behavior on inserts already leaves out referenced documents
-        $expectedDocument = array('_id' => new \MongoDB\BSON\ObjectId($post->getId()));
+        $expectedDocument = ['_id' => new ObjectId($post->getId())];
         $this->assertPostDocument($expectedDocument, $post);
 
         // associate post with many GH597ReferenceMany documents
@@ -73,18 +77,18 @@ class GH597Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $referenceMany2 = new GH597ReferenceMany('two');
         $this->dm->persist($referenceMany2);
 
-        $post->referenceMany = new ArrayCollection(array($referenceMany1, $referenceMany2));
+        $post->referenceMany = new ArrayCollection([$referenceMany1, $referenceMany2]);
         $this->dm->persist($post);
         $this->dm->flush();
         $this->dm->clear();
 
-        $expectedDocument = array(
-            '_id' => new \MongoDB\BSON\ObjectId($post->getId()),
-            'referenceMany' => array(
-                new \MongoDB\BSON\ObjectId($referenceMany1->getId()),
-                new \MongoDB\BSON\ObjectId($referenceMany2->getId())
-            )
-        );
+        $expectedDocument = [
+            '_id' => new ObjectId($post->getId()),
+            'referenceMany' => [
+                new ObjectId($referenceMany1->getId()),
+                new ObjectId($referenceMany2->getId()),
+            ],
+        ];
         $this->assertPostDocument($expectedDocument, $post);
 
         // trigger update
@@ -98,7 +102,7 @@ class GH597Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertCount(0, $post->getReferenceMany());
 
         // make sure reference-many documents got unset
-        $expectedDocument = array('_id' => new \MongoDB\BSON\ObjectId($post->getId()));
+        $expectedDocument = ['_id' => new ObjectId($post->getId())];
         $this->assertPostDocument($expectedDocument, $post);
     }
 
@@ -106,12 +110,11 @@ class GH597Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
      * Asserts that raw document matches expected document.
      *
      * @param array $expected
-     * @param GH597Post $post
      */
     private function assertPostDocument(array $expected, GH597Post $post)
     {
         $collection = $this->dm->getDocumentCollection(__NAMESPACE__ . '\GH597Post');
-        $document = $collection->findOne(array('_id' => new \MongoDB\BSON\ObjectId($post->getId())));
+        $document = $collection->findOne(['_id' => new ObjectId($post->getId())]);
         $this->assertEquals($expected, $document);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
@@ -1,12 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\DocumentNotFoundException;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function iterator_to_array;
 
-class GH602Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH602Test extends BaseTest
 {
     public function testReferenceManyOwningSidePreparesFilterCriteriaForDifferentClass()
     {
@@ -50,11 +54,8 @@ class GH602Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertFalse($user1likes[1]->__isInitialized());
         $this->assertEquals($thing2->getId(), $user1likes[1]->getId());
 
-        try {
-            $user1likes[1]->__load();
-            $this->fail('Expected DocumentNotFoundException for filtered Proxy object');
-        } catch (DocumentNotFoundException $e) {
-        }
+        $user1likes[1]->__load();
+        $this->expectException(DocumentNotFoundException::class);
     }
 
     public function testReferenceManyInverseSidePreparesFilterCriteriaForDifferentClass()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
@@ -54,8 +54,8 @@ class GH602Test extends BaseTest
         $this->assertFalse($user1likes[1]->__isInitialized());
         $this->assertEquals($thing2->getId(), $user1likes[1]->getId());
 
-        $user1likes[1]->__load();
         $this->expectException(DocumentNotFoundException::class);
+        $user1likes[1]->__load();
     }
 
     public function testReferenceManyInverseSidePreparesFilterCriteriaForDifferentClass()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH611Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH611Test.php
@@ -1,14 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use MongoDB\BSON\ObjectId;
 
 class GH611Test extends BaseTest
 {
     public function testPreparationofEmbeddedDocumentValues()
     {
-        $documentId = (string) (new \MongoDB\BSON\ObjectId());
+        $documentId = (string) (new ObjectId());
 
         $document = new GH611Document();
         $document->id = $documentId;
@@ -67,7 +70,7 @@ class GH611Test extends BaseTest
             ->updateOne()
             ->field('id')->equals($documentId)
             ->field('embedded._id')->exists(false)
-            ->field('embedded')->set(array('id' => 5, 'n' => 'c'))
+            ->field('embedded')->set(['id' => 5, 'n' => 'c'])
             ->getQuery()
             ->execute();
 
@@ -84,7 +87,7 @@ class GH611Test extends BaseTest
             ->updateOne()
             ->field('id')->equals($documentId)
             ->field('embedded._id')->exists(false)
-            ->field('embedded')->set((object) array('id' => 6, 'n' => 'd'))
+            ->field('embedded')->set((object) ['id' => 6, 'n' => 'd'])
             ->getQuery()
             ->execute();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH628Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH628Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -13,7 +15,7 @@ class GH628Test extends BaseTest
             ->getQuery()
             ->getQuery();
 
-        $expected = array('f.bar.baz' => 1);
+        $expected = ['f.bar.baz' => 1];
 
         $this->assertEquals($expected, $query['query']);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH665Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH665Test.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH665Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH665Test extends BaseTest
 {
     public function testUseAddToSetStrategyOnEmbeddedDocument()
     {
@@ -18,12 +21,12 @@ class GH665Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\GH665Document')
-            ->findOne(array('embeddedPushAll.name' => 'foo'));
+            ->findOne(['embeddedPushAll.name' => 'foo']);
         $this->assertNotNull($check);
         $this->assertSame($document->id, (string) $check['_id']);
 
         $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\GH665Document')
-            ->findOne(array('embeddedAddToSet.name' => 'bar'));
+            ->findOne(['embeddedAddToSet.name' => 'bar']);
         $this->assertNotNull($check);
         $this->assertSame($document->id, (string) $check['_id']);
 
@@ -33,11 +36,11 @@ class GH665Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->getQuery()
             ->getSingleResult();
 
-        $expected = array(
+        $expected = [
             '_id' => $document->id,
-            'embeddedPushAll' => array(array('name' => 'foo')),
-            'embeddedAddToSet' => array(array('name' => 'bar'))
-        );
+            'embeddedPushAll' => [['name' => 'foo']],
+            'embeddedAddToSet' => [['name' => 'bar']],
+        ];
 
         $this->assertEquals($expected, $persisted);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH683Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH683Test.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\Common\Collections\ArrayCollection;
-
-use Documents\Functional\Ticket\GH683\ParentDocument;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Functional\Ticket\GH683\EmbeddedSubDocument1;
 use Documents\Functional\Ticket\GH683\EmbeddedSubDocument2;
+use Documents\Functional\Ticket\GH683\ParentDocument;
+use function get_class;
 
 class GH683Test extends BaseTest
 {
@@ -16,16 +17,16 @@ class GH683Test extends BaseTest
     {
         $parent = new ParentDocument();
         $parent->name = 'Parent';
-        
+
         $sub1 = new EmbeddedSubDocument1();
         $sub1->name = 'Sub 1';
-        
+
         $parent->embedOne = $sub1;
 
         $this->dm->persist($parent);
         $this->dm->flush();
         $this->dm->clear();
-        
+
         $id = $parent->id;
 
         $parent = $this->dm->find(get_class($parent), $id);
@@ -36,13 +37,13 @@ class GH683Test extends BaseTest
     {
         $parent = new ParentDocument();
         $parent->name = 'Parent';
-        
+
         $sub1 = new EmbeddedSubDocument1();
         $sub1->name = 'Sub 1';
-        
+
         $sub2 = new EmbeddedSubDocument2();
         $sub2->name = 'Sub 2';
-        
+
         $parent->embedMany = new ArrayCollection();
         $parent->embedMany->add($sub1);
         $parent->embedMany->add($sub2);
@@ -50,7 +51,7 @@ class GH683Test extends BaseTest
         $this->dm->persist($parent);
         $this->dm->flush();
         $this->dm->clear();
-        
+
         $id = $parent->id;
 
         $parent = $this->dm->find(get_class($parent), $id);
@@ -59,5 +60,4 @@ class GH683Test extends BaseTest
         $this->assertInstanceOf(get_class($sub1), $firstSub);
         $this->assertInstanceOf(get_class($sub2), $secondSub);
     }
-
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH774Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH774Test.php
@@ -1,15 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
+use MongoDB\BSON\ObjectId;
+use function get_class;
 
 class GH774Test extends BaseTest
 {
     public function testUpsert()
     {
-        $id = (string) new \MongoDB\BSON\ObjectId();
+        $id = (string) new ObjectId();
 
         $thread = new GH774Thread();
         $thread->id = $id;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH788Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH788Test.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use function get_class;
 
 class GH788Test extends BaseTest
 {
@@ -21,11 +24,11 @@ class GH788Test extends BaseTest
         $this->dm->clear();
 
         $doc = $this->dm->find(get_class($listed), $listed->id);
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788DocumentListed', $doc);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788DocumentListed', $doc);
         $this->assertEquals('listed', $doc->name);
 
         $doc = $this->dm->find(get_class($unlisted), $unlisted->id);
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788DocumentUnlisted', $doc);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788DocumentUnlisted', $doc);
         $this->assertEquals('unlisted', $doc->name);
 
         /* Attempting to find the unlisted class by the parent class will not
@@ -57,9 +60,9 @@ class GH788Test extends BaseTest
         $collection = $doc->externEmbedMany;
 
         $this->assertCount(2, $collection);
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788ExternEmbedListed', $collection[0]);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788ExternEmbedListed', $collection[0]);
         $this->assertEquals('listed', $collection[0]->name);
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788ExternEmbedUnlisted', $collection[1]);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788ExternEmbedUnlisted', $collection[1]);
         $this->assertEquals('unlisted', $collection[1]->name);
     }
 
@@ -83,9 +86,9 @@ class GH788Test extends BaseTest
         $collection = $doc->inlineEmbedMany;
 
         $this->assertCount(2, $collection);
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788InlineEmbedListed', $collection[0]);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788InlineEmbedListed', $collection[0]);
         $this->assertEquals('listed', $collection[0]->name);
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788InlineEmbedUnlisted', $collection[1]);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788InlineEmbedUnlisted', $collection[1]);
         $this->assertEquals('unlisted', $collection[1]->name);
     }
 
@@ -109,9 +112,9 @@ class GH788Test extends BaseTest
         $collection = $doc->noTargetEmbedMany;
 
         $this->assertCount(2, $collection);
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788ExternEmbedListed', $collection[0]);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788ExternEmbedListed', $collection[0]);
         $this->assertEquals('listed', $collection[0]->name);
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788ExternEmbedUnlisted', $collection[1]);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788ExternEmbedUnlisted', $collection[1]);
         $this->assertEquals('unlisted', $collection[1]->name);
     }
 
@@ -129,7 +132,7 @@ class GH788Test extends BaseTest
 
         $doc = $this->dm->find(get_class($doc), $doc->id);
 
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788ExternEmbedUnlisted', $doc->externEmbedOne);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788ExternEmbedUnlisted', $doc->externEmbedOne);
         $this->assertEquals('unlisted', $doc->externEmbedOne->name);
     }
 
@@ -147,7 +150,7 @@ class GH788Test extends BaseTest
 
         $doc = $this->dm->find(get_class($doc), $doc->id);
 
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788InlineEmbedUnlisted', $doc->inlineEmbedOne);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788InlineEmbedUnlisted', $doc->inlineEmbedOne);
         $this->assertEquals('unlisted', $doc->inlineEmbedOne->name);
     }
 
@@ -165,7 +168,7 @@ class GH788Test extends BaseTest
 
         $doc = $this->dm->find(get_class($doc), $doc->id);
 
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788ExternEmbedUnlisted', $doc->noTargetEmbedOne);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788ExternEmbedUnlisted', $doc->noTargetEmbedOne);
         $this->assertEquals('unlisted', $doc->noTargetEmbedOne->name);
     }
 
@@ -189,10 +192,10 @@ class GH788Test extends BaseTest
         $collection = $doc->externRefMany;
 
         $this->assertCount(2, $collection);
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788ExternRefListed', $collection[0]);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788ExternRefListed', $collection[0]);
         $this->assertEquals($listed->id, $collection[0]->id);
         $this->assertEquals('listed', $collection[0]->name);
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788ExternRefUnlisted', $collection[1]);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788ExternRefUnlisted', $collection[1]);
         $this->assertEquals($unlisted->id, $collection[1]->id);
         $this->assertEquals('unlisted', $collection[1]->name);
     }
@@ -217,10 +220,10 @@ class GH788Test extends BaseTest
         $collection = $doc->inlineRefMany;
 
         $this->assertCount(2, $collection);
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788InlineRefListed', $collection[0]);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788InlineRefListed', $collection[0]);
         $this->assertEquals($listed->id, $collection[0]->id);
         $this->assertEquals('listed', $collection[0]->name);
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788InlineRefUnlisted', $collection[1]);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788InlineRefUnlisted', $collection[1]);
         $this->assertEquals($unlisted->id, $collection[1]->id);
         $this->assertEquals('unlisted', $collection[1]->name);
     }
@@ -245,10 +248,10 @@ class GH788Test extends BaseTest
         $collection = $doc->noTargetRefMany;
 
         $this->assertCount(2, $collection);
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788ExternRefListed', $collection[0]);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788ExternRefListed', $collection[0]);
         $this->assertEquals($listed->id, $collection[0]->id);
         $this->assertEquals('listed', $collection[0]->name);
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788ExternRefUnlisted', $collection[1]);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788ExternRefUnlisted', $collection[1]);
         $this->assertEquals($unlisted->id, $collection[1]->id);
         $this->assertEquals('unlisted', $collection[1]->name);
     }
@@ -267,7 +270,7 @@ class GH788Test extends BaseTest
 
         $doc = $this->dm->find(get_class($doc), $doc->id);
 
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788ExternRefUnlisted', $doc->externRefOne);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788ExternRefUnlisted', $doc->externRefOne);
         $this->assertEquals($unlisted->id, $doc->externRefOne->id);
         $this->assertEquals('unlisted', $doc->externRefOne->name);
     }
@@ -286,7 +289,7 @@ class GH788Test extends BaseTest
 
         $doc = $this->dm->find(get_class($doc), $doc->id);
 
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788InlineRefUnlisted', $doc->inlineRefOne);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788InlineRefUnlisted', $doc->inlineRefOne);
         $this->assertEquals($unlisted->id, $doc->inlineRefOne->id);
         $this->assertEquals('unlisted', $doc->inlineRefOne->name);
     }
@@ -305,7 +308,7 @@ class GH788Test extends BaseTest
 
         $doc = $this->dm->find(get_class($doc), $doc->id);
 
-        $this->assertInstanceOf(__NAMESPACE__.'\GH788ExternRefUnlisted', $doc->noTargetRefOne);
+        $this->assertInstanceOf(__NAMESPACE__ . '\GH788ExternRefUnlisted', $doc->noTargetRefOne);
         $this->assertEquals($unlisted->id, $doc->noTargetRefOne->id);
         $this->assertEquals('unlisted', $doc->noTargetRefOne->name);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH816Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH816Test.php
@@ -1,15 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use MongoDB\BSON\ObjectId;
 
-class GH816Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH816Test extends BaseTest
 {
     public function testPersistAfterDetachWithIdSet()
     {
         $d=new GH816Document();
-        $d->_id=new \MongoDB\BSON\ObjectId();
+        $d->_id=new ObjectId();
         $this->assertEmpty($this->dm->getRepository('Doctrine\ODM\MongoDB\Tests\GH816Document')->findAll());
         $this->dm->persist($d);
         $this->dm->detach($d);
@@ -20,7 +23,7 @@ class GH816Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testPersistAfterDetachWithTitleSet()
     {
         $d=new GH816Document();
-        $d->title="Test";
+        $d->title='Test';
         $this->assertEmpty($this->dm->getRepository('Doctrine\ODM\MongoDB\Tests\GH816Document')->findAll());
         $this->dm->persist($d);
         $this->dm->detach($d);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH850Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH850Test.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH850Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH850Test extends BaseTest
 {
     /**
      * @expectedException \InvalidArgumentException
@@ -25,7 +28,7 @@ class GH850Document
 {
     /** @ODM\Id */
     public $id;
-    
+
     /** @ODM\ReferenceOne */
-    public $refs = "";
+    public $refs = '';
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
@@ -1,9 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Criteria;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use MongoDB\BSON\Binary;
+use function get_class;
 
 class GH852Test extends BaseTest
 {
@@ -80,18 +85,24 @@ class GH852Test extends BaseTest
         // these lines are relevant for $useKeys = false in DocumentRepository::matching()
         $this->dm->clear();
         $docs = $this->dm->getRepository(get_class($parent))
-                ->matching(new \Doctrine\Common\Collections\Criteria());
+                ->matching(new Criteria());
         $this->assertCount(4, $docs);
     }
 
     public function provideIdGenerators()
     {
-        $binDataType = \MongoDB\BSON\Binary::TYPE_GENERIC;
+        $binDataType = Binary::TYPE_GENERIC;
 
-        return array(
-            array(function($id) { return array('foo' => $id); }),
-            array(function($id) use ($binDataType) { return new \MongoDB\BSON\Binary($id, $binDataType); }),
-        );
+        return [
+            [function ($id) {
+                return ['foo' => $id];
+            },
+            ],
+            [function ($id) use ($binDataType) {
+                return new Binary($id, $binDataType);
+            },
+            ],
+        ];
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH878Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH878Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -40,7 +42,8 @@ class GH878Test extends BaseTest
     /**
      * @return GH878Document
      */
-    private function getPersistedButDetachedDocument() {
+    private function getPersistedButDetachedDocument()
+    {
         $document = new GH878Document();
         $document->embeddedField = new GH878SubDocument();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH880Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH880Test.php
@@ -1,14 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH880Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH880Test extends BaseTest
 {
     public function test880()
     {
-        $docs = array();
+        $docs = [];
         $docs[] = new GH880Document('hello', 1);
         $docs[] = new GH880Document('world', 1);
         foreach ($docs as $doc) {
@@ -47,7 +50,7 @@ class GH880Document
     /** @ODM\Field(type="int") */
     public $category;
 
-    public function __construct($status = "", $category = 0)
+    public function __construct($status = '', $category = 0)
     {
         $this->status = $status;
         $this->category = $category;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH897Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH897Test.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function get_class;
 
-class GH897Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH897Test extends BaseTest
 {
     public function testRecomputeSingleDocumentChangesetForManagedDocumentWithoutChangeset()
     {
@@ -18,8 +22,8 @@ class GH897Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $documentA = $this->dm->find(__NAMESPACE__.'\GH897A', $documentA->id);
-        $documentB = $this->dm->find(__NAMESPACE__.'\GH897B', $documentB->id);
+        $documentA = $this->dm->find(__NAMESPACE__ . '\GH897A', $documentA->id);
+        $documentB = $this->dm->find(__NAMESPACE__ . '\GH897B', $documentB->id);
         $documentB->refOne = $documentA;
 
         /* Necessary to inject DocumentManager since it is not currently
@@ -30,7 +34,7 @@ class GH897Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $documentA = $this->dm->find(__NAMESPACE__.'\GH897A', $documentA->id);
+        $documentA = $this->dm->find(__NAMESPACE__ . '\GH897A', $documentA->id);
 
         $this->assertSame('a-changed', $documentA->name);
     }
@@ -63,7 +67,7 @@ class GH897B
     /** @ODM\PreFlush */
     public function preFlush()
     {
-        if ( ! $this->refOne instanceof GH897A) {
+        if (! $this->refOne instanceof GH897A) {
             return;
         }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH909Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH909Test.php
@@ -1,12 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Documents\Phonenumber;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Group;
+use Documents\Phonenumber;
 use Documents\User;
 
-class GH909Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH909Test extends BaseTest
 {
     public function testManyReferenceAddAndPersist()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH921Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH921Test.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH921Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH921Test extends BaseTest
 {
     public function testPersistentCollectionCountAndIterationShouldBeConsistent()
     {
@@ -16,7 +19,7 @@ class GH921Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $user = $this->dm->getRepository(__NAMESPACE__.'\GH921User')->findOneBy(['name' => 'smith']);
+        $user = $this->dm->getRepository(__NAMESPACE__ . '\GH921User')->findOneBy(['name' => 'smith']);
 
         $postA = new GH921Post();
         $user->addPost($postA);
@@ -67,12 +70,30 @@ class GH921User
     /** @ODM\ReferenceMany(targetDocument="GH921Post") */
     private $posts;
 
-    public function __construct() { $this->posts = new ArrayCollection(); }
-    public function getId() { return $this->id; }
-    public function getName() { return $this->name; }
-    public function setName($name) { $this->name = $name; }
-    public function addPost(GH921Post $post) { $this->posts[] = $post; }
-    public function getPosts() { return $this->posts; }
+    public function __construct()
+    {
+        $this->posts = new ArrayCollection();
+    }
+    public function getId()
+    {
+        return $this->id;
+    }
+    public function getName()
+    {
+        return $this->name;
+    }
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+    public function addPost(GH921Post $post)
+    {
+        $this->posts[] = $post;
+    }
+    public function getPosts()
+    {
+        return $this->posts;
+    }
 }
 
 /** @ODM\Document */
@@ -84,7 +105,16 @@ class GH921Post
     /** @ODM\Field(type="string") */
     private $name;
 
-    public function getId() { return $this->id; }
-    public function getName() { return $this->name; }
-    public function setName($name) { $this->name = $name; }
+    public function getId()
+    {
+        return $this->id;
+    }
+    public function getName()
+    {
+        return $this->name;
+    }
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH927Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH927Test.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH927Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH927Test extends BaseTest
 {
     public function testInheritedClassHasAssociationMapping()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH928Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH928Test.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH928Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH928Test extends BaseTest
 {
     public function testNullIdCriteriaShouldNotRemoveEverything()
     {
@@ -16,11 +19,11 @@ class GH928Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $collection = $this->dm->getDocumentCollection(__NAMESPACE__.'\GH928Document');
+        $collection = $this->dm->getDocumentCollection(__NAMESPACE__ . '\GH928Document');
 
         $this->assertEquals(2, $collection->count());
 
-        $qb = $this->dm->createQueryBuilder(__NAMESPACE__.'\GH928Document')
+        $qb = $this->dm->createQueryBuilder(__NAMESPACE__ . '\GH928Document')
             ->remove()
             ->field('id')->equals(null)
             ->getQuery()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH936Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH936Test.php
@@ -1,12 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
+use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH936Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH936Test extends BaseTest
 {
     public function testRemoveCascadesThroughProxyDocuments()
     {
@@ -38,7 +41,7 @@ class GH936Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 /** @ODM\Document */
 class GH936Document
 {
-    const CLASSNAME = __CLASS__;
+    public const CLASSNAME = __CLASS__;
 
     /** @ODM\Id */
     public $id;
@@ -54,7 +57,7 @@ class GH936Document
 
 class GH936Listener
 {
-    public $removed = array();
+    public $removed = [];
 
     public function postRemove(LifecycleEventArgs $args)
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH942Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH942Test.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\ObjectId;
 
-class GH942Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH942Test extends BaseTest
 {
     public function testDiscriminatorValueUsesClassNameIfMapIsNotDefined()
     {
@@ -16,7 +20,7 @@ class GH942Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $doc = $this->dm->getDocumentCollection(GH942Document::CLASSNAME)
-            ->findOne(array('_id' => new \MongoDB\BSON\ObjectId($doc->id)));
+            ->findOne(['_id' => new ObjectId($doc->id)]);
 
         $this->assertSame('foo', $doc['name']);
         $this->assertSame(GH942Document::CLASSNAME, $doc['type']);
@@ -35,13 +39,13 @@ class GH942Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $parent = $this->dm->getDocumentCollection(GH942DocumentParent::CLASSNAME)
-            ->findOne(array('_id' => new \MongoDB\BSON\ObjectId($parent->id)));
+            ->findOne(['_id' => new ObjectId($parent->id)]);
 
         $this->assertSame('parent', $parent['name']);
         $this->assertSame('p', $parent['type']);
 
         $child = $this->dm->getDocumentCollection(GH942DocumentChild::CLASSNAME)
-            ->findOne(array('_id' => new \MongoDB\BSON\ObjectId($child->id)));
+            ->findOne(['_id' => new ObjectId($child->id)]);
 
         $this->assertSame('child', $child['name']);
         $this->assertSame(GH942DocumentChild::CLASSNAME, $child['type']);
@@ -55,7 +59,7 @@ class GH942Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
  */
 class GH942Document
 {
-    const CLASSNAME = __CLASS__;
+    public const CLASSNAME = __CLASS__;
 
     /** @ODM\Id */
     public $id;
@@ -72,7 +76,7 @@ class GH942Document
  */
 class GH942DocumentParent
 {
-    const CLASSNAME = __CLASS__;
+    public const CLASSNAME = __CLASS__;
 
     /** @ODM\Id */
     public $id;
@@ -84,5 +88,5 @@ class GH942DocumentParent
 /** @ODM\Document */
 class GH942DocumentChild extends GH942DocumentParent
 {
-    const CLASSNAME = __CLASS__;
+    public const CLASSNAME = __CLASS__;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH944Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH944Test.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function get_class;
 
-class GH944Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH944Test extends BaseTest
 {
     public function testIssue()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
@@ -1,19 +1,21 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class GH971Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH971Test extends BaseTest
 {
     public function testUpdateOfInheritedDocumentUsingFindAndUpdate()
     {
-        $name = "Ferrari";
-        $features = array(
-            "Super Engine",
-            "Huge Wheels"
-        );
+        $name = 'Ferrari';
+        $features = [
+            'Super Engine',
+            'Huge Wheels',
+        ];
 
         //first query, create Car with name "Ferrari"
         $this->dm->createQueryBuilder(__NAMESPACE__ . '\Car')
@@ -46,8 +48,8 @@ class GH971Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->createQueryBuilder(__NAMESPACE__ . '\Bicycle')
             ->findAndUpdate()
             ->upsert(true)
-            ->field('name')->equals("Cool")
-            ->field('features')->push("2 people")
+            ->field('name')->equals('Cool')
+            ->field('features')->push('2 people')
             ->getQuery()->execute();
     }
 
@@ -57,8 +59,8 @@ class GH971Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->findAndUpdate()
             ->upsert(true)
             ->field('type')->equals('tandem')
-            ->field('name')->equals("Cool")
-            ->field('features')->push("2 people")
+            ->field('name')->equals('Cool')
+            ->field('features')->push('2 people')
             ->getQuery()->execute();
 
         $results = $this->dm->getRepository(__NAMESPACE__ . '\Tandem')->findAll();
@@ -87,14 +89,20 @@ class Vehicle
 /**
  * @ODM\Document
  */
-class Car extends Vehicle {}
+class Car extends Vehicle
+{
+}
 
 /**
  * @ODM\Document
  */
-class Bicycle extends Vehicle {}
+class Bicycle extends Vehicle
+{
+}
 
 /**
  * @ODM\Document
  */
-class Tandem extends Bicycle {}
+class Tandem extends Bicycle
+{
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH977Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH977Test.php
@@ -1,51 +1,54 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function get_class;
 
 class GH977Test extends BaseTest
 {
     public function testAutoRecompute()
     {
         $d = new GH977TestDocument();
-        $d->value1 = "Value 1";
+        $d->value1 = 'Value 1';
         $this->dm->persist($d);
         $this->dm->flush();
         $this->dm->clear();
 
-        $d = $this->dm->getRepository(get_class($d))->findOneBy(['value1' => "Value 1"]);
-        $d->value1 = "Changed";
+        $d = $this->dm->getRepository(get_class($d))->findOneBy(['value1' => 'Value 1']);
+        $d->value1 = 'Changed';
         $this->uow->computeChangeSet($this->dm->getClassMetadata(get_class($d)), $d);
         $changeSet = $this->uow->getDocumentChangeSet($d);
         if (isset($changeSet['value1'])) {
-            $d->value2 = "v1 has changed";
+            $d->value2 = 'v1 has changed';
         }
         $this->dm->flush();
         $this->dm->clear();
-        
-        $d = $this->dm->getRepository(get_class($d))->findOneBy(['value1' => "Changed"]);
+
+        $d = $this->dm->getRepository(get_class($d))->findOneBy(['value1' => 'Changed']);
         $this->assertNotNull($d);
-        $this->assertEquals("v1 has changed", $d->value2);
+        $this->assertEquals('v1 has changed', $d->value2);
     }
 
     public function testRefreshClearsChangeSet()
     {
         $d = new GH977TestDocument();
-        $d->value1 = "Value 1";
+        $d->value1 = 'Value 1';
         $this->dm->persist($d);
         $this->dm->flush();
         $this->dm->clear();
 
-        $d = $this->dm->getRepository(get_class($d))->findOneBy(['value1' => "Value 1"]);
-        $d->value1 = "Changed";
+        $d = $this->dm->getRepository(get_class($d))->findOneBy(['value1' => 'Value 1']);
+        $d->value1 = 'Changed';
         $this->uow->computeChangeSet($this->dm->getClassMetadata(get_class($d)), $d);
         $this->dm->refresh($d);
         $this->dm->flush();
         $this->dm->clear();
 
-        $d = $this->dm->getRepository(get_class($d))->findOneBy(['value1' => "Value 1"]);
+        $d = $this->dm->getRepository(get_class($d))->findOneBy(['value1' => 'Value 1']);
         $this->assertNotNull($d);
     }
 }
@@ -62,4 +65,3 @@ class GH977TestDocument
     /** @ODM\Field(type="string") */
     public $value2;
 }
-

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH978Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH978Test.php
@@ -1,6 +1,10 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Ecommerce\ConfigurableProduct;
 use Documents\Ecommerce\Currency;
 use Documents\Ecommerce\Money;
@@ -10,7 +14,7 @@ use Documents\Ecommerce\StockItem;
 /**
  * Test for UnitOfWork::detach()
  */
-class GH978Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class GH978Test extends BaseTest
 {
     public function testDetach()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH999Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH999Test.php
@@ -1,17 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
 use Doctrine\ODM\MongoDB\Events;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function get_class;
 
 class GH999Test extends BaseTest
 {
     public function testModifyingInFlushHandler()
     {
-        $this->dm->getEventManager()->addEventListener(array(Events::onFlush), new GH999Listener());
+        $this->dm->getEventManager()->addEventListener([Events::onFlush], new GH999Listener());
 
         $document = new GH999Document('name');
         $this->dm->persist($document);
@@ -26,7 +29,8 @@ class GH999Test extends BaseTest
 
 class GH999Listener
 {
-    public function onFlush(OnFlushEventArgs $args) {
+    public function onFlush(OnFlushEventArgs $args)
+    {
         $dm = $args->getDocumentManager();
 
         foreach ($dm->getUnitOfWork()->getScheduledDocumentInsertions() as $document) {
@@ -72,4 +76,3 @@ class GH999Document
         throw new \Exception('Did not expect postUpdate to be called when persisting a new document');
     }
 }
-

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
@@ -1,10 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function array_values;
+use function get_class;
 
-class MODM116Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM116Test extends BaseTest
 {
     public function testIssue()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM117Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM117Test.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function get_class;
 
-class MODM117Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM117Test extends BaseTest
 {
     public function testIssue()
     {
@@ -34,11 +38,11 @@ class MODM117User
 
     public function __get($name)
     {
-        return $this->{'_'.$name};
+        return $this->{'_' . $name};
     }
 
     public function __set($name, $value)
     {
-        $this->{'_'.$name} = $value;
+        $this->{'_' . $name} = $value;
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM140Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM140Test.php
@@ -1,23 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Functional\EmbeddedTestLevel0;
 use Documents\Functional\EmbeddedTestLevel1;
 use Documents\Functional\EmbeddedTestLevel2;
 
-class MODM140Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM140Test extends BaseTest
 {
-
     public function testInsertingNestedEmbeddedCollections()
     {
-        $category = new Category;
-        $category->name = "My Category";
+        $category = new Category();
+        $category->name = 'My Category';
 
-        $post1 = new Post;
+        $post1 = new Post();
         $post1->versions->add(new PostVersion('P1V1'));
         $post1->versions->add(new PostVersion('P1V2'));
 
@@ -28,7 +29,7 @@ class MODM140Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $category = $this->dm->getRepository(__NAMESPACE__ . '\Category')->findOneBy(['name' => 'My Category']);
-        $post2 = new Post;
+        $post2 = new Post();
         $post2->versions->add(new PostVersion('P2V1'));
         $post2->versions->add(new PostVersion('P2V2'));
         $category->posts->add($post2);
@@ -51,7 +52,7 @@ class MODM140Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $post->comments[] = $comment;
 
         $category = new Category();
-        $category->name = "My Category";
+        $category->name = 'My Category';
         $category->posts->add($post);
 
         $this->dm->persist($comment);
@@ -74,18 +75,18 @@ class MODM140Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $test = $this->dm->getRepository('Documents\Functional\EmbeddedTestLevel0')->findOneBy(array('name' => 'test'));
+        $test = $this->dm->getRepository('Documents\Functional\EmbeddedTestLevel0')->findOneBy(['name' => 'test']);
         $this->assertInstanceOf('Documents\Functional\EmbeddedTestLevel0', $test);
 
         $level1 = new EmbeddedTestLevel1();
-        $level1->name = "test level 1 #1";
+        $level1->name = 'test level 1 #1';
 
         $level2 = new EmbeddedTestLevel2();
-        $level2->name = "test level 2 #1 in level 1 #1";
+        $level2->name = 'test level 2 #1 in level 1 #1';
         $level1->level2[] = $level2;
 
         $level2 = new EmbeddedTestLevel2();
-        $level2->name = "test level 2 #2 in level 1 #1";
+        $level2->name = 'test level 2 #2 in level 1 #1';
         $level1->level2[] = $level2;
 
         $test->level1[] = $level1;
@@ -93,19 +94,19 @@ class MODM140Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $test = $this->dm->getRepository('Documents\Functional\EmbeddedTestLevel0')->findOneBy(array('name' => 'test'));
+        $test = $this->dm->getRepository('Documents\Functional\EmbeddedTestLevel0')->findOneBy(['name' => 'test']);
         $this->assertCount(1, $test->level1);
         $this->assertCount(2, $test->level1[0]->level2);
 
         $level1 = new EmbeddedTestLevel1();
-        $level1->name = "test level 1 #2";
+        $level1->name = 'test level 1 #2';
 
         $level2 = new EmbeddedTestLevel2();
-        $level2->name = "test level 2 #1 in level 1 #2";
+        $level2->name = 'test level 2 #1 in level 1 #2';
         $level1->level2[] = $level2;
 
         $level2 = new EmbeddedTestLevel2();
-        $level2->name = "test level 2 #2 in level 1 #2";
+        $level2->name = 'test level 2 #2 in level 1 #2';
         $level1->level2[] = $level2;
 
         $test->level1[] = $level1;
@@ -113,69 +114,65 @@ class MODM140Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $test = $this->dm->getRepository('Documents\Functional\EmbeddedTestLevel0')->findOneBy(array('name' => 'test'));
+        $test = $this->dm->getRepository('Documents\Functional\EmbeddedTestLevel0')->findOneBy(['name' => 'test']);
         $this->assertCount(2, $test->level1);
         $this->assertCount(2, $test->level1[0]->level2);
         $this->assertCount(2, $test->level1[1]->level2);
     }
-
 }
 
 /** @ODM\Document */
 class Category
 {
-	/** @ODM\Id */
-	protected $id;
+    /** @ODM\Id */
+    protected $id;
 
-	/** @ODM\Field(type="string") */
-	public $name;
+    /** @ODM\Field(type="string") */
+    public $name;
 
-	/** @ODM\EmbedMany(targetDocument="Post") */
-	public $posts;
+    /** @ODM\EmbedMany(targetDocument="Post") */
+    public $posts;
 
-	public function __construct()
-	{
-		$this->posts = new ArrayCollection();
-	}
-
+    public function __construct()
+    {
+        $this->posts = new ArrayCollection();
+    }
 }
 
 /** @ODM\EmbeddedDocument */
 class Post
 {
-	/** @ODM\EmbedMany(targetDocument="PostVersion") */
-	public $versions;
+    /** @ODM\EmbedMany(targetDocument="PostVersion") */
+    public $versions;
 
-	/** @ODM\ReferenceMany(targetDocument="Comment") */
-	public $comments;
+    /** @ODM\ReferenceMany(targetDocument="Comment") */
+    public $comments;
 
-	public function __construct()
-	{
-		$this->versions = new ArrayCollection();
-		$this->comments = new ArrayCollection();
-	}
-
+    public function __construct()
+    {
+        $this->versions = new ArrayCollection();
+        $this->comments = new ArrayCollection();
+    }
 }
 
 /** @ODM\EmbeddedDocument */
 class PostVersion
 {
-	/** @ODM\Field(type="string") */
-	public $name;
+    /** @ODM\Field(type="string") */
+    public $name;
 
-	public function __construct($name)
-	{
-		$this->name = $name;
-	}
-
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
 }
 
 /** @ODM\Document */
 class Comment
 {
-	/** @ODM\Id */
-	protected $id;
+    /** @ODM\Id */
+    protected $id;
 
-	/** @ODM\Field(type="string") */
-	public $content;
+    /** @ODM\Field(type="string") */
+    public $content;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM160Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM160Test.php
@@ -9,6 +9,9 @@ use Documents\Functional\Ticket\MODM160;
 
 class MODM160Test extends BaseTest
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testEmbedManyInArrayMergeNew()
     {
         // create a test document
@@ -26,6 +29,9 @@ class MODM160Test extends BaseTest
         $this->dm->merge($test);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testEmbedManyInArrayCollectionMergeNew()
     {
         // create a test document
@@ -43,6 +49,9 @@ class MODM160Test extends BaseTest
         $this->dm->merge($test);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testEmbedOneMergeNew()
     {
         // create a test document

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM160Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM160Test.php
@@ -1,14 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Documents\Functional\Ticket\MODM160 as MODM160;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\Functional\Ticket\MODM160;
 
-class MODM160Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM160Test extends BaseTest
 {
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testEmbedManyInArrayMergeNew()
     {
         // create a test document
@@ -26,9 +26,6 @@ class MODM160Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->merge($test);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testEmbedManyInArrayCollectionMergeNew()
     {
         // create a test document
@@ -46,9 +43,6 @@ class MODM160Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->merge($test);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testEmbedOneMergeNew()
     {
         // create a test document

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM166Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM166Test.php
@@ -1,15 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
 use Doctrine\ODM\MongoDB\Events;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Phonenumber;
 use Documents\User;
+use function get_class;
+use function sort;
 
-class MODM166Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM166Test extends BaseTest
 {
-
     public function setUp()
     {
         parent::setUp();
@@ -35,15 +39,15 @@ class MODM166Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->clear();
 
         $repository = $this->dm->getRepository(get_class($test));
-        $test = $repository->findOneBy(array('username' => 'lucy'));
+        $test = $repository->findOneBy(['username' => 'lucy']);
 
-        $phonenumbers = array();
-        foreach ($test->getPhonenumbers() as $phonenumber){
+        $phonenumbers = [];
+        foreach ($test->getPhonenumbers() as $phonenumber) {
             $phonenumbers[] = $phonenumber->getPhonenumber();
         }
         sort($phonenumbers);
 
-        $this->assertEquals(array('1111', '2222'), $phonenumbers);
+        $this->assertEquals(['1111', '2222'], $phonenumbers);
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM167Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM167Test.php
@@ -1,14 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
 use Doctrine\ODM\MongoDB\Events;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\User;
+use function get_class;
 
-class MODM167Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM167Test extends BaseTest
 {
-
     public function setUp()
     {
         parent::setUp();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM29Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM29Test.php
@@ -1,18 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class MODM29Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM29Test extends BaseTest
 {
     public function testTest()
     {
-        $collection = new \Doctrine\Common\Collections\ArrayCollection(array(
+        $collection = new ArrayCollection([
             new MODM29Embedded('0'),
             new MODM29Embedded('1'),
-            new MODM29Embedded('2')
-        ));
+            new MODM29Embedded('2'),
+        ]);
 
         // TEST CASE:
         $doc = new MODM29Doc($collection);
@@ -21,11 +25,11 @@ class MODM29Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
 
         // place element '0' after '1'
-        $collection = new \Doctrine\Common\Collections\ArrayCollection(array(
+        $collection = new ArrayCollection([
             $collection[1],
             $collection[0],
-            $collection[2]
-        ));
+            $collection[2],
+        ]);
 
         $doc->set($collection);
 
@@ -37,11 +41,11 @@ class MODM29Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->dm->refresh($doc);
 
-        $array = array();
-        foreach($doc->get() as $value) {
+        $array = [];
+        foreach ($doc->get() as $value) {
             $array[] = $value->get();
         }
-        $this->assertEquals(array('1', 'tmp', '2'), $array);
+        $this->assertEquals(['1', 'tmp', '2'], $array);
     }
 }
 
@@ -54,10 +58,19 @@ class MODM29Doc
     /** @ODM\EmbedMany(targetDocument="MODM29Embedded", strategy="set") */
     protected $collection;
 
-    function __construct($c) {$this->set($c);}
+    function __construct($c)
+    {
+        $this->set($c);
+    }
 
-    function set($c) {$this->collection = $c;}
-    function get() {return $this->collection;}
+    function set($c)
+    {
+        $this->collection = $c;
+    }
+    function get()
+    {
+        return $this->collection;
+    }
 }
 
 /** @ODM\EmbeddedDocument */
@@ -66,7 +79,16 @@ class MODM29Embedded
     /** @ODM\Field(type="string") */
     protected $val;
 
-    function __construct($val) {$this->set($val);}
-    function get() {return $this->val;}
-    function set($val) {$this->val = $val;}
+    function __construct($val)
+    {
+        $this->set($val);
+    }
+    function get()
+    {
+        return $this->val;
+    }
+    function set($val)
+    {
+        $this->val = $val;
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM43Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM43Test.php
@@ -1,21 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Event\PreLoadEventArgs;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use MongoDB\BSON\ObjectId;
+use function explode;
 
-class MODM43Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM43Test extends BaseTest
 {
     public function testTest()
     {
-        $person = array(
+        $person = [
             '_id' => new ObjectId(),
-            'name' => 'Jonathan Wage'
-        );
-        $this->dm->getDocumentCollection(__NAMESPACE__.'\Person')->insertOne($person);
-        $user = $this->dm->find(__NAMESPACE__.'\Person', $person['_id']);
+            'name' => 'Jonathan Wage',
+        ];
+        $this->dm->getDocumentCollection(__NAMESPACE__ . '\Person')->insertOne($person);
+        $user = $this->dm->find(__NAMESPACE__ . '\Person', $person['_id']);
         $this->assertEquals('Jonathan', $user->firstName);
         $this->assertEquals('Wage', $user->lastName);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM45Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM45Test.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class MODM45Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM45Test extends BaseTest
 {
     public function testTest()
     {
@@ -15,8 +18,8 @@ class MODM45Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $a = $this->dm->find(__NAMESPACE__.'\MODM45A', $a->getId());
-        $c = (null !== $a->getB()); 
+        $a = $this->dm->find(__NAMESPACE__ . '\MODM45A', $a->getId());
+        $c = ($a->getB() !== null);
         $this->assertTrue($c); // returns false, while expecting true
     }
 }
@@ -30,9 +33,18 @@ class MODM45A
     /** @ODM\EmbedOne(targetDocument="MODM45B") */
     protected $b;
 
-    function getId()  {return $this->id;}
-    function getB()   {return $this->b;}
-    function setB($b) {$this->b = $b;}
+    function getId()
+    {
+        return $this->id;
+    }
+    function getB()
+    {
+        return $this->b;
+    }
+    function setB($b)
+    {
+        $this->b = $b;
+    }
 }
 
 /** @ODM\EmbeddedDocument */
@@ -40,6 +52,12 @@ class MODM45B
 {
     /** @ODM\Field(type="string") */
     protected $val;
-    function setVal($val) {$this->val = $val;}
-    function getVal() {return $this->val;}
+    function setVal($val)
+    {
+        $this->val = $val;
+    }
+    function getVal()
+    {
+        return $this->val;
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM46Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM46Test.php
@@ -1,21 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use MongoDB\BSON\ObjectId;
 
-class MODM46Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM46Test extends BaseTest
 {
     public function testTest()
     {
-        $a = array(
+        $a = [
             '_id' => new ObjectId(),
-            'c' => array('value' => 'value')
-        );
-        $this->dm->getDocumentCollection(__NAMESPACE__.'\MODM46A')->insertOne($a);
+            'c' => ['value' => 'value'],
+        ];
+        $this->dm->getDocumentCollection(__NAMESPACE__ . '\MODM46A')->insertOne($a);
 
-        $a = $this->dm->find(__NAMESPACE__.'\MODM46A', $a['_id']);
+        $a = $this->dm->find(__NAMESPACE__ . '\MODM46A', $a['_id']);
 
         $this->assertTrue(isset($a->b));
         $this->assertEquals('value', $a->b->value);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM47Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM47Test.php
@@ -1,21 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use MongoDB\BSON\ObjectId;
 
-class MODM47Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM47Test extends BaseTest
 {
     public function testTest()
     {
-        $a = array(
+        $a = [
             '_id' => new ObjectId(),
-            'c' => 'c value'
-        );
-        $this->dm->getDocumentCollection(__NAMESPACE__.'\MODM47A')->insertOne($a);
+            'c' => 'c value',
+        ];
+        $this->dm->getDocumentCollection(__NAMESPACE__ . '\MODM47A')->insertOne($a);
 
-        $a = $this->dm->find(__NAMESPACE__.'\MODM47A', $a['_id']);
+        $a = $this->dm->find(__NAMESPACE__ . '\MODM47A', $a['_id']);
         $this->assertEquals('c value', $a->b);
     }
 }
@@ -30,6 +33,12 @@ class MODM47A
     public $b = 'tmp';
 
     /** @ODM\AlsoLoad("c") */
-    function renameC($c) {$this->b = $c;}
-    function getId() {return $this->id;}
+    function renameC($c)
+    {
+        $this->b = $c;
+    }
+    function getId()
+    {
+        return $this->id;
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM48Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM48Test.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class MODM48Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM48Test extends BaseTest
 {
     public function testTest()
     {
@@ -14,7 +17,7 @@ class MODM48Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $a = $this->dm->find(__NAMESPACE__.'\MODM48A', $a->id);
+        $a = $this->dm->find(__NAMESPACE__ . '\MODM48A', $a->id);
         $this->assertNotNull($a);
 
         $a->getB()->setVal('test');
@@ -22,7 +25,7 @@ class MODM48Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $a = $this->dm->find(__NAMESPACE__.'\MODM48A', $a->id);
+        $a = $this->dm->find(__NAMESPACE__ . '\MODM48A', $a->id);
         $this->assertEquals('test', $a->getB()->getVal());
     }
 }
@@ -36,9 +39,18 @@ class MODM48A
     /** @ODM\EmbedOne(targetDocument="MODM48B") */
     public $b;
 
-    function getId()  {return $this->id;}
-    function getB()   {return $this->b;}
-    function setB($b) {$this->b = $b;}
+    function getId()
+    {
+        return $this->id;
+    }
+    function getB()
+    {
+        return $this->b;
+    }
+    function setB($b)
+    {
+        $this->b = $b;
+    }
 }
 
 /** @ODM\EmbeddedDocument */
@@ -47,6 +59,12 @@ class MODM48B
     /** @ODM\Field(type="string") */
     public $val;
 
-    function setVal($val) {$this->val = $val;}
-    function getVal() {return $this->val;}
+    function setVal($val)
+    {
+        $this->val = $val;
+    }
+    function getVal()
+    {
+        return $this->val;
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM52Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM52Test.php
@@ -1,15 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function count;
 
-class MODM52Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM52Test extends BaseTest
 {
     public function testTest()
     {
-        $emb = new MODM52Embedded(array(new MODM52Embedded(null, 'c1'), new MODM52Embedded(null, 'c2')), 'b');
-        $doc = new MODM52Doc(array($emb), 'a');
+        $emb = new MODM52Embedded([new MODM52Embedded(null, 'c1'), new MODM52Embedded(null, 'c2')], 'b');
+        $doc = new MODM52Doc([$emb], 'a');
 
         $this->dm->persist($doc);
         $this->dm->flush();
@@ -39,7 +43,7 @@ class MODM52Container
     public $value;
 
     /** @ODM\EmbedMany(targetDocument="MODM52Embedded", strategy="set") */
-    public $items = array();
+    public $items = [];
 
     public function __construct($items = null, $value = null)
     {
@@ -67,7 +71,8 @@ class MODM52Container
 
 /** @ODM\EmbeddedDocument */
 class MODM52Embedded extends MODM52Container
-{}
+{
+}
 
 /** @ODM\Document */
 class MODM52Doc extends MODM52Container

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM56Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM56Test.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\UTCDateTime;
 
-class MODM56Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM56Test extends BaseTest
 {
     public function testTest()
     {
@@ -19,10 +23,10 @@ class MODM56Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $parent->children[] = $childTwo;
         $this->dm->flush();
 
-        $test = $this->dm->getDocumentCollection(__NAMESPACE__.'\MODM56Parent')->findOne();
+        $test = $this->dm->getDocumentCollection(__NAMESPACE__ . '\MODM56Parent')->findOne();
 
         $this->assertEquals('Parent', $test['name']);
-        $this->assertInstanceOf(\MongoDB\BSON\UTCDateTime::class, $test['updatedAt']);
+        $this->assertInstanceOf(UTCDateTime::class, $test['updatedAt']);
         $this->assertCount(2, $test['children']);
         $this->assertEquals('Child One', $test['children'][0]['name']);
         $this->assertEquals('Child Two', $test['children'][1]['name']);
@@ -42,7 +46,7 @@ class MODM56Parent
     public $updatedAt;
 
     /** @ODM\EmbedMany(targetDocument="MODM56Child") */
-    public $children = array();
+    public $children = [];
 
     public function __construct($name)
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM62Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM62Test.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class MODM62Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM62Test extends BaseTest
 {
     public function testTest()
     {
@@ -13,12 +16,12 @@ class MODM62Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->refresh($test);
 
-        $test->setB(array('test', 'test2'));
+        $test->setB(['test', 'test2']);
         $this->dm->flush();
         $this->dm->clear();
 
-        $test = $this->dm->find(__NAMESPACE__.'\MODM62Document', $test->id);
-        $this->assertEquals(array('test', 'test2'), $test->b);
+        $test = $this->dm->find(__NAMESPACE__ . '\MODM62Document', $test->id);
+        $this->assertEquals(['test', 'test2'], $test->b);
     }
 }
 
@@ -29,7 +32,10 @@ class MODM62Document
     public $id;
 
     /** @ODM\Field(type="collection") */
-    public $b = array('ok');
+    public $b = ['ok'];
 
-    public function setB($b) {$this->b = $b;}
+    public function setB($b)
+    {
+        $this->b = $b;
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM65Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM65Test.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class MODM65Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM65Test extends BaseTest
 {
     public function testTest()
     {
@@ -16,11 +19,11 @@ class MODM65Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $user = $this->dm->getDocumentCollection(__NAMESPACE__.'\MODM65User')->findOne();
+        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\MODM65User')->findOne();
         $this->assertTrue(isset($user['snu']['lN']));
         $this->assertTrue(isset($user['snu']['fN']));
 
-        $user = $this->dm->find(__NAMESPACE__.'\MODM65User', $user['_id']);
+        $user = $this->dm->find(__NAMESPACE__ . '\MODM65User', $user['_id']);
         $this->assertEquals('Jonathan', $user->socialNetworkUser->firstName);
         $this->assertEquals('Wage', $user->socialNetworkUser->lastName);
     }
@@ -31,20 +34,20 @@ class MODM65Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
  */
 class MODM65User
 {
-	/**
-	 * @ODM\Id
-	 */
-	public $id;
-	/**
-	 * @ODM\EmbedOne(
-	 * 	discriminatorField="php",
-	 * 	discriminatorMap={
-	 * 		"fbu"="Doctrine\ODM\MongoDB\Tests\Functional\Ticket\MODM65SocialNetworkUser"
-	 * 	},
-	 * 	name="snu"
-	 * )
-	 */
-	public $socialNetworkUser;
+    /**
+     * @ODM\Id
+     */
+    public $id;
+    /**
+     * @ODM\EmbedOne(
+     *  discriminatorField="php",
+     *  discriminatorMap={
+     *      "fbu"="Doctrine\ODM\MongoDB\Tests\Functional\Ticket\MODM65SocialNetworkUser"
+     *  },
+     *  name="snu"
+     * )
+     */
+    public $socialNetworkUser;
 }
 
 /**
@@ -52,14 +55,14 @@ class MODM65User
  */
 class MODM65SocialNetworkUser
 {
-	/**
-	 * @ODM\Field(name="fN", type="string")
-	 * @var string
-	 */
-	public $firstName;
-	/**
-	 * @ODM\Field(name="lN", type="string")
-	 * @var string
-	 */
-	public $lastName;
+    /**
+     * @ODM\Field(name="fN", type="string")
+     * @var string
+     */
+    public $firstName;
+    /**
+     * @ODM\Field(name="lN", type="string")
+     * @var string
+     */
+    public $lastName;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM66Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM66Test.php
@@ -1,17 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class MODM66Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM66Test extends BaseTest
 {
-
     public function testTest()
     {
         $b1 = new MODM52B('first');
-        $a = new MODM52A(array($b1));
+        $a = new MODM52A([$b1]);
         $this->dm->persist($a);
         $this->dm->flush();
         $b2 = new MODM52B('second');
@@ -23,17 +25,19 @@ class MODM66Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->assertCount(2, $b);
 
-        $this->assertEquals(array(
-            $b1->getId(), $b2->getId()
-            ), array(
-            $b[0]->getId(), $b[1]->getId()
-        ));
+        $this->assertEquals([
+            $b1->getId(),
+        $b2->getId(),
+            ], [
+            $b[0]->getId(),
+        $b[1]->getId(),
+            ]);
     }
 
     public function testRefresh()
     {
         $b1 = new MODM52B('first');
-        $a = new MODM52A(array($b1));
+        $a = new MODM52A([$b1]);
         $this->dm->persist($a);
         $this->dm->flush();
         $b2 = new MODM52B('second');
@@ -47,13 +51,14 @@ class MODM66Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->assertCount(2, $b);
 
-        $this->assertEquals(array(
-            $b1->getId(), $b2->getId()
-            ), array(
-            $b[0]->getId(), $b[1]->getId()
-        ));
+        $this->assertEquals([
+            $b1->getId(),
+        $b2->getId(),
+            ], [
+            $b[0]->getId(),
+        $b[1]->getId(),
+            ]);
     }
-
 }
 
 /** @ODM\Document */
@@ -79,7 +84,6 @@ class MODM52A
 /** @ODM\Document */
 class MODM52B
 {
-
     /** @ODM\Id */
     protected $id;
 
@@ -95,5 +99,4 @@ class MODM52B
     {
         return $this->id;
     }
-
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM67Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM67Test.php
@@ -1,24 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
+use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class MODM67Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM67Test extends BaseTest
 {
     private function getDocumentManager()
     {
         $this->listener = new MODM67TestEventListener($this->dm);
         $evm = $this->dm->getEventManager();
-        $events = array(
+        $events = [
             Events::prePersist,
             Events::postPersist,
             Events::preUpdate,
             Events::postUpdate,
-        );
+        ];
         $evm->addEventListener($events, $this->listener);
 
         return $this->dm;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
@@ -1,27 +1,31 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function array_search;
 
-class MODM70Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM70Test extends BaseTest
 {
     public function testTest()
     {
-		$avatar = new Avatar('Test', 1, array(new AvatarPart('#000')));
+        $avatar = new Avatar('Test', 1, [new AvatarPart('#000')]);
 
-		$this->dm->persist($avatar);
-		$this->dm->flush();
-		$this->dm->refresh($avatar);
+        $this->dm->persist($avatar);
+        $this->dm->flush();
+        $this->dm->refresh($avatar);
 
-		$avatar->addAvatarPart(new AvatarPart('#FFF'));
+        $avatar->addAvatarPart(new AvatarPart('#FFF'));
 
-		$this->dm->flush();
-		$this->dm->refresh($avatar);
+        $this->dm->flush();
+        $this->dm->refresh($avatar);
 
-		$parts = $avatar->getAvatarParts();
-		$this->assertCount(2, $parts);
-		$this->assertEquals('#FFF', $parts[1]->getColor());
+        $parts = $avatar->getAvatarParts();
+        $this->assertCount(2, $parts);
+        $this->assertEquals('#FFF', $parts[1]->getColor());
     }
 }
 
@@ -30,87 +34,86 @@ class MODM70Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
  */
 class Avatar
 {
+    /**
+     * @ODM\Id
+     */
+    protected $id;
 
-	/**
-	 * @ODM\Id
-	 */
-	protected $id;
+    /**
+     * @ODM\Field(name="na", type="string")
+     * @var string
+     */
+    protected $name;
 
-	/**
-	 * @ODM\Field(name="na", type="string")
-	 * @var string
-	 */
-	protected $name;
+    /**
+     * @ODM\Field(name="sex", type="int")
+     * @var int
+     */
+    protected $sex;
 
-	/**
-	 * @ODM\Field(name="sex", type="int")
-	 * @var int
-	 */
-	protected $sex;
+    /**
+     * @ODM\EmbedMany(
+     *  targetDocument="AvatarPart",
+     *  name="aP"
+     * )
+     * @var array AvatarPart
+     */
+    protected $avatarParts;
 
-	/**
-	 * @ODM\EmbedMany(
-	 *	targetDocument="AvatarPart",
-	 *	name="aP"
-	 * )
-	 * @var array AvatarPart
-	 */
-	protected $avatarParts;
+    public function __construct($name, $sex, $avatarParts = null)
+    {
+        $this->name = $name;
+        $this->sex = $sex;
+        $this->avatarParts = $avatarParts;
+    }
 
-	public function __construct($name, $sex, $avatarParts = null)
-	{
-		$this->name = $name;
-		$this->sex = $sex;
-		$this->avatarParts = $avatarParts;
-	}
+    public function getId()
+    {
+        return $this->id;
+    }
 
-	public function getId()
-	{
-		return $this->id;
-	}
+    public function getName()
+    {
+        return $this->name;
+    }
 
-	public function getName()
-	{
-		return $this->name;
-	}
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
 
-	public function setName($name)
-	{
-		$this->name = $name;
-	}
+    public function getSex()
+    {
+        return $this->sex;
+    }
 
-	public function getSex()
-	{
-		return $this->sex;
-	}
+    public function setSex($sex)
+    {
+        $this->sex = $sex;
+    }
 
-	public function setSex($sex)
-	{
-		$this->sex = $sex;
-	}
+    public function getAvatarParts()
+    {
+        return $this->avatarParts;
+    }
 
-	public function getAvatarParts()
-	{
-		return $this->avatarParts;
-	}
+    public function addAvatarPart($part)
+    {
+        $this->avatarParts[] = $part;
+    }
 
-	public function addAvatarPart($part)
-	{
-		$this->avatarParts[] = $part;
-	}
+    public function setAvatarParts($parts)
+    {
+        $this->avatarParts = $parts;
+    }
 
-	public function setAvatarParts($parts)
-	{
-		$this->avatarParts = $parts;
-	}
-
-	public function removeAvatarPart($part)
-	{
-		$key = array_search($this->avatarParts, $part);
-		if ($key !== false) {
-			unset($this->avatarParts[$key]);
-		}
-	}
+    public function removeAvatarPart($part)
+    {
+        $key = array_search($this->avatarParts, $part);
+        if ($key !== false) {
+            unset($this->avatarParts[$key]);
+        }
+    }
 }
 
 /**
@@ -118,24 +121,24 @@ class Avatar
  */
 class AvatarPart
 {
-	/**
-	 * @ODM\Field(name="col", type="string")
-	 * @var string
-	 */
-	protected $color;
+    /**
+     * @ODM\Field(name="col", type="string")
+     * @var string
+     */
+    protected $color;
 
-	public function __construct($color = null)
-	{
-		$this->color = $color;
-	}
+    public function __construct($color = null)
+    {
+        $this->color = $color;
+    }
 
-	public function getColor()
-	{
-		return $this->color;
-	}
+    public function getColor()
+    {
+        return $this->color;
+    }
 
-	public function setColor($color)
-	{
-		$this->color = $color;
-	}
+    public function setColor($color)
+    {
+        $this->color = $color;
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM72Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM72Test.php
@@ -1,15 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class MODM72Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM72Test extends BaseTest
 {
     public function testTest()
     {
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\MODM72User');
-        $this->assertEquals(array('test' => 'test'), $class->fieldMappings['name']['options']);
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\MODM72User');
+        $this->assertEquals(['test' => 'test'], $class->fieldMappings['name']['options']);
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM76Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM76Test.php
@@ -1,19 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class MODM76Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM76Test extends BaseTest
 {
     public function testTest()
     {
-        $c1 = new MODM76C;
-        $c2 = new MODM76C;
+        $c1 = new MODM76C();
+        $c2 = new MODM76C();
 
         $b = new MODM76B($c1);
-        $a = new MODM76A(array($b), array($c1));
+        $a = new MODM76A([$b], [$c1]);
 
         $this->dm->persist($a);
         $this->dm->persist($b);
@@ -21,7 +24,7 @@ class MODM76Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->persist($c2);
         $this->dm->flush();
 
-        $this->assertTrue($a->getId() != null);
+        $this->assertTrue($a->getId() !== null);
     }
 }
 
@@ -35,10 +38,10 @@ class MODM76A
     protected $test = 'test';
 
     /** @ODM\EmbedMany(targetDocument="MODM76B") */
-    protected $b = array();
+    protected $b = [];
 
     /** @ODM\ReferenceMany(targetDocument="MODM76C") */
-    protected $c = array();
+    protected $c = [];
 
     public function __construct($b, $c)
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class MODM81Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM81Test extends BaseTest
 {
     /**
      * @return DocumentManager
@@ -30,8 +33,8 @@ class MODM81Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $dm->flush();
 
         $embedded = new MODM81TestEmbeddedDocument($doc1, $doc2, 'Test1');
-        $doc1->setEmbeddedDocuments(array($embedded));
-        $doc2->setEmbeddedDocuments(array($embedded));
+        $doc1->setEmbeddedDocuments([$embedded]);
+        $doc2->setEmbeddedDocuments([$embedded]);
 
         $dm->flush();
         $dm->clear();
@@ -95,7 +98,7 @@ class MODM81TestDocument
     }
 
     /**
-     * @return \Doctrine\Common\Collections\ArrayCollection
+     * @return ArrayCollection
      */
     public function getEmbeddedDocuments()
     {
@@ -109,7 +112,6 @@ class MODM81TestDocument
     {
         $this->embeddedDocuments = new ArrayCollection($documents);
     }
-
 }
 
 /** @ODM\EmbeddedDocument */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM83Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM83Test.php
@@ -1,20 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function get_class;
 
-class MODM83Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM83Test extends BaseTest
 {
     private function getDocumentManager()
     {
         $this->listener = new MODM83EventListener();
         $evm = $this->dm->getEventManager();
-        $events = array(
+        $events = [
             Events::preUpdate,
             Events::postUpdate,
-        );
+        ];
         $evm->addEventListener($events, $this->listener);
         return $this->dm;
     }
@@ -34,23 +38,23 @@ class MODM83Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $dm->flush();
         $dm->clear();
 
-        $won = $dm->find(__NAMESPACE__.'\MODM83TestDocument', $won->id);
-        $too = $dm->find(__NAMESPACE__.'\MODM83OtherDocument', $too->id);
+        $won = $dm->find(__NAMESPACE__ . '\MODM83TestDocument', $won->id);
+        $too = $dm->find(__NAMESPACE__ . '\MODM83OtherDocument', $too->id);
         $too->name = 'Bob';
         $dm->flush();
         $dm->clear();
 
-        $called = array(
-            Events::preUpdate  => array(__NAMESPACE__.'\MODM83OtherDocument'),
-            Events::postUpdate => array(__NAMESPACE__.'\MODM83OtherDocument')
-        );
+        $called = [
+            Events::preUpdate  => [__NAMESPACE__ . '\MODM83OtherDocument'],
+            Events::postUpdate => [__NAMESPACE__ . '\MODM83OtherDocument'],
+        ];
         $this->assertEquals($called, $this->listener->called);
     }
 }
 
 class MODM83EventListener
 {
-    public $called = array();
+    public $called = [];
     public function __call($method, $args)
     {
         $document = $args[0]->getDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM88Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM88Test.php
@@ -1,12 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-class MODM88Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\Article;
+
+class MODM88Test extends BaseTest
 {
     public function testTest()
     {
-        $article = new \Documents\Article;
+        $article = new Article();
         $article->setTitle('Test Title');
         $article->setBody('Test Body');
         $this->dm->persist($article);
@@ -17,7 +22,7 @@ class MODM88Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->select('_id', 'title');
         $q = $qb->getQuery();
         $document = $q->getSingleResult();
-        
+
         $this->assertEquals('Test Title', $document->getTitle());
         $this->assertNull($document->getBody());
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM90Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM90Test.php
@@ -1,20 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function get_class;
 
-class MODM90Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM90Test extends BaseTest
 {
     private function getDocumentManager()
     {
         $this->listener = new MODM90EventListener();
         $evm = $this->dm->getEventManager();
-        $events = array(
+        $events = [
             Events::preUpdate,
             Events::postUpdate,
-        );
+        ];
         $evm->addEventListener($events, $this->listener);
         return $this->dm;
     }
@@ -31,14 +35,14 @@ class MODM90Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $dm->flush();
         $dm->clear();
 
-        $testDoc = $dm->find(__NAMESPACE__.'\MODM90TestDocument', $testDoc->id);
+        $testDoc = $dm->find(__NAMESPACE__ . '\MODM90TestDocument', $testDoc->id);
 
         // run a flush, in theory, nothing should be flushed.
         $dm->flush();
         $dm->clear();
 
         // no update events should be called
-        $called = array();
+        $called = [];
         $this->assertEquals($called, $this->listener->called);
     }
 
@@ -58,7 +62,7 @@ class MODM90Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $dm->flush();
         $dm->clear();
 
-        $testDoc = $dm->find(__NAMESPACE__.'\MODM90TestDocument', $testDoc->id);
+        $testDoc = $dm->find(__NAMESPACE__ . '\MODM90TestDocument', $testDoc->id);
 
         $this->assertEquals($testDoc->embedded->type, 'test2');
     }
@@ -66,7 +70,7 @@ class MODM90Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
 class MODM90EventListener
 {
-    public $called = array();
+    public $called = [];
     public function __call($method, $args)
     {
         $document = $args[0]->getDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM91Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM91Test.php
@@ -1,20 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function get_class;
 
-class MODM91Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM91Test extends BaseTest
 {
     private function getDocumentManager()
     {
         $this->listener = new MODM91EventListener();
         $evm = $this->dm->getEventManager();
-        $events = array(
+        $events = [
             Events::preUpdate,
             Events::postUpdate,
-        );
+        ];
         $evm->addEventListener($events, $this->listener);
         return $this->dm;
     }
@@ -31,18 +35,18 @@ class MODM91Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $dm->flush();
         $dm->clear();
 
-        $testDoc = $dm->find(__NAMESPACE__.'\MODM91TestDocument', $testDoc->id);
+        $testDoc = $dm->find(__NAMESPACE__ . '\MODM91TestDocument', $testDoc->id);
         $dm->flush();
         $dm->clear();
 
-        $called = array();
+        $called = [];
         $this->assertEquals($called, $this->listener->called);
     }
 }
 
 class MODM91EventListener
 {
-    public $called = array();
+    public $called = [];
     public function __call($method, $args)
     {
         $document = $args[0]->getDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM92Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM92Test.php
@@ -1,15 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function is_array;
 
-class MODM92Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM92Test extends BaseTest
 {
     public function testDocumentWithEmbeddedDocuments()
     {
-        $embeddedDocuments = array(new MODM92TestEmbeddedDocument('foo'));
+        $embeddedDocuments = [new MODM92TestEmbeddedDocument('foo')];
 
         $testDoc = new MODM92TestDocument();
         $testDoc->setEmbeddedDocuments($embeddedDocuments);
@@ -17,17 +21,17 @@ class MODM92Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $testDoc = $this->dm->find(__NAMESPACE__.'\MODM92TestDocument', $testDoc->id);
+        $testDoc = $this->dm->find(__NAMESPACE__ . '\MODM92TestDocument', $testDoc->id);
         $this->assertEquals($embeddedDocuments, $testDoc->embeddedDocuments->toArray());
 
-        $embeddedDocuments = array(new MODM92TestEmbeddedDocument('bar'));
+        $embeddedDocuments = [new MODM92TestEmbeddedDocument('bar')];
 
         $testDoc->setEmbeddedDocuments($embeddedDocuments);
         $this->assertEquals($embeddedDocuments, $testDoc->embeddedDocuments->toArray());
 
         $this->dm->flush();
         $this->dm->clear();
-        $testDoc = $this->dm->find(__NAMESPACE__.'\MODM92TestDocument', $testDoc->id);
+        $testDoc = $this->dm->find(__NAMESPACE__ . '\MODM92TestDocument', $testDoc->id);
 
         $this->assertEquals($embeddedDocuments, $testDoc->embeddedDocuments->toArray());
     }
@@ -43,7 +47,8 @@ class MODM92TestDocument
     /** @ODM\EmbedMany(targetDocument="MODM92TestEmbeddedDocument") */
     public $embeddedDocuments;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->embeddedDocuments = new ArrayCollection();
     }
 
@@ -58,7 +63,8 @@ class MODM92TestDocument
      *
      * @param array|Traversable $children
      */
-    public function setEmbeddedDocuments($embeddedDocuments) {
+    public function setEmbeddedDocuments($embeddedDocuments)
+    {
         $this->embeddedDocuments->clear();
 
         if (! (is_array($embeddedDocuments) || $embeddedDocuments instanceof \Traversable)) {
@@ -77,7 +83,8 @@ class MODM92TestEmbeddedDocument
     /** @ODM\Field(type="string") */
     public $name;
 
-    public function __construct($name) {
+    public function __construct($name)
+    {
         $this->name = $name;
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM95Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM95Test.php
@@ -1,15 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function is_array;
 
-class MODM95Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MODM95Test extends BaseTest
 {
     public function testDocumentWithEmbeddedDocuments()
     {
-        $embeddedDocuments = array(new MODM95TestEmbeddedDocument('foo'));
+        $embeddedDocuments = [new MODM95TestEmbeddedDocument('foo')];
 
         $testDoc = new MODM95TestDocument();
         $testDoc->setEmbeddedDocuments($embeddedDocuments);
@@ -17,7 +21,7 @@ class MODM95Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $testDoc = $this->dm->find(__NAMESPACE__.'\MODM95TestDocument', $testDoc->id);
+        $testDoc = $this->dm->find(__NAMESPACE__ . '\MODM95TestDocument', $testDoc->id);
 
         $this->assertEquals($embeddedDocuments, $testDoc->embeddedDocuments->toArray());
 
@@ -25,14 +29,14 @@ class MODM95Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
-        $testDocLoad = $this->dm->find(__NAMESPACE__.'\MODM95TestDocument', $testDoc->id);
+        $testDocLoad = $this->dm->find(__NAMESPACE__ . '\MODM95TestDocument', $testDoc->id);
         $this->assertNull($testDocLoad);
 
         $this->dm->persist($testDoc);
         $this->dm->flush();
         $this->dm->clear();
 
-        $testDocLoad = $this->dm->find(__NAMESPACE__.'\MODM95TestDocument', $testDoc->id);
+        $testDocLoad = $this->dm->find(__NAMESPACE__ . '\MODM95TestDocument', $testDoc->id);
         $this->assertNotNull($testDocLoad);
 
         $this->assertEquals($embeddedDocuments, $testDocLoad->embeddedDocuments->toArray());
@@ -49,7 +53,8 @@ class MODM95TestDocument
     /** @ODM\EmbedMany(targetDocument="MODM95TestEmbeddedDocument") */
     public $embeddedDocuments;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->embeddedDocuments = new ArrayCollection();
     }
 
@@ -64,7 +69,8 @@ class MODM95TestDocument
      *
      * @param array|Traversable $children
      */
-    public function setEmbeddedDocuments($embeddedDocuments) {
+    public function setEmbeddedDocuments($embeddedDocuments)
+    {
         $this->embeddedDocuments->clear();
 
         if (! (is_array($embeddedDocuments) || $embeddedDocuments instanceof \Traversable)) {
@@ -83,7 +89,8 @@ class MODM95TestEmbeddedDocument
     /** @ODM\Field(type="string") */
     public $name;
 
-    public function __construct($name) {
+    public function __construct($name)
+    {
         $this->name = $name;
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/UpsertTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/UpsertTest.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\ObjectId;
 
-class UpsertTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class UpsertTest extends BaseTest
 {
     /**
      * Tests for "MongoCursorException: Cannot apply $push/$pushAll modifier to non-array" error.
@@ -14,10 +18,10 @@ class UpsertTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     public function testUpsertEmbedManyDoesNotCreateObject()
     {
         $test = new UpsertTestUser();
-        $test->id = (string) new \MongoDB\BSON\ObjectId();
+        $test->id = (string) new ObjectId();
 
         $embedded = new UpsertTestUserEmbedded();
-        $embedded->id = (string) new \MongoDB\BSON\ObjectId();
+        $embedded->id = (string) new ObjectId();
         $embedded->test = 'test';
 
         $test->embedMany[] = $embedded;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class VersionTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class VersionTest extends BaseTest
 {
     public function testVersioningWhenManipulatingEmbedMany()
     {
@@ -20,19 +24,19 @@ class VersionTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $doc->embedMany[] = new VersionedEmbeddedDocument('embed 3');
         $this->dm->flush();
         $this->assertEquals($expectedVersion++, $doc->version);
-        
+
         $doc->embedMany[0]->embedMany[] = new VersionedEmbeddedDocument('deeply embed 1');
         $this->dm->flush();
         $this->assertEquals($expectedVersion++, $doc->version);
-        
+
         unset($doc->embedMany[1]);
         $this->dm->flush();
         $this->assertEquals($expectedVersion++, $doc->version);
 
         $doc->embedMany->clear();
         $this->dm->flush();
-        $this->assertEquals($expectedVersion++, $doc->version); 
-        
+        $this->assertEquals($expectedVersion++, $doc->version);
+
         $doc->embedMany = null;
         $this->dm->flush();
         $this->assertEquals($expectedVersion++, $doc->version);
@@ -46,19 +50,19 @@ class VersionedDocument
 {
     /** @ODM\Id */
     public $id;
-    
+
     /** @ODM\Field(type="int", name="_version") @ODM\Version */
     public $version = 1;
-    
+
     /** @ODM\Field(type="string") */
     public $name;
-    
+
     /** @ODM\EmbedMany(targetDocument="VersionedEmbeddedDocument") */
-    public $embedMany = array();
-    
+    public $embedMany = [];
+
     public function __construct()
     {
-        $this->embedMany = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->embedMany = new ArrayCollection();
     }
 }
 
@@ -69,13 +73,13 @@ class VersionedEmbeddedDocument
 {
     /** @ODM\Field(type="string") */
     public $value;
-    
+
     /** @ODM\EmbedMany(targetDocument="VersionedEmbeddedDocument") */
     public $embedMany;
-    
-    public function __construct($value) 
+
+    public function __construct($value)
     {
         $this->value = $value;
-        $this->embedMany = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->embedMany = new ArrayCollection();
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -9,34 +11,30 @@ class HydratorTest extends BaseTest
 {
     public function testHydrator()
     {
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\HydrationClosureUser');
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\HydrationClosureUser');
 
         $user = new HydrationClosureUser();
-        $this->dm->getHydratorFactory()->hydrate($user, array(
+        $this->dm->getHydratorFactory()->hydrate($user, [
             '_id' => 1,
             'title' => null,
             'name' => 'jon',
             'birthdate' => new \DateTime('1961-01-01'),
-            'referenceOne' => array('$id' => '1'),
-            'referenceMany' => array(
-                array(
-                    '$id' => '1'
-                ),
-                array(
-                    '$id' => '2'
-                )
-            ),
-            'embedOne' => array('name' => 'jon'),
-            'embedMany' => array(
-                array('name' => 'jon')
-            )
-        ));
+            'referenceOne' => ['$id' => '1'],
+            'referenceMany' => [
+                ['$id' => '1'],
+                ['$id' => '2'],
+            ],
+            'embedOne' => ['name' => 'jon'],
+            'embedMany' => [
+                ['name' => 'jon'],
+            ],
+        ]);
 
         $this->assertEquals(1, $user->id);
         $this->assertNull($user->title);
         $this->assertEquals('jon', $user->name);
         $this->assertInstanceOf('DateTime', $user->birthdate);
-        $this->assertInstanceOf(__NAMESPACE__.'\HydrationClosureReferenceOne', $user->referenceOne);
+        $this->assertInstanceOf(__NAMESPACE__ . '\HydrationClosureReferenceOne', $user->referenceOne);
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\PersistentCollection', $user->referenceMany);
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $user->referenceMany[0]);
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\Proxy\Proxy', $user->referenceMany[1]);
@@ -47,7 +45,7 @@ class HydratorTest extends BaseTest
 
     public function testReadOnly()
     {
-        $class = $this->dm->getClassMetadata(__NAMESPACE__.'\HydrationClosureUser');
+        $class = $this->dm->getClassMetadata(__NAMESPACE__ . '\HydrationClosureUser');
 
         $user = new HydrationClosureUser();
         $this->dm->getHydratorFactory()->hydrate($user, [
@@ -56,7 +54,7 @@ class HydratorTest extends BaseTest
             'birthdate' => new \DateTime('1961-01-01'),
             'embedOne' => ['name' => 'maciej'],
             'embedMany' => [
-                ['name' => 'maciej']
+                ['name' => 'maciej'],
             ],
         ], [ Query::HINT_READ_ONLY => true ]);
 
@@ -85,13 +83,13 @@ class HydrationClosureUser
     public $referenceOne;
 
     /** @ODM\ReferenceMany(targetDocument="HydrationClosureReferenceMany") */
-    public $referenceMany = array();
+    public $referenceMany = [];
 
     /** @ODM\EmbedOne(targetDocument="HydrationClosureEmbedOne") */
     public $embedOne;
 
     /** @ODM\EmbedMany(targetDocument="HydrationClosureEmbedMany") */
-    public $embedMany = array();
+    public $embedMany = [];
 }
 
 /** @ODM\Document */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Id/IncrementGeneratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Id/IncrementGeneratorTest.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Id;
 
 use Doctrine\ODM\MongoDB\Id\IncrementGenerator;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\User;
+use const DOCTRINE_MONGODB_DATABASE;
 
-class IncrementGeneratorTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class IncrementGeneratorTest extends BaseTest
 {
     public function testIdGeneratorWithStartingValue()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -16,6 +16,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
 {
     abstract protected function _loadDriver();
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testLoadMapping()
     {
         $className = __NAMESPACE__ . '\AbstractMappingDriverUser';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -1,20 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function key;
+use function strcmp;
+use function usort;
 
-abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+abstract class AbstractMappingDriverTest extends BaseTest
 {
     abstract protected function _loadDriver();
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testLoadMapping()
     {
-        $className = __NAMESPACE__.'\AbstractMappingDriverUser';
+        $className = __NAMESPACE__ . '\AbstractMappingDriverUser';
         $mappingDriver = $this->_loadDriver();
 
         $class = new ClassMetadata($className);
@@ -52,7 +56,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
      */
     public function testDocumentLevelReadPreference($class)
     {
-        $this->assertEquals("primaryPreferred", $class->readPreference);
+        $this->assertEquals('primaryPreferred', $class->readPreference);
         $this->assertEquals([
             ['dc' => 'east'],
             ['dc' => 'west'],
@@ -164,9 +168,9 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
     }
 
     /**
-    * @depends testFieldMappings
-    * @param ClassMetadata $class
-    */
+     * @depends testFieldMappings
+     * @param ClassMetadata $class
+     */
     public function testLockFieldMappings($class)
     {
         $this->assertEquals('int', $class->fieldMappings['lock']['type']);
@@ -210,10 +214,10 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
      */
     public function testLifecycleCallbacks($class)
     {
-        $expectedLifecycleCallbacks = array(
-            'prePersist' => array('doStuffOnPrePersist', 'doOtherStuffOnPrePersistToo'),
-            'postPersist' => array('doStuffOnPostPersist'),
-        );
+        $expectedLifecycleCallbacks = [
+            'prePersist' => ['doStuffOnPrePersist', 'doOtherStuffOnPrePersistToo'],
+            'postPersist' => ['doStuffOnPostPersist'],
+        ];
 
         $this->assertEquals($expectedLifecycleCallbacks, $class->lifecycleCallbacks);
 
@@ -266,9 +270,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
         $this->assertTrue(isset($class->discriminatorMap));
         $this->assertTrue(isset($class->defaultDiscriminatorValue));
         $this->assertEquals('discr', $class->discriminatorField);
-        $this->assertEquals(array(
-            'default' => 'Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser',
-        ), $class->discriminatorMap);
+        $this->assertEquals(['default' => 'Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser'], $class->discriminatorMap);
         $this->assertEquals('default', $class->defaultDiscriminatorValue);
 
         return $class;
@@ -284,10 +286,10 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
         $this->assertTrue(isset($class->fieldMappings['otherPhonenumbers']['discriminatorMap']));
         $this->assertTrue(isset($class->fieldMappings['otherPhonenumbers']['defaultDiscriminatorValue']));
         $this->assertEquals('discr', $class->fieldMappings['otherPhonenumbers']['discriminatorField']);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'home' => 'Doctrine\ODM\MongoDB\Tests\Mapping\HomePhonenumber',
-            'work' => 'Doctrine\ODM\MongoDB\Tests\Mapping\WorkPhonenumber'
-        ), $class->fieldMappings['otherPhonenumbers']['discriminatorMap']);
+            'work' => 'Doctrine\ODM\MongoDB\Tests\Mapping\WorkPhonenumber',
+        ], $class->fieldMappings['otherPhonenumbers']['discriminatorMap']);
         $this->assertEquals('home', $class->fieldMappings['otherPhonenumbers']['defaultDiscriminatorValue']);
 
         return $class;
@@ -303,10 +305,10 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
         $this->assertTrue(isset($class->fieldMappings['phonenumbers']['discriminatorMap']));
         $this->assertTrue(isset($class->fieldMappings['phonenumbers']['defaultDiscriminatorValue']));
         $this->assertEquals('discr', $class->fieldMappings['phonenumbers']['discriminatorField']);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'home' => 'Doctrine\ODM\MongoDB\Tests\Mapping\HomePhonenumber',
-            'work' => 'Doctrine\ODM\MongoDB\Tests\Mapping\WorkPhonenumber'
-        ), $class->fieldMappings['phonenumbers']['discriminatorMap']);
+            'work' => 'Doctrine\ODM\MongoDB\Tests\Mapping\WorkPhonenumber',
+        ], $class->fieldMappings['phonenumbers']['discriminatorMap']);
         $this->assertEquals('home', $class->fieldMappings['phonenumbers']['defaultDiscriminatorValue']);
 
         return $class;
@@ -323,7 +325,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
         /* Sort indexes by their first fieldname. This is necessary since the
          * index registration order may differ among drivers.
          */
-        $this->assertTrue(usort($indexes, function(array $a, array $b) {
+        $this->assertTrue(usort($indexes, function (array $a, array $b) {
             return strcmp(key($a['keys']), key($b['keys']));
         }));
 
@@ -345,7 +347,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
         $this->assertEquals(1, $indexes[2]['keys']['lock']);
         $this->assertNotEmpty($indexes[2]['options']);
         $this->assertTrue(isset($indexes[2]['options']['partialFilterExpression']));
-        $this->assertSame(array('version' => array('$gt' => 1), 'discr' => array('$eq' => 'default')), $indexes[2]['options']['partialFilterExpression']);
+        $this->assertSame(['version' => ['$gt' => 1], 'discr' => ['$eq' => 'default']], $indexes[2]['options']['partialFilterExpression']);
 
         $this->assertTrue(isset($indexes[3]['keys']['mysqlProfileId']));
         $this->assertEquals(-1, $indexes[3]['keys']['mysqlProfileId']);
@@ -472,7 +474,7 @@ class AbstractMappingDriverUser
     /**
      * @ODM\Field(type="collection")
      */
-    public $roles = array();
+    public $roles = [];
 
     /**
      * @ODM\PrePersist
@@ -502,97 +504,92 @@ class AbstractMappingDriverUser
         $metadata->addLifecycleCallback('doStuffOnPrePersist', 'prePersist');
         $metadata->addLifecycleCallback('doOtherStuffOnPrePersistToo', 'prePersist');
         $metadata->addLifecycleCallback('doStuffOnPostPersist', 'postPersist');
-        $metadata->setDiscriminatorField(array(
-            'fieldName' => 'discr',
-        ));
-        $metadata->setDiscriminatorMap(array(
-            'default' => __CLASS__,
-        ));
+        $metadata->setDiscriminatorField(['fieldName' => 'discr']);
+        $metadata->setDiscriminatorMap(['default' => __CLASS__]);
         $metadata->setDefaultDiscriminatorValue('default');
-        $metadata->mapField(array(
+        $metadata->mapField([
             'id' => true,
             'fieldName' => 'id',
-        ));
-        $metadata->mapField(array(
+        ]);
+        $metadata->mapField([
             'fieldName' => 'version',
             'type' => 'int',
             'version' => true,
-        ));
-        $metadata->mapField(array(
+        ]);
+        $metadata->mapField([
             'fieldName' => 'lock',
             'type' => 'int',
             'lock' => true,
-        ));
-        $metadata->mapField(array(
+        ]);
+        $metadata->mapField([
             'fieldName' => 'name',
             'name' => 'username',
             'type' => 'string',
-        ));
-        $metadata->mapField(array(
+        ]);
+        $metadata->mapField([
             'fieldName' => 'email',
             'type' => 'string',
-        ));
-        $metadata->mapField(array(
+        ]);
+        $metadata->mapField([
             'fieldName' => 'mysqlProfileId',
             'type' => 'integer',
-        ));
-        $metadata->mapOneReference(array(
+        ]);
+        $metadata->mapOneReference([
             'fieldName' => 'address',
             'targetDocument' => 'Doctrine\\ODM\\MongoDB\\Tests\\Mapping\\Address',
-            'cascade' => array(0 => 'remove'),
-        ));
-        $metadata->mapManyReference(array(
+            'cascade' => [0 => 'remove'],
+        ]);
+        $metadata->mapManyReference([
             'fieldName' => 'phonenumbers',
             'targetDocument' => 'Doctrine\\ODM\\MongoDB\\Tests\\Mapping\\Phonenumber',
             'collectionClass' => 'Doctrine\\ODM\\MongoDB\\Tests\\Mapping\\PhonenumberCollection',
-            'cascade' => array(1 => 'persist'),
+            'cascade' => [1 => 'persist'],
             'discriminatorField' => 'discr',
-            'discriminatorMap' => array(
+            'discriminatorMap' => [
                 'home' => 'HomePhonenumber',
-                'work' => 'WorkPhonenumber'
-            ),
+                'work' => 'WorkPhonenumber',
+            ],
             'defaultDiscriminatorValue' => 'home',
-        ));
-        $metadata->mapManyReference(array(
+        ]);
+        $metadata->mapManyReference([
             'fieldName' => 'morePhoneNumbers',
             'name' => 'more_phone_numbers',
             'targetDocument' => 'Doctrine\\ODM\\MongoDB\\Tests\\Mapping\\Phonenumber',
             'collectionClass' => 'Doctrine\\ODM\\MongoDB\\Tests\\Mapping\\PhonenumberCollection',
-        ));
-        $metadata->mapManyReference(array(
+        ]);
+        $metadata->mapManyReference([
             'fieldName' => 'groups',
             'targetDocument' => 'Doctrine\\ODM\\MongoDB\\Tests\\Mapping\\Group',
-            'cascade' => array(
+            'cascade' => [
                 0 => 'remove',
                 1 => 'persist',
                 2 => 'refresh',
                 3 => 'merge',
                 4 => 'detach',
-            ),
-        ));
-        $metadata->mapOneEmbedded(array(
+            ],
+        ]);
+        $metadata->mapOneEmbedded([
            'fieldName' => 'embeddedPhonenumber',
            'name' => 'embedded_phone_number',
-        ));
-        $metadata->mapManyEmbedded(array(
+        ]);
+        $metadata->mapManyEmbedded([
            'fieldName' => 'otherPhonenumbers',
            'targetDocument' => 'Doctrine\\ODM\\MongoDB\\Tests\\Mapping\\Phonenumber',
            'discriminatorField' => 'discr',
-           'discriminatorMap' => array(
+           'discriminatorMap' => [
                 'home' => 'HomePhonenumber',
                 'work' => 'WorkPhonenumber',
-           ),
+           ],
             'defaultDiscriminatorValue' => 'home',
-        ));
-        $metadata->addIndex(array('username' => 'desc'), array('unique' => true, 'dropDups' => false));
-        $metadata->addIndex(array('email' => 'desc'), array('unique' => true, 'dropDups' => true));
-        $metadata->addIndex(array('mysqlProfileId' => 'desc'), array('unique' => true, 'dropDups' => true));
-        $metadata->addIndex(array('createdAt' => 'asc'), array('expireAfterSeconds' => 3600));
-        $metadata->setShardKey(array('name' => 'asc'), array('unique' => true, 'numInitialChunks' => 4096));
+        ]);
+        $metadata->addIndex(['username' => 'desc'], ['unique' => true, 'dropDups' => false]);
+        $metadata->addIndex(['email' => 'desc'], ['unique' => true, 'dropDups' => true]);
+        $metadata->addIndex(['mysqlProfileId' => 'desc'], ['unique' => true, 'dropDups' => true]);
+        $metadata->addIndex(['createdAt' => 'asc'], ['expireAfterSeconds' => 3600]);
+        $metadata->setShardKey(['name' => 'asc'], ['unique' => true, 'numInitialChunks' => 4096]);
     }
 }
 
-class PhonenumberCollection extends \Doctrine\Common\Collections\ArrayCollection
+class PhonenumberCollection extends ArrayCollection
 {
-
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
@@ -1,9 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Doctrine\ODM\MongoDB\Mapping\MappingException;
 
 class AnnotationDriverTest extends AbstractMappingDriverTest
 {
@@ -65,10 +70,10 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
     public function testLoadMetadataForNonDocumentThrowsException()
     {
         $cm = new ClassMetadata('stdClass');
-        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
-        $annotationDriver = new \Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver($reader);
+        $reader = new AnnotationReader();
+        $annotationDriver = new AnnotationDriver($reader);
 
-        $this->expectException(\Doctrine\ODM\MongoDB\Mapping\MappingException::class);
+        $this->expectException(MappingException::class);
         $annotationDriver->loadMetadataForClass('stdClass', $cm);
     }
 
@@ -78,8 +83,8 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
     public function testColumnWithMissingTypeDefaultsToString()
     {
         $cm = new ClassMetadata('Doctrine\ODM\MongoDB\Tests\Mapping\ColumnWithoutType');
-        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
-        $annotationDriver = new \Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver($reader);
+        $reader = new AnnotationReader();
+        $annotationDriver = new AnnotationDriver($reader);
 
         $annotationDriver->loadMetadataForClass('Doctrine\ODM\MongoDB\Tests\Mapping\InvalidColumn', $cm);
         $this->assertEquals('id', $cm->fieldMappings['id']['type']);
@@ -163,14 +168,14 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
     protected function _loadDriverForCMSDocuments()
     {
         $annotationDriver = $this->_loadDriver();
-        $annotationDriver->addPaths(array(__DIR__ . '/../../../../../Documents'));
+        $annotationDriver->addPaths([__DIR__ . '/../../../../../Documents']);
         return $annotationDriver;
     }
 
     protected function _loadDriver()
     {
-        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
-        return new \Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver($reader);
+        $reader = new AnnotationReader();
+        return new AnnotationDriver($reader);
     }
 }
 
@@ -178,7 +183,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
 class ColumnWithoutType
 {
      /** @ODM\Id */
-     public $id;
+    public $id;
 }
 
 /** @ODM\MappedSuperclass */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
@@ -1,11 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use function serialize;
+use function unserialize;
 
-class BasicInheritanceMappingTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class BasicInheritanceMappingTest extends BaseTest
 {
     private $factory;
 
@@ -72,7 +77,7 @@ class BasicInheritanceMappingTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $class = $this->factory->getMetadataFor(DocumentSubClass2::class);
 
-        $this->assertSame("secondary", $class->readPreference);
+        $this->assertSame('secondary', $class->readPreference);
         $this->assertEquals([ ['dc' => 'east'] ], $class->readPreferenceTags);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataFactoryTest.php
@@ -1,14 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Tests\Mocks\DocumentManagerMock;
 
-class ClassMetadataFactoryTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class ClassMetadataFactoryTest extends BaseTest
 {
     public function testGetMetadataForSingleClass()
     {
@@ -16,19 +19,19 @@ class ClassMetadataFactoryTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $cm1 = new ClassMetadata('Doctrine\ODM\MongoDB\Tests\Mapping\TestDocument1');
         $cm1->setCollection('group');
         // Add a mapped field
-        $cm1->mapField(array('fieldName' => 'name', 'type' => 'string'));
+        $cm1->mapField(['fieldName' => 'name', 'type' => 'string']);
         // Add a mapped field
-        $cm1->mapField(array('fieldName' => 'id', 'id' => true));
+        $cm1->mapField(['fieldName' => 'id', 'id' => true]);
         // and a mapped association
-        $cm1->mapOneEmbedded(array('fieldName' => 'other', 'targetDocument' => 'Other'));
-        $cm1->mapOneEmbedded(array('fieldName' => 'association', 'targetDocument' => 'Other'));
+        $cm1->mapOneEmbedded(['fieldName' => 'other', 'targetDocument' => 'Other']);
+        $cm1->mapOneEmbedded(['fieldName' => 'association', 'targetDocument' => 'Other']);
 
         // SUT
         $cmf = new ClassMetadataFactoryTestSubject();
         $cmf->setMetadataFor('Doctrine\ODM\MongoDB\Tests\Mapping\TestDocument1', $cm1);
 
         // Prechecks
-        $this->assertEquals(array(), $cm1->parentClasses);
+        $this->assertEquals([], $cm1->parentClasses);
         $this->assertEquals(ClassMetadata::INHERITANCE_TYPE_NONE, $cm1->inheritanceType);
         $this->assertTrue($cm1->hasField('name'));
         $this->assertCount(4, $cm1->fieldMappings);
@@ -37,13 +40,13 @@ class ClassMetadataFactoryTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $cm1 = $cmf->getMetadataFor('Doctrine\ODM\MongoDB\Tests\Mapping\TestDocument1');
 
         $this->assertEquals('group', $cm1->collection);
-        $this->assertEquals(array(), $cm1->parentClasses);
+        $this->assertEquals([], $cm1->parentClasses);
         $this->assertTrue($cm1->hasField('name'));
     }
 
     public function testHasGetMetadata_NamespaceSeperatorIsNotNormalized()
     {
-        require_once __DIR__."/Documents/GlobalNamespaceDocument.php";
+        require_once __DIR__ . '/Documents/GlobalNamespaceDocument.php';
 
         $driver = AnnotationDriver::create(__DIR__ . '/Documents');
 
@@ -53,10 +56,10 @@ class ClassMetadataFactoryTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $cmf->setConfiguration($dm->getConfiguration());
         $cmf->setDocumentManager($dm);
 
-        $m1 = $cmf->getMetadataFor("DoctrineGlobal_Article");
-        $h1 = $cmf->hasMetadataFor("DoctrineGlobal_Article");
-        $h2 = $cmf->hasMetadataFor("\DoctrineGlobal_Article");
-        $m2 = $cmf->getMetadataFor("\DoctrineGlobal_Article");
+        $m1 = $cmf->getMetadataFor('DoctrineGlobal_Article');
+        $h1 = $cmf->hasMetadataFor('DoctrineGlobal_Article');
+        $h2 = $cmf->hasMetadataFor('\DoctrineGlobal_Article');
+        $m2 = $cmf->getMetadataFor('\DoctrineGlobal_Article');
 
         $this->assertNotSame($m1, $m2);
         $this->assertFalse($h2);
@@ -79,16 +82,15 @@ class ClassMetadataFactoryTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 }
 
 /* Test subject class with overriden factory method for mocking purposes */
-class ClassMetadataFactoryTestSubject extends \Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory
+class ClassMetadataFactoryTestSubject extends ClassMetadataFactory
 {
-    private $_mockMetadata = array();
-    private $_requestedClasses = array();
+    private $_mockMetadata = [];
+    private $_requestedClasses = [];
 
-    /** @override */
     protected function _newClassMetadataInstance($className)
     {
         $this->_requestedClasses[] = $className;
-        if ( ! isset($this->_mockMetadata[$className])) {
+        if (! isset($this->_mockMetadata[$className])) {
             throw new InvalidArgumentException("No mock metadata found for class $className.");
         }
         return $this->_mockMetadata[$className];

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
+use Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-class ClassMetadataLoadEventTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class ClassMetadataLoadEventTest extends BaseTest
 {
     public function testEvent()
     {
@@ -16,13 +20,13 @@ class ClassMetadataLoadEventTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertTrue($classMetadata->hasField('about'));
     }
 
-    public function loadClassMetadata(\Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs $eventArgs)
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
     {
         $classMetadata = $eventArgs->getClassMetadata();
-        $field = array(
+        $field = [
             'fieldName' => 'about',
-            'type' => 'string'
-        );
+            'type' => 'string',
+        ];
         $classMetadata->mapField($field);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Documents/GlobalNamespaceDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Documents/GlobalNamespaceDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mapping\Driver;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use TestDocuments\PrimedCollectionDocument;
 use PHPUnit\Framework\TestCase;
+use TestDocuments\PrimedCollectionDocument;
 
 require_once 'fixtures/InvalidPartialFilterDocument.php';
 require_once 'fixtures/PartialFilterDocument.php';
@@ -24,16 +26,15 @@ abstract class AbstractDriverTest extends TestCase
 
     public function tearDown()
     {
-        unset ($this->driver);
+        unset($this->driver);
     }
 
     public function testDriver()
     {
-
         $classMetadata = new ClassMetadata('TestDocuments\User');
         $this->driver->loadMetadataForClass('TestDocuments\User', $classMetadata);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'fieldName' => 'id',
             'id' => true,
             'name' => '_id',
@@ -45,10 +46,10 @@ abstract class AbstractDriverTest extends TestCase
             'isCascadeRemove' => false,
             'isInverseSide' => false,
             'isOwningSide' => true,
-            'nullable' => false
-        ), $classMetadata->fieldMappings['id']);
+            'nullable' => false,
+        ], $classMetadata->fieldMappings['id']);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'fieldName' => 'username',
             'name' => 'username',
             'type' => 'string',
@@ -63,16 +64,16 @@ abstract class AbstractDriverTest extends TestCase
             'unique' => true,
             'sparse' => true,
             'strategy' => ClassMetadata::STORAGE_STRATEGY_SET,
-        ), $classMetadata->fieldMappings['username']);
+        ], $classMetadata->fieldMappings['username']);
 
-        $this->assertEquals(array(
-            array(
-                'keys' => array('username' => 1),
-                'options' => array('unique' => true, 'sparse' => true)
-            )
-        ), $classMetadata->getIndexes());
+        $this->assertEquals([
+            [
+                'keys' => ['username' => 1],
+                'options' => ['unique' => true, 'sparse' => true],
+            ],
+        ], $classMetadata->getIndexes());
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'fieldName' => 'createdAt',
             'name' => 'createdAt',
             'type' => 'date',
@@ -85,9 +86,9 @@ abstract class AbstractDriverTest extends TestCase
             'isOwningSide' => true,
             'nullable' => false,
             'strategy' => ClassMetadata::STORAGE_STRATEGY_SET,
-        ), $classMetadata->fieldMappings['createdAt']);
+        ], $classMetadata->fieldMappings['createdAt']);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'fieldName' => 'tags',
             'name' => 'tags',
             'type' => 'collection',
@@ -100,9 +101,9 @@ abstract class AbstractDriverTest extends TestCase
             'isOwningSide' => true,
             'nullable' => false,
             'strategy' => ClassMetadata::STORAGE_STRATEGY_SET,
-        ), $classMetadata->fieldMappings['tags']);
+        ], $classMetadata->fieldMappings['tags']);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'association' => 3,
             'fieldName' => 'address',
             'name' => 'address',
@@ -119,9 +120,9 @@ abstract class AbstractDriverTest extends TestCase
             'isOwningSide' => true,
             'nullable' => false,
             'strategy' => ClassMetadata::STORAGE_STRATEGY_SET,
-        ), $classMetadata->fieldMappings['address']);
+        ], $classMetadata->fieldMappings['address']);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'association' => 4,
             'fieldName' => 'phonenumbers',
             'name' => 'phonenumbers',
@@ -138,9 +139,9 @@ abstract class AbstractDriverTest extends TestCase
             'isOwningSide' => true,
             'nullable' => false,
             'strategy' => ClassMetadata::STORAGE_STRATEGY_PUSH_ALL,
-        ), $classMetadata->fieldMappings['phonenumbers']);
+        ], $classMetadata->fieldMappings['phonenumbers']);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'association' => 1,
             'fieldName' => 'profile',
             'name' => 'profile',
@@ -149,7 +150,7 @@ abstract class AbstractDriverTest extends TestCase
             'storeAs' => ClassMetadata::REFERENCE_STORE_AS_ID,
             'targetDocument' => 'Documents\Profile',
             'collectionClass' => null,
-            'cascade' => array('remove', 'persist', 'refresh', 'merge', 'detach'),
+            'cascade' => ['remove', 'persist', 'refresh', 'merge', 'detach'],
             'isCascadeDetach' => true,
             'isCascadeMerge' => true,
             'isCascadePersist' => true,
@@ -166,9 +167,9 @@ abstract class AbstractDriverTest extends TestCase
             'skip' => null,
             'orphanRemoval' => true,
             'prime' => [],
-        ), $classMetadata->fieldMappings['profile']);
+        ], $classMetadata->fieldMappings['profile']);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'association' => 1,
             'fieldName' => 'account',
             'name' => 'account',
@@ -177,7 +178,7 @@ abstract class AbstractDriverTest extends TestCase
             'storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF,
             'targetDocument' => 'Documents\Account',
             'collectionClass' => null,
-            'cascade' => array('remove', 'persist', 'refresh', 'merge', 'detach'),
+            'cascade' => ['remove', 'persist', 'refresh', 'merge', 'detach'],
             'isCascadeDetach' => true,
             'isCascadeMerge' => true,
             'isCascadePersist' => true,
@@ -194,9 +195,9 @@ abstract class AbstractDriverTest extends TestCase
             'skip' => null,
             'orphanRemoval' => false,
             'prime' => [],
-        ), $classMetadata->fieldMappings['account']);
+        ], $classMetadata->fieldMappings['account']);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'association' => 2,
             'fieldName' => 'groups',
             'name' => 'groups',
@@ -205,7 +206,7 @@ abstract class AbstractDriverTest extends TestCase
             'storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF,
             'targetDocument' => 'Documents\Group',
             'collectionClass' => null,
-            'cascade' => array('remove', 'persist', 'refresh', 'merge', 'detach'),
+            'cascade' => ['remove', 'persist', 'refresh', 'merge', 'detach'],
             'isCascadeDetach' => true,
             'isCascadeMerge' => true,
             'isCascadePersist' => true,
@@ -222,27 +223,27 @@ abstract class AbstractDriverTest extends TestCase
             'skip' => null,
             'orphanRemoval' => false,
             'prime' => [],
-        ), $classMetadata->fieldMappings['groups']);
+        ], $classMetadata->fieldMappings['groups']);
 
         $this->assertEquals(
-            array(
-                'postPersist' => array('doStuffOnPostPersist', 'doOtherStuffOnPostPersist'),
-                'prePersist' => array('doStuffOnPrePersist'),
-            ),
+            [
+                'postPersist' => ['doStuffOnPostPersist', 'doOtherStuffOnPostPersist'],
+                'prePersist' => ['doStuffOnPrePersist'],
+            ],
             $classMetadata->lifecycleCallbacks
         );
 
         $this->assertEquals(
-            array(
-                "doStuffOnAlsoLoad" => array("unmappedField"),
-            ),
+            [
+                'doStuffOnAlsoLoad' => ['unmappedField'],
+            ],
             $classMetadata->alsoLoadMethods
         );
 
         $classMetadata = new ClassMetadata('TestDocuments\EmbeddedDocument');
         $this->driver->loadMetadataForClass('TestDocuments\EmbeddedDocument', $classMetadata);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'fieldName' => 'name',
             'name' => 'name',
             'type' => 'string',
@@ -255,12 +256,12 @@ abstract class AbstractDriverTest extends TestCase
             'isOwningSide' => true,
             'nullable' => false,
             'strategy' => ClassMetadata::STORAGE_STRATEGY_SET,
-        ), $classMetadata->fieldMappings['name']);
+        ], $classMetadata->fieldMappings['name']);
 
         $classMetadata = new ClassMetadata('TestDocuments\QueryResultDocument');
         $this->driver->loadMetadataForClass('TestDocuments\QueryResultDocument', $classMetadata);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'fieldName' => 'name',
             'name' => 'name',
             'type' => 'string',
@@ -273,9 +274,9 @@ abstract class AbstractDriverTest extends TestCase
             'isOwningSide' => true,
             'nullable' => false,
             'strategy' => ClassMetadata::STORAGE_STRATEGY_SET,
-        ), $classMetadata->fieldMappings['name']);
+        ], $classMetadata->fieldMappings['name']);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'fieldName' => 'count',
             'name' => 'count',
             'type' => 'integer',
@@ -288,7 +289,7 @@ abstract class AbstractDriverTest extends TestCase
             'isOwningSide' => true,
             'nullable' => false,
             'strategy' => ClassMetadata::STORAGE_STRATEGY_SET,
-        ), $classMetadata->fieldMappings['count']);
+        ], $classMetadata->fieldMappings['count']);
     }
 
     public function testPartialFilterExpressions()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mapping\Driver;
 
-use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
 
 class XmlDriverTest extends AbstractDriverTest
 {
@@ -16,13 +18,13 @@ class XmlDriverTest extends AbstractDriverTest
     {
         $classMetadata = new ClassMetadata('TestDocuments\UserCustomIdGenerator');
         $this->driver->loadMetadataForClass('TestDocuments\UserCustomIdGenerator', $classMetadata);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'fieldName' => 'id',
             'strategy' => 'custom',
-            'options' => array(
+            'options' => [
                 'class' => 'TestDocuments\CustomIdGenerator',
-                'someOption' => 'some-option'
-            ),
+                'someOption' => 'some-option',
+            ],
             'id' => true,
             'name' => '_id',
             'type' => 'custom_id',
@@ -33,8 +35,8 @@ class XmlDriverTest extends AbstractDriverTest
             'isCascadeRemove' => false,
             'isInverseSide' => false,
             'isOwningSide' => true,
-            'nullable' => false
-        ), $classMetadata->fieldMappings['id']);
+            'nullable' => false,
+        ], $classMetadata->fieldMappings['id']);
     }
 
     public function testDriverShouldParseNonStringAttributes()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/EmbeddedDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/EmbeddedDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestDocuments;
 
 class EmbeddedDocument

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/InvalidPartialFilterDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/InvalidPartialFilterDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestDocuments;
 
 class InvalidPartialFilterDocument

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/PartialFilterDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/PartialFilterDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestDocuments;
 
 class PartialFilterDocument

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/PrimedCollectionDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/PrimedCollectionDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestDocuments;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/QueryResultDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/QueryResultDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestDocuments;
 
 class QueryResultDocument

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/User.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/User.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TestDocuments;
+
+use Doctrine\Common\Collections\ArrayCollection;
 
 class User
 {
@@ -22,14 +26,14 @@ class User
 
     protected $account;
 
-    protected $tags = array();
+    protected $tags = [];
 
     protected $test;
 
     public function __construct()
     {
-        $this->phonenumbers = new \Doctrine\Common\Collections\ArrayCollection();
-        $this->groups = array();
+        $this->phonenumbers = new ArrayCollection();
+        $this->groups = [];
         $this->createdAt = new \DateTime();
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -25,7 +27,7 @@ class ShardKeyInheritanceMappingTest extends BaseTest
         $class = $this->factory->getMetadataFor(ShardedSubclass::class);
 
         $this->assertTrue($class->isSharded());
-        $this->assertEquals(array('keys' => array('_id' => 1), 'options' => array()), $class->getShardKey());
+        $this->assertEquals(['keys' => ['_id' => 1], 'options' => []], $class->getShardKey());
     }
 
     public function testShardKeySingleCollectionInheritance()
@@ -33,7 +35,7 @@ class ShardKeyInheritanceMappingTest extends BaseTest
         $class = $this->factory->getMetadataFor(ShardedSingleCollInheritance2::class);
 
         $this->assertTrue($class->isSharded());
-        $this->assertEquals(array('keys' => array('_id' => 1), 'options' => array()), $class->getShardKey());
+        $this->assertEquals(['keys' => ['_id' => 1], 'options' => []], $class->getShardKey());
     }
 
     /**
@@ -49,7 +51,7 @@ class ShardKeyInheritanceMappingTest extends BaseTest
         $class = $this->factory->getMetadataFor(ShardedCollectionPerClass2::class);
 
         $this->assertTrue($class->isSharded());
-        $this->assertEquals(array('keys' => array('_id' => 1), 'options' => array()), $class->getShardKey());
+        $this->assertEquals(['keys' => ['_id' => 1], 'options' => []], $class->getShardKey());
     }
 
     public function testShardKeyCollectionPerClassInheritanceOverriding()
@@ -57,7 +59,7 @@ class ShardKeyInheritanceMappingTest extends BaseTest
         $class = $this->factory->getMetadataFor(ShardedCollectionPerClass3::class);
 
         $this->assertTrue($class->isSharded());
-        $this->assertEquals(array('keys' => array('_id' => 'hashed'), 'options' => array()), $class->getShardKey());
+        $this->assertEquals(['keys' => ['_id' => 'hashed'], 'options' => []], $class->getShardKey());
     }
 }
 
@@ -94,14 +96,16 @@ class ShardedSingleCollInheritance1
  * @ODM\Document
  */
 class ShardedSingleCollInheritance2 extends ShardedSingleCollInheritance1
-{}
+{
+}
 
 /**
  * @ODM\Document
  * @ODM\ShardKey(keys={"_id"="hashed"})
  */
 class ShardedSingleCollInheritance3 extends ShardedSingleCollInheritance1
-{}
+{
+}
 
 /**
  * @ODM\Document
@@ -118,11 +122,13 @@ class ShardedCollectionPerClass1
  * @ODM\Document
  */
 class ShardedCollectionPerClass2 extends ShardedCollectionPerClass1
-{}
+{
+}
 
 /**
  * @ODM\Document
  * @ODM\ShardKey(keys={"_id"="hashed"})
  */
 class ShardedCollectionPerClass3 extends ShardedCollectionPerClass1
-{}
+{
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/AbstractDriverTest.php
@@ -74,9 +74,9 @@ abstract class AbstractDriverTest extends TestCase
 
         foreach ($iterator as $path) {
             if ($path->isDir()) {
-                @rmdir($path);
+                @rmdir((string) $path);
             } else {
-                @unlink($path);
+                @unlink((string) $path);
             }
         }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/AbstractDriverTest.php
@@ -1,8 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mapping\Symfony;
 
+use Doctrine\Common\Persistence\Mapping\MappingException;
 use PHPUnit\Framework\TestCase;
+use function mkdir;
+use function rmdir;
+use function sys_get_temp_dir;
+use function touch;
+use function unlink;
 
 /**
  * @group DDC-1418
@@ -11,52 +19,52 @@ abstract class AbstractDriverTest extends TestCase
 {
     public function testFindMappingFile()
     {
-        $driver = $this->getDriver(array(
+        $driver = $this->getDriver([
             'MyNamespace\MySubnamespace\DocumentFoo' => 'foo',
             'MyNamespace\MySubnamespace\Document' => $this->dir,
-        ));
+        ]);
 
-        touch($filename = $this->dir.'/Foo'.$this->getFileExtension());
+        touch($filename = $this->dir . '/Foo' . $this->getFileExtension());
         $this->assertEquals($filename, $driver->getLocator()->findMappingFile('MyNamespace\MySubnamespace\Document\Foo'));
     }
 
     public function testFindMappingFileInSubnamespace()
     {
-        $driver = $this->getDriver(array(
+        $driver = $this->getDriver([
             'MyNamespace\MySubnamespace\Document' => $this->dir,
-        ));
+        ]);
 
-        touch($filename = $this->dir.'/Foo.Bar'.$this->getFileExtension());
+        touch($filename = $this->dir . '/Foo.Bar' . $this->getFileExtension());
         $this->assertEquals($filename, $driver->getLocator()->findMappingFile('MyNamespace\MySubnamespace\Document\Foo\Bar'));
     }
 
     public function testFindMappingFileNamespacedFoundFileNotFound()
     {
-        $this->expectException(\Doctrine\Common\Persistence\Mapping\MappingException::class);
-        $this->expectExceptionMessage("No mapping file found named");
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('No mapping file found named');
 
-        $driver = $this->getDriver(array(
+        $driver = $this->getDriver([
             'MyNamespace\MySubnamespace\Document' => $this->dir,
-        ));
+        ]);
 
         $driver->getLocator()->findMappingFile('MyNamespace\MySubnamespace\Document\Foo');
     }
 
     public function testFindMappingNamespaceNotFound()
     {
-        $this->expectException(\Doctrine\Common\Persistence\Mapping\MappingException::class);
-        $this->expectExceptionMessage("No mapping file found named 'Foo".$this->getFileExtension()."' for class 'MyOtherNamespace\MySubnamespace\Document\Foo'.");
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage("No mapping file found named 'Foo" . $this->getFileExtension() . "' for class 'MyOtherNamespace\MySubnamespace\Document\Foo'.");
 
-        $driver = $this->getDriver(array(
+        $driver = $this->getDriver([
             'MyNamespace\MySubnamespace\Document' => $this->dir,
-        ));
+        ]);
 
         $driver->getLocator()->findMappingFile('MyOtherNamespace\MySubnamespace\Document\Foo');
     }
 
     protected function setUp()
     {
-        $this->dir = sys_get_temp_dir().'/abstract_driver_test';
+        $this->dir = sys_get_temp_dir() . '/abstract_driver_test';
         @mkdir($this->dir, 0775, true);
     }
 
@@ -76,7 +84,7 @@ abstract class AbstractDriverTest extends TestCase
     }
 
     abstract protected function getFileExtension();
-    abstract protected function getDriver(array $paths = array());
+    abstract protected function getDriver(array $paths = []);
 
     private function setField($obj, $field, $value)
     {
@@ -85,7 +93,7 @@ abstract class AbstractDriverTest extends TestCase
         $ref->setValue($obj, $value);
     }
 
-    private function invoke($obj, $method, array $args = array())
+    private function invoke($obj, $method, array $args = [])
     {
         $ref = new \ReflectionMethod($obj, $method);
         $ref->setAccessible(true);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/XmlDriverTest.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mapping\Symfony;
 
 use Doctrine\ODM\MongoDB\Mapping\Driver\SimplifiedXmlDriver;
+use function array_flip;
 
 /**
  * @group DDC-1418
@@ -14,7 +17,7 @@ class XmlDriverTest extends AbstractDriverTest
         return '.mongodb-odm.xml';
     }
 
-    protected function getDriver(array $paths = array())
+    protected function getDriver(array $paths = [])
     {
         $driver = new SimplifiedXmlDriver(array_flip($paths));
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
 use Documents\User;
+use const DIRECTORY_SEPARATOR;
+use function get_class;
 
 class XmlMappingDriverTest extends AbstractMappingDriverTest
 {
@@ -26,8 +30,8 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
 
         $this->assertTrue($class->isSharded());
         $shardKey = $class->getShardKey();
-        $this->assertSame(array('unique' => true, 'numInitialChunks' => 4096), $shardKey['options']);
-        $this->assertSame(array('_id' => 1), $shardKey['keys']);
+        $this->assertSame(['unique' => true, 'numInitialChunks' => 4096], $shardKey['options']);
+        $this->assertSame(['_id' => 1], $shardKey['keys']);
     }
 
     public function testGetAssociationCollectionClass()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mocks/ClassMetadataMock.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mocks/ClassMetadataMock.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mocks;
 
-class ClassMetadataMock extends \Doctrine\ODM\MongoDB\Mapping\ClassMetadata
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+
+class ClassMetadataMock extends ClassMetadata
 {
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mocks/DocumentManagerMock.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mocks/DocumentManagerMock.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mocks;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use function get_parent_class;
 
 class DocumentManagerMock extends DocumentManager
 {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mocks/DocumentPersisterMock.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mocks/DocumentPersisterMock.php
@@ -1,26 +1,30 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mocks;
+
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 
 /**
  * DocumentPersister implementation used for mocking during tests.
  */
-class DocumentPersisterMock extends \Doctrine\ODM\MongoDB\Persisters\DocumentPersister
+class DocumentPersisterMock extends DocumentPersister
 {
-    private $inserts = array();
-    private $upserts = array();
-    private $updates = array();
-    private $deletes = array();
+    private $inserts = [];
+    private $upserts = [];
+    private $updates = [];
+    private $deletes = [];
     private $identityColumnValueCounter = 1;
     private $mockIdGeneratorType;
-    private $postInsertIds = array();
+    private $postInsertIds = [];
     private $existsCalled = false;
 
-    public function insert($document, array $options = array())
+    public function insert($document, array $options = [])
     {
         $this->inserts[] = $document;
         $id = $this->identityColumnValueCounter++;
-        $this->postInsertIds[$id] = array($id, $document);
+        $this->postInsertIds[$id] = [$id, $document];
         return $id;
     }
 
@@ -28,7 +32,7 @@ class DocumentPersisterMock extends \Doctrine\ODM\MongoDB\Persisters\DocumentPer
     {
         $this->inserts[] = $document;
         $id = $this->identityColumnValueCounter++;
-        $this->postInsertIds[$id] = array($id, $document);
+        $this->postInsertIds[$id] = [$id, $document];
         return $id;
     }
 
@@ -36,19 +40,19 @@ class DocumentPersisterMock extends \Doctrine\ODM\MongoDB\Persisters\DocumentPer
     {
         $this->upserts[] = $document;
         $id = $this->identityColumnValueCounter++;
-        $this->postInsertIds[$id] = array($id, $document);
+        $this->postInsertIds[$id] = [$id, $document];
         return $id;
     }
 
-    public function executeInserts(array $options = array())
+    public function executeInserts(array $options = [])
     {
     }
 
-    public function executeUpserts(array $options = array())
+    public function executeUpserts(array $options = [])
     {
     }
 
-    public function update($document, array $options = array())
+    public function update($document, array $options = [])
     {
         $this->updates[] = $document;
     }
@@ -58,7 +62,7 @@ class DocumentPersisterMock extends \Doctrine\ODM\MongoDB\Persisters\DocumentPer
         $this->existsCalled = true;
     }
 
-    public function delete($document, array $options = array())
+    public function delete($document, array $options = [])
     {
         $this->deletes[] = $document;
     }
@@ -87,9 +91,9 @@ class DocumentPersisterMock extends \Doctrine\ODM\MongoDB\Persisters\DocumentPer
     {
         $this->existsCalled = false;
         $this->identityColumnValueCounter = 1;
-        $this->inserts = array();
-        $this->updates = array();
-        $this->deletes = array();
+        $this->inserts = [];
+        $this->updates = [];
+        $this->deletes = [];
     }
 
     public function isExistsCalled()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mocks/ExceptionThrowingListenerMock.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mocks/ExceptionThrowingListenerMock.php
@@ -1,18 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mocks;
 
-use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
-use Doctrine\ODM\MongoDB\Event\PreUpdateEventArgs;
 use Doctrine\Common\EventSubscriber;
+use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
 
 class ExceptionThrowingListenerMock implements EventSubscriber
 {
     public function getSubscribedEvents()
     {
-        return [
-            'onFlush',
-        ];
+        return ['onFlush'];
     }
 
     public function onFlush(OnFlushEventArgs $args)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mocks/MetadataDriverMock.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mocks/MetadataDriverMock.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mocks;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
@@ -19,6 +21,6 @@ class MetadataDriverMock implements MappingDriver
 
     public function getAllClassNames()
     {
-        return array();
+        return [];
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mocks/PreUpdateListenerMock.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mocks/PreUpdateListenerMock.php
@@ -29,6 +29,6 @@ class PreUpdateListenerMock implements EventSubscriber
 
     public function preUpdate(PreUpdateEventArgs $args)
     {
-        return; // fatal error
+        return;
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mocks/PreUpdateListenerMock.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mocks/PreUpdateListenerMock.php
@@ -1,19 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mocks;
 
+use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
 use Doctrine\ODM\MongoDB\Event\PreUpdateEventArgs;
-use Doctrine\Common\EventSubscriber;
+use function spl_object_hash;
 
 class PreUpdateListenerMock implements EventSubscriber
 {
     public function getSubscribedEvents()
     {
-        return array(
+        return [
             'onFlush',
-            'preUpdate'
-        );
+            'preUpdate',
+        ];
     }
 
     public function onFlush(OnFlushEventArgs $args)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mocks/UnitOfWorkMock.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mocks/UnitOfWorkMock.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Mocks;
 
-class UnitOfWorkMock extends \Doctrine\ODM\MongoDB\UnitOfWork
+use Doctrine\ODM\MongoDB\UnitOfWork;
+use function spl_object_hash;
+
+class UnitOfWorkMock extends UnitOfWork
 {
-    private $_mockDataChangeSets = array();
+    private $_mockDataChangeSets = [];
     private $_persisterMock;
 
-    /**
-     * @override
-     */
     public function getDocumentPersister($documentName)
     {
         return $this->_persisterMock[$documentName] ?? parent::getDocumentPersister($documentName);

--- a/tests/Doctrine/ODM/MongoDB/Tests/MongoCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/MongoCollectionTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
 
-class MongoCollectionTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MongoCollectionTest extends BaseTest
 {
     public function testGridFSEmptyResult()
     {
         $mongoCollection = $this->dm->getDocumentCollection('Documents\File');
-        $this->assertNull($mongoCollection->findOne(array('_id' => 'definitelynotanid')));
+        $this->assertNull($mongoCollection->findOne(['_id' => 'definitelynotanid']));
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/HydrationPerformanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/HydrationPerformanceTest.php
@@ -1,13 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ODM\MongoDB\Performance;
 
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\CmsUser;
+use const PHP_EOL;
+use function gc_collect_cycles;
+use function memory_get_usage;
+use function microtime;
 
 /**
  * @group performance
  */
-class HydrationPerformanceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class HydrationPerformanceTest extends BaseTest
 {
     /**
      * [jwage: 10000 objects in ~6 seconds]
@@ -18,12 +25,12 @@ class HydrationPerformanceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $batchSize = 20;
         for ($i = 1; $i <= 10000; ++$i) {
-            $user = new CmsUser;
+            $user = new CmsUser();
             $user->status = 'user';
             $user->username = 'user' . $i;
             $user->name = 'Mr.Smith-' . $i;
             $this->dm->persist($user);
-            if (($i % $batchSize) == 0) {
+            if (($i % $batchSize) === 0) {
                 $this->dm->flush();
                 $this->dm->clear();
             }
@@ -31,16 +38,14 @@ class HydrationPerformanceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         gc_collect_cycles();
 
-        echo "Memory usage before: " . (memory_get_usage() / 1024) . " KB" . PHP_EOL;
+        echo 'Memory usage before: ' . (memory_get_usage() / 1024) . ' KB' . PHP_EOL;
 
-        $users = $this->dm->getRepository('Documents\CmsUser')->findAll();
-        foreach ($users as $user) {
-        }
+        $this->dm->getRepository('Documents\CmsUser')->findAll();
 
         $this->dm->clear();
         gc_collect_cycles();
 
-        echo "Memory usage after: " . (memory_get_usage() / 1024) . " KB" . PHP_EOL;
+        echo 'Memory usage after: ' . (memory_get_usage() / 1024) . ' KB' . PHP_EOL;
 
         $e = microtime(true);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/InsertPerformanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/InsertPerformanceTest.php
@@ -1,13 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ODM\MongoDB\Performance;
 
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\CmsUser;
+use const PHP_EOL;
+use function gc_collect_cycles;
+use function memory_get_usage;
+use function microtime;
 
 /**
  * @group performance
  */
-class InsertPerformanceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class InsertPerformanceTest extends BaseTest
 {
     /**
      * [jwage: 10000 objects in ~4 seconds]
@@ -16,23 +23,23 @@ class InsertPerformanceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $s = microtime(true);
 
-        echo "Memory usage before: " . (memory_get_usage() / 1024) . " KB" . PHP_EOL;
+        echo 'Memory usage before: ' . (memory_get_usage() / 1024) . ' KB' . PHP_EOL;
 
         $batchSize = 20;
         for ($i = 1; $i <= 10000; ++$i) {
-            $user = new CmsUser;
+            $user = new CmsUser();
             $user->status = 'user';
             $user->username = 'user' . $i;
             $user->name = 'Mr.Smith-' . $i;
             $this->dm->persist($user);
-            if (($i % $batchSize) == 0) {
+            if (($i % $batchSize) === 0) {
                 $this->dm->flush();
                 $this->dm->clear();
             }
         }
 
         gc_collect_cycles();
-        echo "Memory usage after: " . (memory_get_usage() / 1024) . " KB" . PHP_EOL;
+        echo 'Memory usage after: ' . (memory_get_usage() / 1024) . ' KB' . PHP_EOL;
 
         $e = microtime(true);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/MemoryUsageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/MemoryUsageTest.php
@@ -1,21 +1,34 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Performance;
 
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\CmsPhonenumber;
 use Documents\CmsUser;
+use const PHP_EOL;
+use function current;
+use function end;
+use function floor;
+use function gc_collect_cycles;
+use function log;
+use function memory_get_usage;
+use function pow;
+use function round;
+use function sprintf;
 
 /**
  * @group performance
  */
-class MemoryUsageTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class MemoryUsageTest extends BaseTest
 {
     /**
      * [jwage: Memory increased by 14.09 kb]
      */
     public function testMemoryUsage()
     {
-        $memoryUsage = array();
+        $memoryUsage = [];
         for ($i = 0; $i < 100; $i++) {
             $ph1 = new CmsPhonenumber();
             $ph1->phonenumber = '12345';
@@ -46,7 +59,7 @@ class MemoryUsageTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     private function formatMemory($size)
     {
-        $unit = array('b', 'kb', 'mb', 'gb', 'tb', 'pb');
+        $unit = ['b', 'kb', 'mb', 'gb', 'tb', 'pb'];
         return round($size / pow(1024, ($i = floor(log($size, 1024)))), 2) . ' ' . $unit[$i];
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/UnitOfWorkPerformanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/UnitOfWorkPerformanceTest.php
@@ -1,22 +1,28 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ODM\MongoDB\Performance;
 
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\CmsUser;
+use const PHP_EOL;
+use function microtime;
+use function str_replace;
 
 /**
  * @group performance
  */
-class UnitOfWorkPerformanceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class UnitOfWorkPerformanceTest extends BaseTest
 {
     /**
      * [jwage: compute changesets for 10000 objects in ~10 seconds]
      */
     public function testComputeChanges()
     {
-        $users = array();
+        $users = [];
         for ($i = 1; $i <= 10000; ++$i) {
-            $user = new CmsUser;
+            $user = new CmsUser();
             $user->status = 'user';
             $user->username = 'user' . $i;
             $user->name = 'Mr.Smith-' . $i;
@@ -35,6 +41,6 @@ class UnitOfWorkPerformanceTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->dm->flush();
         $e = microtime(true);
 
-        echo 'Compute ChangeSet '.$n.' objects in ' . ($e - $s) . ' seconds' . PHP_EOL;
+        echo 'Compute ChangeSet ' . $n . ' objects in ' . ($e - $s) . ' seconds' . PHP_EOL;
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/CollNoReturnType.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/CollNoReturnType.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\PersistentCollection;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
 class CollNoReturnType extends ArrayCollection
 {
-
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/CollWithNullableReturnType.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/CollWithNullableReturnType.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\PersistentCollection;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use function rand;
 
 class CollWithNullableReturnType extends ArrayCollection
 {

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/CollWithReturnType.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/CollWithReturnType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\PersistentCollection;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/DefaultPersistentCollectionGeneratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/DefaultPersistentCollectionGeneratorTest.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\PersistentCollection;
 
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\PersistentCollection\DefaultPersistentCollectionGenerator;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use const PHP_VERSION_ID;
+use function sprintf;
 
 /**
  * Tests aims to check if classes generated for various PHP versions are correct (i.e. parses).

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterFilterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterFilterTest.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Persisters;
 
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\BlogPost;
+use Documents\Comment;
 
 class DocumentPersisterFilterTest extends BaseTest
 {
@@ -17,21 +21,23 @@ class DocumentPersisterFilterTest extends BaseTest
         $testFilter->setParameter('field', 'username');
         $testFilter->setParameter('value', 'Tim');
 
-        $preparedQuery = array('username' => 'Toby');
+        $preparedQuery = ['username' => 'Toby'];
 
-        $expectedCriteria = array('$and' => array(
-            array('username' => 'Toby'),
-            array('username' => 'Tim'),
-        ));
+        $expectedCriteria = [
+        '$and' => [
+            ['username' => 'Toby'],
+            ['username' => 'Tim'],
+        ],
+        ];
 
         $this->assertSame($expectedCriteria, $persister->addFilterToPreparedQuery($preparedQuery));
     }
 
     public function testFilterCrieriaShouldAndWithMappingCriteriaOwningSide()
     {
-        $blogPost = new \Documents\BlogPost('Roger');
-        $blogPost->addComment(new \Documents\Comment('comment by normal user', new \DateTime(), false));
-        $blogPost->addComment(new \Documents\Comment('comment by admin', new \DateTime(), true));
+        $blogPost = new BlogPost('Roger');
+        $blogPost->addComment(new Comment('comment by normal user', new \DateTime(), false));
+        $blogPost->addComment(new Comment('comment by admin', new \DateTime(), true));
 
         $this->dm->persist($blogPost);
         $this->dm->flush();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php
@@ -1,15 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Persisters;
 
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
+use Doctrine\ODM\MongoDB\Query\Builder;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
-use Documents\Ecommerce\Currency;
-use Documents\Ecommerce\ConfigurableProduct;
 use Documents\CmsArticle;
 use Documents\CmsComment;
+use Documents\Ecommerce\ConfigurableProduct;
+use Documents\Ecommerce\Currency;
 use Documents\Functional\SameCollection1;
 use Documents\Functional\SameCollection2;
+use MongoDB\BSON\ObjectId;
+use function array_keys;
+use function get_class;
 
 class PersistenceBuilderTest extends BaseTest
 {
@@ -39,7 +45,7 @@ class PersistenceBuilderTest extends BaseTest
         $this->uow->computeChangeSets();
 
         /**
-         * @var \Doctrine\ODM\MongoDB\Query\Builder $qb
+         * @var Builder $qb
          */
         $qb = $this->dm->createQueryBuilder('Documents\Functional\SameCollection1');
         $qb->updateOne()
@@ -60,11 +66,11 @@ class PersistenceBuilderTest extends BaseTest
         $sameCollection1 = new SameCollection1();
         $sameCollection2a = new SameCollection2();
         $sameCollection2b = new SameCollection2();
-        $ids = array(
+        $ids = [
             '4f28aa84acee413889000001',
             '4f28aa84acee41388900002a',
-            '4f28aa84acee41388900002b'
-        );
+            '4f28aa84acee41388900002b',
+        ];
 
         $sameCollection1->id = $ids[0];
         $sameCollection1->name = 'First entry in SameCollection1';
@@ -87,7 +93,7 @@ class PersistenceBuilderTest extends BaseTest
         $this->uow->computeChangeSets();
 
         /**
-         * @var \Doctrine\ODM\MongoDB\Query\Builder $qb
+         * @var Builder $qb
          */
         $qb = $this->dm->createQueryBuilder(SameCollection2::class);
         $qb
@@ -136,12 +142,12 @@ class PersistenceBuilderTest extends BaseTest
         $this->dm->persist($comment);
         $this->uow->computeChangeSets();
 
-        $expectedData = array(
-            'article' => array(
-                '$id' => new \MongoDB\BSON\ObjectId($article->id),
-                '$ref' => 'CmsArticle'
-            )
-        );
+        $expectedData = [
+            'article' => [
+                '$id' => new ObjectId($article->id),
+                '$ref' => 'CmsArticle',
+            ],
+        ];
         $this->assertDocumentInsertData($expectedData, $this->pb->prepareInsertData($comment));
     }
 
@@ -160,12 +166,12 @@ class PersistenceBuilderTest extends BaseTest
         $this->dm->persist($comment);
         $this->uow->computeChangeSets();
 
-        $expectedData = array(
-            'article' => array(
-                '$id' => new \MongoDB\BSON\ObjectId($article->id),
-                '$ref' => 'CmsArticle'
-            )
-        );
+        $expectedData = [
+            'article' => [
+                '$id' => new ObjectId($article->id),
+                '$ref' => 'CmsArticle',
+            ],
+        ];
         $this->assertDocumentInsertData($expectedData, $this->pb->prepareInsertData($comment));
     }
 
@@ -186,17 +192,17 @@ class PersistenceBuilderTest extends BaseTest
         $this->dm->persist($comment);
         $this->uow->computeChangeSets();
 
-        $expectedData = array(
-            '$set' => array(
+        $expectedData = [
+            '$set' => [
                 'topic' => 'test',
                 'text' => 'text',
-                'article' => array(
-                    '$id' => new \MongoDB\BSON\ObjectId($article->id),
-                    '$ref' => 'CmsArticle'
-                ),
-                '_id' => new \MongoDB\BSON\ObjectId($comment->id),
-            )
-        );
+                'article' => [
+                    '$id' => new ObjectId($article->id),
+                    '$ref' => 'CmsArticle',
+                ],
+                '_id' => new ObjectId($comment->id),
+            ],
+        ];
         $this->assertEquals($expectedData, $this->pb->prepareUpsertData($comment));
     }
 
@@ -218,22 +224,22 @@ class PersistenceBuilderTest extends BaseTest
      */
     public function getDocumentsAndExpectedData()
     {
-        return array(
-            array(new ConfigurableProduct('Test Product'), array('name' => 'Test Product')),
-            array(new Currency('USD', 1), array('name' => 'USD', 'multiplier' => 1)),
-        );
+        return [
+            [new ConfigurableProduct('Test Product'), ['name' => 'Test Product']],
+            [new Currency('USD', 1), ['name' => 'USD', 'multiplier' => 1]],
+        ];
     }
 
-    private function assertDocumentInsertData(array $expectedData, array $preparedData = null)
+    private function assertDocumentInsertData(array $expectedData, ?array $preparedData = null)
     {
         foreach ($preparedData as $key => $value) {
             if ($key === '_id') {
-                $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $value);
+                $this->assertInstanceOf(ObjectId::class, $value);
                 continue;
             }
             $this->assertEquals($expectedData[$key], $value);
         }
-        if ( ! isset($preparedData['_id'])) {
+        if (! isset($preparedData['_id'])) {
             $this->fail('insert data should always contain id');
         }
         unset($preparedData['_id']);
@@ -260,11 +266,11 @@ class PersistenceBuilderTest extends BaseTest
         $commentId = (string) $comment->id;
 
         /**
-         * @var \Doctrine\ODM\MongoDB\Query\Builder $qb
+         * @var Builder $qb
          */
         $qb = $this->dm->createQueryBuilder('Documents\CmsComment');
         $qb
-            ->field('article.id')->in(array($articleId));
+            ->field('article.id')->in([$articleId]);
         $query = $qb->getQuery();
         $results = $query->execute();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/CriteriaMergerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/CriteriaMergerTest.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Query;
 
 use Doctrine\ODM\MongoDB\Query\CriteriaMerger;
 use PHPUnit\Framework\TestCase;
+use function call_user_func_array;
 
 class CriteriaMergerTest extends TestCase
 {
@@ -12,40 +15,40 @@ class CriteriaMergerTest extends TestCase
      */
     public function testMerge(array $args, array $merged)
     {
-        $this->assertSame($merged, call_user_func_array(array(new CriteriaMerger(), 'merge'), $args));
+        $this->assertSame($merged, call_user_func_array([new CriteriaMerger(), 'merge'], $args));
     }
 
     public function provideMerge()
     {
-        return array(
-            'no args' => array(
-                array(),
-                array(),
-            ),
-            'one arg returned as-is' => array(
-                array(array('x' => 1)),
-                array('x' => 1),
-            ),
-            'empty criteria arrays are ignored' => array(
-                array(array('x' => 1), array()),
-                array('x' => 1),
-            ),
-            'two identical args' => array(
-                array(array('x' => 1), array('x' => 1)),
-                array('$and' => array(array('x' => 1), array('x' => 1))),
-            ),
-            'two different args' => array(
-                array(array('x' => 1), array('y' => 1)),
-                array('$and' => array(array('x' => 1), array('y' => 1))),
-            ),
-            'two conflicting args' => array(
-                array(array('x' => 1), array('x' => 2)),
-                array('$and' => array(array('x' => 1), array('x' => 2))),
-            ),
-            'existing $and criteria gets nested' => array(
-                array(array('$and' => array(array('x' => 1))), array('x' => 1)),
-                array('$and' => array(array('$and' => array(array('x' => 1))), array('x' => 1))),
-            ),
-        );
+        return [
+            'no args' => [
+                [],
+                [],
+            ],
+            'one arg returned as-is' => [
+                [['x' => 1]],
+                ['x' => 1],
+            ],
+            'empty criteria arrays are ignored' => [
+                [['x' => 1], []],
+                ['x' => 1],
+            ],
+            'two identical args' => [
+                [['x' => 1], ['x' => 1]],
+                ['$and' => [['x' => 1], ['x' => 1]]],
+            ],
+            'two different args' => [
+                [['x' => 1], ['y' => 1]],
+                ['$and' => [['x' => 1], ['y' => 1]]],
+            ],
+            'two conflicting args' => [
+                [['x' => 1], ['x' => 2]],
+                ['$and' => [['x' => 1], ['x' => 2]]],
+            ],
+            'existing $and criteria gets nested' => [
+                [['$and' => [['x' => 1]]], ['x' => 1]],
+                ['$and' => [['$and' => [['x' => 1]]], ['x' => 1]]],
+            ],
+        ];
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -1,15 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Query;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use Doctrine\ODM\MongoDB\Query\Expr;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use Documents\User;
+use MongoDB\BSON\ObjectId;
 
-class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class ExprTest extends BaseTest
 {
     public function testSelectIsPrepared()
     {
@@ -17,12 +21,12 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->select('id');
         $query = $qb->getQuery();
 
-        $this->assertEquals(array('_id' => 1), $query->debug('select'));
+        $this->assertEquals(['_id' => 1], $query->debug('select'));
     }
 
     public function testInIsPrepared()
     {
-        $ids = array('4f28aa84acee41388900000a');
+        $ids = ['4f28aa84acee41388900000a'];
 
         $qb = $this->dm->createQueryBuilder('Documents\User')
             ->field('groups.id')->in($ids)
@@ -30,13 +34,13 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $query = $qb->getQuery();
         $debug = $query->debug('query');
 
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $debug['groups.$id']['$in'][0]);
+        $this->assertInstanceOf(ObjectId::class, $debug['groups.$id']['$in'][0]);
         $this->assertEquals($ids[0], (string) $debug['groups.$id']['$in'][0]);
     }
 
     public function testAllIsPrepared()
     {
-        $ids = array('4f28aa84acee41388900000a');
+        $ids = ['4f28aa84acee41388900000a'];
 
         $qb = $this->dm->createQueryBuilder('Documents\User')
             ->field('groups.id')->all($ids)
@@ -44,7 +48,7 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $query = $qb->getQuery();
         $debug = $query->debug('query');
 
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $debug['groups.$id']['$all'][0]);
+        $this->assertInstanceOf(ObjectId::class, $debug['groups.$id']['$all'][0]);
         $this->assertEquals($ids[0], (string) $debug['groups.$id']['$all'][0]);
     }
 
@@ -58,13 +62,13 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $query = $qb->getQuery();
         $debug = $query->debug('query');
 
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $debug['groups.$id']['$ne']);
+        $this->assertInstanceOf(ObjectId::class, $debug['groups.$id']['$ne']);
         $this->assertEquals($id, (string) $debug['groups.$id']['$ne']);
     }
 
     public function testNotInIsPrepared()
     {
-        $ids = array('4f28aa84acee41388900000a');
+        $ids = ['4f28aa84acee41388900000a'];
 
         $qb = $this->dm->createQueryBuilder('Documents\User')
             ->field('groups.id')->notIn($ids)
@@ -72,13 +76,13 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $query = $qb->getQuery();
         $debug = $query->debug('query');
 
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $debug['groups.$id']['$nin'][0]);
+        $this->assertInstanceOf(ObjectId::class, $debug['groups.$id']['$nin'][0]);
         $this->assertEquals($ids[0], (string) $debug['groups.$id']['$nin'][0]);
     }
 
     public function testAndIsPrepared()
     {
-        $ids = array('4f28aa84acee41388900000a');
+        $ids = ['4f28aa84acee41388900000a'];
 
         $qb = $this->dm->createQueryBuilder('Documents\User');
         $qb
@@ -87,13 +91,13 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $query = $qb->getQuery();
         $debug = $query->debug('query');
 
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $debug['$and'][0]['groups.$id']['$in'][0]);
+        $this->assertInstanceOf(ObjectId::class, $debug['$and'][0]['groups.$id']['$in'][0]);
         $this->assertEquals($ids[0], (string) $debug['$and'][0]['groups.$id']['$in'][0]);
     }
 
     public function testOrIsPrepared()
     {
-        $ids = array('4f28aa84acee41388900000a');
+        $ids = ['4f28aa84acee41388900000a'];
 
         $qb = $this->dm->createQueryBuilder('Documents\User');
         $qb
@@ -102,16 +106,16 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $query = $qb->getQuery();
         $debug = $query->debug('query');
 
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $debug['$or'][0]['groups.$id']['$in'][0]);
+        $this->assertInstanceOf(ObjectId::class, $debug['$or'][0]['groups.$id']['$in'][0]);
         $this->assertEquals($ids[0], (string) $debug['$or'][0]['groups.$id']['$in'][0]);
     }
 
     public function testMultipleQueryOperatorsArePrepared()
     {
-        $all = array('4f28aa84acee41388900000a');
-        $in = array('4f28aa84acee41388900000b');
+        $all = ['4f28aa84acee41388900000a'];
+        $in = ['4f28aa84acee41388900000b'];
         $ne = '4f28aa84acee41388900000c';
-        $nin = array('4f28aa84acee41388900000d');
+        $nin = ['4f28aa84acee41388900000d'];
 
         $qb = $this->dm->createQueryBuilder('Documents\User')
             ->field('groups.id')->all($all)
@@ -122,13 +126,13 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $query = $qb->getQuery();
         $debug = $query->debug('query');
 
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $debug['groups.$id']['$all'][0]);
+        $this->assertInstanceOf(ObjectId::class, $debug['groups.$id']['$all'][0]);
         $this->assertEquals($all[0], (string) $debug['groups.$id']['$all'][0]);
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $debug['groups.$id']['$in'][0]);
+        $this->assertInstanceOf(ObjectId::class, $debug['groups.$id']['$in'][0]);
         $this->assertEquals($in[0], (string) $debug['groups.$id']['$in'][0]);
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $debug['groups.$id']['$ne']);
+        $this->assertInstanceOf(ObjectId::class, $debug['groups.$id']['$ne']);
         $this->assertEquals($ne, (string) $debug['groups.$id']['$ne']);
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $debug['groups.$id']['$nin'][0]);
+        $this->assertInstanceOf(ObjectId::class, $debug['groups.$id']['$nin'][0]);
         $this->assertEquals($nin[0], (string) $debug['groups.$id']['$nin'][0]);
     }
 
@@ -138,7 +142,7 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->field('address.subAddress.subAddress.subAddress.test')->equals('test');
         $query = $qb->getQuery();
         $debug = $query->debug('query');
-        $this->assertEquals(array('address.subAddress.subAddress.subAddress.testFieldName' => 'test'), $debug);
+        $this->assertEquals(['address.subAddress.subAddress.subAddress.testFieldName' => 'test'], $debug);
     }
 
     public function testPreparePositionalOperator()
@@ -146,10 +150,10 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $qb = $this->dm->createQueryBuilder('Documents\User')
             ->updateOne()
             ->field('phonenumbers.$.phonenumber')->equals('foo')
-            ->field('phonenumbers.$')->set(array('phonenumber' => 'bar'));
+            ->field('phonenumbers.$')->set(['phonenumber' => 'bar']);
 
-        $this->assertEquals(array('phonenumbers.$.phonenumber' => 'foo'), $qb->getQueryArray());
-        $this->assertEquals(array('$set' => array('phonenumbers.$' => array('phonenumber' => 'bar'))), $qb->getNewObj());
+        $this->assertEquals(['phonenumbers.$.phonenumber' => 'foo'], $qb->getQueryArray());
+        $this->assertEquals(['$set' => ['phonenumbers.$' => ['phonenumber' => 'bar']]], $qb->getNewObj());
     }
 
     public function testSortIsPrepared()
@@ -158,22 +162,22 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->sort('id', 'desc');
         $query = $qb->getQuery();
         $query = $query->getQuery();
-        $this->assertEquals(array('_id' => -1), $query['sort']);
+        $this->assertEquals(['_id' => -1], $query['sort']);
 
         $qb = $this->dm->createQueryBuilder('Documents\User')
             ->sort('address.subAddress.subAddress.subAddress.test', 'asc');
         $query = $qb->getQuery();
         $query = $query->getQuery();
-        $this->assertEquals(array('address.subAddress.subAddress.subAddress.testFieldName' => 1), $query['sort']);
+        $this->assertEquals(['address.subAddress.subAddress.subAddress.testFieldName' => 1], $query['sort']);
     }
 
     public function testNestedWithOperator()
     {
         $qb = $this->dm->createQueryBuilder('Documents\User')
-            ->field('address.subAddress.subAddress.subAddress.test')->notIn(array('test'));
+            ->field('address.subAddress.subAddress.subAddress.test')->notIn(['test']);
         $query = $qb->getQuery();
         $query = $query->getQuery();
-        $this->assertEquals(array('address.subAddress.subAddress.subAddress.testFieldName' => array('$nin' => array('test'))), $query['query']);
+        $this->assertEquals(['address.subAddress.subAddress.subAddress.testFieldName' => ['$nin' => ['test']]], $query['query']);
     }
 
     public function testNewObjectIsPrepared()
@@ -183,7 +187,7 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->field('address.subAddress.subAddress.subAddress.test')->popFirst();
         $query = $qb->getQuery();
         $query = $query->getQuery();
-        $this->assertEquals(array('$pop' => array('address.subAddress.subAddress.subAddress.testFieldName' => 1)), $query['newObj']);
+        $this->assertEquals(['$pop' => ['address.subAddress.subAddress.subAddress.testFieldName' => 1]], $query['newObj']);
     }
 
     public function testReferencesUsesMinimalKeys()
@@ -193,12 +197,12 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $documentPersister = $this->createMock(DocumentPersister::class);
         $class = $this->createMock(ClassMetadata::class);
 
-        $expected = array('foo.$id' => '1234');
+        $expected = ['foo.$id' => '1234'];
 
         $dm
             ->expects($this->once())
             ->method('createReference')
-            ->will($this->returnValue(array('$ref' => 'coll', '$id' => '1234', '$db' => 'db')));
+            ->will($this->returnValue(['$ref' => 'coll', '$id' => '1234', '$db' => 'db']));
         $dm
             ->expects($this->once())
             ->method('getUnitOfWork')
@@ -218,7 +222,7 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $class
             ->expects($this->once())
             ->method('getFieldMapping')
-            ->will($this->returnValue(array('targetDocument' => 'Foo', 'name' => 'foo', 'storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF_WITH_DB)));
+            ->will($this->returnValue(['targetDocument' => 'Foo', 'name' => 'foo', 'storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF_WITH_DB]));
 
         $expr = $this->createExpr($dm, $class);
         $expr->field('bar')->references(new \stdClass());
@@ -233,12 +237,12 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $documentPersister = $this->createMock(DocumentPersister::class);
         $class = $this->createMock(ClassMetadata::class);
 
-        $expected = array('foo.$ref' => 'coll', 'foo.$id' => '1234', 'foo.$db' => 'db');
+        $expected = ['foo.$ref' => 'coll', 'foo.$id' => '1234', 'foo.$db' => 'db'];
 
         $dm
             ->expects($this->once())
             ->method('createReference')
-            ->will($this->returnValue(array('$ref' => 'coll', '$id' => '1234', '$db' => 'db')));
+            ->will($this->returnValue(['$ref' => 'coll', '$id' => '1234', '$db' => 'db']));
         $dm
             ->expects($this->once())
             ->method('getUnitOfWork')
@@ -258,7 +262,7 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $class
             ->expects($this->once())
             ->method('getFieldMapping')
-            ->will($this->returnValue(array('name' => 'foo', 'storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF_WITH_DB)));
+            ->will($this->returnValue(['name' => 'foo', 'storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF_WITH_DB]));
 
         $expr = $this->createExpr($dm, $class);
         $expr->field('bar')->references(new \stdClass());
@@ -273,12 +277,12 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $documentPersister = $this->createMock(DocumentPersister::class);
         $class = $this->createMock(ClassMetadata::class);
 
-        $expected = array('foo.$ref' => 'coll', 'foo.$id' => '1234');
+        $expected = ['foo.$ref' => 'coll', 'foo.$id' => '1234'];
 
         $dm
             ->expects($this->once())
             ->method('createReference')
-            ->will($this->returnValue(array('$ref' => 'coll', '$id' => '1234')));
+            ->will($this->returnValue(['$ref' => 'coll', '$id' => '1234']));
         $dm
             ->expects($this->once())
             ->method('getUnitOfWork')
@@ -298,7 +302,7 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $class
             ->expects($this->once())
             ->method('getFieldMapping')
-            ->will($this->returnValue(array('storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF, 'name' => 'foo')));
+            ->will($this->returnValue(['storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF, 'name' => 'foo']));
 
         $expr = $this->createExpr($dm, $class);
         $expr->field('bar')->references(new \stdClass());
@@ -548,11 +552,13 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->sort('x', 1);
 
         $expectedNewObj = [
-            '$push' => ['a' => [
+            '$push' => [
+        'a' => [
                 '$each' => [['x' => 1], ['x' => 2]],
                 '$slice' => -2,
                 '$sort' => ['x' => 1],
-            ]],
+            ],
+            ],
         ];
 
         $this->assertSame($expr, $expr->field('a')->push($innerExpr));
@@ -569,11 +575,13 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->each([['x' => 1], ['x' => 2]]);
 
         $expectedNewObj = [
-            '$push' => ['a' => [
+            '$push' => [
+        'a' => [
                 '$each' => [['x' => 1], ['x' => 2]],
                 '$sort' => ['x' => 1],
                 '$slice' => -2,
-            ]],
+            ],
+            ],
         ];
 
         $this->assertSame($expr, $expr->field('a')->push($innerExpr));
@@ -589,10 +597,12 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->position(0);
 
         $expectedNewObj = [
-            '$push' => ['a' => [
+            '$push' => [
+        'a' => [
                 '$each' => [20, 30],
                 '$position' => 0,
-            ]],
+            ],
+            ],
         ];
 
         $this->assertSame($expr, $expr->field('a')->push($innerExpr));
@@ -743,9 +753,9 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals(['$nin' => ['value1', 'value2']], $expr->getQuery());
     }
 
-    private function createExpr(DocumentManager $dm = null, ClassMetadata $class = null): Expr
+    private function createExpr(?DocumentManager $dm = null, ?ClassMetadata $class = null): Expr
     {
-        if (!$dm) {
+        if (! $dm) {
             $dm = $this->createMock(DocumentManager::class);
             $uow = $this->createMock(UnitOfWork::class);
             $documentPersister = $this->createMock(DocumentPersister::class);
@@ -766,7 +776,7 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                 ->will($this->returnArgument(0));
         }
 
-        if (!$class) {
+        if (! $class) {
             $class = new ClassMetadata(User::class);
         }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/BsonFilterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/BsonFilterTest.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Query\Filter;
 
-class BsonFilterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class BsonFilterTest extends BaseTest
 {
     /**
      * @expectedException InvalidArgumentException

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/Filter.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/Filter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Query\Filter;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
@@ -9,8 +11,8 @@ class Filter extends BsonFilter
 {
     public function addFilterCriteria(ClassMetadata $class)
     {
-        return ($class->name == $this->parameters['class'])
-            ? array($this->parameters['field'] => $this->parameters['value'])
-            : array();
+        return ($class->name === $this->parameters['class'])
+            ? [$this->parameters['field'] => $this->parameters['value']]
+            : [];
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/FilterCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/FilterCollectionTest.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Query;
 
-class FilterCollectionTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class FilterCollectionTest extends BaseTest
 {
     public function testEnable()
     {
@@ -71,7 +75,7 @@ class FilterCollectionTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $testFilter->setParameter('field', 'username');
         $testFilter->setParameter('value', 'Tim');
 
-        $this->assertSame(array('username' => 'Tim'), $filterCollection->getFilterCriteria($class));
+        $this->assertSame(['username' => 'Tim'], $filterCollection->getFilterCriteria($class));
     }
 
     public function testGetFilterCriteriaMergesCriteria()
@@ -91,10 +95,12 @@ class FilterCollectionTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $testFilter->setParameter('field', 'username');
         $testFilter->setParameter('value', 'John');
 
-        $expectedCriteria = array('$and' => array(
-            array('username' => 'Tim'),
-            array('username' => 'John'),
-        ));
+        $expectedCriteria = [
+        '$and' => [
+            ['username' => 'Tim'],
+            ['username' => 'John'],
+        ],
+        ];
 
         $this->assertSame($expectedCriteria, $filterCollection->getFilterCriteria($class));
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/QueryExpressionVisitorTest.php
@@ -1,13 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Query;
 
-use Doctrine\Common\Collections\ExpressionBuilder;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\Expr\Value;
+use Doctrine\Common\Collections\ExpressionBuilder;
 use Doctrine\ODM\MongoDB\Query\QueryExpressionVisitor;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\Regex;
 
 class QueryExpressionVisitorTest extends BaseTest
 {
@@ -36,18 +39,18 @@ class QueryExpressionVisitorTest extends BaseTest
     {
         $builder = new ExpressionBuilder();
 
-        return array(
-            array($builder->eq('field', 'value'), array('field' => 'value')),
-            array($builder->contains('field', 'value'), array('field' => new \MongoDB\BSON\Regex('value', ''))),
-            array($builder->gt('field', 'value'), array('field' => array('$gt' => 'value'))),
-            array($builder->gte('field', 'value'), array('field' => array('$gte' => 'value'))),
-            array($builder->in('field', array(1, 2)), array('field' => array('$in' => array(1, 2)))),
-            array($builder->isNull('field'), array('field' => null)),
-            array($builder->lt('field', 'value'), array('field' => array('$lt' => 'value'))),
-            array($builder->lte('field', 'value'), array('field' => array('$lte' => 'value'))),
-            array($builder->neq('field', 'value'), array('field' => array('$ne' => 'value'))),
-            array($builder->notIn('field', array(1, 2)), array('field' => array('$nin' => array(1, 2)))),
-        );
+        return [
+            [$builder->eq('field', 'value'), ['field' => 'value']],
+            [$builder->contains('field', 'value'), ['field' => new Regex('value', '')]],
+            [$builder->gt('field', 'value'), ['field' => ['$gt' => 'value']]],
+            [$builder->gte('field', 'value'), ['field' => ['$gte' => 'value']]],
+            [$builder->in('field', [1, 2]), ['field' => ['$in' => [1, 2]]]],
+            [$builder->isNull('field'), ['field' => null]],
+            [$builder->lt('field', 'value'), ['field' => ['$lt' => 'value']]],
+            [$builder->lte('field', 'value'), ['field' => ['$lte' => 'value']]],
+            [$builder->neq('field', 'value'), ['field' => ['$ne' => 'value']]],
+            [$builder->notIn('field', [1, 2]), ['field' => ['$nin' => [1, 2]]]],
+        ];
     }
 
     /**
@@ -69,11 +72,13 @@ class QueryExpressionVisitorTest extends BaseTest
             $builder->eq('b', 3)
         );
 
-        $expectedQuery = array('$and' => array(
-            array('a' => 1),
-            array('a' => array('$ne' => 2)),
-            array('b' => 3),
-        ));
+        $expectedQuery = [
+        '$and' => [
+            ['a' => 1],
+            ['a' => ['$ne' => 2]],
+            ['b' => 3],
+        ],
+        ];
 
         $expr = $this->visitor->dispatch($compositeExpr);
 
@@ -86,7 +91,7 @@ class QueryExpressionVisitorTest extends BaseTest
      */
     public function testWalkCompositeExpressionShouldThrowExceptionForUnsupportedComposite()
     {
-        $compositeExpr = new CompositeExpression('invalidComposite', array());
+        $compositeExpr = new CompositeExpression('invalidComposite', []);
         $expr = $this->visitor->dispatch($compositeExpr);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryLogger.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryLogger.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
+
+use function count;
 
 class QueryLogger implements \Countable
 {
-    private $queries = array();
+    private $queries = [];
 
     /**
      * Log a query.
@@ -21,14 +25,14 @@ class QueryLogger implements \Countable
      */
     public function clear()
     {
-        $this->queries = array();
+        $this->queries = [];
     }
 
     /**
      * Returns the number of logged queries.
      *
      * @see php.net/countable.count
-     * @return integer
+     * @return int
      */
     public function count()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/RepositoryFactoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/RepositoryFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\ODM\MongoDB\DocumentManager;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH1299/BaseUser.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH1299/BaseUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Tools\GH1299;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH1299/GH1299User.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH1299/GH1299User.php
@@ -1,9 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Tools\GH1299;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\Tools\GH1299\BaseUser;
 
 /** @ODM\Document */
 class GH1299User extends BaseUser

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/Address.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/Address.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Tools\GH297;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -9,12 +11,12 @@ class Address
 {
     /** @ODM\Field(type="string") */
     private $street;
-    
+
     public function getStreet()
     {
         return $this->street;
     }
-    
+
     public function setStreet($street)
     {
         $this->street = $street;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/AddressTrait.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/AddressTrait.php
@@ -1,20 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Tools\GH297;
 
-trait AddressTrait 
+trait AddressTrait
 {
     /**
      * @ODM\EmbedOne
      */
     private $address;
 
-    public function getAddress() 
+    public function getAddress()
     {
         return $this->address;
     }
 
-    public function setAddress(Address $address) 
+    public function setAddress(Address $address)
     {
         $this->address = $address;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/Admin.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/Admin.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Tools\GH297;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -7,5 +9,4 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\Document */
 class Admin extends User
 {
-    
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/User.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Tools\GH297;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -8,23 +10,23 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 class User
 {
     use AddressTrait;
-    
+
     /** @ODM\Id */
     private $id;
-    
+
     /** @ODM\Field(type="string") */
     private $name;
-    
+
     public function getId()
     {
         return $this->id;
     }
-    
+
     public function getName()
     {
         return $this->name;
     }
-    
+
     public function setName($name)
     {
         $this->name = $name;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
@@ -1,15 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Tools;
 
+use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Events;
-use Doctrine\ODM\MongoDB\Tools\ResolveTargetDocumentListener;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tools\ResolveTargetDocumentListener;
 
-class ResolveTargetDocumentListenerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class ResolveTargetDocumentListenerTest extends BaseTest
 {
     /**
-     * @var \Doctrine\ODM\MongoDB\DocumentManager
+     * @var DocumentManager
      */
     protected $dm;
 
@@ -32,13 +36,13 @@ class ResolveTargetDocumentListenerTest extends \Doctrine\ODM\MongoDB\Tests\Base
         $this->listener->addResolveTargetDocument(
             'Doctrine\ODM\MongoDB\Tests\Tools\ResolveTargetInterface',
             'Doctrine\ODM\MongoDB\Tests\Tools\ResolveTargetDocument',
-            array()
+            []
         );
 
         $this->listener->addResolveTargetDocument(
             'Doctrine\ODM\MongoDB\Tests\Tools\TargetInterface',
             'Doctrine\ODM\MongoDB\Tests\Tools\TargetDocument',
-            array()
+            []
         );
 
         $evm->addEventListener(Events::loadClassMetadata, $this->listener);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
@@ -37,7 +37,7 @@ class DateTypeTest extends TestCase
         $this->assertSame($mongoDate, $type->convertToDatabaseValue($mongoDate), 'MongoDate objects are not converted');
 
         $timestamp = 100000000.123;
-        $dateTime = \DateTime::createFromFormat('U.u', $timestamp);
+        $dateTime = \DateTime::createFromFormat('U.u', (string) $timestamp);
         $mongoDate = new UTCDateTime(100000000123);
         $this->assertEquals($mongoDate, $type->convertToDatabaseValue($dateTime), 'DateTime objects are converted to MongoDate objects');
         $this->assertEquals($mongoDate, $type->convertToDatabaseValue($timestamp), 'Numeric timestamps are converted to MongoDate objects');
@@ -53,7 +53,7 @@ class DateTypeTest extends TestCase
         $timestamp = 100000000.123;
         $mongoDate = new UTCDateTime(100000000123);
 
-        $dateTimeImmutable = \DateTimeImmutable::createFromFormat('U.u', $timestamp);
+        $dateTimeImmutable = \DateTimeImmutable::createFromFormat('U.u', (string) $timestamp);
         $this->assertEquals($mongoDate, $type->convertToDatabaseValue($dateTimeImmutable), 'DateTimeImmutable objects are converted to MongoDate objects');
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
@@ -1,9 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Types;
 
 use Doctrine\ODM\MongoDB\Types\Type;
+use MongoDB\BSON\UTCDateTime;
 use PHPUnit\Framework\TestCase;
+use const PHP_INT_SIZE;
+use function call_user_func;
+use function date;
+use function strtotime;
 
 class DateTypeTest extends TestCase
 {
@@ -15,7 +22,7 @@ class DateTypeTest extends TestCase
         $dateTime = $type->getDateTime($timestamp);
         $this->assertEquals($timestamp, $dateTime->format('U.u'));
 
-        $mongoDate = new \MongoDB\BSON\UTCDateTime(100000000001);
+        $mongoDate = new UTCDateTime(100000000001);
         $dateTime = $type->getDateTime($mongoDate);
         $this->assertEquals($timestamp, $dateTime->format('U.u'));
     }
@@ -26,12 +33,12 @@ class DateTypeTest extends TestCase
 
         $this->assertNull($type->convertToDatabaseValue(null), 'null is not converted');
 
-        $mongoDate = new \MongoDB\BSON\UTCDateTime();
+        $mongoDate = new UTCDateTime();
         $this->assertSame($mongoDate, $type->convertToDatabaseValue($mongoDate), 'MongoDate objects are not converted');
 
         $timestamp = 100000000.123;
         $dateTime = \DateTime::createFromFormat('U.u', $timestamp);
-        $mongoDate = new \MongoDB\BSON\UTCDateTime(100000000123);
+        $mongoDate = new UTCDateTime(100000000123);
         $this->assertEquals($mongoDate, $type->convertToDatabaseValue($dateTime), 'DateTime objects are converted to MongoDate objects');
         $this->assertEquals($mongoDate, $type->convertToDatabaseValue($timestamp), 'Numeric timestamps are converted to MongoDate objects');
         $this->assertEquals($mongoDate, $type->convertToDatabaseValue('' . $timestamp), 'String dates are converted to MongoDate objects');
@@ -44,7 +51,7 @@ class DateTypeTest extends TestCase
         $type = Type::getType(Type::DATE);
 
         $timestamp = 100000000.123;
-        $mongoDate = new \MongoDB\BSON\UTCDateTime(100000000123);
+        $mongoDate = new UTCDateTime(100000000123);
 
         $dateTimeImmutable = \DateTimeImmutable::createFromFormat('U.u', $timestamp);
         $this->assertEquals($mongoDate, $type->convertToDatabaseValue($dateTimeImmutable), 'DateTimeImmutable objects are converted to MongoDate objects');
@@ -55,7 +62,7 @@ class DateTypeTest extends TestCase
         $type = Type::getType(Type::DATE);
 
         $date = new \DateTime('1900-01-01 00:00:00.123', new \DateTimeZone('UTC'));
-        $timestamp = "-2208988800.123";
+        $timestamp = '-2208988800.123';
         $this->assertEquals($type->convertToDatabaseValue($timestamp), $type->convertToDatabaseValue($date));
     }
 
@@ -71,13 +78,13 @@ class DateTypeTest extends TestCase
 
     public function provideInvalidDateValues()
     {
-        return array(
-            'array'  => array(array()),
-            'string' => array('whatever'),
-            'bool'   => array(false),
-            'object' => array(new \stdClass()),
-            'invalid string' => array('foo'),
-        );
+        return [
+            'array'  => [[]],
+            'string' => ['whatever'],
+            'bool'   => [false],
+            'object' => [new \stdClass()],
+            'invalid string' => ['foo'],
+        ];
     }
 
     /**
@@ -107,7 +114,7 @@ class DateTypeTest extends TestCase
         $type = Type::getType(Type::DATE);
         $return = null;
 
-        call_user_func(function($value) use ($type, &$return) {
+        call_user_func(function ($value) use ($type, &$return) {
             eval($type->closureToPHP());
         }, $input);
 
@@ -118,16 +125,16 @@ class DateTypeTest extends TestCase
     public function provideDatabaseToPHPValues()
     {
         $yesterday = strtotime('yesterday');
-        $mongoDate = new \MongoDB\BSON\UTCDateTime($yesterday * 1000);
+        $mongoDate = new UTCDateTime($yesterday * 1000);
         $dateTime = new \DateTime('@' . $yesterday);
 
-        return array(
-            array($dateTime, $dateTime),
-            array($mongoDate, $dateTime),
-            array($yesterday, $dateTime),
-            array(date('c', $yesterday), $dateTime),
-            array(new \MongoDB\BSON\UTCDateTime(100000000123), \DateTime::createFromFormat('U.u', '100000000.123')),
-        );
+        return [
+            [$dateTime, $dateTime],
+            [$mongoDate, $dateTime],
+            [$yesterday, $dateTime],
+            [date('c', $yesterday), $dateTime],
+            [new UTCDateTime(100000000123), \DateTime::createFromFormat('U.u', '100000000.123')],
+        ];
     }
 
     /**
@@ -136,7 +143,7 @@ class DateTypeTest extends TestCase
     public function test32bit1900Date()
     {
         if (PHP_INT_SIZE !== 4) {
-            $this->markTestSkipped("Platform is not 32-bit");
+            $this->markTestSkipped('Platform is not 32-bit');
         }
 
         $type = Type::getType(Type::DATE);
@@ -146,14 +153,14 @@ class DateTypeTest extends TestCase
     public function test64bit1900Date()
     {
         if (PHP_INT_SIZE !== 8) {
-            $this->markTestSkipped("Platform is not 64-bit");
+            $this->markTestSkipped('Platform is not 64-bit');
         }
 
         $type = Type::getType(Type::DATE);
         $return = $type->convertToDatabaseValue('1900-01-01');
 
-        $this->assertInstanceOf(\MongoDB\BSON\UTCDateTime::class, $return);
-        $this->assertEquals(new \MongoDB\BSON\UTCDateTime(strtotime('1900-01-01') * 1000), $return);
+        $this->assertInstanceOf(UTCDateTime::class, $return);
+        $this->assertEquals(new UTCDateTime(strtotime('1900-01-01') * 1000), $return);
     }
 
     private function assertTimestampEquals(\DateTime $expected, \DateTime $actual)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/IdTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/IdTypeTest.php
@@ -1,15 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Types;
 
 use Doctrine\ODM\MongoDB\Types\Type;
+use MongoDB\BSON\ObjectId;
 use PHPUnit\Framework\TestCase;
 
 class IdTypeTest extends TestCase
 {
     public function testConvertToDatabaseValue()
     {
-        $identifier = new \MongoDB\BSON\ObjectId();
+        $identifier = new ObjectId();
         $type = Type::getType('id');
 
         $this->assertNull($type->convertToDatabaseValue(null), 'null is not converted');
@@ -24,17 +27,17 @@ class IdTypeTest extends TestCase
     {
         $type = Type::getType('id');
 
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $type->convertToDatabaseValue($value));
+        $this->assertInstanceOf(ObjectId::class, $type->convertToDatabaseValue($value));
     }
 
     public function provideInvalidObjectIdConstructorArguments()
     {
-        return array(
-            'integer' => array(1),
-            'float'   => array(3.14),
-            'string'  => array('string'),
-            'bool'    => array(true),
-            'object'  => array(array('x' => 1, 'y' => 2)),
-        );
+        return [
+            'integer' => [1],
+            'float'   => [3.14],
+            'string'  => ['string'],
+            'bool'    => [true],
+            'object'  => [['x' => 1, 'y' => 2]],
+        ];
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/IdTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/IdTypeTest.php
@@ -37,7 +37,6 @@ class IdTypeTest extends TestCase
             'float'   => [3.14],
             'string'  => ['string'],
             'bool'    => [true],
-            'object'  => [['x' => 1, 'y' => 2]],
         ];
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/InvalidValueExceptionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/InvalidValueExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Types;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
@@ -1,10 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Types;
 
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Types\Type;
+use MongoDB\BSON\Binary;
+use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\Timestamp;
+use MongoDB\BSON\UTCDateTime;
+use const STR_PAD_LEFT;
+use function md5;
+use function str_pad;
+use function str_repeat;
+use function time;
 
-class TypeTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+class TypeTest extends BaseTest
 {
     /**
      * @dataProvider provideTypes
@@ -16,31 +28,31 @@ class TypeTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function provideTypes()
     {
-        return array(
-            'id' => array(Type::getType(Type::ID), "507f1f77bcf86cd799439011"),
-            'intId' => array(Type::getType(Type::INTID), 1),
-            'customId' => array(Type::getType(Type::CUSTOMID), (object) array('foo' => 'bar')),
-            'bool' => array(Type::getType(Type::BOOL), true),
-            'boolean' => array(Type::getType(Type::BOOLEAN), false),
-            'int' => array(Type::getType(Type::INT), 69),
-            'integer' => array(Type::getType(Type::INTEGER), 42),
-            'float' => array(Type::getType(Type::FLOAT), 3.14),
-            'string' => array(Type::getType(Type::STRING), 'ohai'),
-            'minKey' => array(Type::getType(Type::KEY), 0),
-            'maxKey' => array(Type::getType(Type::KEY), 1),
-            'timestamp' => array(Type::getType(Type::TIMESTAMP), time()),
-            'binData' => array(Type::getType(Type::BINDATA), 'foobarbaz'),
-            'binDataFunc' => array(Type::getType(Type::BINDATAFUNC), 'foobarbaz'),
-            'binDataByteArray' => array(Type::getType(Type::BINDATABYTEARRAY), 'foobarbaz'),
-            'binDataUuid' => array(Type::getType(Type::BINDATAUUID), "testtesttesttest"),
-            'binDataUuidRFC4122' => array(Type::getType(Type::BINDATAUUIDRFC4122), str_repeat('a', 16)),
-            'binDataMD5' => array(Type::getType(Type::BINDATAMD5), md5('ODM')),
-            'binDataCustom' => array(Type::getType(Type::BINDATACUSTOM), 'foobarbaz'),
-            'hash' => array(Type::getType(Type::HASH), array('foo' => 'bar')),
-            'collection' => array(Type::getType(Type::COLLECTION), array('foo', 'bar')),
-            'objectId' => array(Type::getType(Type::OBJECTID), "507f1f77bcf86cd799439011"),
-            'raw' => array(Type::getType(Type::RAW), (object) array('foo' => 'bar')),
-       );
+        return [
+            'id' => [Type::getType(Type::ID), '507f1f77bcf86cd799439011'],
+            'intId' => [Type::getType(Type::INTID), 1],
+            'customId' => [Type::getType(Type::CUSTOMID), (object) ['foo' => 'bar']],
+            'bool' => [Type::getType(Type::BOOL), true],
+            'boolean' => [Type::getType(Type::BOOLEAN), false],
+            'int' => [Type::getType(Type::INT), 69],
+            'integer' => [Type::getType(Type::INTEGER), 42],
+            'float' => [Type::getType(Type::FLOAT), 3.14],
+            'string' => [Type::getType(Type::STRING), 'ohai'],
+            'minKey' => [Type::getType(Type::KEY), 0],
+            'maxKey' => [Type::getType(Type::KEY), 1],
+            'timestamp' => [Type::getType(Type::TIMESTAMP), time()],
+            'binData' => [Type::getType(Type::BINDATA), 'foobarbaz'],
+            'binDataFunc' => [Type::getType(Type::BINDATAFUNC), 'foobarbaz'],
+            'binDataByteArray' => [Type::getType(Type::BINDATABYTEARRAY), 'foobarbaz'],
+            'binDataUuid' => [Type::getType(Type::BINDATAUUID), 'testtesttesttest'],
+            'binDataUuidRFC4122' => [Type::getType(Type::BINDATAUUIDRFC4122), str_repeat('a', 16)],
+            'binDataMD5' => [Type::getType(Type::BINDATAMD5), md5('ODM')],
+            'binDataCustom' => [Type::getType(Type::BINDATACUSTOM), 'foobarbaz'],
+            'hash' => [Type::getType(Type::HASH), ['foo' => 'bar']],
+            'collection' => [Type::getType(Type::COLLECTION), ['foo', 'bar']],
+            'objectId' => [Type::getType(Type::OBJECTID), '507f1f77bcf86cd799439011'],
+            'raw' => [Type::getType(Type::RAW), (object) ['foo' => 'bar']],
+        ];
     }
 
     /**
@@ -53,19 +65,19 @@ class TypeTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
     public function provideTypesForIdempotent()
     {
-        return array(
-            'id' => array(Type::getType(Type::ID), new \MongoDB\BSON\ObjectId()),
-            'date' => array(Type::getType(Type::DATE), new \MongoDB\BSON\UTCDateTime()),
-            'timestamp' => array(Type::getType(Type::TIMESTAMP), new \MongoDB\BSON\Timestamp(0, time())),
-            'binData' => array(Type::getType(Type::BINDATA), new \MongoDB\BSON\Binary('foobarbaz', \MongoDB\BSON\Binary::TYPE_GENERIC)),
-            'binDataFunc' => array(Type::getType(Type::BINDATAFUNC), new \MongoDB\BSON\Binary('foobarbaz', \MongoDB\BSON\Binary::TYPE_FUNCTION)),
-            'binDataByteArray' => array(Type::getType(Type::BINDATABYTEARRAY), new \MongoDB\BSON\Binary('foobarbaz', \MongoDB\BSON\Binary::TYPE_OLD_BINARY)),
-            'binDataUuid' => array(Type::getType(Type::BINDATAUUID), new \MongoDB\BSON\Binary("testtesttesttest", \MongoDB\BSON\Binary::TYPE_OLD_UUID)),
-            'binDataUuidRFC4122' => array(Type::getType(Type::BINDATAUUIDRFC4122), new \MongoDB\BSON\Binary(str_repeat('a', 16), \MongoDB\BSON\Binary::TYPE_UUID)),
-            'binDataMD5' => array(Type::getType(Type::BINDATAMD5), new \MongoDB\BSON\Binary(md5('ODM'), \MongoDB\BSON\Binary::TYPE_MD5)),
-            'binDataCustom' => array(Type::getType(Type::BINDATACUSTOM), new \MongoDB\BSON\Binary('foobarbaz', \MongoDB\BSON\Binary::TYPE_USER_DEFINED)),
-            'objectId' => array(Type::getType(Type::OBJECTID), new \MongoDB\BSON\ObjectId()),
-        );
+        return [
+            'id' => [Type::getType(Type::ID), new ObjectId()],
+            'date' => [Type::getType(Type::DATE), new UTCDateTime()],
+            'timestamp' => [Type::getType(Type::TIMESTAMP), new Timestamp(0, time())],
+            'binData' => [Type::getType(Type::BINDATA), new Binary('foobarbaz', Binary::TYPE_GENERIC)],
+            'binDataFunc' => [Type::getType(Type::BINDATAFUNC), new Binary('foobarbaz', Binary::TYPE_FUNCTION)],
+            'binDataByteArray' => [Type::getType(Type::BINDATABYTEARRAY), new Binary('foobarbaz', Binary::TYPE_OLD_BINARY)],
+            'binDataUuid' => [Type::getType(Type::BINDATAUUID), new Binary('testtesttesttest', Binary::TYPE_OLD_UUID)],
+            'binDataUuidRFC4122' => [Type::getType(Type::BINDATAUUIDRFC4122), new Binary(str_repeat('a', 16), Binary::TYPE_UUID)],
+            'binDataMD5' => [Type::getType(Type::BINDATAMD5), new Binary(md5('ODM'), Binary::TYPE_MD5)],
+            'binDataCustom' => [Type::getType(Type::BINDATACUSTOM), new Binary('foobarbaz', Binary::TYPE_USER_DEFINED)],
+            'objectId' => [Type::getType(Type::OBJECTID), new ObjectId()],
+        ];
     }
 
     public function testConvertDatePreservesMilliseconds()
@@ -84,6 +96,6 @@ class TypeTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
     {
         $date = new \DateTimeImmutable('now');
 
-        $this->assertInstanceOf(\MongoDB\BSON\UTCDateTime::class, Type::convertPHPToDatabaseValue($date));
+        $this->assertInstanceOf(UTCDateTime::class, Type::convertPHPToDatabaseValue($date));
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
@@ -86,7 +86,7 @@ class TypeTest extends BaseTest
         $expectedDate = clone $date;
 
         $cleanMicroseconds = (int) $date->format('v') * 1000;
-        $expectedDate->modify($date->format('H:i:s') . '.' . str_pad($cleanMicroseconds, 6, '0', STR_PAD_LEFT));
+        $expectedDate->modify($date->format('H:i:s') . '.' . str_pad((string) $cleanMicroseconds, 6, '0', STR_PAD_LEFT));
 
         $type = Type::getType(Type::DATE);
         $this->assertEquals($expectedDate, $type->convertToPHPValue($type->convertToDatabaseValue($date)));

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -305,6 +305,9 @@ class UnitOfWorkTest extends BaseTest
         $this->assertEquals([['name' => 'd'], $c, 'b.c.d'], $unitOfWork->getParentAssociation($d));
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testPreUpdateTriggeredWithEmptyChangeset()
     {
         $this->dm->getEventManager()->addEventSubscriber(

--- a/tests/Documents/Account.php
+++ b/tests/Documents/Account.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Address.php
+++ b/tests/Documents/Address.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Agent.php
+++ b/tests/Documents/Agent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Album.php
+++ b/tests/Documents/Album.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -14,7 +16,7 @@ class Album
     private $name;
 
     /** @ODM\EmbedMany(targetDocument="Song") */
-    private $songs = array();
+    private $songs = [];
 
     public function __construct($name)
     {

--- a/tests/Documents/Article.php
+++ b/tests/Documents/Article.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use function array_search;
+use function in_array;
 
 /**
  * @ODM\Document(collection="articles")
@@ -22,7 +26,7 @@ class Article
     private $createdAt;
 
     /** @ODM\Field(type="collection") */
-    private $tags = array();
+    private $tags = [];
 
     public function getId()
     {
@@ -66,8 +70,7 @@ class Article
 
     public function removeTag($tag)
     {
-        if ( ! in_array($tag, $this->tags))
-        {
+        if (! in_array($tag, $this->tags)) {
             return;
         }
         unset($this->tags[array_search($tag, $this->tags)]);

--- a/tests/Documents/Bars/Bar.php
+++ b/tests/Documents/Bars/Bar.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Bars;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -14,7 +16,7 @@ class Bar
     private $name;
 
     /** @ODM\EmbedMany(targetDocument="Documents\Bars\Location") */
-    private $locations = array();
+    private $locations = [];
 
     public function __construct($name = null)
     {
@@ -45,7 +47,7 @@ class Bar
     {
         return $this->locations;
     }
-    
+
     public function setLocations($locations)
     {
         $this->locations = $locations;

--- a/tests/Documents/Bars/Location.php
+++ b/tests/Documents/Bars/Location.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Bars;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/BaseCategory.php
+++ b/tests/Documents/BaseCategory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -8,38 +10,38 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 abstract class BaseCategory
 {
     /** @ODM\Field(type="string") */
-     protected $name;
+    protected $name;
 
      /** @ODM\EmbedMany(targetDocument="SubCategory") */
-     protected $children = array();
+    protected $children = [];
 
-     public function __construct($name = null)
-     {
-         $this->name = $name;
-     }
-    
-     public function getId()
-     {
-         return $this->id;
-     }
+    public function __construct($name = null)
+    {
+        $this->name = $name;
+    }
 
-     public function setName($name)
-     {
-         $this->name = $name;
-     }
+    public function getId()
+    {
+        return $this->id;
+    }
 
-     public function getName()
-     {
-         return $this->name;
-     }
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
 
-     public function addChild(BaseCategory $child)
-     {
-         $this->children[] = $child;
-     }
+    public function getName()
+    {
+        return $this->name;
+    }
 
-     public function getChildren()
-     {
-         return $this->children;
-     }
+    public function addChild(BaseCategory $child)
+    {
+        $this->children[] = $child;
+    }
+
+    public function getChildren()
+    {
+        return $this->children;
+    }
 }

--- a/tests/Documents/BaseCategoryRepository.php
+++ b/tests/Documents/BaseCategoryRepository.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\DocumentRepository;
 
-class BaseCategoryRepository extends DocumentRepository {}
+class BaseCategoryRepository extends DocumentRepository
+{
+}

--- a/tests/Documents/BaseDocument.php
+++ b/tests/Documents/BaseDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/BaseEmployee.php
+++ b/tests/Documents/BaseEmployee.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -14,7 +16,7 @@ abstract class BaseEmployee
     protected $changes = 0;
 
     /** @ODM\Field(type="collection") */
-    protected $notes = array();
+    protected $notes = [];
 
     /** @ODM\Field(type="string") */
     protected $name;

--- a/tests/Documents/BlogPost.php
+++ b/tests/Documents/BlogPost.php
@@ -1,9 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Documents\User;
 
 /** @ODM\Document */
 class BlogPost
@@ -15,10 +16,10 @@ class BlogPost
     public $name;
 
     /** @ODM\ReferenceMany(targetDocument="Tag", inversedBy="blogPosts", cascade={"all"}) */
-    public $tags = array();
+    public $tags = [];
 
     /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", cascade={"all"}, prime={"author"}) */
-    public $comments = array();
+    public $comments = [];
 
     /** @ODM\ReferenceOne(targetDocument="Comment", mappedBy="parent", sort={"date"="asc"}) */
     public $firstComment;
@@ -27,10 +28,10 @@ class BlogPost
     public $latestComment;
 
     /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", sort={"date"="desc"}, limit=5) */
-    public $last5Comments = array();
+    public $last5Comments = [];
 
     /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", criteria={"isByAdmin"=true}, sort={"date"="desc"}) */
-    public $adminComments = array();
+    public $adminComments = [];
 
     /** @ODM\ReferenceOne(targetDocument="Comment", mappedBy="parent", repositoryMethod="findOneComment") */
     public $repoComment;
@@ -75,7 +76,7 @@ class BlogPost
         $this->comments[] = $comment;
     }
 
-    public function setUser(User $user = null)
+    public function setUser(?User $user = null)
     {
         $this->user = $user;
     }

--- a/tests/Documents/BlogTagAggregation.php
+++ b/tests/Documents/BlogTagAggregation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Book.php
+++ b/tests/Documents/Book.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\Common\Collections\ArrayCollection;
@@ -8,7 +10,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\Document */
 class Book
 {
-    const CLASSNAME = __CLASS__;
+    public const CLASSNAME = __CLASS__;
 
     /** @ODM\Id */
     public $id;

--- a/tests/Documents/BrowseNode.php
+++ b/tests/Documents/BrowseNode.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\Document */
@@ -26,7 +29,7 @@ class BrowseNode
     public function __construct($name = null)
     {
         $this->name = $name;
-        $this->children = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->children = new ArrayCollection();
     }
 
     public function addChild(BrowseNode $child)

--- a/tests/Documents/Cart.php
+++ b/tests/Documents/Cart.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Category.php
+++ b/tests/Documents/Category.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Chapter.php
+++ b/tests/Documents/Chapter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Documents/CmsAddress.php
+++ b/tests/Documents/CmsAddress.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -37,27 +39,33 @@ class CmsAddress
      */
     public $user;
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
-    
-    public function getUser() {
+
+    public function getUser()
+    {
         return $this->user;
     }
 
-    public function getCountry() {
+    public function getCountry()
+    {
         return $this->country;
     }
 
-    public function getZipCode() {
+    public function getZipCode()
+    {
         return $this->zip;
     }
 
-    public function getCity() {
+    public function getCity()
+    {
         return $this->city;
     }
-    
-    public function setUser(CmsUser $user) {
+
+    public function setUser(CmsUser $user)
+    {
         if ($this->user !== $user) {
             $this->user = $user;
             $user->setAddress($this);

--- a/tests/Documents/CmsArticle.php
+++ b/tests/Documents/CmsArticle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -33,11 +35,13 @@ class CmsArticle
      */
     public $comments;
 
-    public function setAuthor(CmsUser $author) {
+    public function setAuthor(CmsUser $author)
+    {
         $this->user = $author;
     }
 
-    public function addComment(CmsComment $comment) {
+    public function addComment(CmsComment $comment)
+    {
         $this->comments[] = $comment;
         $comment->setArticle($this);
     }

--- a/tests/Documents/CmsComment.php
+++ b/tests/Documents/CmsComment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -32,11 +34,13 @@ class CmsComment
     /** @ODM\Field(name="ip", type="string") */
     public $authorIp;
 
-    public function setArticle(CmsArticle $article) {
+    public function setArticle(CmsArticle $article)
+    {
         $this->article = $article;
     }
 
-    public function __toString() {
-        return __CLASS__."[id=".$this->id."]";
+    public function __toString()
+    {
+        return __CLASS__ . '[id=' . $this->id . ']';
     }
 }

--- a/tests/Documents/CmsContent.php
+++ b/tests/Documents/CmsContent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/CmsGroup.php
+++ b/tests/Documents/CmsGroup.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -22,19 +24,23 @@ class CmsGroup
      */
     public $users;
 
-    public function setName($name) {
+    public function setName($name)
+    {
         $this->name = $name;
     }
 
-    public function getName() {
+    public function getName()
+    {
         return $this->name;
     }
 
-    public function addUser(CmsUser $user) {
+    public function addUser(CmsUser $user)
+    {
         $this->users[] = $user;
     }
 
-    public function getUsers() {
+    public function getUsers()
+    {
         return $this->users;
     }
 }

--- a/tests/Documents/CmsPage.php
+++ b/tests/Documents/CmsPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/CmsPhonenumber.php
+++ b/tests/Documents/CmsPhonenumber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -17,11 +19,13 @@ class CmsPhonenumber
      */
     public $user;
 
-    public function setUser(CmsUser $user) {
+    public function setUser(CmsUser $user)
+    {
         $this->user = $user;
     }
-    
-    public function getUser() {
+
+    public function getUser()
+    {
         return $this->user;
     }
 }

--- a/tests/Documents/CmsProduct.php
+++ b/tests/Documents/CmsProduct.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/CmsUser.php
+++ b/tests/Documents/CmsUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\Common\Collections\ArrayCollection;
@@ -49,58 +51,68 @@ class CmsUser
      * @ODM\ReferenceMany(targetDocument="CmsGroup", cascade={"persist", "merge"})
      */
     public $groups;
-    
-    public function __construct() {
-        $this->phonenumbers = new ArrayCollection;
-        $this->articles = new ArrayCollection;
-        $this->groups = new ArrayCollection;
+
+    public function __construct()
+    {
+        $this->phonenumbers = new ArrayCollection();
+        $this->articles = new ArrayCollection();
+        $this->groups = new ArrayCollection();
     }
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getStatus() {
+    public function getStatus()
+    {
         return $this->status;
     }
 
-    public function getUsername() {
+    public function getUsername()
+    {
         return $this->username;
     }
 
-    public function getName() {
+    public function getName()
+    {
         return $this->name;
     }
 
     /**
      * Adds a phonenumber to the user.
      *
-     * @param CmsPhonenumber $phone
      */
-    public function addPhonenumber(CmsPhonenumber $phone) {
+    public function addPhonenumber(CmsPhonenumber $phone)
+    {
         $this->phonenumbers[] = $phone;
         $phone->setUser($this);
     }
 
-    public function getPhonenumbers() {
+    public function getPhonenumbers()
+    {
         return $this->phonenumbers;
     }
 
-    public function addArticle(CmsArticle $article) {
+    public function addArticle(CmsArticle $article)
+    {
         $this->articles[] = $article;
         $article->setAuthor($this);
     }
 
-    public function addGroup(CmsGroup $group) {
+    public function addGroup(CmsGroup $group)
+    {
         $this->groups[] = $group;
         $group->addUser($this);
     }
 
-    public function getGroups() {
+    public function getGroups()
+    {
         return $this->groups;
     }
 
-    public function removePhonenumber($index) {
+    public function removePhonenumber($index)
+    {
         if (isset($this->phonenumbers[$index])) {
             $ph = $this->phonenumbers[$index];
             unset($this->phonenumbers[$index]);
@@ -109,10 +121,14 @@ class CmsUser
         }
         return false;
     }
-    
-    public function getAddress() { return $this->address; }
-    
-    public function setAddress(CmsAddress $address) {
+
+    public function getAddress()
+    {
+        return $this->address;
+    }
+
+    public function setAddress(CmsAddress $address)
+    {
         if ($this->address !== $address) {
             $this->address = $address;
             $address->setUser($this);

--- a/tests/Documents/Comment.php
+++ b/tests/Documents/Comment.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use DateTime;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\Document(repositoryClass="Documents\CommentRepository") */
 class Comment
@@ -37,5 +39,4 @@ class Comment
     {
         return $this->text;
     }
-
 }

--- a/tests/Documents/CommentRepository.php
+++ b/tests/Documents/CommentRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\DocumentRepository;

--- a/tests/Documents/CustomRepository/Document.php
+++ b/tests/Documents/CustomRepository/Document.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\CustomRepository;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -7,9 +9,10 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /**
  * @ODM\Document(repositoryClass="Documents\CustomRepository\Repository")
  */
-class Document {
-	/**
-	 * @ODM\Id
-	 */
-	protected $id;
+class Document
+{
+    /**
+     * @ODM\Id
+     */
+    protected $id;
 }

--- a/tests/Documents/CustomRepository/Repository.php
+++ b/tests/Documents/CustomRepository/Repository.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\CustomRepository;
 
 use Doctrine\ODM\MongoDB\DocumentRepository;
 
-class Repository extends DocumentRepository {}
+class Repository extends DocumentRepository
+{
+}

--- a/tests/Documents/CustomUser.php
+++ b/tests/Documents/CustomUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Customer.php
+++ b/tests/Documents/Customer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Developer.php
+++ b/tests/Documents/Developer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\Common\Collections\ArrayCollection;
@@ -26,10 +28,10 @@ class Developer
      */
     private $projects;
 
-    public function __construct($name, Collection $projects = null)
+    public function __construct($name, ?Collection $projects = null)
     {
         $this->name = $name;
-        $this->projects = null === $projects ? new ArrayCollection() : $projects;
+        $this->projects = $projects === null ? new ArrayCollection() : $projects;
     }
 
     public function getId()

--- a/tests/Documents/Ecommerce/ConfigurableProduct.php
+++ b/tests/Documents/Ecommerce/ConfigurableProduct.php
@@ -1,8 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Ecommerce;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use function array_map;
+use function array_search;
+use function in_array;
 
 /**
  * @ODM\Document
@@ -22,14 +28,14 @@ class ConfigurableProduct
     /**
      * @ODM\EmbedMany(targetDocument="Documents\Ecommerce\Option")
      */
-    protected $options = array();
+    protected $options = [];
 
     /**
      * @var Documents\Option
      */
     protected $selectedOption;
 
-    public function  __construct($name)
+    public function __construct($name)
     {
         $this->setName($name);
     }
@@ -61,12 +67,11 @@ class ConfigurableProduct
 
     /**
      * @param string|Option $name
-     * @param float|null $price
-     * @param StockItem|null $item
+     * @param float|null    $price
      */
-    public function addOption($name, $price = null, StockItem $item = null)
+    public function addOption($name, $price = null, ?StockItem $item = null)
     {
-        if ( ! $name instanceof Option) {
+        if (! $name instanceof Option) {
             $name = (string) $name;
             if (empty($name)) {
                 throw new \InvalidArgumentException('option name cannot be empty');
@@ -74,7 +79,7 @@ class ConfigurableProduct
             $name = new Option($name, $price, $item);
             unset($price, $item);
         }
-        if (null !== $this->_findOption($name->getName())
+        if ($this->_findOption($name->getName()) !== null
             || in_array($name->getStockItem(), $this->_getStockItems(), true)) {
             throw new \InvalidArgumentException('cannot add option with the same name twice');
         }
@@ -88,10 +93,10 @@ class ConfigurableProduct
 
     public function removeOption($name)
     {
-        if(null === ($option = $this->_findOption($name))) {
+        if (($option = $this->_findOption($name)) === null) {
             throw new \InvalidArgumentException('option ' . $name . ' doesn\'t exist');
         }
-        if ($this->options instanceof \Doctrine\Common\Collections\Collection) {
+        if ($this->options instanceof Collection) {
             $index = $this->options->indexOf($option);
         } else {
             $index = array_search($option, $this->options);
@@ -102,13 +107,13 @@ class ConfigurableProduct
 
     public function hasOption($name)
     {
-        return null !== $this->_findOption($name);
+        return $this->_findOption($name) !== null;
     }
 
     public function selectOption($name)
     {
         $option = $this->_findOption($name);
-        if ( ! isset($option)) {
+        if (! isset($option)) {
             throw new \InvalidArgumentException('specified option: ' . $name . ' doesn\'t exist');
         }
         $this->selectedOption = $option;
@@ -118,7 +123,7 @@ class ConfigurableProduct
     protected function _findOption($name)
     {
         foreach ($this->options as $option) {
-            if ($name == $option->getName()) {
+            if ($name === $option->getName()) {
                 return $option;
             }
         }
@@ -137,5 +142,4 @@ class ConfigurableProduct
             return $option->getStockItem();
         }, $this->getOptions());
     }
-
 }

--- a/tests/Documents/Ecommerce/Currency.php
+++ b/tests/Documents/Ecommerce/Currency.php
@@ -1,15 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Ecommerce;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use function implode;
+use function in_array;
 
 /**
  * @ODM\Document
  */
 class Currency
 {
-    const
+    public const
         USD   = 'USD',
         EURO  = 'EURO',
         JPN   = 'JPN';
@@ -32,7 +36,7 @@ class Currency
     public function __construct($name, $multiplier = 1)
     {
         $name = (string) $name;
-        if ( ! in_array($name, self::getAll())) {
+        if (! in_array($name, self::getAll())) {
             throw new \InvalidArgumentException(
                 'Currency must be one of ' . implode(', ', self::getAll()) .
                 $name . 'given'
@@ -70,10 +74,10 @@ class Currency
 
     public static function getAll()
     {
-        return array(
+        return [
             self::USD,
             self::EURO,
             self::JPN,
-        );
+        ];
     }
 }

--- a/tests/Documents/Ecommerce/Money.php
+++ b/tests/Documents/Ecommerce/Money.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Ecommerce;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Ecommerce/Option.php
+++ b/tests/Documents/Ecommerce/Option.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Ecommerce;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -32,8 +34,7 @@ class Option
 
     /**
      * @param string $name
-     * @param float $price
-     * @param StockItem $stockItem
+     * @param float  $price
      */
     public function __construct($name, Money $money, StockItem $stockItem)
     {
@@ -61,7 +62,7 @@ class Option
      */
     public function getPrice($object = false)
     {
-        if (true === $object) {
+        if ($object === true) {
             return $this->money;
         }
         return $this->money->getAmount();

--- a/tests/Documents/Ecommerce/StockItem.php
+++ b/tests/Documents/Ecommerce/StockItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Ecommerce;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -34,15 +36,15 @@ class StockItem
         return $this->id;
     }
 
-    public function  __construct($name = null, $cost = null, $inventory = null)
+    public function __construct($name = null, $cost = null, $inventory = null)
     {
-        if (null !== $name) {
+        if ($name !== null) {
             $this->setName($name);
         }
-        if (null !== $cost) {
+        if ($cost !== null) {
             $this->setCost($cost);
         }
-        if (null !== $inventory) {
+        if ($inventory !== null) {
             $this->setInventory($inventory);
         }
     }

--- a/tests/Documents/Employee.php
+++ b/tests/Documents/Employee.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Event.php
+++ b/tests/Documents/Event.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Feature.php
+++ b/tests/Documents/Feature.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/File.php
+++ b/tests/Documents/File.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/ForumAvatar.php
+++ b/tests/Documents/ForumAvatar.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/ForumUser.php
+++ b/tests/Documents/ForumUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -15,24 +17,24 @@ class ForumUser
 
     /** @ODM\ReferenceOne(targetDocument="ForumAvatar", cascade={"persist"}) */
     public $avatar;
-    
+
     public function getId()
     {
-    	return $this->id;
+        return $this->id;
     }
-    
+
     public function getUsername()
     {
-    	return $this->username;
+        return $this->username;
     }
-    
+
     public function getAvatar()
     {
-    	return $this->avatar;
+        return $this->avatar;
     }
-    
+
     public function setAvatar(ForumAvatar $avatar)
     {
-    	$this->avatar = $avatar;
+        $this->avatar = $avatar;
     }
 }

--- a/tests/Documents/FriendUser.php
+++ b/tests/Documents/FriendUser.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\Document */
@@ -26,8 +29,8 @@ class FriendUser
     public function __construct($name)
     {
         $this->name = $name;
-        $this->friendsWithMe = new \Doctrine\Common\Collections\ArrayCollection();
-        $this->myFriends = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->friendsWithMe = new ArrayCollection();
+        $this->myFriends = new ArrayCollection();
     }
 
     public function addFriend(FriendUser $user)

--- a/tests/Documents/Functional/EmbedNamed.php
+++ b/tests/Documents/Functional/EmbedNamed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/Embedded.php
+++ b/tests/Documents/Functional/Embedded.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/EmbeddedTestLevel0.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel0.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -12,5 +14,5 @@ class EmbeddedTestLevel0
     /** @ODM\Field(type="string") */
     public $name;
     /** @ODM\EmbedMany(targetDocument="EmbeddedTestLevel1") */
-    public $level1 = array();
+    public $level1 = [];
 }

--- a/tests/Documents/Functional/EmbeddedTestLevel0b.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel0b.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -14,5 +16,5 @@ class EmbeddedTestLevel0b
     /** @ODM\EmbedOne(targetDocument="EmbeddedTestLevel1") */
     public $oneLevel1;
     /** @ODM\EmbedMany(targetDocument="EmbeddedTestLevel1") */
-    public $level1 = array();
+    public $level1 = [];
 }

--- a/tests/Documents/Functional/EmbeddedTestLevel1.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel1.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -10,7 +12,7 @@ class EmbeddedTestLevel1
     /** @ODM\Field(type="string") */
     public $name;
     /** @ODM\EmbedMany(targetDocument="EmbeddedTestLevel2") */
-    public $level2 = array();
+    public $level2 = [];
 
     public $preRemove = false;
     public $postRemove = false;

--- a/tests/Documents/Functional/EmbeddedTestLevel2.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel2.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/EmbeddedWhichReferences.php
+++ b/tests/Documents/Functional/EmbeddedWhichReferences.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/FavoritesUser.php
+++ b/tests/Documents/Functional/FavoritesUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -22,10 +24,10 @@ class FavoritesUser
      *   }
      * )
      */
-    private $favorites = array();
+    private $favorites = [];
 
     /** @ODM\EmbedMany */
-    private $embedded = array();
+    private $embedded = [];
 
     /** @ODM\ReferenceOne */
     private $favorite;

--- a/tests/Documents/Functional/NotAnnotatedDocument.php
+++ b/tests/Documents/Functional/NotAnnotatedDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/NotSaved.php
+++ b/tests/Documents/Functional/NotSaved.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/NotSavedEmbedded.php
+++ b/tests/Documents/Functional/NotSavedEmbedded.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/NullFieldValues.php
+++ b/tests/Documents/Functional/NullFieldValues.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/PreUpdateTestProduct.php
+++ b/tests/Documents/Functional/PreUpdateTestProduct.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/PreUpdateTestSellable.php
+++ b/tests/Documents/Functional/PreUpdateTestSellable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/PreUpdateTestSeller.php
+++ b/tests/Documents/Functional/PreUpdateTestSeller.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/Reference.php
+++ b/tests/Documents/Functional/Reference.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/SameCollection1.php
+++ b/tests/Documents/Functional/SameCollection1.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/SameCollection2.php
+++ b/tests/Documents/Functional/SameCollection2.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/SameCollection3.php
+++ b/tests/Documents/Functional/SameCollection3.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/SimpleEmbedAndReference.php
+++ b/tests/Documents/Functional/SimpleEmbedAndReference.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -11,10 +13,10 @@ class SimpleEmbedAndReference
     public $id;
 
     /** @ODM\EmbedMany(targetDocument="Embedded") */
-    public $embedMany = array();
+    public $embedMany = [];
 
     /** @ODM\ReferenceMany(targetDocument="Reference") */
-    public $referenceMany = array();
+    public $referenceMany = [];
 
     /** @ODM\EmbedOne(targetDocument="Embedded") */
     public $embedOne;

--- a/tests/Documents/Functional/Ticket/GH683/AbstractEmbedded.php
+++ b/tests/Documents/Functional/Ticket/GH683/AbstractEmbedded.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional\Ticket\GH683;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/Ticket/GH683/EmbeddedSubDocument1.php
+++ b/tests/Documents/Functional/Ticket/GH683/EmbeddedSubDocument1.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional\Ticket\GH683;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/Ticket/GH683/EmbeddedSubDocument2.php
+++ b/tests/Documents/Functional/Ticket/GH683/EmbeddedSubDocument2.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional\Ticket\GH683;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/Ticket/GH683/ParentDocument.php
+++ b/tests/Documents/Functional/Ticket/GH683/ParentDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional\Ticket\GH683;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayCollectionLevel0.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayCollectionLevel0.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional\Ticket\MODM160;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\Document(collection="embedded_test") */
 class EmbedManyInArrayCollectionLevel0

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayCollectionLevel1.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayCollectionLevel1.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional\Ticket\MODM160;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\EmbeddedDocument */
 class EmbedManyInArrayCollectionLevel1

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayLevel0.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayLevel0.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional\Ticket\MODM160;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -12,5 +14,5 @@ class EmbedManyInArrayLevel0
     /** @ODM\Field(type="string") */
     public $name;
     /** @ODM\EmbedMany(targetDocument="EmbedManyInArrayLevel1") */
-    public $level1 = array();
+    public $level1 = [];
 }

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayLevel1.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayLevel1.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional\Ticket\MODM160;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -10,5 +12,5 @@ class EmbedManyInArrayLevel1
     /** @ODM\Field(type="string") */
     public $name;
     /** @ODM\EmbedMany(targetDocument="MODM160Level2") */
-    public $level2 = array();
+    public $level2 = [];
 }

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedOneLevel0.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedOneLevel0.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional\Ticket\MODM160;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedOneLevel1.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedOneLevel1.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional\Ticket\MODM160;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Functional/Ticket/MODM160/MODM160Level2.php
+++ b/tests/Documents/Functional/Ticket/MODM160/MODM160Level2.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional\Ticket\MODM160;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -9,6 +11,4 @@ class MODM160Level2
 {
     /** @ODM\Field(type="string") */
     public $name;
-
-
 }

--- a/tests/Documents/Functional/VirtualHost.php
+++ b/tests/Documents/Functional/VirtualHost.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -9,7 +11,6 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  */
 class VirtualHost
 {
-
     /** @ODM\Id */
     protected $id;
     /**
@@ -27,7 +28,7 @@ class VirtualHost
      */
     public function getVHostDirective()
     {
-        if (!$this->vhostDirective) {
+        if (! $this->vhostDirective) {
             $this->vhostDirective = new VirtualHostDirective('VirtualHost', '*:80');
         }
         return $this->vhostDirective;
@@ -39,6 +40,4 @@ class VirtualHost
 
         return $this;
     }
-
 }
-

--- a/tests/Documents/Functional/VirtualHostDirective.php
+++ b/tests/Documents/Functional/VirtualHostDirective.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Functional;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use function uniqid;
 
 /** @ODM\EmbeddedDocument */
 class VirtualHostDirective
@@ -19,7 +23,7 @@ class VirtualHostDirective
     protected $directives;
 
 
-    public function __construct($name='', $value='')
+    public function __construct($name = '', $value = '')
     {
         $this->name = $name;
         $this->value = $value;
@@ -35,10 +39,11 @@ class VirtualHostDirective
         return $this->recId;
     }
 
-    public function setRecId($value=null)
+    public function setRecId($value = null)
     {
-        if (!$value)
+        if (! $value) {
             $value = uniqid();
+        }
 
         $this->recId = $value;
     }
@@ -67,8 +72,9 @@ class VirtualHostDirective
 
     public function getDirectives()
     {
-        if (!$this->directives)
-            $this->directives = new \Doctrine\Common\Collections\ArrayCollection(array());
+        if (! $this->directives) {
+            $this->directives = new ArrayCollection([]);
+        }
         return $this->directives;
     }
 
@@ -94,7 +100,7 @@ class VirtualHostDirective
     public function hasDirective($name)
     {
         foreach ($this->getDirectives() as $d) {
-            if ($d->getName() == $name) {
+            if ($d->getName() === $name) {
                 return $d;
             }
         }
@@ -114,5 +120,4 @@ class VirtualHostDirective
 
         return $this;
     }
-
 }

--- a/tests/Documents/GraphLookup/Airport.php
+++ b/tests/Documents/GraphLookup/Airport.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\GraphLookup;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Documents/GraphLookup/Employee.php
+++ b/tests/Documents/GraphLookup/Employee.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\GraphLookup;
 
 use Doctrine\Common\Collections\ArrayCollection;
@@ -25,7 +27,7 @@ class Employee
     /** @ODM\ReferenceMany(targetDocument=Employee::class, mappedBy="reportsTo") */
     public $reportingEmployees;
 
-    public function __construct($name, Employee $reportsTo = null)
+    public function __construct($name, ?Employee $reportsTo = null)
     {
         $this->name = $name;
         $this->reportsTo = $reportsTo;

--- a/tests/Documents/GraphLookup/ReportingHierarchy.php
+++ b/tests/Documents/GraphLookup/ReportingHierarchy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\GraphLookup;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Documents/GraphLookup/Traveller.php
+++ b/tests/Documents/GraphLookup/Traveller.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\GraphLookup;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Group.php
+++ b/tests/Documents/Group.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/GuestServer.php
+++ b/tests/Documents/GuestServer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/IdentifiedChapter.php
+++ b/tests/Documents/IdentifiedChapter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Documents/Issue.php
+++ b/tests/Documents/Issue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Manager.php
+++ b/tests/Documents/Manager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -8,7 +10,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 class Manager extends BaseEmployee
 {
     /** @ODM\ReferenceMany(targetDocument="Documents\Project") */
-    private $projects = array();
+    private $projects = [];
 
     public function getProjects()
     {

--- a/tests/Documents/Message.php
+++ b/tests/Documents/Message.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/OtherSubProject.php
+++ b/tests/Documents/OtherSubProject.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Page.php
+++ b/tests/Documents/Page.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Phonebook.php
+++ b/tests/Documents/Phonebook.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Documents/Phonenumber.php
+++ b/tests/Documents/Phonenumber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -13,7 +15,7 @@ class Phonenumber
     /** @ODM\ReferenceOne(targetDocument="User", cascade={"persist"}) */
     private $lastCalledBy;
 
-    public function __construct($phonenumber = null, User $lastCalledBy = null)
+    public function __construct($phonenumber = null, ?User $lastCalledBy = null)
     {
         $this->phonenumber = $phonenumber;
         $this->lastCalledBy = $lastCalledBy;
@@ -34,7 +36,7 @@ class Phonenumber
         return $this->lastCalledBy;
     }
 
-    public function setLastCalledBy(User $lastCalledBy = null)
+    public function setLastCalledBy(?User $lastCalledBy = null)
     {
         $this->lastCalledBy = $lastCalledBy;
     }

--- a/tests/Documents/Product.php
+++ b/tests/Documents/Product.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\Document */
@@ -21,7 +24,7 @@ class Product
     public function __construct($name)
     {
         $this->name = $name;
-        $this->features = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->features = new ArrayCollection();
     }
 
     public function addFeature(Feature $feature)

--- a/tests/Documents/Profile.php
+++ b/tests/Documents/Profile.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/ProfileNotify.php
+++ b/tests/Documents/ProfileNotify.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\Common\Collections\ArrayCollection;
@@ -26,7 +28,7 @@ class ProfileNotify implements NotifyPropertyChanged
     private $images;
 
     /** @var PropertyChangedListener[] */
-    private $listeners = array();
+    private $listeners = [];
 
     public function __construct()
     {

--- a/tests/Documents/Project.php
+++ b/tests/Documents/Project.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\Common\Collections\ArrayCollection;
@@ -28,7 +30,7 @@ class Project
      */
     private $subProjects;
 
-    public function __construct($name, Collection $subProjects = null)
+    public function __construct($name, ?Collection $subProjects = null)
     {
         $this->name = $name;
         $this->subProjects = $subProjects ? $subProjects : new ArrayCollection();

--- a/tests/Documents/ReferenceUser.php
+++ b/tests/Documents/ReferenceUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -28,7 +30,7 @@ class ReferenceUser
      *
      * @var User[]
      */
-    public $users = array();
+    public $users = [];
 
     /**
      * @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="dbRef")
@@ -42,7 +44,7 @@ class ReferenceUser
      *
      * @var User[]
      */
-    public $parentUsers = array();
+    public $parentUsers = [];
 
     /**
      * @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="dbRefWithDb")
@@ -56,7 +58,7 @@ class ReferenceUser
      *
      * @var User[]
      */
-    public $otherUsers = array();
+    public $otherUsers = [];
 
     /**
      * @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="ref")
@@ -70,7 +72,7 @@ class ReferenceUser
      *
      * @var User[]
      */
-    public $referencedUsers = array();
+    public $referencedUsers = [];
 
     /**
      * @ODM\Field(type="string")
@@ -79,9 +81,6 @@ class ReferenceUser
      */
     public $name;
 
-    /**
-     * @param User $user
-     */
     public function setUser(User $user)
     {
         $this->user = $user;
@@ -95,9 +94,6 @@ class ReferenceUser
         return $this->user;
     }
 
-    /**
-     * @param User $user
-     */
     public function addUser(User $user)
     {
         $this->users[] = $user;
@@ -111,9 +107,6 @@ class ReferenceUser
         return $this->users;
     }
 
-    /**
-     * @param User $parentUser
-     */
     public function setParentUser(User $parentUser)
     {
         $this->parentUser = $parentUser;
@@ -127,9 +120,6 @@ class ReferenceUser
         return $this->parentUser;
     }
 
-    /**
-     * @param User $parentUser
-     */
     public function addParentUser(User $parentUser)
     {
         $this->parentUsers[] = $parentUser;
@@ -143,9 +133,6 @@ class ReferenceUser
         return $this->parentUsers;
     }
 
-    /**
-     * @param User $otherUser
-     */
     public function setOtherUser(User $otherUser)
     {
         $this->otherUser = $otherUser;
@@ -159,9 +146,6 @@ class ReferenceUser
         return $this->otherUser;
     }
 
-    /**
-     * @param User $otherUser
-     */
     public function addOtherUser(User $otherUser)
     {
         $this->otherUsers[] = $otherUser;
@@ -175,9 +159,6 @@ class ReferenceUser
         return $this->otherUsers;
     }
 
-    /**
-     * @param User $referencedUser
-     */
     public function setReferencedUser(User $referencedUser)
     {
         $this->referencedUser = $referencedUser;
@@ -191,9 +172,6 @@ class ReferenceUser
         return $this->referencedUser;
     }
 
-    /**
-     * @param User $referencedUser
-     */
     public function addReferencedUser(User $referencedUser)
     {
         $this->referencedUsers[] = $referencedUser;

--- a/tests/Documents/Server.php
+++ b/tests/Documents/Server.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Sharded/ShardedOne.php
+++ b/tests/Documents/Sharded/ShardedOne.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Sharded;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Sharded/ShardedOneWithDifferentKey.php
+++ b/tests/Documents/Sharded/ShardedOneWithDifferentKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Sharded;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Sharded/ShardedUser.php
+++ b/tests/Documents/Sharded/ShardedUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Sharded;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/SimpleReferenceUser.php
+++ b/tests/Documents/SimpleReferenceUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -16,7 +18,7 @@ class SimpleReferenceUser
     public $user;
 
     /** @ODM\ReferenceMany(targetDocument="Documents\User", storeAs="id") */
-    public $users = array();
+    public $users = [];
 
     /** @ODM\Field(type="string") */
     public $name;

--- a/tests/Documents/Song.php
+++ b/tests/Documents/Song.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/SpecialUser.php
+++ b/tests/Documents/SpecialUser.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** * @ODM\Document */
+/** @ODM\Document */
 class SpecialUser extends User
 {
     /** @ODM\Field(type="collection") */
-    private $rules = array();
+    private $rules = [];
 
     public function setRules(array $rules)
     {

--- a/tests/Documents/Strategy.php
+++ b/tests/Documents/Strategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -11,11 +13,11 @@ class Strategy
     public $id;
 
     /** @ODM\Field(type="collection") */
-    public $logs = array();
+    public $logs = [];
 
     /** @ODM\EmbedMany(targetDocument="Message", strategy="set") */
-    public $messages = array();
+    public $messages = [];
 
     /** @ODM\ReferenceMany(targetDocument="Task", strategy="set") */
-    public $tasks = array();
+    public $tasks = [];
 }

--- a/tests/Documents/SubCategory.php
+++ b/tests/Documents/SubCategory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/SubProject.php
+++ b/tests/Documents/SubProject.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\Common\Collections\Collection;

--- a/tests/Documents/Tag.php
+++ b/tests/Documents/Tag.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Task.php
+++ b/tests/Documents/Task.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Tournament/Participant.php
+++ b/tests/Documents/Tournament/Participant.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Tournament;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Tournament/ParticipantSolo.php
+++ b/tests/Documents/Tournament/ParticipantSolo.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Tournament;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Tournament/ParticipantTeam.php
+++ b/tests/Documents/Tournament/ParticipantTeam.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Tournament;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Tournament/Tournament.php
+++ b/tests/Documents/Tournament/Tournament.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Tournament;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -18,7 +20,7 @@ class Tournament
     private $name;
 
     /** @ODM\ReferenceMany(targetDocument="Participant", cascade={"all"}) */
-    protected $participants = array();
+    protected $participants = [];
 
     public function __construct($name)
     {

--- a/tests/Documents/Tournament/TournamentFootball.php
+++ b/tests/Documents/Tournament/TournamentFootball.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Tournament;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/Tournament/TournamentTennis.php
+++ b/tests/Documents/Tournament/TournamentTennis.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents\Tournament;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\Common\Collections\ArrayCollection;
@@ -87,7 +89,7 @@ class User extends BaseDocument
     protected $embeddedReferenceManyInverse;
 
     /** @ODM\Field(type="collection") */
-    private $logs = array();
+    private $logs = [];
 
     public function __construct()
     {
@@ -161,7 +163,7 @@ class User extends BaseDocument
         return $this->address;
     }
 
-    public function setAddress(Address $address = null)
+    public function setAddress(?Address $address = null)
     {
         $this->address = $address;
     }

--- a/tests/Documents/UserUpsert.php
+++ b/tests/Documents/UserUpsert.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/UserUpsertChild.php
+++ b/tests/Documents/UserUpsertChild.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/UserUpsertIdStrategyNone.php
+++ b/tests/Documents/UserUpsertIdStrategyNone.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/VersionedDocument.php
+++ b/tests/Documents/VersionedDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/Documents/VersionedUser.php
+++ b/tests/Documents/VersionedUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tests/NativePhpunitTask.php
+++ b/tests/NativePhpunitTask.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once 'PHPUnit/Framework.php';
 
 /**
@@ -18,86 +20,92 @@ class NativePhpunitTask extends Task
     private $haltonfailure = true;
     private $haltonerror = true;
 
-    public function setTestdirectory($directory) {
+    public function setTestdirectory($directory)
+    {
         $this->testdirectory = $directory;
     }
 
-    public function setTest($test) {
+    public function setTest($test)
+    {
         $this->test = $test;
     }
 
-    public function setTestfile($testfile) {
+    public function setTestfile($testfile)
+    {
         $this->testfile = $testfile;
     }
 
-    public function setJunitlogfile($junitlogfile) {
-        if (strlen($junitlogfile) == 0) {
-            $junitlogfile = NULL;
+    public function setJunitlogfile($junitlogfile)
+    {
+        if (strlen($junitlogfile) === 0) {
+            $junitlogfile = null;
         }
 
         $this->junitlogfile = $junitlogfile;
     }
 
-    public function setConfiguration($configuration) {
-        if (strlen($configuration) == 0) {
-            $configuration = NULL;
+    public function setConfiguration($configuration)
+    {
+        if (strlen($configuration) === 0) {
+            $configuration = null;
         }
 
         $this->configuration = $configuration;
     }
 
-    public function setCoverageClover($coverageClover) {
-        if (strlen($coverageClover) == 0) {
-            $coverageClover = NULL;
+    public function setCoverageClover($coverageClover)
+    {
+        if (strlen($coverageClover) === 0) {
+            $coverageClover = null;
         }
 
         $this->coverageClover = $coverageClover;
     }
 
-    public function setHaltonfailure($haltonfailures) {
+    public function setHaltonfailure($haltonfailures)
+    {
         $this->haltonfailure = $haltonfailures;
     }
 
-    public function setHaltonerror($haltonerrors) {
+    public function setHaltonerror($haltonerrors)
+    {
         $this->haltonerror = $haltonerrors;
     }
 
     public function init()
     {
-        require_once "PHPUnit/Runner/Version.php";
+        require_once 'PHPUnit/Runner/Version.php';
         $version = PHPUnit_Runner_Version::id();
 
-        if (version_compare($version, '3.4.0') < 0)
-        {
-            throw new BuildException("NativePHPUnitTask requires PHPUnit version >= 3.2.0", $this->getLocation());
+        if (version_compare($version, '3.4.0') < 0) {
+            throw new BuildException('NativePHPUnitTask requires PHPUnit version >= 3.2.0', $this->getLocation());
         }
 
         require_once 'PHPUnit/Util/Filter.php';
 
         // point PHPUnit_MAIN_METHOD define to non-existing method
-        if (!defined('PHPUnit_MAIN_METHOD'))
-        {
+        if (! defined('PHPUnit_MAIN_METHOD')) {
             define('PHPUnit_MAIN_METHOD', 'PHPUnitTask::undefined');
         }
     }
 
     public function main()
     {
-        if (!is_dir(realpath($this->testdirectory))) {
-            throw new BuildException("NativePHPUnitTask requires a Test Directory path given, '".$this->testdirectory."' given.");
+        if (! is_dir(realpath($this->testdirectory))) {
+            throw new BuildException("NativePHPUnitTask requires a Test Directory path given, '" . $this->testdirectory . "' given.");
         }
         set_include_path(realpath($this->testdirectory) . PATH_SEPARATOR . get_include_path());
 
         $printer = new NativePhpunitPrinter();
 
-        $arguments = array(
+        $arguments = [
             'configuration' => $this->configuration,
             'coverageClover' => $this->coverageClover,
             'junitLogfile' => $this->junitlogfile,
             'printer' => $printer,
-        );
+        ];
 
-        require_once "PHPUnit/TextUI/TestRunner.php";
+        require_once 'PHPUnit/TextUI/TestRunner.php';
         $runner = new PHPUnit_TextUI_TestRunner();
         $suite = $runner->getTest($this->test, $this->testfile, true);
 
@@ -105,32 +113,31 @@ class NativePhpunitTask extends Task
             $result = $runner->doRun($suite, $arguments);
             /* @var $result PHPUnit_Framework_TestResult */
 
-            if ( ($this->haltonfailure && $result->failureCount() > 0) || ($this->haltonerror && $result->errorCount() > 0) ) {
-                throw new BuildException("PHPUnit: ".$result->failureCount()." Failures and ".$result->errorCount()." Errors, ".
-                    "last failure message: ".$printer->getMessages());
+            if (($this->haltonfailure && $result->failureCount() > 0) || ($this->haltonerror && $result->errorCount() > 0)) {
+                throw new BuildException('PHPUnit: ' . $result->failureCount() . ' Failures and ' . $result->errorCount() . ' Errors, ' .
+                    'last failure message: ' . $printer->getMessages());
             }
 
-            $this->log("PHPUnit Success: ".count($result->passed())." tests passed, no ".
-                "failures (".$result->skippedCount()." skipped, ".$result->notImplementedCount()." not implemented)");
+            $this->log('PHPUnit Success: ' . count($result->passed()) . ' tests passed, no ' .
+                'failures (' . $result->skippedCount() . ' skipped, ' . $result->notImplementedCount() . ' not implemented)');
 
             // Hudson for example doesn't like the backslash in class names
             if (file_exists($this->coverageClover)) {
-                $this->log("Generated Clover Coverage XML to: ".$this->coverageClover);
+                $this->log('Generated Clover Coverage XML to: ' . $this->coverageClover);
                 $content = file_get_contents($this->coverageClover);
-                $content = str_replace("\\", ".", $content);
+                $content = str_replace('\\', '.', $content);
                 file_put_contents($this->coverageClover, $content);
                 unset($content);
             }
-
-        } catch(\Exception $e) {
-            throw new BuildException("NativePhpunitTask failed: ".$e->getMessage());
+        } catch (Throwable $e) {
+            throw new BuildException('NativePhpunitTask failed: ' . $e->getMessage());
         }
     }
 }
 
 class NativePhpunitPrinter extends PHPUnit_Util_Printer implements PHPUnit_Framework_TestListener
 {
-    private $_messages = array();
+    private $_messages = [];
 
     public function write($buffer)
     {
@@ -145,92 +152,74 @@ class NativePhpunitPrinter extends PHPUnit_Util_Printer implements PHPUnit_Frame
     /**
      * An error occurred.
      *
-     * @param  PHPUnit_Framework_Test $test
-     * @param  Exception              $e
-     * @param  float                  $time
+     * @param  Exception $e
+     * @param  float     $time
      */
-    public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addError(PHPUnit_Framework_Test $test, Throwable $e, $time)
     {
-        $this->_messages[] = "Test ERROR: ".$test->getName().": ".$e->getMessage();
+        $this->_messages[] = 'Test ERROR: ' . $test->getName() . ': ' . $e->getMessage();
     }
 
     /**
      * A failure occurred.
      *
-     * @param  PHPUnit_Framework_Test                 $test
-     * @param  PHPUnit_Framework_AssertionFailedError $e
-     * @param  float                                  $time
+     * @param  float $time
      */
     public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
     {
-        $this->_messages[] = "Test FAILED: ".$test->getName().": ".$e->getMessage();
+        $this->_messages[] = 'Test FAILED: ' . $test->getName() . ': ' . $e->getMessage();
     }
 
     /**
      * Incomplete test.
      *
-     * @param  PHPUnit_Framework_Test $test
-     * @param  Exception              $e
-     * @param  float                  $time
+     * @param  Exception $e
+     * @param  float     $time
      */
-    public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addIncompleteTest(PHPUnit_Framework_Test $test, Throwable $e, $time)
     {
-
     }
 
     /**
      * Skipped test.
      *
-     * @param  PHPUnit_Framework_Test $test
-     * @param  Exception              $e
-     * @param  float                  $time
-     * @since  Method available since Release 3.0.0
+     * @param  Exception $e
+     * @param  float     $time
      */
-    public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addSkippedTest(PHPUnit_Framework_Test $test, Throwable $e, $time)
     {
-
     }
 
     /**
      * A test suite started.
      *
-     * @param  PHPUnit_Framework_TestSuite $suite
-     * @since  Method available since Release 2.2.0
      */
     public function startTestSuite(PHPUnit_Framework_TestSuite $suite)
     {
-
     }
 
     /**
      * A test suite ended.
      *
-     * @param  PHPUnit_Framework_TestSuite $suite
-     * @since  Method available since Release 2.2.0
      */
     public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
     {
-
     }
 
     /**
      * A test started.
      *
-     * @param  PHPUnit_Framework_Test $test
      */
     public function startTest(PHPUnit_Framework_Test $test)
     {
-
     }
 
     /**
      * A test ended.
      *
-     * @param  PHPUnit_Framework_Test $test
-     * @param  float                  $time
+     * @param  float $time
      */
     public function endTest(PHPUnit_Framework_Test $test, $time)
     {
-        
     }
 }

--- a/tests/Stubs/DocumentManager.php
+++ b/tests/Stubs/DocumentManager.php
@@ -1,15 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Stubs;
 
+use Doctrine\Common\EventManager;
 use Doctrine\ODM\MongoDB\DocumentManager as BaseDocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use Doctrine\Common\EventManager;
 
 class DocumentManager extends BaseDocumentManager
 {
-
-    protected $classMetadatas = array();
+    protected $classMetadatas = [];
 
     private $_eventManager;
 
@@ -30,10 +31,9 @@ class DocumentManager extends BaseDocumentManager
 
     public function getClassMetadata($className)
     {
-        if ( ! isset($this->classMetadatas[$className])) {
+        if (! isset($this->classMetadatas[$className])) {
             throw new \InvalidArgumentException('Metadata for class ' . $className . ' doesn\'t exist, try calling ->setClassMetadata() first');
         }
         return $this->classMetadatas[$className];
     }
-
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,8 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
-if (!file_exists($file = __DIR__.'/../vendor/autoload.php')) {
+if (! file_exists($file = __DIR__ . '/../vendor/autoload.php')) {
     throw new RuntimeException('Install dependencies to run test suite.');
 }
 

--- a/tools/sandbox/Documents/Account.php
+++ b/tools/sandbox/Documents/Account.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tools/sandbox/Documents/Address.php
+++ b/tools/sandbox/Documents/Address.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tools/sandbox/Documents/Phonenumber.php
+++ b/tools/sandbox/Documents/Phonenumber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/tools/sandbox/Documents/User.php
+++ b/tools/sandbox/Documents/User.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use function md5;
 
 /** @ODM\Document(collection="users") */
 class User

--- a/tools/sandbox/Documents/UserRepository.php
+++ b/tools/sandbox/Documents/UserRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\DocumentRepository;

--- a/tools/sandbox/cli-config.php
+++ b/tools/sandbox/cli-config.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 use Doctrine\ODM\MongoDB\Tools\Console\Helper\DocumentManagerHelper;
 use Symfony\Component\Console\Helper\HelperSet;
 
 require_once __DIR__ . '/config.php';
 
-$helperSet = new HelperSet(array(
+$helperSet = new HelperSet([
     'dm' => new DocumentManagerHelper($dm),
-));
+]);

--- a/tools/sandbox/config.php
+++ b/tools/sandbox/config.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\MongoDB\Connection;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 
-if (!file_exists($file = __DIR__.'/../../vendor/autoload.php')) {
+if (! file_exists($file = __DIR__ . '/../../vendor/autoload.php')) {
     throw new RuntimeException('Install dependencies to run this script.');
 }
 

--- a/tools/sandbox/index.php
+++ b/tools/sandbox/index.php
@@ -1,10 +1,8 @@
 <?php
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/config.php';
 
-use Documents\Account;
-use Documents\Address;
-use Documents\Phonenumber;
-use Documents\User;
 
 // Your code here...

--- a/tools/sandbox/mongodb.php
+++ b/tools/sandbox/mongodb.php
@@ -1,21 +1,31 @@
 <?php
 
-require __DIR__ . '/cli-config.php';
+declare(strict_types=1);
 
-$app = new \Symfony\Component\Console\Application('Doctrine MongoDB ODM');
+require __DIR__ . '/cli-config.php';
+use Doctrine\ODM\MongoDB\Tools\Console\Command\ClearCache\MetadataCommand;
+use Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateHydratorsCommand;
+use Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateProxiesCommand;
+use Doctrine\ODM\MongoDB\Tools\Console\Command\QueryCommand;
+use Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\CreateCommand;
+use Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\DropCommand;
+use Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\UpdateCommand;
+use Symfony\Component\Console\Application;
+
+$app = new Application('Doctrine MongoDB ODM');
 
 if (isset($helperSet)) {
     $app->setHelperSet($helperSet);
 }
 
-$app->addCommands(array(
-    new \Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateHydratorsCommand(),
-    new \Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateProxiesCommand(),
-    new \Doctrine\ODM\MongoDB\Tools\Console\Command\QueryCommand(),
-    new \Doctrine\ODM\MongoDB\Tools\Console\Command\ClearCache\MetadataCommand(),
-    new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\CreateCommand(),
-    new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\DropCommand(),
-    new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\UpdateCommand(),
-));
+$app->addCommands([
+    new GenerateHydratorsCommand(),
+    new GenerateProxiesCommand(),
+    new QueryCommand(),
+    new MetadataCommand(),
+    new CreateCommand(),
+    new DropCommand(),
+    new UpdateCommand(),
+]);
 
 $app->run();


### PR DESCRIPTION
Part of #1702. To help with reviews, this PR only applies automatic fixes and disables all other sniffs for later fixing.

Note: some tests fail, these will have to be fixed. Most of them are due to strict typing.

Note: if you want to expand all diffs by default (at your own risk), you can copy the following snippet into the dev console while on the "Files changed" tab:
```
document.querySelectorAll('.load-diff-button').forEach(item => item.click())
```