### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BC_Break.md
+++ b/.github/ISSUE_TEMPLATE/BC_Break.md
@@ -1,0 +1,39 @@
+---
+name: 💥 BC Break
+about: Have you encountered an issue during upgrade? 💣
+---
+
+<!--
+Before reporting a BC break, please consult the changelog to make sure it's not an expected change.
+For 1.2: https://github.com/doctrine/mongodb-odm/blob/master/CHANGELOG-1.2.md
+For 2.0: https://github.com/doctrine/mongodb-odm/blob/master/CHANGELOG-2.0.md
+-->
+
+### BC Break Report
+
+<!-- Fill in the relevant information below to help triage your issue. -->
+
+|    Q        |   A
+|------------ | ------
+| BC Break    | yes
+| Version     | x.y.z
+
+#### Summary
+
+<!-- Provide a summary desciribing the problem you are experiencing. -->
+
+#### Previous behavior
+
+<!-- What was the previous (working) behavior? -->
+
+#### Current behavior
+
+<!-- What is the current (broken) behavior? -->
+
+#### How to reproduce
+
+<!--
+Provide steps to reproduce the BC break.
+If possible, also add a code snippet relevant configuration etc.
+Adding a failing Unit or Functional Test would help us a lot - you can submit it in a Pull Request separately, referencing this bug report.
+-->

--- a/.github/ISSUE_TEMPLATE/Bug.md
+++ b/.github/ISSUE_TEMPLATE/Bug.md
@@ -1,0 +1,34 @@
+---
+name: 🐞 Bug Report
+about: Something is broken? 🔨
+---
+
+### Bug Report
+
+<!-- Fill in the relevant information below to help triage your issue. -->
+
+|    Q        |   A
+|------------ | ------
+| BC Break    | yes/no
+| Version     | x.y.z
+
+#### Summary
+
+<!-- Provide a summary desciribing the problem you are experiencing. -->
+
+#### Current behavior
+
+<!-- What is the current (buggy) behavior? -->
+
+#### How to reproduce
+
+<!--
+Provide steps to reproduce the bug.
+If possible, also add a code snippet with relevant configuration etc.
+Adding a failing Unit or Functional Test would help us a lot - you can submit one in a Pull Request separately, referencing this bug report.
+-->
+
+#### Expected behavior
+
+<!-- What was the expected (correct) behavior? -->
+

--- a/.github/ISSUE_TEMPLATE/Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.md
@@ -1,0 +1,18 @@
+---
+name: 🎉 Feature Request
+about: You have a neat idea that should be implemented? 🎩
+---
+
+### Feature Request
+
+<!-- Fill in the relevant information below to help triage your issue. -->
+
+|    Q        |   A
+|------------ | ------
+| New Feature | yes
+| RFC         | yes/no
+| BC Break    | yes/no
+
+#### Summary
+
+<!-- Provide a summary of the feature you would like to see implemented. -->

--- a/.github/ISSUE_TEMPLATE/Support_Question.md
+++ b/.github/ISSUE_TEMPLATE/Support_Question.md
@@ -1,0 +1,20 @@
+---
+name: ❓ Support Question
+about: Have a problem that you can't figure out? 🤔
+---
+
+<!-- Fill in the relevant information below to help triage your issue. -->
+
+|    Q        |   A
+|------------ | -----
+| Version     | x.y.z
+
+<!--
+Before asking question here, please try asking on Gitter or Slack first.
+Find out more about Doctrine support channels here: https://www.doctrine-project.org/community/
+Keep in mind that GitHub is primarily an issue tracker.
+-->
+
+### Support Question
+
+<!-- Describe the issue you are facing here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+<!-- Fill in the relevant information below to help triage your pull request. -->
+
+|      Q       |   A
+|------------- | -----------
+| Type         | bug/feature
+| BC Break     | yes/no
+| Fixed issues | <!-- use #NUM format to reference an issue -->
+
+#### Summary
+
+<!-- Provide a summary your change. -->


### PR DESCRIPTION
Issue templates taken from https://github.com/doctrine/doctrine2/pull/7216.
PR templates are not working the same way (yet?) so for now I added one in _legacy_ format (` .github/PULL_REQUEST_TEMPLATE.md `).