### PR TITLE
Fix upsert handling of nullable fields

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -329,11 +329,15 @@ class DocumentPersister
 
         foreach (array_keys($criteria) as $field) {
             unset($data['$set'][$field]);
+            unset($data['$inc'][$field]);
+            unset($data['$setOnInsert'][$field]);
         }
 
-        // Do not send an empty $set modifier
-        if (empty($data['$set'])) {
-            unset($data['$set']);
+        // Do not send empty update operators
+        foreach (['$set', '$inc', '$setOnInsert'] as $operator) {
+            if (empty($data[$operator])) {
+                unset($data[$operator]);
+            }
         }
 
         /* If there are no modifiers remaining, we're upserting a document with

--- a/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
@@ -243,16 +243,18 @@ class PersistenceBuilder
 
             // Scalar fields
             if ( ! isset($mapping['association'])) {
-                if ($new !== null || $mapping['nullable'] === true) {
-                    if ($new !== null && empty($mapping['id']) && isset($mapping['strategy']) && $mapping['strategy'] === ClassMetadataInfo::STORAGE_STRATEGY_INCREMENT) {
+                if ($new !== null) {
+                    if (empty($mapping['id']) && isset($mapping['strategy']) && $mapping['strategy'] === ClassMetadataInfo::STORAGE_STRATEGY_INCREMENT) {
                         $operator = '$inc';
                         $value = Type::getType($mapping['type'])->convertToDatabaseValue($new - $old);
                     } else {
                         $operator = '$set';
-                        $value = $new === null ? null : Type::getType($mapping['type'])->convertToDatabaseValue($new);
+                        $value = Type::getType($mapping['type'])->convertToDatabaseValue($new);
                     }
 
                     $updateData[$operator][$mapping['name']] = $value;
+                } elseif ($mapping['nullable'] === true) {
+                    $updateData['$setOnInsert'][$mapping['name']] = null;
                 }
 
             // @EmbedOne

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -62,6 +62,8 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals((string) $id, (string) $check['_id']);
         $this->assertEquals($group->getId(), (string) $check['groups'][0]['$id']);
         $this->assertEquals($discriminator, $check['discriminator']);
+        $this->assertArrayHasKey('nullableField', $check);
+        $this->assertNull($check['nullableField']);
 
         $group2 = new \Documents\Group('Group');
 
@@ -70,6 +72,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $user->hits = 5;
         $user->count = 2;
         $user->groups = array($group2);
+        $user->nullableField = 'foo';
         $this->dm->persist($user);
         $this->dm->flush();
         $this->dm->clear();
@@ -83,6 +86,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals($group2->getId(), (string) $check['groups'][1]['$id']);
         $this->assertArrayHasKey('username', $check);
         $this->assertEquals('test', $check['username']);
+        $this->assertEquals('foo', $check['nullableField']);
 
         $user = new $className();
         $user->id = $id;
@@ -99,6 +103,7 @@ class FunctionalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertEquals($group2->getId(), (string) $check['groups'][1]['$id']);
         $this->assertArrayHasKey('username', $check);
         $this->assertEquals('test', $check['username']);
+        $this->assertEquals('foo', $check['nullableField']);
     }
 
     public function testInheritedAssociationMappings()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php
@@ -150,7 +150,8 @@ class PersistenceBuilderTest extends BaseTest
                 '$db' => DOCTRINE_MONGODB_DATABASE,
                 '$id' => new \MongoId($article->id),
                 '$ref' => 'CmsArticle'
-            )
+            ),
+            'nullableField' => null,
         );
         $this->assertDocumentInsertData($expectedData, $this->pb->prepareInsertData($comment));
     }
@@ -175,7 +176,8 @@ class PersistenceBuilderTest extends BaseTest
                 '$db' => DOCTRINE_MONGODB_DATABASE,
                 '$id' => new \MongoId($article->id),
                 '$ref' => 'CmsArticle'
-            )
+            ),
+            'nullableField' => null,
         );
         $this->assertDocumentInsertData($expectedData, $this->pb->prepareInsertData($comment));
     }
@@ -207,6 +209,9 @@ class PersistenceBuilderTest extends BaseTest
                     '$ref' => 'CmsArticle'
                 ),
                 '_id' => new \MongoId($comment->id),
+            ),
+            '$setOnInsert' => array(
+                'nullableField' => null,
             )
         );
         $this->assertEquals($expectedData, $this->pb->prepareUpsertData($comment));

--- a/tests/Documents/CmsComment.php
+++ b/tests/Documents/CmsComment.php
@@ -32,6 +32,11 @@ class CmsComment
     /** @ODM\Field(name="ip", type="string") */
     public $authorIp;
 
+    /**
+     * @ODM\Field(type="string", nullable=true)
+     */
+    public $nullableField;
+
     public function setArticle(CmsArticle $article) {
         $this->article = $article;
     }

--- a/tests/Documents/UserUpsert.php
+++ b/tests/Documents/UserUpsert.php
@@ -29,4 +29,7 @@ class UserUpsert
 
     /** @ODM\ReferenceMany(targetDocument="Group", cascade={"all"}) */
     public $groups;
+
+    /** @ODM\Field(type="string", nullable=true) */
+    public $nullableField;
 }

--- a/tests/Documents/UserUpsertIdStrategyNone.php
+++ b/tests/Documents/UserUpsertIdStrategyNone.php
@@ -28,4 +28,7 @@ class UserUpsertIdStrategyNone
 
     /** @ODM\ReferenceMany(targetDocument="Group", cascade={"all"}) */
     public $groups;
+
+    /** @ODM\Field(type="string", nullable=true) */
+    public $nullableField;
 }


### PR DESCRIPTION
Based on the feedback on #1761, the handling for upserting fields with a null value is correct: `null` values should never overwrite pre-existing data in upsert queries, since the document being upserted is in an unknown state and we can't know for certain that the value should be unset.

This PR brings this same behavior to fields with the `nullable` attribute set, where an upsert would always overwrite database values with a `null` value: this is now only done if the upsert results in an insertion, thus preserving pre-existing data but ensuring the normal behavior of the `nullable` flag is preserved.