### PR TITLE
[2.0] Separate ID mapping from fields in XML driver

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -234,7 +234,7 @@ Here is an example:
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
           <document name="Documents\User">
-                <field fieldName="id" id="true" />
+            <id />
           </document>
         </doctrine-mongo-mapping>
 
@@ -278,7 +278,7 @@ Here is an example how to manually set a string identifier for your documents:
                                                     http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
             <document name="MyPersistentClass">
-                <field name="id" id="true" strategy="NONE" type="string" />
+                <id strategy="NONE" type="string" />
             </document>
         </doctrine-mongo-mapping>
 
@@ -337,9 +337,9 @@ as an option for the ``CUSTOM`` strategy:
                                                     http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
             <document name="MyPersistentClass">
-                <field name="id" id="true" strategy="CUSTOM" type="string">
-                    <id-generator-option name="class" value="Vendor\Specific\Generator" />
-                </field>
+                <id strategy="CUSTOM" type="string">
+                    <generator-option name="class" value="Vendor\Specific\Generator" />
+                </id>
             </document>
         </doctrine-mongo-mapping>
 
@@ -380,7 +380,7 @@ Example:
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
           <document name="Documents\User">
-                <field fieldName="id" id="true" />
+                <id />
                 <field fieldName="username" type="string" />
           </document>
         </doctrine-mongo-mapping>

--- a/docs/en/reference/capped-collections.rst
+++ b/docs/en/reference/capped-collections.rst
@@ -47,7 +47,7 @@ the ``@Document`` annotation:
                           xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                           http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
             <document name="Documents\Category" collection="collname" capped-collection="true" capped-collection-size="100000" capped-collection-max="1000">
-                <field fieldName="id" id="true" />
+                <id />
                 <field fieldName="name" type="string" />
             </document>
         </doctrine-mongo-mapping>

--- a/docs/en/reference/xml-mapping.rst
+++ b/docs/en/reference/xml-mapping.rst
@@ -109,7 +109,7 @@ of several common elements:
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
         <document name="Documents\User" db="documents" collection="users">
-            <field fieldName="id" id="true" />
+            <id />
             <field fieldName="username" name="login" type="string" />
             <field fieldName="email" type="string" unique="true" order="desc" />
             <field fieldName="createdAt" type="date" />
@@ -156,7 +156,7 @@ Lock
 ^^^^
 
 The field with the ``lock`` attribute will be used to store lock information for :ref:`pessimistic locking <transactions_and_concurrency_pessimistic_locking>`.
-This is only compatible with the ``int`` field type, and cannot be combined with ``id="true"``.
+This is only compatible with the ``int`` field type.
 
 .. code-block:: xml
 
@@ -170,7 +170,7 @@ Version
 ^^^^^^^
 
 The field with the ``version`` attribute will be used to store version information for :ref:`optimistic locking <transactions_and_concurrency_optimistic_locking>`.
-This is only compatible with ``int`` and ``date`` field types, and cannot be combined with ``id="true"``.
+This is only compatible with ``int`` and ``date`` field types.
 
 .. code-block:: xml
 

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -114,7 +114,7 @@ You can provide your mapping information in Annotations or XML:
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
           <document name="Documents\User">
-                <field fieldName="id" id="true" />
+                <id />
                 <field fieldName="name" type="string" />
                 <field fieldName="email" type="string" />
                 <reference-many fieldName="posts" targetDocument="Documents\BlogPost">
@@ -131,7 +131,7 @@ You can provide your mapping information in Annotations or XML:
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
           <document name="Documents\BlogPost">
-                <field fieldName="id" id="true" />
+                <id />
                 <field fieldName="title" type="string" />
                 <field fieldName="body" type="string" />
                 <field fieldName="createdAt" type="date" />

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -37,6 +37,7 @@
 
   <xs:complexType name="document">
     <xs:sequence>
+      <xs:element name="id" type="odm:id" minOccurs="0" maxOccurs="1"/>
       <xs:element name="field" type="odm:field" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="embed-one" type="odm:embed-one" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="embed-many" type="odm:embed-many" minOccurs="0" maxOccurs="unbounded"/>
@@ -72,10 +73,6 @@
   </xs:complexType>
 
   <xs:complexType name="field">
-    <xs:sequence>
-      <xs:element name="id-generator-option" type="odm:id-generator-option" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
-    <xs:attribute name="id" type="xs:boolean" default="false" />
     <xs:attribute name="name" type="xs:NMTOKEN" />
     <xs:attribute name="type" type="xs:NMTOKEN" />
     <xs:attribute name="strategy" type="xs:NMTOKEN" default="set" />
@@ -95,6 +92,15 @@
     <xs:attribute name="order" type="xs:NMTOKEN" />
     <xs:attribute name="sparse" type="xs:boolean" />
     <xs:attribute name="unique" type="xs:boolean" />
