### PR TITLE
Fix querying fields in reference structures

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1222,7 +1222,15 @@ class DocumentPersister
                 ? $this->dm->getClassMetadata($targetMapping['targetDocument'])
                 : null;
 
-            $fieldNames = $this->prepareQueryElement($nextObjectProperty, $value, $nextTargetClass, $prepareValue);
+            if (empty($targetMapping['reference'])) {
+                $fieldNames = $this->prepareQueryElement($nextObjectProperty, $value, $nextTargetClass, $prepareValue);
+            } else {
+                // No recursive processing for references as most probably somebody is querying DBRef or alike
+                if ($nextObjectProperty[0] !== '$' && in_array($targetMapping['storeAs'], [ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF_WITH_DB, ClassMetadataInfo::REFERENCE_STORE_AS_DB_REF])) {
+                    $nextObjectProperty = '$' . $nextObjectProperty;
+                }
+                $fieldNames = [[$nextObjectProperty, $value]];
+            }
 
             return array_map(function ($preparedTuple) use ($fieldName) {
                 list($key, $value) = $preparedTuple;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
@@ -6,7 +6,10 @@ use Documents\Article;
 use Documents\Account;
 use Documents\Address;
 use Documents\CmsComment;
+use Documents\Group;
+use Documents\IndirectlyReferencedUser;
 use Documents\Phonenumber;
+use Documents\ReferenceUser;
 use Documents\User;
 
 class QueryTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
@@ -368,6 +371,35 @@ class QueryTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
         $query = $qb->getQuery();
         $user2 = $query->getSingleResult();
         $this->assertSame($user, $user2);
+    }
+
+    public function testNestedQueryReference()
+    {
+        $referencedUser = new User();
+        $referencedUser->setUsername('boo');
+        $phonenumber = new Phonenumber('6155139185');
+        $referencedUser->addPhonenumber($phonenumber);
+
+        $indirectlyReferencedUser = new IndirectlyReferencedUser();
+        $indirectlyReferencedUser->user = $referencedUser;
+
+        $user = new ReferenceUser();
+        $user->indirectlyReferencedUsers[] = $indirectlyReferencedUser;
+
+        $this->dm->persist($referencedUser);
+        $this->dm->persist($user);
+        $this->dm->flush();
+
+        $qb = $this->dm->createQueryBuilder('Documents\ReferenceUser');
+
+        $referencedUsersQuery = $qb
+            ->field('indirectlyReferencedUsers.user.id')->equals(new \MongoId($referencedUser->getId()))
+            ->getQuery();
+
+        $referencedUsers = iterator_to_array($referencedUsersQuery->execute(), false);
+
+        $this->assertCount(1, $referencedUsers);
+        $this->assertSame($user, $referencedUsers[0]);
     }
 
     public function testQueryWhereIn()

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -285,8 +285,22 @@ class QueryTest extends BaseTest
         $query = $qb->getQuery();
         $debug = $query->debug('query');
 
-        $this->assertArrayHasKey('eO.eO.e1.eO.eP.pO._id', $debug);
-        $this->assertEquals($mongoId, $debug['eO.eO.e1.eO.eP.pO._id']);
+        $this->assertArrayHasKey('eO.eO.e1.eO.eP.pO.$id', $debug);
+        $this->assertEquals($mongoId, $debug['eO.eO.e1.eO.eP.pO.$id']);
+    }
+
+    public function testQueryWithMultipleEmbeddedDocumentsAndReferenceUsingDollarSign()
+    {
+        $mongoId = new \MongoId();
+
+        $qb = $this->dm->createQueryBuilder(__NAMESPACE__.'\EmbedTest')
+            ->find()
+            ->field('embeddedOne.embeddedOne.embeddedMany.embeddedOne.pet.owner.$id')->equals((string) $mongoId);
+        $query = $qb->getQuery();
+        $debug = $query->debug('query');
+
+        $this->assertArrayHasKey('eO.eO.e1.eO.eP.pO.$id', $debug);
+        $this->assertEquals($mongoId, $debug['eO.eO.e1.eO.eP.pO.$id']);
     }
 
     public function testSelectVsSingleCollectionInheritance()

--- a/tests/Documents/IndirectlyReferencedUser.php
+++ b/tests/Documents/IndirectlyReferencedUser.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class IndirectlyReferencedUser
+{
+
+    /**
+     * @var User
+     *
+     * @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="ref")
+     */
+    public $user;
+}

--- a/tests/Documents/ReferenceUser.php
+++ b/tests/Documents/ReferenceUser.php
@@ -73,6 +73,13 @@ class ReferenceUser
     public $referencedUsers = array();
 
     /**
+     * @ODM\EmbedMany(targetDocument="Documents\IndirectlyReferencedUser")
+     *
+     * @var IndirectlyReferencedUser[]
+     */
+    public $indirectlyReferencedUsers = array();
+
+    /**
      * @ODM\Field(type="string")
      *
      * @var string


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1723

#### Summary

While fixing #1723 it turned out that querying any reference-structure is producing wrong query (like `_id` instead of `$id` in a `DBRef` object). This should be fixed now, at least when references are in embedded documents.
