### PR TITLE
Schema manager should also know how to handle shard key on reference

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -609,10 +609,26 @@ class SchemaManager
         $shardKey = $class->getShardKey();
         $adminDb = $this->dm->getConnection()->selectDatabase('admin');
 
+        $shardKeyPart = array();
+        foreach ($shardKey['keys'] as $key => $order) {
+            if ($class->hasField($key)) {
+                $mapping = $class->getFieldMapping($key);
+                $fieldName = $mapping['name'];
+
+                if ($class->isSingleValuedReference($key)) {
+                    $fieldName = ClassMetadataInfo::getReferenceFieldName($mapping['storeAs'], $fieldName);
+                }
+            } else {
+                $fieldName = $key;
+            }
+
+            $shardKeyPart[$fieldName] = $order;
+        }
+
         $result = $adminDb->command(
             array(
                 'shardCollection' => $dbName . '.' . $class->getCollection(),
-                'key'             => $shardKey['keys']
+                'key'             => $shardKeyPart,
             )
         );
 

--- a/tests/Documents/Sharded/ShardedByUser.php
+++ b/tests/Documents/Sharded/ShardedByUser.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Documents\Sharded;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document(collection="sharded.users")
+ * @ODM\ShardKey(keys={"user"="desc"})
+ */
+class ShardedByUser
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\ReferenceOne(targetDocument="Documents\Sharded\ShardedUser", name="db_user") */
+    public $user;
+}


### PR DESCRIPTION
This backports #1693 to the 1.2 branch. My initial hunch regarding field name translation was correct - this was an additional issue affecting all shard keys that have a different database name. This is also fixed in this PR.

// cc @notrix 