### PR TITLE
Fix hydration of proxy objects with lazy public properties

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -453,11 +453,15 @@ EOF
             }
         }
 
-        $data = $this->getHydratorFor($metadata->name)->hydrate($document, $data, $hints);
         if ($document instanceof Proxy) {
             $document->__isInitialized__ = true;
             $document->__setInitializer(null);
             $document->__setCloner(null);
+        }
+
+        $data = $this->getHydratorFor($metadata->name)->hydrate($document, $data, $hints);
+
+        if ($document instanceof Proxy) {
             // lazy properties may be left uninitialized
             $properties = $document->__getLazyProperties();
             foreach ($properties as $propertyName => $property) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1775Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1775Test.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class GH1775Test extends BaseTest
+{
+    public function testProxyInitializationDoesNotLoseData()
+    {
+        $image = new GH1775Image();
+        $this->dm->persist($image);
+
+        $blog = new GH1775Blog();
+        $this->dm->persist($blog);
+        $this->dm->flush();
+
+        $post1 = new GH1775Post([$blog], [$image]);
+        $this->dm->persist($post1);
+
+        $post1->addReferences();
+        $this->dm->persist($blog);
+        $this->dm->flush();
+
+        $post1Id = $post1->id;
+        $imageId = $image->id;
+        $blogId = $blog->id;
+
+        // Clear out DM and read from DB afresh
+        $this->dm->clear();
+
+        $blog = $this->dm->find(GH1775Blog::class, $blogId);
+        $image = $this->dm->find(GH1775Image::class, $imageId);
+
+        $post2 = new GH1775Post([$blog], [$image]);
+        $this->dm->persist($post2);
+
+        $post2->addReferences();
+        $this->dm->persist($blog);
+        $this->dm->flush();
+
+        // Clear out DM and read from DB afresh
+        $this->dm->clear();
+
+        $post1 = $this->dm->find(GH1775Post::class, $post1Id);
+        $blog = $this->dm->find(GH1775Blog::class, $blogId);
+
+        $this->assertCount(1, $post1->getImages());
+        $this->assertCount(2, $blog->posts);
+    }
+}
+
+/** @ODM\MappedSuperclass */
+class GH1775MetaDocument
+{
+    /** @ODM\Id */
+    public $id;
+
+    /**
+     * @var int
+     *
+     * @ODM\Field(type="int")
+     */
+    public $version = 5;
+}
+
+/** @ODM\Document */
+class GH1775Image
+{
+    /** @ODM\Id */
+    public $id;
+
+    public function __construct()
+    {
+    }
+}
+
+/** @ODM\Document */
+class GH1775Blog
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\ReferenceMany(targetDocument="GH1775Post", inversedBy="blogs") */
+    public $posts = [];
+}
+
+/** @ODM\Document */
+class GH1775Post extends GH1775MetaDocument
+{
+    /** @ODM\ReferenceMany(targetDocument="GH1775Image", simple=true) */
+    protected $images;
+
+    /** @ODM\ReferenceMany(targetDocument="GH1775Blog", mappedBy="posts") */
+    protected $blogs;
+
+    public function __construct(array $blogs, array $images)
+    {
+        $this->blogs = new ArrayCollection($blogs);
+        $this->images = new ArrayCollection($images);
+    }
+
+    function addReferences() {
+        foreach ($this->blogs as $blog) {
+            if (!$blog->posts->contains($this)) {
+                $blog->posts->add($this);
+            }
+        }
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getImages()
+    {
+        return $this->images;
+    }
+}


### PR DESCRIPTION
This pull request fixes #1775 by ensuring the proxy initializer is unset before hydration for a proxy document begins. As shown in the provided test case, this can lead to data loss if
a) a document contains public properties and is still an uninitialized proxy
b) the document contains a `many` relationship (reference or embed) which isn't changed during the process.

The data loss occurs because the hydrator sets the value of a lazy public property, triggering proxy initialization. For one, this causes an additional database read which can cause performance problems. 
Setting aside any issues due to data being changed in the database in the meantime, the document in the end will be exactly what to expect, without any issues. However, after proxy initialization is complete, the original hydration cycle for the document sets the `originalValue` for the document in UnitOfWork. This sets a different `PersistentCollection` (containing the same data internally) as `originalValue` for any `many` relationship.

The next time a change set is computed for the (initialized) proxy document, UnitOfWork compares `originalValue` and `actualValue` for the relationship. Since the instance changed, it schedules a collection deletion for the `originalValue`. However, since `actualValue` already is a `PersistentCollection` and isn't marked as `dirty` (because we didn't change anything in the collection), it won't be persisted, leaving only the collection deletion to cause some data loss.

The root issue is fixed by the changes in `HydratorFactory`, which ensures that a proxy object with public properties is not hydrated twice, removing the cause for the issue. I checked to see whether we need to apply some changes to the logic which deals with collection replacements, but I figured out that the only way we could end up with a non-dirty persistent collection in `actualValue` is if
a) a non-empty collection was replaced with an empty one; in this case the deletion without insertion is the correct course of action
b) a non-dirty persistent collection containing data was injected into a document; in this case, we won't prevent a user from shooting themselves in the foot.