+  </xs:complexType>
+
+  <xs:complexType name="id">
+    <xs:sequence>
+      <xs:element name="generator-option" type="odm:id-generator-option" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:attribute name="type" type="xs:NMTOKEN" />
+    <xs:attribute name="strategy" type="xs:NMTOKEN" default="auto" />
+    <xs:attribute name="fieldName" type="xs:NMTOKEN" default="id" />
   </xs:complexType>
 
   <xs:complexType name="id-generator-option">

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH774/Doctrine.ODM.MongoDB.Tests.GH774AbstractThread.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH774/Doctrine.ODM.MongoDB.Tests.GH774AbstractThread.dcm.xml
@@ -4,9 +4,9 @@
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-    <mapped-superclass name="Doctrine\ODM\MongoDB\Tests\GH774AbstractThread" collection="threads" customId="true">
+    <mapped-superclass name="Doctrine\ODM\MongoDB\Tests\GH774AbstractThread" collection="threads">
 
-        <field name="id" type="string" id="true" strategy="NONE" />
+        <id type="string" strategy="NONE" />
 
         <field name="permalink" type="string" />
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.InvalidPartialFilterDocument.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.InvalidPartialFilterDocument.dcm.xml
@@ -6,7 +6,7 @@
                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <document name="TestDocuments\InvalidPartialFilterDocument" db="documents" collection="partialFilterDocument">
-        <field name="id" id="true" />
+        <id />
         <indexes>
             <index>
                 <key name="fieldA" order="asc" />

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.PartialFilterDocument.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.PartialFilterDocument.dcm.xml
@@ -6,7 +6,7 @@
                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <document name="TestDocuments\PartialFilterDocument" db="documents" collection="partialFilterDocument">
-        <field name="id" id="true" />
+        <id />
         <indexes>
             <index>
                 <key name="fieldA" order="asc" />

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.PrimedCollectionDocument.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.PrimedCollectionDocument.dcm.xml
@@ -6,7 +6,7 @@
                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <document name="TestDocuments\PrimedCollectionDocument" collection="primed_collection">
-        <field name="id" id="true" />
+        <id />
 
         <reference-many target-document="TestDocuments\PrimedCollectionDocument" field="references" />
         <reference-many target-document="TestDocuments\PrimedCollectionDocument" field="inverseMappedBy" mapped-by="references">

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.User.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.User.dcm.xml
@@ -6,7 +6,7 @@
                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <document name="TestDocuments\User" db="documents" collection="users">
-        <field name="id" id="true" />
+        <id />
         <field name="username" type="string" unique="true" sparse="true"/>
         <field name="createdAt" type="date" />
         <field name="tags" type="collection" />

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.UserCustomIdGenerator.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.UserCustomIdGenerator.dcm.xml
@@ -6,9 +6,9 @@
                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <document name="TestDocuments\UserCustomIdGenerator" db="documents" collection="users">
-        <field name="id" id="true" strategy="custom">
-            <id-generator-option name="class" value="TestDocuments\CustomIdGenerator"/>
-            <id-generator-option name="someOption" value="some-option"/>
-        </field>
+        <id strategy="custom">
+            <generator-option name="class" value="TestDocuments\CustomIdGenerator"/>
+            <generator-option name="someOption" value="some-option"/>
+        </id>
     </document>
 </doctrine-mongo-mapping>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.UserNonStringOptions.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.UserNonStringOptions.dcm.xml
@@ -6,7 +6,7 @@
                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <document name="TestDocuments\UserNonStringOptions">
-        <field name="id" id="true" />
+        <id />
         <reference-one target-document="Documents\Profile" field="profile" store-as="id" orphan-removal="true" />
         <reference-many target-document="Documents\Group" field="groups" orphan-removal="" limit="0" skip="2" />
     </document>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
@@ -20,7 +20,7 @@
             </tag-set>
             <tag-set />
         </read-preference>
-        <field fieldName="id" id="true" />
+        <id fieldName="id" />
         <field fieldName="version" version="true" type="int" />
         <field fieldName="lock" lock="true" type="int" />
         <field fieldName="name" name="username" type="string" />


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | #1806 

#### Summary

This PR extracts identifier options from the `field` tag in the XML mapping and moves it to a new `id` field. This is done to make it easier to map identifiers and to have fewer incompatibilities to take care of (e.g. it doesn't make sense to specify generator options on non-identifier fields and identifiers can't take many of the options available to regular fields). It also brings identifier mappings more in-line with what we're planning to do with GridFS fields (see #1790).

Note: this change needs to be backported to 1.3, along with a deprecation warning about `id="true"` being removed in 2.0.