### PR TITLE
Fix some misspellings

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
@@ -635,8 +635,8 @@ class Expr
     }
 
     /**
-     * Searches an array for an occurence of a specified value and returns the
-     * array index (zero-based) of the first occurence. If the value is not
+     * Searches an array for an occurrence of a specified value and returns the
+     * array index (zero-based) of the first occurrence. If the value is not
      * found, returns -1.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/indexOfArray/
@@ -661,8 +661,8 @@ class Expr
     }
 
     /**
-     * Searches a string for an occurence of a substring and returns the UTF-8
-     * byte index (zero-based) of the first occurence. If the substring is not
+     * Searches a string for an occurrence of a substring and returns the UTF-8
+     * byte index (zero-based) of the first occurrence. If the substring is not
      * found, returns -1.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/indexOfBytes/
@@ -688,8 +688,8 @@ class Expr
     }
 
     /**
-     * Searches a string for an occurence of a substring and returns the UTF-8
-     * code point index (zero-based) of the first occurence. If the substring is
+     * Searches a string for an occurrence of a substring and returns the UTF-8
+     * code point index (zero-based) of the first occurrence. If the substring is
      * not found, returns -1.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/indexOfCP/

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Operator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Operator.php
@@ -542,8 +542,8 @@ abstract class Operator extends Stage
     }
 
     /**
-     * Searches an array for an occurence of a specified value and returns the
-     * array index (zero-based) of the first occurence. If the value is not
+     * Searches an array for an occurrence of a specified value and returns the
+     * array index (zero-based) of the first occurrence. If the value is not
      * found, returns -1.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/indexOfArray/
@@ -562,8 +562,8 @@ abstract class Operator extends Stage
     }
 
     /**
-     * Searches a string for an occurence of a substring and returns the UTF-8
-     * byte index (zero-based) of the first occurence. If the substring is not
+     * Searches a string for an occurrence of a substring and returns the UTF-8
+     * byte index (zero-based) of the first occurrence. If the substring is not
      * found, returns -1.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/indexOfBytes/
@@ -582,8 +582,8 @@ abstract class Operator extends Stage
     }
 
     /**
-     * Searches a string for an occurence of a substring and returns the UTF-8
-     * code point index (zero-based) of the first occurence. If the substring is
+     * Searches a string for an occurrence of a substring and returns the UTF-8
+     * code point index (zero-based) of the first occurrence. If the substring is
      * not found, returns -1.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/indexOfCP/

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataFactoryTest.php
@@ -44,7 +44,7 @@ class ClassMetadataFactoryTest extends BaseTest
         $this->assertTrue($cm1->hasField('name'));
     }
 
-    public function testHasGetMetadata_NamespaceSeperatorIsNotNormalized()
+    public function testHasGetMetadata_NamespaceSeparatorIsNotNormalized()
     {
         require_once __DIR__ . '/Documents/GlobalNamespaceDocument.php';
 


### PR DESCRIPTION
```diff
-occurence
+occurrence
```
Also a test had `Seperator` instead os `Separator`