### PR TITLE
Fix behavior of null values in upsert queries

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -329,11 +329,15 @@ class DocumentPersister
 
         foreach (array_keys($criteria) as $field) {
             unset($data['$set'][$field]);
+            unset($data['$inc'][$field]);
+            unset($data['$unset'][$field]);
         }
 
-        // Do not send an empty $set modifier
-        if (empty($data['$set'])) {
-            unset($data['$set']);
+        // Do not send an empty $set, $inc or $unset modifiers
+        foreach (['$set', '$unset', '$unset'] as $operator) {
+            if (isset($data[$operator]) && empty($data[$operator])) {
+                unset($data[$operator]);
+            }
         }
 
         /* If there are no modifiers remaining, we're upserting a document with

--- a/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
@@ -251,9 +251,12 @@ class PersistenceBuilder
                         $operator = '$set';
                         $value = $new === null ? null : Type::getType($mapping['type'])->convertToDatabaseValue($new);
                     }
-
-                    $updateData[$operator][$mapping['name']] = $value;
+                } else {
+                    $operator = '$unset';
+                    $value = true;
                 }
+
+                $updateData[$operator][$mapping['name']] = $value;
 
             // @EmbedOne
             } elseif (isset($mapping['association']) && $mapping['association'] === ClassMetadata::EMBED_ONE) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -38,7 +38,7 @@ class DocumentPersisterTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $updatedData = $this->dm->getDocumentCollection($this->class)->findOne(array('_id' => $originalData['_id']));
 
-        $this->assertEquals($originalData, $updatedData);
+        $this->assertEquals(['_id' => $originalData['_id']], $updatedData);
     }
 
     public function testExistsReturnsTrueForExistentDocuments()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1671Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1671Test.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+class GH1671Test extends \Doctrine\ODM\MongoDB\Tests\BaseTest
+{
+    public static function upsertData()
+    {
+        return [
+            'nullValueInNonNullableField' => [GH1671Document::class, null],
+            'nullValueInNullableField' => [GH1671NullableDocument::class, null],
+            'nonNullValueInNonNullableField' => [GH1671Document::class, '1'],
+        ];
+    }
+
+    /**
+     * @dataProvider upsertData
+     */
+    public function testUpsert($documentClass, $value)
+    {
+        $document = new $documentClass;
+        $document->text = "value";
+        $this->dm->persist($document);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $updateDoc = new $documentClass;
+        $updateDoc->id = $document->id;
+        $updateDoc->text = $value;
+        $this->dm->persist($updateDoc);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $dbDocument = $this->dm->getRepository($documentClass)->find($document->id);
+
+        self::assertSame($value, $dbDocument->text);
+    }
+}
+
+/** @ODM\Document */
+class GH1671Document
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\Field(type="string") */
+    public $text;
+}
+
+/** @ODM\Document */
+class GH1671NullableDocument
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\Field(type="string", nullable=true) */
+    public $text;
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php
@@ -207,7 +207,10 @@ class PersistenceBuilderTest extends BaseTest
                     '$ref' => 'CmsArticle'
                 ),
                 '_id' => new \MongoId($comment->id),
-            )
+            ),
+            '$unset' => array(
+                'ip' => true,
+            ),
         );
         $this->assertEquals($expectedData, $this->pb->prepareUpsertData($comment));
     }


### PR DESCRIPTION
Fixes #1671.

In upsert queries, `null` values were only properly handled if the field in question was marked as `nullable`. This is incorrect, as we must assume that the document state should be properly upserted to the database, which also means clearing any `null` fields from the document. To achieve this, we also use `$unset` for `null` values, as is done in insert queries.

This commit also hardens the handling of the `$inc` and `$unset` operators in upsert queries to ensure no empty operators are sent to the database. Also, any fields from the criteria of an upsert (normally only the identifier, except for sharded collections) are also excluded from any `$inc` and `$unset` operations, not only from `$set`.

Note: PR will need cherry-picking to master branch. I'll take care of that once this has been merged.