### PR TITLE
Implicitly cascade remove operations when orphanRemoval is enabled

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2229,7 +2229,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         $class = $this->dm->getClassMetadata(get_class($document));
         foreach ($class->fieldMappings as $mapping) {
-            if ( ! $mapping['isCascadeRemove']) {
+            if ( ! $mapping['isCascadeRemove'] && ( ! isset($mapping['orphanRemoval']) || ! $mapping['orphanRemoval'])) {
                 continue;
             }
             if ($document instanceof Proxy && ! $document->__isInitialized__) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
@@ -240,6 +240,41 @@ class OrphanRemovalTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $this->assertNotNull($this->getProfileRepository()->find($profile->id), 'Profile 1 should not have been removed');
     }
 
+    public function testOrphanRemovalOnRemoveWithoutCascade()
+    {
+        $profile1 = new OrphanRemovalProfile();
+        $user = new OrphanRemovalUser();
+        $user->profile = $profile1;
+        $this->dm->persist($user);
+        $this->dm->persist($user->profile);
+        $this->dm->flush();
+
+        $this->dm->remove($user);
+        $this->dm->flush();
+
+        $this->assertNull($this->getProfileRepository()->find($profile1->id), 'Profile 1 should have been removed');
+    }
+
+    public function testOrphanRemovalReferenceManyOnRemoveWithoutCascade()
+    {
+        $profile1 = new OrphanRemovalProfile();
+        $profile2 = new OrphanRemovalProfile();
+
+        $user = new OrphanRemovalUser();
+        $user->profileMany[] = $profile1;
+        $user->profileMany[] = $profile2;
+        $this->dm->persist($user);
+        $this->dm->persist($profile1);
+        $this->dm->persist($profile2);
+        $this->dm->flush();
+
+        $this->dm->remove($user);
+        $this->dm->flush();
+
+        $this->assertNull($this->getProfileRepository()->find($profile1->id), 'Profile 1 should have been removed');
+        $this->assertNull($this->getProfileRepository()->find($profile2->id), 'Profile 2 should have been removed');
+    }
+
     /**
      * @return \Doctrine\ODM\MongoDB\DocumentRepository
      */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

#### Summary

When `orphanRemoval` is enabled on a reference, the referenced object is removed as soon as it no longer belongs to a parent. However, this also means that it needs to be dropped when the parent no longer exists. This is normally achieved by cascading `remove` operations in the reference mapping, but in case if `orphanRemoval` is set, we need to implicitly assume that remove operations need to be cascaded to the referenced object.