### PR TITLE
 [2.0] Drop namespace property from ClassMetadata

### DIFF
--- a/UPGRADE-1.2.md
+++ b/UPGRADE-1.2.md
@@ -170,7 +170,7 @@ to a regular document:
 /** @QueryResultDocument */
 class UserPurchases
 {
-    /** @ReferenceOne(targetDocument="User", name="_id") */
+    /** @ReferenceOne(targetDocument=User::class, name="_id") */
     private $user;
 
     /** @Field(type="int") */

--- a/docs/en/cookbook/simple-search-engine.rst
+++ b/docs/en/cookbook/simple-search-engine.rst
@@ -148,7 +148,7 @@ Now you can embed the ``Keyword`` document many times in the ``Product``:
     {
         // ...
 
-        /** @EmbedMany(targetDocument="Keyword") */
+        /** @EmbedMany(targetDocument=Keyword::class) */
         private $keywords;
 
         // ...

--- a/docs/en/reference/aggregation-builder.rst
+++ b/docs/en/reference/aggregation-builder.rst
@@ -134,7 +134,7 @@ they can't be persisted to the database.
         /** @QueryResultDocument */
         class UserPurchases
         {
-            /** @ReferenceOne(targetDocument="User", name="_id") */
+            /** @ReferenceOne(targetDocument=User::class, name="_id") */
             private $user;
 
             /** @Field(type="int") */

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -306,7 +306,7 @@ to be stored within an `@EmbedOne`_ or `@EmbedMany`_ relationship.
     /** @Document(db="finance", collection="wallets") */
     class Wallet
     {
-        /** @EmbedOne(targetDocument="Money") */
+        /** @EmbedOne(targetDocument=Money::class) */
         private $money;
 
         public function setMoney(Money $money)

--- a/docs/en/reference/bidirectional-references.rst
+++ b/docs/en/reference/bidirectional-references.rst
@@ -14,7 +14,7 @@ and changes are tracked and persisted separately. Here is an example:
     {
         // ...
 
-        /** @ReferenceOne(targetDocument="User") */
+        /** @ReferenceOne(targetDocument=User::class) */
         private $user;
     }
 
@@ -23,7 +23,7 @@ and changes are tracked and persisted separately. Here is an example:
     {
         // ...
 
-        /** @ReferenceMany(targetDocument="BlogPost") */
+        /** @ReferenceMany(targetDocument=BlogPost::class) */
         private $posts;
     }
 
@@ -56,7 +56,7 @@ One to Many
     {
         // ...
 
-        /** @ReferenceOne(targetDocument="User", inversedBy="posts") */
+        /** @ReferenceOne(targetDocument=User::class, inversedBy="posts") */
         private $user;
     }
 
@@ -65,7 +65,7 @@ One to Many
     {
         // ...
 
-        /** @ReferenceMany(targetDocument="BlogPost", mappedBy="user") */
+        /** @ReferenceMany(targetDocument=BlogPost::class, mappedBy="user") */
         private $posts;
     }
 
@@ -136,7 +136,7 @@ Here is an example where we have a one to one relationship between ``Cart`` and 
         // ...
 
         /**
-         * @ReferenceOne(targetDocument="Customer", inversedBy="cart")
+         * @ReferenceOne(targetDocument=Customer::class, inversedBy="cart")
          */
         public $customer;
     }
@@ -147,7 +147,7 @@ Here is an example where we have a one to one relationship between ``Cart`` and 
         // ...
 
         /**
-         * @ReferenceOne(targetDocument="Cart", mappedBy="customer")
+         * @ReferenceOne(targetDocument=Cart::class, mappedBy="customer")
          */
         public $cart;
     }
@@ -192,12 +192,12 @@ Self-Referencing Many to Many
         // ...
 
         /**
-         * @ReferenceMany(targetDocument="User", mappedBy="myFriends")
+         * @ReferenceMany(targetDocument=User::class, mappedBy="myFriends")
          */
         public $friendsWithMe;
 
         /**
-         * @ReferenceMany(targetDocument="User", inversedBy="friendsWithMe")
+         * @ReferenceMany(targetDocument=User::class, inversedBy="friendsWithMe")
          */
         public $myFriends;
 

--- a/docs/en/reference/complex-references.rst
+++ b/docs/en/reference/complex-references.rst
@@ -35,12 +35,12 @@ querying by the BlogPost's ID.
     {
         // ...
 
-        /** @ReferenceMany(targetDocument="Comment", mappedBy="blogPost") */
+        /** @ReferenceMany(targetDocument=Comment::class, mappedBy="blogPost") */
         private $comments;
 
         /**
          * @ReferenceMany(
-         *      targetDocument="Comment",
+         *      targetDocument=Comment::class,
          *      mappedBy="blogPost",
          *      sort={"date"="desc"},
          *      limit=5
@@ -54,7 +54,7 @@ querying by the BlogPost's ID.
     {
         // ...
 
-        /** @ReferenceOne(targetDocument="BlogPost", inversedBy="comments") */
+        /** @ReferenceOne(targetDocument=BlogPost::class, inversedBy="comments") */
         private $blogPost;
     }
 
@@ -67,7 +67,7 @@ following example:
 
     /**
      * @ReferenceOne(
-     *      targetDocument="Comment",
+     *      targetDocument=Comment::class,
      *      mappedBy="blogPost",
      *      sort={"date"="desc"}
      * )
@@ -87,7 +87,7 @@ administrators:
 
     /**
      * @ReferenceMany(
-     *      targetDocument="Comment",
+     *      targetDocument=Comment::class,
      *      mappedBy="blogPost",
      *      criteria={"isByAdmin" : true}
      * )
@@ -106,7 +106,7 @@ call on the Comment repository class to populate the reference.
 
     /**
      * @ReferenceMany(
-     *      targetDocument="Comment",
+     *      targetDocument=Comment::class,
      *      mappedBy="blogPost",
      *      repositoryMethod="findSomeComments"
      * )

--- a/docs/en/reference/custom-collections.rst
+++ b/docs/en/reference/custom-collections.rst
@@ -23,7 +23,7 @@ persistence-related features.
         // ...
 
         /**
-         * @EmbedMany(targetDocument="Section")
+         * @EmbedMany(targetDocument=Section::class)
          */
         private $sections;
 
@@ -65,8 +65,8 @@ and ensuring that your custom class is initialized in the owning class' construc
 
         /**
          * @EmbedMany(
-         *  collectionClass="SectionCollection"
-         *  targetDocument="Section"
+         *  collectionClass=SectionCollection::class
+         *  targetDocument=Section::class
          * )
          */
         private $sections;

--- a/docs/en/reference/embedded-mapping.rst
+++ b/docs/en/reference/embedded-mapping.rst
@@ -22,7 +22,7 @@ Embed a single document:
         {
             // ...
 
-            /** @EmbedOne(targetDocument="Address") */
+            /** @EmbedOne(targetDocument=Address::class) */
             private $address;
 
             // ...
@@ -64,7 +64,7 @@ Embed many documents:
         {
             // ...
 
-            /** @EmbedMany(targetDocument="Phonenumber") */
+            /** @EmbedMany(targetDocument=Phonenumber::class) */
             private $phonenumbers = array();
 
             // ...

--- a/docs/en/reference/geospatial-queries.rst
+++ b/docs/en/reference/geospatial-queries.rst
@@ -27,7 +27,7 @@ First, setup some documents like the following:
             /** @Field(type="string") */
             public $name;
 
-            /** @EmbedOne(targetDocument="Coordinates") */
+            /** @EmbedOne(targetDocument=Coordinates::class) */
             public $coordinates;
         }
 

--- a/docs/en/reference/indexes.rst
+++ b/docs/en/reference/indexes.rst
@@ -253,7 +253,7 @@ Now if we had a ``BlogPost`` document with the ``Comment`` document embedded man
         /** @Field(type="string") @Index */
         private $slug;
 
-        /** @EmbedMany(targetDocument="Comment") */
+        /** @EmbedMany(targetDocument=Comment::class) */
         private $comments;
     }
 
@@ -308,7 +308,7 @@ options structures manually:
             /** @Id */
             public $id;
 
-            /** @EmbedOne(targetDocument="Coordinates") */
+            /** @EmbedOne(targetDocument=Coordinates::class) */
             public $coordinates;
         }
 

--- a/docs/en/reference/introduction.rst
+++ b/docs/en/reference/introduction.rst
@@ -52,7 +52,7 @@ Here is a quick example of some PHP object documents that demonstrates a few of 
         /** @ODM\Field(type="date") */
         private $left;
 
-        /** @ODM\EmbedOne(targetDocument="Address") */
+        /** @ODM\EmbedOne(targetDocument=Address::class) */
         private $address;
 
         public function getId(): ?string { return $this->id; }
@@ -82,7 +82,7 @@ Here is a quick example of some PHP object documents that demonstrates a few of 
     /** @ODM\Document */
     class Employee extends BaseEmployee
     {
-        /** @ODM\ReferenceOne(targetDocument="Documents\Manager") */
+        /** @ODM\ReferenceOne(targetDocument=Manager::class) */
         private $manager;
 
         public function getManager(): ?Manager { return $this->manager; }
@@ -92,7 +92,7 @@ Here is a quick example of some PHP object documents that demonstrates a few of 
     /** @ODM\Document */
     class Manager extends BaseEmployee
     {
-        /** @ODM\ReferenceMany(targetDocument="Documents\Project") */
+        /** @ODM\ReferenceMany(targetDocument=Project::class) */
         private $projects;
 
         public __construct() { $this->projects = new ArrayCollection(); }

--- a/docs/en/reference/map-reduce.rst
+++ b/docs/en/reference/map-reduce.rst
@@ -29,7 +29,7 @@ named ``Event`` and it was related to a ``User`` document:
         /** @Id */
         private $id;
 
-        /** @ReferenceOne(targetDocument="Documents\User") */
+        /** @ReferenceOne(targetDocument=User::class) */
         private $user;
 
         /** @Field(type="string") */

--- a/docs/en/reference/migrating-schemas.rst
+++ b/docs/en/reference/migrating-schemas.rst
@@ -172,7 +172,7 @@ Later on, you may want to migrate this data into an embedded Address document:
         /** @NotSaved */
         public $city;
 
-        /** @EmbedOne(targetDocument="Address") */
+        /** @EmbedOne(targetDocument=Address::class) */
         public $address;
 
         /** @PostLoad */

--- a/docs/en/reference/priming-references.rst
+++ b/docs/en/reference/priming-references.rst
@@ -18,7 +18,7 @@ Consider the following abbreviated model:
     /** @Document */
     class User
     {
-        /** @ReferenceMany(targetDocument="Account") */
+        /** @ReferenceMany(targetDocument=Account::class) */
         private $accounts;
     }
 
@@ -111,7 +111,7 @@ specifying them in the mapping:
     /** @Document */
     class User
     {
-        /** @ReferenceMany(targetDocument="Account", prime={"user"}) */
+        /** @ReferenceMany(targetDocument=Account::class, prime={"user"}) */
         private $accounts;
     }
 

--- a/docs/en/reference/reference-mapping.rst
+++ b/docs/en/reference/reference-mapping.rst
@@ -53,7 +53,7 @@ Reference one document:
             // ...
 
             /**
-             * @ReferenceOne(targetDocument="Shipping")
+             * @ReferenceOne(targetDocument=Shipping::class)
              */
             private $shipping;
 
@@ -97,7 +97,7 @@ Reference many documents:
             // ...
 
             /**
-             * @ReferenceMany(targetDocument="Account")
+             * @ReferenceMany(targetDocument=Account::class)
              */
             private $accounts = array();
 
@@ -286,7 +286,7 @@ Example:
         <?php
 
         /**
-         * @ReferenceOne(targetDocument="Profile", storeAs="id")
+         * @ReferenceOne(targetDocument=Profile::class, storeAs="id")
          */
         private $profile;
 
@@ -334,7 +334,7 @@ referenced documents. You must explicitly enable this functionality:
         <?php
 
         /**
-         * @ReferenceOne(targetDocument="Profile", cascade={"persist"})
+         * @ReferenceOne(targetDocument=Profile::class, cascade={"persist"})
          */
         private $profile;
 
@@ -391,10 +391,10 @@ and StandingData:
         /** @Id */
         private $id;
 
-        /** @ReferenceOne(targetDocument="StandingData", orphanRemoval=true) */
+        /** @ReferenceOne(targetDocument=StandingData::class, orphanRemoval=true) */
         private $standingData;
 
-        /** @ReferenceMany(targetDocument="Address", mappedBy="contact", orphanRemoval=true) */
+        /** @ReferenceMany(targetDocument=Address::class, mappedBy="contact", orphanRemoval=true) */
         private $addresses;
 
         public function __construct()

--- a/docs/en/reference/trees.rst
+++ b/docs/en/reference/trees.rst
@@ -23,7 +23,7 @@ Full Tree in Single Document
         /** @Field(type="string") */
         private $body;
 
-        /** @EmbedMany(targetDocument="Comment") */
+        /** @EmbedMany(targetDocument=Comment::class) */
         private $comments = array();
 
         // ...
@@ -38,7 +38,7 @@ Full Tree in Single Document
         /** @Field(type="string") */
         private $text;
 
-        /** @EmbedMany(targetDocument="Comment") */
+        /** @EmbedMany(targetDocument=Comment::class) */
         private $replies = array();
 
         // ...
@@ -77,7 +77,7 @@ Parent Reference
         private $name;
 
         /**
-         * @ReferenceOne(targetDocument="Category")
+         * @ReferenceOne(targetDocument=Category::class)
          * @Index
          */
         private $parent;
@@ -116,7 +116,7 @@ Child Reference
         private $name;
 
         /**
-         * @ReferenceMany(targetDocument="Category")
+         * @ReferenceMany(targetDocument=Category::class)
          * @Index
          */
         private $children = array();
@@ -174,13 +174,13 @@ Array of Ancestors
         private $id;
 
         /**
-         * @ReferenceMany(targetDocument="Category")
+         * @ReferenceMany(targetDocument=Category::class)
          * @Index
          */
         private $ancestors = array();
 
         /**
-         * @ReferenceOne(targetDocument="Category")
+         * @ReferenceOne(targetDocument=Category::class)
          * @Index
          */
         private $parent;

--- a/docs/en/reference/working-with-objects.rst
+++ b/docs/en/reference/working-with-objects.rst
@@ -429,7 +429,7 @@ in the $addresses collection.
     {
         //...
         /**
-         * @ReferenceMany(targetDocument="Address", cascade={"persist", "remove"})
+         * @ReferenceMany(targetDocument=Address::class, cascade={"persist", "remove"})
          */
         private $addresses;
         //...

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -82,7 +82,7 @@ You can provide your mapping information in Annotations or XML:
             /** @ODM\Field(type="string") */
             private $email;
 
-            /** @ODM\ReferenceMany(targetDocument="BlogPost", cascade="all") */
+            /** @ODM\ReferenceMany(targetDocument=BlogPost::class, cascade="all") */
             private $posts = array();
 
             // ...

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -239,15 +239,15 @@ class ReferenceStoreAsDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="id") */
+    /** @ODM\ReferenceOne(targetDocument=User::class, storeAs="id") */
     public $ref1;
 
-    /** @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="dbRef") */
+    /** @ODM\ReferenceOne(targetDocument=User::class, storeAs="dbRef") */
     public $ref2;
 
-    /** @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="dbRefWithDb") */
+    /** @ODM\ReferenceOne(targetDocument=User::class, storeAs="dbRefWithDb") */
     public $ref3;
 
-    /** @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="ref") */
+    /** @ODM\ReferenceOne(targetDocument=User::class, storeAs="ref") */
     public $ref4;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleCallbacksTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleCallbacksTest.php
@@ -250,13 +250,13 @@ class User extends BaseDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="Profile") */
+    /** @ODM\EmbedOne(targetDocument=Profile::class) */
     public $profile;
 
-    /** @ODM\EmbedMany(targetDocument="Profile") */
+    /** @ODM\EmbedMany(targetDocument=Profile::class) */
     public $profiles = [];
 
-    /** @ODM\ReferenceMany(targetDocument="User") */
+    /** @ODM\ReferenceMany(targetDocument=User::class) */
     public $friends = [];
 }
 
@@ -266,7 +266,7 @@ class Cart extends BaseDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument="Customer", inversedBy="cart") */
+    /** @ODM\ReferenceOne(targetDocument=Customer::class, inversedBy="cart") */
     public $customer;
 }
 
@@ -276,14 +276,14 @@ class Customer extends BaseDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument="Cart", mappedBy="customer") */
+    /** @ODM\ReferenceOne(targetDocument=Cart::class, mappedBy="customer") */
     public $cart;
 }
 
 /** @ODM\EmbeddedDocument */
 class Profile extends BaseDocument
 {
-    /** @ODM\EmbedOne(targetDocument="Profile") */
+    /** @ODM\EmbedOne(targetDocument=Profile::class) */
     public $profile;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleListenersTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleListenersTest.php
@@ -261,16 +261,16 @@ class TestDocument
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\EmbedMany(targetDocument="TestEmbeddedDocument") */
+    /** @ODM\EmbedMany(targetDocument=TestEmbeddedDocument::class) */
     public $embedded;
 
-    /** @ODM\EmbedOne(targetDocument="Image") */
+    /** @ODM\EmbedOne(targetDocument=Image::class) */
     public $image;
 
-    /** @ODM\ReferenceMany(targetDocument="TestProfile") */
+    /** @ODM\ReferenceMany(targetDocument=TestProfile::class) */
     public $profiles;
 
-    /** @ODM\ReferenceOne(targetDocument="TestProfile") */
+    /** @ODM\ReferenceOne(targetDocument=TestProfile::class) */
     public $profile;
 }
 
@@ -296,7 +296,7 @@ class TestProfile
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\EmbedOne(targetDocument="Image") */
+    /** @ODM\EmbedOne(targetDocument=Image::class) */
     public $image;
 }
 
@@ -308,7 +308,7 @@ class Image
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\EmbedMany(targetDocument="Thumbnail") */
+    /** @ODM\EmbedMany(targetDocument=Thumbnail::class) */
     public $thumbnails = [];
 
     public function __construct($name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
@@ -568,10 +568,10 @@ class AtomicSetUser
     /** @ODM\EmbedMany(strategy="atomicSet", targetDocument="Documents\Phonebook") */
     public $phonebooks;
 
-    /** @ODM\EmbedMany(strategy="atomicSet", targetDocument="AtomicSetInception") */
+    /** @ODM\EmbedMany(strategy="atomicSet", targetDocument=AtomicSetInception::class) */
     public $inception;
 
-    /** @ODM\ReferenceMany(strategy="atomicSetArray", targetDocument="AtomicSetUser") */
+    /** @ODM\ReferenceMany(strategy="atomicSetArray", targetDocument=AtomicSetUser::class) */
     public $friends;
 
     public function __construct($name)
@@ -592,10 +592,10 @@ class AtomicSetInception
     /** @ODM\Field(type="string") */
     public $value;
 
-    /** @ODM\EmbedOne(targetDocument="AtomicSetInception") */
+    /** @ODM\EmbedOne(targetDocument=AtomicSetInception::class) */
     public $one;
 
-    /** @ODM\EmbedMany(targetDocument="AtomicSetInception") */
+    /** @ODM\EmbedMany(targetDocument=AtomicSetInception::class) */
     public $many;
 
     public function __construct($value)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -266,10 +266,10 @@ class CollectionPersisterUser
     /** @ODM\Field(type="string") */
     public $username;
 
-    /** @ODM\EmbedMany(targetDocument="CollectionPersisterCategory") */
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterCategory::class) */
     public $categories = [];
 
-    /** @ODM\ReferenceMany(targetDocument="CollectionPersisterPhonenumber", cascade={"persist"}) */
+    /** @ODM\ReferenceMany(targetDocument=CollectionPersisterPhonenumber::class, cascade={"persist"}) */
     public $phonenumbers = [];
 }
 
@@ -279,7 +279,7 @@ class CollectionPersisterCategory
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\EmbedMany(targetDocument="CollectionPersisterCategory") */
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterCategory::class) */
     public $children = [];
 
     public function __construct($name)
@@ -312,7 +312,7 @@ class CollectionPersisterPost
   /** @ODM\Field(type="string") */
     public $post;
 
-  /** @ODM\EmbedMany(targetDocument="CollectionPersisterComment", strategy="set") */
+  /** @ODM\EmbedMany(targetDocument=CollectionPersisterComment::class, strategy="set") */
     public $comments = [];
 
     public function __construct($post)
@@ -334,7 +334,7 @@ class CollectionPersisterComment
   /** @ODM\Field(type="string") */
     public $by;
 
-  /** @ODM\EmbedMany(targetDocument="CollectionPersisterComment", strategy="set") */
+  /** @ODM\EmbedMany(targetDocument=CollectionPersisterComment::class, strategy="set") */
     public $comments = [];
 
     public function __construct($comment, $by)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php
@@ -175,24 +175,24 @@ class DocumentWithCustomCollection
 
     /**
      * @ODM\EmbedMany(
-     *   collectionClass="MyEmbedsCollection",
-     *   targetDocument="EmbeddedDocumentInCustomCollection"
+     *   collectionClass=MyEmbedsCollection::class,
+     *   targetDocument=EmbeddedDocumentInCustomCollection::class
      * )
      */
     public $coll;
 
     /**
      * @ODM\EmbedMany(
-     *   targetDocument="EmbeddedDocumentInCustomCollection"
+     *   targetDocument=EmbeddedDocumentInCustomCollection::class
      * )
      */
     public $boring;
 
     /**
      * @ODM\ReferenceMany(
-     *   collectionClass="MyDocumentsCollection",
+     *   collectionClass=MyDocumentsCollection::class,
      *   orphanRemoval=true,
-     *   targetDocument="DocumentWithCustomCollection"
+     *   targetDocument=DocumentWithCustomCollection::class
      * )
      */
     public $refMany;
@@ -201,7 +201,7 @@ class DocumentWithCustomCollection
      * @ODM\ReferenceMany(
      *   collectionClass="\Doctrine\ODM\MongoDB\Tests\Functional\MyDocumentsCollection",
      *   mappedBy="refMany",
-     *   targetDocument="DocumentWithCustomCollection"
+     *   targetDocument=DocumentWithCustomCollection::class
      * )
      */
     public $inverseRefMany;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
@@ -162,16 +162,16 @@ abstract class ChildDocument
 /** @ODM\Document(collection="discriminator_parent") */
 class ParentDocumentWithoutDiscriminator extends ParentDocument
 {
-    /** @ODM\ReferenceOne(targetDocument="ChildDocumentWithoutDiscriminator") */
+    /** @ODM\ReferenceOne(targetDocument=ChildDocumentWithoutDiscriminator::class) */
     protected $referencedChild;
 
-    /** @ODM\ReferenceMany(targetDocument="ChildDocumentWithoutDiscriminator") */
+    /** @ODM\ReferenceMany(targetDocument=ChildDocumentWithoutDiscriminator::class) */
     protected $referencedChildren;
 
-    /** @ODM\EmbedOne(targetDocument="ChildDocumentWithoutDiscriminator") */
+    /** @ODM\EmbedOne(targetDocument=ChildDocumentWithoutDiscriminator::class) */
     protected $embeddedChild;
 
-    /** @ODM\EmbedMany(targetDocument="ChildDocumentWithoutDiscriminator") */
+    /** @ODM\EmbedMany(targetDocument=ChildDocumentWithoutDiscriminator::class) */
     protected $embeddedChildren;
 }
 
@@ -184,16 +184,16 @@ class ChildDocumentWithoutDiscriminator extends ChildDocument
 /** @ODM\Document(collection="discriminator_parent") */
 class ParentDocumentWithDiscriminator extends ParentDocument
 {
-    /** @ODM\ReferenceOne(targetDocument="ChildDocumentWithDiscriminator") */
+    /** @ODM\ReferenceOne(targetDocument=ChildDocumentWithDiscriminator::class) */
     protected $referencedChild;
 
-    /** @ODM\ReferenceMany(targetDocument="ChildDocumentWithDiscriminator") */
+    /** @ODM\ReferenceMany(targetDocument=ChildDocumentWithDiscriminator::class) */
     protected $referencedChildren;
 
-    /** @ODM\EmbedOne(targetDocument="ChildDocumentWithDiscriminator") */
+    /** @ODM\EmbedOne(targetDocument=ChildDocumentWithDiscriminator::class) */
     protected $embeddedChild;
 
-    /** @ODM\EmbedMany(targetDocument="ChildDocumentWithDiscriminator") */
+    /** @ODM\EmbedMany(targetDocument=ChildDocumentWithDiscriminator::class) */
     protected $embeddedChildren;
 }
 
@@ -201,7 +201,7 @@ class ParentDocumentWithDiscriminator extends ParentDocument
  * @ODM\Document(collection="discriminator_child")
  * @ODM\InheritanceType("SINGLE_COLLECTION")
  * @ODM\DiscriminatorField("discriminator")
- * @ODM\DiscriminatorMap({"simple"="ChildDocumentWithDiscriminatorSimple", "complex"="ChildDocumentWithDiscriminatorComplex"})
+ * @ODM\DiscriminatorMap({"simple"=ChildDocumentWithDiscriminatorSimple::class, "complex"=ChildDocumentWithDiscriminatorComplex::class})
  * @ODM\DefaultDiscriminatorValue("simple")
  */
 class ChildDocumentWithDiscriminator extends ChildDocument

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -613,16 +613,16 @@ class DocumentPersisterTestDocument
      */
     public $association;
 
-    /** @ODM\ReferenceOne(targetDocument="DocumentPersisterTestHashIdDocument", storeAs="id") */
+    /** @ODM\ReferenceOne(targetDocument=DocumentPersisterTestHashIdDocument::class, storeAs="id") */
     public $simpleRef;
 
-    /** @ODM\ReferenceOne(targetDocument="DocumentPersisterTestHashIdDocument", storeAs="dbRef") */
+    /** @ODM\ReferenceOne(targetDocument=DocumentPersisterTestHashIdDocument::class, storeAs="dbRef") */
     public $semiComplexRef;
 
-    /** @ODM\ReferenceOne(targetDocument="DocumentPersisterTestHashIdDocument", storeAs="dbRefWithDb") */
+    /** @ODM\ReferenceOne(targetDocument=DocumentPersisterTestHashIdDocument::class, storeAs="dbRefWithDb") */
     public $complexRef;
 
-    /** @ODM\ReferenceOne(targetDocument="DocumentPersisterTestHashIdDocument", storeAs="ref") */
+    /** @ODM\ReferenceOne(targetDocument=DocumentPersisterTestHashIdDocument::class, storeAs="ref") */
     public $embeddedRef;
 }
 
@@ -696,16 +696,16 @@ class DocumentPersisterTestHashIdDocument
     /** @ODM\Id(strategy="none", options={"type"="hash"}) */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument="DocumentPersisterTestDocument", storeAs="id") */
+    /** @ODM\ReferenceOne(targetDocument=DocumentPersisterTestDocument::class, storeAs="id") */
     public $simpleRef;
 
-    /** @ODM\ReferenceOne(targetDocument="DocumentPersisterTestDocument", storeAs="dbRef") */
+    /** @ODM\ReferenceOne(targetDocument=DocumentPersisterTestDocument::class, storeAs="dbRef") */
     public $semiComplexRef;
 
-    /** @ODM\ReferenceOne(targetDocument="DocumentPersisterTestDocument", storeAs="dbRefWithDb") */
+    /** @ODM\ReferenceOne(targetDocument=DocumentPersisterTestDocument::class, storeAs="dbRefWithDb") */
     public $complexRef;
 
-    /** @ODM\ReferenceOne(targetDocument="DocumentPersisterTestDocument", storeAs="ref") */
+    /** @ODM\ReferenceOne(targetDocument=DocumentPersisterTestDocument::class, storeAs="ref") */
     public $embeddedRef;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedIdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedIdTest.php
@@ -61,10 +61,10 @@ class EmbeddedIdTestUser
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="DefaultIdEmbeddedDocument") */
+    /** @ODM\EmbedOne(targetDocument=DefaultIdEmbeddedDocument::class) */
     public $embedOne;
 
-    /** @ODM\EmbedMany(targetDocument="DefaultIdEmbeddedDocument") */
+    /** @ODM\EmbedMany(targetDocument=DefaultIdEmbeddedDocument::class) */
     public $embedMany = [];
 }
 
@@ -74,10 +74,10 @@ class EmbeddedStrategyNoneIdTestUser
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="DefaultIdStrategyNoneEmbeddedDocument") */
+    /** @ODM\EmbedOne(targetDocument=DefaultIdStrategyNoneEmbeddedDocument::class) */
     public $embedOne;
 
-    /** @ODM\EmbedMany(targetDocument="DefaultIdStrategyNoneEmbeddedDocument") */
+    /** @ODM\EmbedMany(targetDocument=DefaultIdStrategyNoneEmbeddedDocument::class) */
     public $embedMany = [];
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedReferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedReferenceTest.php
@@ -66,7 +66,7 @@ class Offer
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\EmbedMany(targetDocument="Link") */
+    /** @ODM\EmbedMany(targetDocument=Link::class) */
     public $links;
 
     public function __construct($name)
@@ -85,7 +85,7 @@ class Link
     /** @ODM\Field(type="string") */
     public $url;
 
-    /** @ODM\ReferenceMany(targetDocument="ReferencedDocument") */
+    /** @ODM\ReferenceMany(targetDocument=ReferencedDocument::class) */
     public $referencedDocuments;
 
     public function __construct($url)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
@@ -629,10 +629,10 @@ class ChangeEmbeddedIdTest
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="EmbeddedDocumentWithId") */
+    /** @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithId::class) */
     public $embed;
 
-    /** @ODM\EmbedMany(targetDocument="EmbeddedDocumentWithId") */
+    /** @ODM\EmbedMany(targetDocument=EmbeddedDocumentWithId::class) */
     public $embedMany;
 
     public function __construct()
@@ -658,10 +658,10 @@ class ChangeEmbeddedWithNameAnnotationTest
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="EmbeddedDocumentWithAnotherEmbedded") */
+    /** @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithAnotherEmbedded::class) */
     public $embedOne;
 
-    /** @ODM\EmbedOne(targetDocument="EmbeddedDocumentWithAnotherEmbedded") */
+    /** @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithAnotherEmbedded::class) */
     public $embedTwo;
 }
 
@@ -670,6 +670,6 @@ class ChangeEmbeddedWithNameAnnotationTest
  */
 class EmbedDocumentWithAnotherEmbed
 {
-    /** @ODM\EmbedOne(targetDocument="EmbeddedDocumentWithId", name="m_id") */
+    /** @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithId::class, name="m_id") */
     public $embed;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
@@ -408,10 +408,10 @@ class CollectionIdUser
     /** @ODM\Field(name="t", type="string") */
     public $name;
 
-    /** @ODM\ReferenceOne(targetDocument="ReferencedCollectionId", cascade={"persist"}) */
+    /** @ODM\ReferenceOne(targetDocument=ReferencedCollectionId::class, cascade={"persist"}) */
     public $reference;
 
-    /** @ODM\EmbedMany(targetDocument="EmbeddedCollectionId") */
+    /** @ODM\EmbedMany(targetDocument=EmbeddedCollectionId::class) */
     public $embedded = [];
 
     public function __construct($name)
@@ -429,10 +429,10 @@ class CollectionIdUserWithStartingId
     /** @ODM\Field(name="t", type="string") */
     public $name;
 
-    /** @ODM\ReferenceOne(targetDocument="ReferencedCollectionId", cascade={"persist"}) */
+    /** @ODM\ReferenceOne(targetDocument=ReferencedCollectionId::class, cascade={"persist"}) */
     public $reference;
 
-    /** @ODM\EmbedMany(targetDocument="EmbeddedCollectionId") */
+    /** @ODM\EmbedMany(targetDocument=EmbeddedCollectionId::class) */
     public $embedded = [];
 
     public function __construct($name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
@@ -370,10 +370,10 @@ class DocumentWithEmbeddedIndexes
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\EmbedOne(targetDocument="EmbeddedDocumentWithIndexes") */
+    /** @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithIndexes::class) */
     public $embedded;
 
-    /** @ODM\EmbedOne(targetDocument="EmbeddedDocumentWithIndexes") */
+    /** @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithIndexes::class) */
     public $embedded_secondary;
 }
 
@@ -394,7 +394,7 @@ class EmbeddedDocumentWithIndexes
     /** @ODM\Field(type="string") @ODM\Index */
     public $name;
 
-    /** @ODM\EmbedMany(targetDocument="EmbeddedManyDocumentWithIndexes") */
+    /** @ODM\EmbedMany(targetDocument=EmbeddedManyDocumentWithIndexes::class) */
     public $embeddedMany;
 }
 
@@ -421,8 +421,8 @@ class DocumentWithIndexInDiscriminatedEmbeds
     /**
      * @ODM\EmbedOne(
      *  discriminatorMap={
-     *   "d1"="EmbeddedDocumentWithIndexes",
-     *   "d2"="YetAnotherEmbeddedDocumentWithIndex",
+     *   "d1"=EmbeddedDocumentWithIndexes::class,
+     *   "d2"=YetAnotherEmbeddedDocumentWithIndex::class,
      * })
      */
     public $embedded;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LifecycleTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LifecycleTest.php
@@ -57,13 +57,13 @@ class ParentObject
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\ReferenceMany(targetDocument="ChildObject", cascade="all") */
+    /** @ODM\ReferenceMany(targetDocument=ChildObject::class, cascade="all") */
     private $children;
 
     /** @ODM\Field(type="string") */
     private $name;
 
-    /** @ODM\EmbedOne(targetDocument="ChildEmbeddedObject") */
+    /** @ODM\EmbedOne(targetDocument=ChildEmbeddedObject::class) */
     private $childEmbedded;
 
     private $child;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
@@ -437,7 +437,7 @@ abstract class AbstractVersionBase
     /** @ODM\Lock @ODM\Field(type="int") */
     public $locked;
 
-    /** @ODM\EmbedMany(targetDocument="Documents\Issue") */
+    /** @ODM\EmbedMany(targetDocument=Issue::class) */
     public $issues;
 
     public function __construct($title = null)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/MappedSuperclassTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/MappedSuperclassTest.php
@@ -47,7 +47,7 @@ class MappedSuperclassBase
     /** @ODM\Field(type="string") */
     private $mapped2;
 
-    /** @ODM\ReferenceOne(targetDocument="MappedSuperclassRelated1") */
+    /** @ODM\ReferenceOne(targetDocument=MappedSuperclassRelated1::class) */
     private $mappedRelated1;
 
     public function setMapped1($val)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
@@ -147,7 +147,7 @@ class Hierarchy
     /** @ODM\Field(type="string") */
     private $name;
 
-    /** @ODM\ReferenceMany(targetDocument="Hierarchy") */
+    /** @ODM\ReferenceMany(targetDocument=Hierarchy::class) */
     private $children = [];
 
     public function __construct($name)
@@ -204,7 +204,7 @@ class BaseCategory
     /** @ODM\Field(type="string") */
     protected $name;
 
-    /** @ODM\EmbedMany(targetDocument="ChildCategory") */
+    /** @ODM\EmbedMany(targetDocument=ChildCategory::class) */
     protected $children;
 
     public function __construct($name)
@@ -277,7 +277,7 @@ class Order
     /** @ODM\Field(type="string") */
     public $title;
 
-    /** @ODM\EmbedOne(targetDocument="ProductBackup") */
+    /** @ODM\EmbedOne(targetDocument=ProductBackup::class) */
     public $product;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalEmbedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalEmbedTest.php
@@ -163,10 +163,10 @@ class OrphanRemovalCascadeUser
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="OrphanRemovalCascadeProfile") */
+    /** @ODM\EmbedOne(targetDocument=OrphanRemovalCascadeProfile::class) */
     public $profile;
 
-    /** @ODM\EmbedMany(targetDocument="OrphanRemovalCascadeProfile") */
+    /** @ODM\EmbedMany(targetDocument=OrphanRemovalCascadeProfile::class) */
     public $profileMany = [];
 }
 
@@ -179,10 +179,10 @@ class OrphanRemovalCascadeProfile
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\ReferenceOne(targetDocument="OrphanRemovalCascadeAddress", orphanRemoval=true, cascade={"all"}) */
+    /** @ODM\ReferenceOne(targetDocument=OrphanRemovalCascadeAddress::class, orphanRemoval=true, cascade={"all"}) */
     public $address;
 
-    /** @ODM\ReferenceMany(targetDocument="OrphanRemovalCascadeAddress", orphanRemoval=true, cascade={"all"}) */
+    /** @ODM\ReferenceMany(targetDocument=OrphanRemovalCascadeAddress::class, orphanRemoval=true, cascade={"all"}) */
     public $addressMany;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
@@ -302,16 +302,16 @@ class OrphanRemovalUser
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument="OrphanRemovalProfile", orphanRemoval=true) */
+    /** @ODM\ReferenceOne(targetDocument=OrphanRemovalProfile::class, orphanRemoval=true) */
     public $profile;
 
-    /** @ODM\ReferenceOne(targetDocument="OrphanRemovalProfile", orphanRemoval=false) */
+    /** @ODM\ReferenceOne(targetDocument=OrphanRemovalProfile::class, orphanRemoval=false) */
     public $profileNoOrphanRemoval;
 
-    /** @ODM\ReferenceMany(targetDocument="OrphanRemovalProfile", orphanRemoval=true) */
+    /** @ODM\ReferenceMany(targetDocument=OrphanRemovalProfile::class, orphanRemoval=true) */
     public $profileMany = [];
 
-    /** @ODM\ReferenceMany(targetDocument="OrphanRemovalProfile", orphanRemoval=false) */
+    /** @ODM\ReferenceMany(targetDocument=OrphanRemovalProfile::class, orphanRemoval=false) */
     public $profileManyNoOrphanRemoval = [];
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
@@ -94,7 +94,7 @@ class ReferenceDiscriminatorsTest extends BaseTest
  * @ODM\Document(collection="rdt_action")
  * @ODM\InheritanceType("SINGLE_COLLECTION")
  * @ODM\DiscriminatorField("discriminator")
- * @ODM\DiscriminatorMap({"action"="Action", "commentable_action"="CommentableAction"})
+ * @ODM\DiscriminatorMap({"action"=Action::class, "commentable_action"=CommentableAction::class})
  */
 class Action
 {
@@ -144,7 +144,7 @@ abstract class ActivityStreamItem
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\ReferenceOne(targetDocument="Action") */
+    /** @ODM\ReferenceOne(targetDocument=Action::class) */
     protected $action;
 
     public function __construct(Action $action)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
@@ -483,7 +483,7 @@ class DocumentWithArrayReference
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument="DocumentWithArrayId") */
+    /** @ODM\ReferenceOne(targetDocument=DocumentWithArrayId::class) */
     public $referenceOne;
 }
 
@@ -501,7 +501,7 @@ class DocumentWithMongoBinDataReference
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument="DocumentWithMongoBinDataId") */
+    /** @ODM\ReferenceOne(targetDocument=DocumentWithMongoBinDataId::class) */
     public $referenceOne;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php
@@ -44,7 +44,7 @@ class GH1011Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedMany(targetDocument="GH1011Embedded", strategy="set") */
+    /** @ODM\EmbedMany(targetDocument=GH1011Embedded::class, strategy="set") */
     public $embeds;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1017Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1017Test.php
@@ -55,7 +55,7 @@ class GH1017Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="GH1017EmbeddedDocument") */
+    /** @ODM\EmbedOne(targetDocument=GH1017EmbeddedDocument::class) */
     public $embedded;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php
@@ -39,7 +39,7 @@ class GH1117Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedMany(strategy="set", targetDocument="GH1117EmbeddedDocument") */
+    /** @ODM\EmbedMany(strategy="set", targetDocument=GH1117EmbeddedDocument::class) */
     public $embeds;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1152Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1152Test.php
@@ -42,7 +42,7 @@ class GH1152Parent
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="GH1152Child") */
+    /** @ODM\EmbedOne(targetDocument=GH1152Child::class) */
     public $child;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
@@ -40,7 +40,7 @@ class GH1225Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedMany(strategy="atomicSet", targetDocument="GH1225EmbeddedDocument") */
+    /** @ODM\EmbedMany(strategy="atomicSet", targetDocument=GH1225EmbeddedDocument::class) */
     public $embeds;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
@@ -40,12 +40,12 @@ class GH1232Post
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceMany(targetDocument="GH1232Comment", mappedBy="post", cascade={"remove"}) */
+    /** @ODM\ReferenceMany(targetDocument=GH1232Comment::class, mappedBy="post", cascade={"remove"}) */
     protected $comments;
 
     /**
      * @ODM\ReferenceMany(
-     *     targetDocument="GH1232Comment",
+     *     targetDocument=GH1232Comment::class,
      *     mappedBy="post",
      *     repositoryMethod="getLongComments",
      * )
@@ -64,7 +64,7 @@ class GH1232Comment
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument="GH1232Post") */
+    /** @ODM\ReferenceOne(targetDocument=GH1232Post::class) */
     public $post;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
@@ -232,7 +232,7 @@ class Container
     public $id;
 
     /** @ODM\ReferenceMany(
-     *     targetDocument="Item",
+     *     targetDocument=Item::class,
      *     cascade={"refresh","persist"},
      *     orphanRemoval="true",
      *     strategy="atomicSet"
@@ -242,7 +242,7 @@ class Container
 
     /**
      * @ODM\ReferenceOne(
-     *     targetDocument="Item",
+     *     targetDocument=Item::class,
      *     cascade={"refresh"}
      * )
      */
@@ -250,7 +250,7 @@ class Container
 
     /**
      * @ODM\EmbedMany(
-     *     targetDocument="Element",
+     *     targetDocument=Element::class,
      *     strategy="addToSet"
      * )
      */
@@ -258,7 +258,7 @@ class Container
 
     /**
      * @ODM\EmbedMany(
-     *     targetDocument="Element",
+     *     targetDocument=Element::class,
      *     strategy="set"
      * )
      */
@@ -266,7 +266,7 @@ class Container
 
     /**
      * @ODM\EmbedMany(
-     *     targetDocument="Element",
+     *     targetDocument=Element::class,
      *     strategy="setArray"
      * )
      */
@@ -274,7 +274,7 @@ class Container
 
     /**
      * @ODM\EmbedMany(
-     *     targetDocument="Element",
+     *     targetDocument=Element::class,
      *     strategy="pushAll"
      * )
      */
@@ -282,7 +282,7 @@ class Container
 
     /**
      * @ODM\EmbedMany(
-     *     targetDocument="Element",
+     *     targetDocument=Element::class,
      *     strategy="atomicSet"
      * )
      */
@@ -290,7 +290,7 @@ class Container
 
     /**
      * @ODM\EmbedMany(
-     *     targetDocument="Element",
+     *     targetDocument=Element::class,
      *     strategy="atomicSetArray"
      * )
      */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1346Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1346Test.php
@@ -49,7 +49,7 @@ class GH1346Document
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\ReferenceMany(targetDocument="GH1346ReferencedDocument") */
+    /** @ODM\ReferenceMany(targetDocument=GH1346ReferencedDocument::class) */
     protected $references;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
@@ -104,10 +104,10 @@ class GH1418Document
     /** @ODM\Id(strategy="none") */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="GH1418Embedded") */
+    /** @ODM\EmbedOne(targetDocument=GH1418Embedded::class) */
     public $embedOne;
 
-    /** @ODM\EmbedMany(targetDocument="GH1418Embedded") */
+    /** @ODM\EmbedMany(targetDocument=GH1418Embedded::class) */
     public $embedMany;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1428Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1428Test.php
@@ -39,14 +39,14 @@ class GH1428Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="GH1428EmbeddedDocument") */
+    /** @ODM\EmbedOne(targetDocument=GH1428EmbeddedDocument::class) */
     public $embedded;
 }
 
 /** @ODM\EmbeddedDocument */
 class GH1428EmbeddedDocument
 {
-    /** @ODM\EmbedOne(targetDocument="GH1428NestedEmbeddedDocument", name="shortNameThatDoesntExist") */
+    /** @ODM\EmbedOne(targetDocument=GH1428NestedEmbeddedDocument::class, name="shortNameThatDoesntExist") */
     public $nestedEmbedded;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1525Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1525Test.php
@@ -103,10 +103,10 @@ class GH1525Document
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\EmbedOne(targetDocument="GH1525Embedded") */
+    /** @ODM\EmbedOne(targetDocument=GH1525Embedded::class) */
     public $embedded;
 
-    /** @ODM\EmbedMany(targetDocument="GH1525Embedded") */
+    /** @ODM\EmbedMany(targetDocument=GH1525Embedded::class) */
     public $embedMany;
 
     public function __construct($name)
@@ -125,7 +125,7 @@ class GH1525DocumentIdStrategyNone
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\EmbedOne(targetDocument="GH1525Embedded") */
+    /** @ODM\EmbedOne(targetDocument=GH1525Embedded::class) */
     public $embedded;
 
     public function __construct($id, $name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1572Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1572Test.php
@@ -47,23 +47,23 @@ class GH1572Blog
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceMany(targetDocument="GH1572Post", mappedBy="blog") */
+    /** @ODM\ReferenceMany(targetDocument=GH1572Post::class, mappedBy="blog") */
     public $allPosts = [];
 
-    /** @ODM\ReferenceMany(targetDocument="GH1572Post", mappedBy="blog", sort={"id"="asc"}, limit=2) */
+    /** @ODM\ReferenceMany(targetDocument=GH1572Post::class, mappedBy="blog", sort={"id"="asc"}, limit=2) */
     public $latestPosts = [];
 
-    /** @ODM\ReferenceMany(targetDocument="GH1572Post", repositoryMethod="getPostsForBlog") */
+    /** @ODM\ReferenceMany(targetDocument=GH1572Post::class, repositoryMethod="getPostsForBlog") */
     public $latestPostsRepositoryMethod = [];
 }
 
-/** @ODM\Document(repositoryClass="GH1572PostRepository") */
+/** @ODM\Document(repositoryClass=GH1572PostRepository::class) */
 class GH1572Post
 {
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument="GH1572Blog") */
+    /** @ODM\ReferenceOne(targetDocument=GH1572Blog::class) */
     public $blog;
 
     public function __construct(GH1572Blog $blog)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1775Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1775Test.php
@@ -87,17 +87,17 @@ class GH1775Blog
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceMany(targetDocument="GH1775Post", inversedBy="blogs") */
+    /** @ODM\ReferenceMany(targetDocument=GH1775Post::class, inversedBy="blogs") */
     public $posts = [];
 }
 
 /** @ODM\Document */
 class GH1775Post extends GH1775MetaDocument
 {
-    /** @ODM\ReferenceMany(targetDocument="GH1775Image", storeAs=ClassMetadata::REFERENCE_STORE_AS_ID) */
+    /** @ODM\ReferenceMany(targetDocument=GH1775Image::class, storeAs=ClassMetadata::REFERENCE_STORE_AS_ID) */
     protected $images;
 
-    /** @ODM\ReferenceMany(targetDocument="GH1775Blog", mappedBy="posts") */
+    /** @ODM\ReferenceMany(targetDocument=GH1775Blog::class, mappedBy="posts") */
     protected $blogs;
 
     public function __construct(array $blogs, array $images)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH232Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH232Test.php
@@ -46,10 +46,10 @@ class Product
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\EmbedMany(targetDocument="Price") */
+    /** @ODM\EmbedMany(targetDocument=Price::class) */
     public $prices = [];
 
-    /** @ODM\EmbedMany(targetDocument="SubProduct") */
+    /** @ODM\EmbedMany(targetDocument=SubProduct::class) */
     public $subproducts = [];
 
     public function __construct($name)
@@ -62,7 +62,7 @@ class Product
 /** @ODM\EmbeddedDocument */
 class SubProduct
 {
-    /** @ODM\EmbedMany(targetDocument="Price") */
+    /** @ODM\EmbedMany(targetDocument=Price::class) */
     public $prices = [];
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH245Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH245Test.php
@@ -45,6 +45,6 @@ class GH245OrderLog
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument="GH245Order") */
+    /** @ODM\ReferenceOne(targetDocument=GH245Order::class) */
     public $order;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
@@ -67,7 +67,7 @@ class GH267User
     /** @ODM\Field(type="string") */
     protected $name;
 
-    /** @ODM\ReferenceOne(name="company", targetDocument="GH267Company", discriminatorMap={"seller"="SellerCompany", "buyer"="BuyerCompany"}, inversedBy="users") */
+    /** @ODM\ReferenceOne(name="company", targetDocument=GH267Company::class, discriminatorMap={"seller"="SellerCompany", "buyer"="BuyerCompany"}, inversedBy="users") */
     protected $company;
 
     public function __construct($name)
@@ -110,14 +110,14 @@ class GH267User
  * @ODM\Document(collection="companies")
  * @ODM\InheritanceType("SINGLE_COLLECTION")
  * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"seller"="GH267SellerCompany", "buyer"="GH267BuyerCompany"})
+ * @ODM\DiscriminatorMap({"seller"=GH267SellerCompany::class, "buyer"=GH267BuyerCompany::class})
  */
 class GH267Company
 {
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\ReferenceMany(targetDocument="GH267User", mappedBy="company") */
+    /** @ODM\ReferenceMany(targetDocument=GH267User::class, mappedBy="company") */
     protected $users;
 
     public function setId($id)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH389Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH389Test.php
@@ -37,7 +37,7 @@ class RootDocument
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\EmbedOne(targetDocument="EmptyMappedSuperClass") */
+    /** @ODM\EmbedOne(targetDocument=EmptyMappedSuperClass::class) */
     protected $emptyEmbeddedDocument;
 
     public function __construct()
@@ -60,7 +60,7 @@ class RootDocument
  * @ODM\MappedSuperClass
  * @ODM\DiscriminatorField("foobar")
  * @ODM\DiscriminatorMap({
- *     "empty"="EmptyEmbeddedDocument"
+ *     "empty"=EmptyEmbeddedDocument::class
  * })
  */
 class EmptyMappedSuperClass

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH426Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH426Test.php
@@ -35,13 +35,13 @@ class GH426Form
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceMany(targetDocument="GH426Field", mappedBy="form", cascade={"all"}) */
+    /** @ODM\ReferenceMany(targetDocument=GH426Field::class, mappedBy="form", cascade={"all"}) */
     public $fields = [];
 
-    /** @ODM\ReferenceOne(targetDocument="GH426Field", mappedBy="form", sort={"_id":1}) */
+    /** @ODM\ReferenceOne(targetDocument=GH426Field::class, mappedBy="form", sort={"_id":1}) */
     public $firstField;
 
-    /** @ODM\ReferenceOne(targetDocument="GH426Field", mappedBy="form", sort={"_id":-1}) */
+    /** @ODM\ReferenceOne(targetDocument=GH426Field::class, mappedBy="form", sort={"_id":-1}) */
     public $lastField;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH467Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH467Test.php
@@ -37,10 +37,10 @@ class GH467Document
     /** @ODM\Field(type="collection") */
     public $col;
 
-    /** @ODM\EmbedMany(targetDocument="GH467EmbeddedDocument") */
+    /** @ODM\EmbedMany(targetDocument=GH467EmbeddedDocument::class) */
     public $embedMany;
 
-    /** @ODM\ReferenceMany(targetDocument="GH467EmbeddedDocument") */
+    /** @ODM\ReferenceMany(targetDocument=GH467EmbeddedDocument::class) */
     public $refMany;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH499Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH499Test.php
@@ -41,7 +41,7 @@ class GH499Document
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\ReferenceMany(targetDocument="GH499Document", storeAs="id", strategy="set") */
+    /** @ODM\ReferenceMany(targetDocument=GH499Document::class, storeAs="id", strategy="set") */
     protected $refMany;
 
     public function __construct($id = null)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH520Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH520Test.php
@@ -68,6 +68,6 @@ class GH520Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument="GH520Document", cascade={"persist"}) */
+    /** @ODM\ReferenceOne(targetDocument=GH520Document::class, cascade={"persist"}) */
     public $ref;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH561Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH561Test.php
@@ -42,7 +42,7 @@ class GH561Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedMany(targetDocument="GH561EmbeddedDocument", strategy="set") */
+    /** @ODM\EmbedMany(targetDocument=GH561EmbeddedDocument::class, strategy="set") */
     public $embeddedDocuments;
 
     public function __construct()
@@ -54,7 +54,7 @@ class GH561Document
 /** @ODM\EmbeddedDocument */
 class GH561EmbeddedDocument
 {
-    /** @ODM\EmbedMany(targetDocument="GH561AnotherEmbeddedDocument", strategy="set") */
+    /** @ODM\EmbedMany(targetDocument=GH561AnotherEmbeddedDocument::class, strategy="set") */
     public $embeddedDocuments;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH566Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH566Test.php
@@ -70,15 +70,15 @@ class GH566Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="GH566EmbeddedDocument") */
+    /** @ODM\EmbedOne(targetDocument=GH566EmbeddedDocument::class) */
     public $version;
 
-    /** @ODM\EmbedMany(targetDocument="GH566EmbeddedDocument") */
+    /** @ODM\EmbedMany(targetDocument=GH566EmbeddedDocument::class) */
     public $versions;
 
     /**
      * @ODM\ReferenceMany(
-     *      targetDocument="GH566Document",
+     *      targetDocument=GH566Document::class,
      *      cascade={"all"},
      *      mappedBy="version.parent",
      *      sort={"version.sequence"="asc"}
@@ -99,6 +99,6 @@ class GH566EmbeddedDocument
     /** @ODM\Field(type="int") */
     public $sequence = 0;
 
-    /** @ODM\ReferenceOne(targetDocument="GH566Document", cascade={"all"}, inversedBy="children") */
+    /** @ODM\ReferenceOne(targetDocument=GH566Document::class, cascade={"all"}, inversedBy="children") */
     public $parent;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH593Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH593Test.php
@@ -107,10 +107,10 @@ class GH593User
     /** @ODM\Field(name="d", type="bool") */
     public $deleted = false;
 
-    /** @ODM\ReferenceMany(targetDocument="GH593User", inversedBy="followedBy", storeAs="id") */
+    /** @ODM\ReferenceMany(targetDocument=GH593User::class, inversedBy="followedBy", storeAs="id") */
     public $following;
 
-    /** @ODM\ReferenceMany(targetDocument="GH593User", mappedBy="following") */
+    /** @ODM\ReferenceMany(targetDocument=GH593User::class, mappedBy="following") */
     public $followedBy;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH597Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH597Test.php
@@ -125,10 +125,10 @@ class GH597Post
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedMany(targetDocument="GH597Comment") */
+    /** @ODM\EmbedMany(targetDocument=GH597Comment::class) */
     public $comments;
 
-    /** @ODM\ReferenceMany(targetDocument="GH597ReferenceMany", storeAs="id") */
+    /** @ODM\ReferenceMany(targetDocument=GH597ReferenceMany::class, storeAs="id") */
     public $referenceMany;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
@@ -109,7 +109,7 @@ class GH602User
     /** @ODM\Field(name="user_deleted", type="bool") */
     public $deleted = false;
 
-    /** @ODM\ReferenceMany(targetDocument="GH602Thing", inversedBy="likedBy", storeAs="id") */
+    /** @ODM\ReferenceMany(targetDocument=GH602Thing::class, inversedBy="likedBy", storeAs="id") */
     public $likes;
 
     public function __construct()
@@ -133,7 +133,7 @@ class GH602Thing
     /** @ODM\Field(name="thing_deleted", type="bool") */
     public $deleted = false;
 
-    /** @ODM\ReferenceMany(targetDocument="GH602User", mappedBy="likes") */
+    /** @ODM\ReferenceMany(targetDocument=GH602User::class, mappedBy="likes") */
     public $likedBy;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH611Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH611Test.php
@@ -124,7 +124,7 @@ class GH611Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="GH611EmbeddedDocument") */
+    /** @ODM\EmbedOne(targetDocument=GH611EmbeddedDocument::class) */
     public $embedded;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH665Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH665Test.php
@@ -52,10 +52,10 @@ class GH665Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedMany(targetDocument="GH665Embedded", strategy="pushAll") */
+    /** @ODM\EmbedMany(targetDocument=GH665Embedded::class, strategy="pushAll") */
     public $embeddedPushAll;
 
-    /** @ODM\EmbedMany(targetDocument="GH665Embedded", strategy="addToSet") */
+    /** @ODM\EmbedMany(targetDocument=GH665Embedded::class, strategy="addToSet") */
     public $embeddedAddToSet;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH788Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH788Test.php
@@ -320,16 +320,16 @@ class GH788Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedMany(targetDocument="GH788ExternEmbedListed") */
+    /** @ODM\EmbedMany(targetDocument=GH788ExternEmbedListed::class) */
     public $externEmbedMany;
 
-    /** @ODM\EmbedOne(targetDocument="GH788ExternEmbedListed") */
+    /** @ODM\EmbedOne(targetDocument=GH788ExternEmbedListed::class) */
     public $externEmbedOne;
 
-    /** @ODM\ReferenceMany(targetDocument="GH788ExternRefListed", cascade="all") */
+    /** @ODM\ReferenceMany(targetDocument=GH788ExternRefListed::class, cascade="all") */
     public $externRefMany;
 
-    /** @ODM\ReferenceOne(targetDocument="GH788ExternRefListed", cascade="all") */
+    /** @ODM\ReferenceOne(targetDocument=GH788ExternRefListed::class, cascade="all") */
     public $externRefOne;
 
     /**
@@ -401,7 +401,7 @@ class GH788Document
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
  * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"a"="GH788DocumentListed"})
+ * @ODM\DiscriminatorMap({"a"=GH788DocumentListed::class})
  */
 class GH788DocumentListed extends GH788Document
 {
@@ -447,7 +447,7 @@ class GH788InlineRefUnlisted extends GH788InlineRefListed
 /**
  * @ODM\EmbeddedDocument
  * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"d"="GH788ExternEmbedListed"})
+ * @ODM\DiscriminatorMap({"d"=GH788ExternEmbedListed::class})
  */
 class GH788ExternEmbedListed
 {
@@ -467,7 +467,7 @@ class GH788ExternEmbedUnlisted extends GH788ExternEmbedListed
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
  * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"e"="GH788ExternRefListed"})
+ * @ODM\DiscriminatorMap({"e"=GH788ExternRefListed::class})
  */
 class GH788ExternRefListed
 {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
@@ -116,10 +116,10 @@ class GH852Document
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\ReferenceOne(targetDocument="GH852Document", cascade="all") */
+    /** @ODM\ReferenceOne(targetDocument=GH852Document::class, cascade="all") */
     public $refOne;
 
-    /** @ODM\ReferenceMany(targetDocument="GH852Document", cascade="all") */
+    /** @ODM\ReferenceMany(targetDocument=GH852Document::class, cascade="all") */
     public $refMany;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH878Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH878Test.php
@@ -62,7 +62,7 @@ class GH878Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="GH878SubDocument") */
+    /** @ODM\EmbedOne(targetDocument=GH878SubDocument::class) */
     public $embeddedField;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH897Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH897Test.php
@@ -59,7 +59,7 @@ class GH897B
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\ReferenceOne(targetDocument="GH897A") */
+    /** @ODM\ReferenceOne(targetDocument=GH897A::class) */
     public $refOne;
 
     public $dm;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH921Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH921Test.php
@@ -67,7 +67,7 @@ class GH921User
     /** @ODM\Field(type="string") */
     private $name;
 
-    /** @ODM\ReferenceMany(targetDocument="GH921Post") */
+    /** @ODM\ReferenceMany(targetDocument=GH921Post::class) */
     private $posts;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH936Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH936Test.php
@@ -45,7 +45,7 @@ class GH936Document
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument="GH936Document", cascade={"persist","remove"}) */
+    /** @ODM\ReferenceOne(targetDocument=GH936Document::class, cascade={"persist","remove"}) */
     public $ref;
 
     public function __construct($ref = null)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH942Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH942Test.php
@@ -72,7 +72,7 @@ class GH942Document
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
  * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"p"="GH942DocumentParent"})
+ * @ODM\DiscriminatorMap({"p"=GH942DocumentParent::class})
  */
 class GH942DocumentParent
 {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
@@ -72,7 +72,7 @@ class GH971Test extends BaseTest
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
  * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"car"="Car", "bicycle"="Bicycle", "tandem"="Tandem"})
+ * @ODM\DiscriminatorMap({"car"=Car::class, "bicycle"=Bicycle::class, "tandem"=Tandem::class})
  */
 class Vehicle
 {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
@@ -47,7 +47,7 @@ class MODM116Parent
     /** @ODM\Field(type="string") */
     private $name;
 
-    /** @ODM\ReferenceOne(targetDocument="MODM116Child") **/
+    /** @ODM\ReferenceOne(targetDocument=MODM116Child::class) **/
     private $child;
 
     public function getId()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM140Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM140Test.php
@@ -130,7 +130,7 @@ class Category
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\EmbedMany(targetDocument="Post") */
+    /** @ODM\EmbedMany(targetDocument=Post::class) */
     public $posts;
 
     public function __construct()
@@ -142,10 +142,10 @@ class Category
 /** @ODM\EmbeddedDocument */
 class Post
 {
-    /** @ODM\EmbedMany(targetDocument="PostVersion") */
+    /** @ODM\EmbedMany(targetDocument=PostVersion::class) */
     public $versions;
 
-    /** @ODM\ReferenceMany(targetDocument="Comment") */
+    /** @ODM\ReferenceMany(targetDocument=Comment::class) */
     public $comments;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM29Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM29Test.php
@@ -55,7 +55,7 @@ class MODM29Doc
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\EmbedMany(targetDocument="MODM29Embedded", strategy="set") */
+    /** @ODM\EmbedMany(targetDocument=MODM29Embedded::class, strategy="set") */
     protected $collection;
 
     public function __construct($c)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM45Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM45Test.php
@@ -30,7 +30,7 @@ class MODM45A
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\EmbedOne(targetDocument="MODM45B") */
+    /** @ODM\EmbedOne(targetDocument=MODM45B::class) */
     protected $b;
 
     public function getId()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM46Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM46Test.php
@@ -32,7 +32,7 @@ class MODM46A
     public $id;
 
     /**
-     * @ODM\EmbedOne(targetDocument="MODM46AB")
+     * @ODM\EmbedOne(targetDocument=MODM46AB::class)
      * @ODM\AlsoLoad("c")
      */
     public $b;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM48Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM48Test.php
@@ -36,7 +36,7 @@ class MODM48A
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="MODM48B") */
+    /** @ODM\EmbedOne(targetDocument=MODM48B::class) */
     public $b;
 
     public function getId()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM52Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM52Test.php
@@ -42,7 +42,7 @@ class MODM52Container
     /** @ODM\Field(type="string") */
     public $value;
 
-    /** @ODM\EmbedMany(targetDocument="MODM52Embedded", strategy="set") */
+    /** @ODM\EmbedMany(targetDocument=MODM52Embedded::class, strategy="set") */
     public $items = [];
 
     public function __construct($items = null, $value = null)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM56Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM56Test.php
@@ -45,7 +45,7 @@ class MODM56Parent
     /** @ODM\Field(type="date") */
     public $updatedAt;
 
-    /** @ODM\EmbedMany(targetDocument="MODM56Child") */
+    /** @ODM\EmbedMany(targetDocument=MODM56Child::class) */
     public $children = [];
 
     public function __construct($name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM66Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM66Test.php
@@ -67,7 +67,7 @@ class MODM52A
     /** @ODM\Id */
     protected $id;
 
-    /** @ODM\ReferenceMany(targetDocument="MODM52B", cascade="all") */
+    /** @ODM\ReferenceMany(targetDocument=MODM52B::class, cascade="all") */
     protected $b;
 
     public function __construct($b)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM67Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM67Test.php
@@ -112,7 +112,7 @@ class MODM67DerivedClass
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="MODM67EmbeddedObject") */
+    /** @ODM\EmbedOne(targetDocument=MODM67EmbeddedObject::class) */
     public $embedOne;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
@@ -51,7 +51,7 @@ class Avatar
 
     /**
      * @ODM\EmbedMany(
-     *  targetDocument="AvatarPart",
+     *  targetDocument=AvatarPart::class,
      *  name="aP"
      * )
      * @var array AvatarPart

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM76Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM76Test.php
@@ -37,10 +37,10 @@ class MODM76A
     /** @ODM\Field(type="string") */
     protected $test = 'test';
 
-    /** @ODM\EmbedMany(targetDocument="MODM76B") */
+    /** @ODM\EmbedMany(targetDocument=MODM76B::class) */
     protected $b = [];
 
-    /** @ODM\ReferenceMany(targetDocument="MODM76C") */
+    /** @ODM\ReferenceMany(targetDocument=MODM76C::class) */
     protected $c = [];
 
     public function __construct($b, $c)
@@ -68,7 +68,7 @@ class MODM76A
 /** @ODM\EmbeddedDocument */
 class MODM76B
 {
-    /** @ODM\ReferenceOne(targetDocument="MODM76C") */
+    /** @ODM\ReferenceOne(targetDocument=MODM76C::class) */
     protected $c;
 
     public function __construct($c)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
@@ -70,7 +70,7 @@ class MODM81TestDocument
     /** @ODM\Field(type="string") */
     protected $name;
 
-    /** @ODM\EmbedMany(targetDocument="MODM81TestEmbeddedDocument") */
+    /** @ODM\EmbedMany(targetDocument=MODM81TestEmbeddedDocument::class) */
     protected $embeddedDocuments;
 
     /**
@@ -120,10 +120,10 @@ class MODM81TestEmbeddedDocument
     /** @ODM\Field(type="string") */
     public $message;
 
-    /** @ODM\ReferenceOne(targetDocument="MODM81TestDocument") */
+    /** @ODM\ReferenceOne(targetDocument=MODM81TestDocument::class) */
     public $refTodocument1;
 
-    /** @ODM\ReferenceOne(targetDocument="MODM81TestDocument") */
+    /** @ODM\ReferenceOne(targetDocument=MODM81TestDocument::class) */
     public $refTodocument2;
 
     public function __construct($document1, $document2, $message)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM83Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM83Test.php
@@ -72,7 +72,7 @@ class MODM83TestDocument
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\EmbedOne(targetDocument="MODM83TestEmbeddedDocument") */
+    /** @ODM\EmbedOne(targetDocument=MODM83TestEmbeddedDocument::class) */
     public $embedded;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM90Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM90Test.php
@@ -93,8 +93,8 @@ class MODM90TestDocument
      * (
      *   discriminatorField="type",
      *   discriminatorMap={
-     *     "test"="MODM90TestEmbeddedDocument",
-     *     "test2"="MODM90Test2EmbeddedDocument"
+     *     "test"=MODM90TestEmbeddedDocument::class,
+     *     "test2"=MODM90Test2EmbeddedDocument::class
      *   }
      *  )
      */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM91Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM91Test.php
@@ -64,7 +64,7 @@ class MODM91TestDocument
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\EmbedOne(targetDocument="MODM91TestEmbeddedDocument") */
+    /** @ODM\EmbedOne(targetDocument=MODM91TestEmbeddedDocument::class) */
     public $embedded;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM92Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM92Test.php
@@ -44,7 +44,7 @@ class MODM92TestDocument
     public $id;
 
     // Note: Test case fails with default "pushAll" strategy, but "set" works
-    /** @ODM\EmbedMany(targetDocument="MODM92TestEmbeddedDocument") */
+    /** @ODM\EmbedMany(targetDocument=MODM92TestEmbeddedDocument::class) */
     public $embeddedDocuments;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM95Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM95Test.php
@@ -50,7 +50,7 @@ class MODM95TestDocument
     public $id;
 
     // Note: Test case fails with default "pushAll" strategy, but "set" works
-    /** @ODM\EmbedMany(targetDocument="MODM95TestEmbeddedDocument") */
+    /** @ODM\EmbedMany(targetDocument=MODM95TestEmbeddedDocument::class) */
     public $embeddedDocuments;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/UpsertTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/UpsertTest.php
@@ -44,7 +44,7 @@ class UpsertTestUser
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedMany(targetDocument="UpsertTestUserEmbedded") */
+    /** @ODM\EmbedMany(targetDocument=UpsertTestUserEmbedded::class) */
     public $embedMany;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
@@ -57,7 +57,7 @@ class VersionedDocument
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\EmbedMany(targetDocument="VersionedEmbeddedDocument") */
+    /** @ODM\EmbedMany(targetDocument=VersionedEmbeddedDocument::class) */
     public $embedMany = [];
 
     public function __construct()
@@ -74,7 +74,7 @@ class VersionedEmbeddedDocument
     /** @ODM\Field(type="string") */
     public $value;
 
-    /** @ODM\EmbedMany(targetDocument="VersionedEmbeddedDocument") */
+    /** @ODM\EmbedMany(targetDocument=VersionedEmbeddedDocument::class) */
     public $embedMany;
 
     public function __construct($value)

--- a/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
@@ -82,16 +82,16 @@ class HydrationClosureUser
     /** @ODM\Field(type="date") */
     public $birthdate;
 
-    /** @ODM\ReferenceOne(targetDocument="HydrationClosureReferenceOne") */
+    /** @ODM\ReferenceOne(targetDocument=HydrationClosureReferenceOne::class) */
     public $referenceOne;
 
-    /** @ODM\ReferenceMany(targetDocument="HydrationClosureReferenceMany") */
+    /** @ODM\ReferenceMany(targetDocument=HydrationClosureReferenceMany::class) */
     public $referenceMany = [];
 
-    /** @ODM\EmbedOne(targetDocument="HydrationClosureEmbedOne") */
+    /** @ODM\EmbedOne(targetDocument=HydrationClosureEmbedOne::class) */
     public $embedOne;
 
-    /** @ODM\EmbedMany(targetDocument="HydrationClosureEmbedMany") */
+    /** @ODM\EmbedMany(targetDocument=HydrationClosureEmbedMany::class) */
     public $embedMany = [];
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -437,22 +437,22 @@ class AbstractMappingDriverUser
      */
     public $mysqlProfileId;
 
-    /** @ODM\ReferenceOne(targetDocument="Address", cascade={"remove"}) */
+    /** @ODM\ReferenceOne(targetDocument=Address::class, cascade={"remove"}) */
     public $address;
 
-    /** @ODM\ReferenceMany(targetDocument="Phonenumber", collectionClass="PhonenumberCollection", cascade={"persist"}, discriminatorField="discr", discriminatorMap={"home"="HomePhonenumber", "work"="WorkPhonenumber"}, defaultDiscriminatorValue="home") */
+    /** @ODM\ReferenceMany(targetDocument=Phonenumber::class, collectionClass=PhonenumberCollection::class, cascade={"persist"}, discriminatorField="discr", discriminatorMap={"home"=HomePhonenumber::class, "work"=WorkPhonenumber::class}, defaultDiscriminatorValue="home") */
     public $phonenumbers;
 
-    /** @ODM\ReferenceMany(targetDocument="Group", cascade={"all"}) */
+    /** @ODM\ReferenceMany(targetDocument=Group::class, cascade={"all"}) */
     public $groups;
 
-    /** @ODM\ReferenceMany(targetDocument="Phonenumber", collectionClass="PhonenumberCollection", name="more_phone_numbers") */
+    /** @ODM\ReferenceMany(targetDocument=Phonenumber::class, collectionClass=PhonenumberCollection::class, name="more_phone_numbers") */
     public $morePhoneNumbers;
 
-    /** @ODM\EmbedMany(targetDocument="Phonenumber", name="embedded_phone_number") */
+    /** @ODM\EmbedMany(targetDocument=Phonenumber::class, name="embedded_phone_number") */
     public $embeddedPhonenumber;
 
-    /** @ODM\EmbedMany(targetDocument="Phonenumber", discriminatorField="discr", discriminatorMap={"home"="HomePhonenumber", "work"="WorkPhonenumber"}, defaultDiscriminatorValue="home") */
+    /** @ODM\EmbedMany(targetDocument=Phonenumber::class, discriminatorField="discr", discriminatorMap={"home"=HomePhonenumber::class, "work"=WorkPhonenumber::class}, defaultDiscriminatorValue="home") */
     public $otherPhonenumbers;
 
     /** @ODM\Field(type="date") */
@@ -531,8 +531,8 @@ class AbstractMappingDriverUser
             'cascade' => [1 => 'persist'],
             'discriminatorField' => 'discr',
             'discriminatorMap' => [
-                'home' => 'HomePhonenumber',
-                'work' => 'WorkPhonenumber',
+                'home' => HomePhonenumber::class,
+                'work' => WorkPhonenumber::class,
             ],
             'defaultDiscriminatorValue' => 'home',
         ]);
@@ -562,8 +562,8 @@ class AbstractMappingDriverUser
            'targetDocument' => Phonenumber::class,
            'discriminatorField' => 'discr',
            'discriminatorMap' => [
-                'home' => 'HomePhonenumber',
-                'work' => 'WorkPhonenumber',
+                'home' => HomePhonenumber::class,
+                'work' => WorkPhonenumber::class,
            ],
             'defaultDiscriminatorValue' => 'home',
         ]);
@@ -576,6 +576,26 @@ class AbstractMappingDriverUser
 }
 
 class PhonenumberCollection extends ArrayCollection
+{
+}
+
+class HomePhonenumber
+{
+}
+
+class WorkPhonenumber
+{
+}
+
+class Address
+{
+}
+
+class Group
+{
+}
+
+class Phonenumber
 {
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
@@ -109,7 +109,7 @@ class MappedSuperclassBase
     /** @ODM\Field(type="string") */
     private $mapped2;
 
-    /** @ODM\ReferenceOne(targetDocument="MappedSuperclassRelated1") */
+    /** @ODM\ReferenceOne(targetDocument=MappedSuperclassRelated1::class) */
     private $mappedRelated1;
 
     private $transient;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -44,9 +44,9 @@ class ClassMetadataTest extends BaseTest
         $cm->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_SINGLE_COLLECTION);
         $cm->setSubclasses(['One', 'Two', 'Three']);
         $cm->setParentClasses(['UserParent']);
-        $cm->setCustomRepositoryClass('UserRepository');
+        $cm->setCustomRepositoryClass(UserRepository::class);
         $cm->setDiscriminatorField('disc');
-        $cm->mapOneEmbedded(['fieldName' => 'phonenumbers', 'targetDocument' => 'Bar']);
+        $cm->mapOneEmbedded(['fieldName' => 'phonenumbers', 'targetDocument' => Bar::class]);
         $cm->setShardKey(['_id' => '1']);
         $cm->setCollectionCapped(true);
         $cm->setCollectionMax(1000);
@@ -60,11 +60,10 @@ class ClassMetadataTest extends BaseTest
 
         // Check state
         $this->assertGreaterThan(0, $cm->getReflectionProperties());
-        $this->assertEquals('Documents', $cm->namespace);
         $this->assertInstanceOf(\ReflectionClass::class, $cm->reflClass);
         $this->assertEquals(CmsUser::class, $cm->name);
         $this->assertEquals('UserParent', $cm->rootDocumentName);
-        $this->assertEquals(['Documents\One', 'Documents\Two', 'Documents\Three'], $cm->subClasses);
+        $this->assertEquals(['One', 'Two', 'Three'], $cm->subClasses);
         $this->assertEquals(['UserParent'], $cm->parentClasses);
         $this->assertEquals(UserRepository::class, $cm->customRepositoryClassName);
         $this->assertEquals('disc', $cm->discriminatorField);
@@ -385,7 +384,7 @@ class ClassMetadataTest extends BaseTest
 
         $cm->setCustomRepositoryClass('TestCustomRepositoryClass');
 
-        $this->assertEquals('Doctrine\ODM\MongoDB\Tests\Mapping\TestCustomRepositoryClass', $cm->customRepositoryClassName);
+        $this->assertEquals('TestCustomRepositoryClass', $cm->customRepositoryClassName);
 
         $cm->setCustomRepositoryClass('Doctrine\ODM\MongoDB\Tests\Mapping\TestCustomRepositoryClass');
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Documents/GlobalNamespaceDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Documents/GlobalNamespaceDocument.php
@@ -18,7 +18,7 @@ class DoctrineGlobal_Article
     /** @ODM\Field(type="string") */
     protected $text;
 
-    /** @ODM\ReferenceMany(targetDocument="DoctrineGlobal_User") */
+    /** @ODM\ReferenceMany(targetDocument=DoctrineGlobal_User::class) */
     protected $author;
 
     /** @ODM\ReferenceMany(targetDocument="\DoctrineGlobal_User") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
@@ -45,36 +45,36 @@
                 </partial-filter-expression>
             </index>
         </indexes>
-        <reference-one target-document="Address" field="address">
+        <reference-one target-document="Doctrine\ODM\MongoDB\Tests\Mapping\Address" field="address">
             <cascade>
                 <remove />
             </cascade>
         </reference-one>
-        <reference-many target-document="Phonenumber" collection-class="PhonenumberCollection" field="phonenumbers">
+        <reference-many target-document="Doctrine\ODM\MongoDB\Tests\Mapping\Phonenumber" collection-class="Doctrine\ODM\MongoDB\Tests\Mapping\PhonenumberCollection" field="phonenumbers">
             <cascade>
                 <persist />
             </cascade>
             <discriminator-field name="discr" />
             <discriminator-map>
-                <discriminator-mapping value="home" class="HomePhonenumber" />
-                <discriminator-mapping value="work" class="WorkPhonenumber" />
+                <discriminator-mapping value="home" class="Doctrine\ODM\MongoDB\Tests\Mapping\HomePhonenumber" />
+                <discriminator-mapping value="work" class="Doctrine\ODM\MongoDB\Tests\Mapping\WorkPhonenumber" />
             </discriminator-map>
             <default-discriminator-value value="home" />
         </reference-many>
-        <reference-many target-document="Group" field="groups">
+        <reference-many target-document="Doctrine\ODM\MongoDB\Tests\Mapping\Group" field="groups">
             <cascade>
                 <all />
             </cascade>
         </reference-many>
-        <reference-many target-document="Phonenumber" field-name="morePhoneNumbers" field="more_phone_numbers">
+        <reference-many target-document="Doctrine\ODM\MongoDB\Tests\Mapping\Phonenumber" field-name="morePhoneNumbers" field="more_phone_numbers">
         </reference-many>
-        <embed-one target-document="Phonenumber" field-name="embeddedPhonenumber" field="embedded_phone_number">
+        <embed-one target-document="Doctrine\ODM\MongoDB\Tests\Mapping\Phonenumber" field-name="embeddedPhonenumber" field="embedded_phone_number">
         </embed-one>
-        <embed-many target-document="Phonenumber" collection-class="PhonenumberCollection" field="otherPhonenumbers">
+        <embed-many target-document="Doctrine\ODM\MongoDB\Tests\Mapping\Phonenumber" collection-class="Doctrine\ODM\MongoDB\Tests\Mapping\PhonenumberCollection" field="otherPhonenumbers">
             <discriminator-field name="discr" />
             <discriminator-map>
-                <discriminator-mapping value="home" class="HomePhonenumber" />
-                <discriminator-mapping value="work" class="WorkPhonenumber" />
+                <discriminator-mapping value="home" class="Doctrine\ODM\MongoDB\Tests\Mapping\HomePhonenumber" />
+                <discriminator-mapping value="work" class="Doctrine\ODM\MongoDB\Tests\Mapping\WorkPhonenumber" />
             </discriminator-map>
             <default-discriminator-value value="home" />
         </embed-many>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
@@ -160,6 +160,6 @@ class ShardedByReferenceOne
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument="Documents\User") */
+    /** @ODM\ReferenceOne(targetDocument=User::class) */
     public $reference;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -925,7 +925,7 @@ class BuilderTest extends BaseTest
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
  * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"ca"="ChildA", "cb"="ChildB", "cc"="ChildC"})
+ * @ODM\DiscriminatorMap({"ca"=ChildA::class, "cb"=ChildB::class, "cc"=ChildC::class})
  */
 class ParentClass
 {

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -528,7 +528,7 @@ class Person
     /** @ODM\ReferenceMany */
     public $friendsPartial = [];
 
-    /** @ODM\EmbedOne(targetDocument="Pet") */
+    /** @ODM\EmbedOne(targetDocument=Pet::class) */
     public $pet;
 
     public function __construct($firstName)

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -707,7 +707,7 @@ class NotifyChangedDocument implements NotifyPropertyChanged
     /** @ODM\Field(type="string") */
     private $data;
 
-    /** @ODM\ReferenceMany(targetDocument="NotifyChangedRelatedItem") */
+    /** @ODM\ReferenceMany(targetDocument=NotifyChangedRelatedItem::class) */
     private $items;
 
     private $transient; // not persisted
@@ -776,7 +776,7 @@ class NotifyChangedRelatedItem
     /** @ODM\Id(type="int_id", strategy="none") */
     private $id;
 
-    /** @ODM\ReferenceOne(targetDocument="NotifyChangedDocument") */
+    /** @ODM\ReferenceOne(targetDocument=NotifyChangedDocument::class) */
     private $owner;
 
     public function getId()
@@ -862,6 +862,6 @@ class PersistRemovedEmbeddedDocument
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="EmbeddedDocumentWithId") */
+    /** @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithId::class) */
     public $embedded;
 }

--- a/tests/Documents/Address.php
+++ b/tests/Documents/Address.php
@@ -24,7 +24,7 @@ class Address
     /** @ODM\Field(type="int", strategy="increment") */
     public $count = 0;
 
-    /** @ODM\EmbedOne(targetDocument="Address") */
+    /** @ODM\EmbedOne(targetDocument=Address::class) */
     private $subAddress;
 
     /** @ODM\Field(name="testFieldName", type="string") */

--- a/tests/Documents/Agent.php
+++ b/tests/Documents/Agent.php
@@ -14,8 +14,8 @@ class Agent
 
     /**
      * @ODM\ReferenceOne(discriminatorMap={
-     * "server"="Server",
-     * "server_guest"="GuestServer"
+     * "server"=Server::class,
+     * "server_guest"=GuestServer::class
      * })
      */
     public $server;

--- a/tests/Documents/Album.php
+++ b/tests/Documents/Album.php
@@ -15,7 +15,7 @@ class Album
     /** @ODM\Field(type="string") */
     private $name;
 
-    /** @ODM\EmbedMany(targetDocument="Song") */
+    /** @ODM\EmbedMany(targetDocument=Song::class) */
     private $songs = [];
 
     public function __construct($name)

--- a/tests/Documents/BaseCategory.php
+++ b/tests/Documents/BaseCategory.php
@@ -12,7 +12,7 @@ abstract class BaseCategory
     /** @ODM\Field(type="string") */
     protected $name;
 
-     /** @ODM\EmbedMany(targetDocument="SubCategory") */
+     /** @ODM\EmbedMany(targetDocument=SubCategory::class) */
     protected $children = [];
 
     public function __construct($name = null)

--- a/tests/Documents/BaseEmployee.php
+++ b/tests/Documents/BaseEmployee.php
@@ -30,7 +30,7 @@ abstract class BaseEmployee
     /** @ODM\Field(type="date") */
     protected $left;
 
-    /** @ODM\EmbedOne(targetDocument="Address") */
+    /** @ODM\EmbedOne(targetDocument=Address::class) */
     protected $address;
 
     public function getId()

--- a/tests/Documents/BlogPost.php
+++ b/tests/Documents/BlogPost.php
@@ -15,43 +15,43 @@ class BlogPost
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\ReferenceMany(targetDocument="Tag", inversedBy="blogPosts", cascade={"all"}) */
+    /** @ODM\ReferenceMany(targetDocument=Tag::class, inversedBy="blogPosts", cascade={"all"}) */
     public $tags = [];
 
-    /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", cascade={"all"}, prime={"author"}) */
+    /** @ODM\ReferenceMany(targetDocument=Comment::class, mappedBy="parent", cascade={"all"}, prime={"author"}) */
     public $comments = [];
 
-    /** @ODM\ReferenceOne(targetDocument="Comment", mappedBy="parent", sort={"date"="asc"}) */
+    /** @ODM\ReferenceOne(targetDocument=Comment::class, mappedBy="parent", sort={"date"="asc"}) */
     public $firstComment;
 
-    /** @ODM\ReferenceOne(targetDocument="Comment", mappedBy="parent", sort={"date"="desc"}) */
+    /** @ODM\ReferenceOne(targetDocument=Comment::class, mappedBy="parent", sort={"date"="desc"}) */
     public $latestComment;
 
-    /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", sort={"date"="desc"}, limit=5) */
+    /** @ODM\ReferenceMany(targetDocument=Comment::class, mappedBy="parent", sort={"date"="desc"}, limit=5) */
     public $last5Comments = [];
 
-    /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", criteria={"isByAdmin"=true}, sort={"date"="desc"}) */
+    /** @ODM\ReferenceMany(targetDocument=Comment::class, mappedBy="parent", criteria={"isByAdmin"=true}, sort={"date"="desc"}) */
     public $adminComments = [];
 
-    /** @ODM\ReferenceOne(targetDocument="Comment", mappedBy="parent", repositoryMethod="findOneComment") */
+    /** @ODM\ReferenceOne(targetDocument=Comment::class, mappedBy="parent", repositoryMethod="findOneComment") */
     public $repoComment;
 
-    /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", repositoryMethod="findManyComments") */
+    /** @ODM\ReferenceMany(targetDocument=Comment::class, mappedBy="parent", repositoryMethod="findManyComments") */
     public $repoComments;
 
-    /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", repositoryMethod="findManyComments", prime={"author"}) */
+    /** @ODM\ReferenceMany(targetDocument=Comment::class, mappedBy="parent", repositoryMethod="findManyComments", prime={"author"}) */
     public $repoCommentsWithPrimer;
 
-    /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", strategy="set", repositoryMethod="findManyComments") */
+    /** @ODM\ReferenceMany(targetDocument=Comment::class, mappedBy="parent", strategy="set", repositoryMethod="findManyComments") */
     public $repoCommentsSet;
 
-    /** @ODM\ReferenceMany(targetDocument="Comment", repositoryMethod="findManyComments") */
+    /** @ODM\ReferenceMany(targetDocument=Comment::class, repositoryMethod="findManyComments") */
     public $repoCommentsWithoutMappedBy;
 
-    /** @ODM\ReferenceMany(targetDocument="Comment", mappedBy="parent", repositoryMethod="findManyCommentsEager", prime={"author"}) */
+    /** @ODM\ReferenceMany(targetDocument=Comment::class, mappedBy="parent", repositoryMethod="findManyCommentsEager", prime={"author"}) */
     public $repoCommentsEager;
 
-    /** @ODM\ReferenceOne(targetDocument="User", inversedBy="posts", nullable=true) */
+    /** @ODM\ReferenceOne(targetDocument=User::class, inversedBy="posts", nullable=true) */
     public $user;
 
     public function __construct($name = null)

--- a/tests/Documents/BlogTagAggregation.php
+++ b/tests/Documents/BlogTagAggregation.php
@@ -11,7 +11,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  */
 class BlogTagAggregation
 {
-    /** @ODM\ReferenceOne(targetDocument="Tag", name="_id") */
+    /** @ODM\ReferenceOne(targetDocument=Tag::class, name="_id") */
     public $tag;
 
     /** @ODM\Field(type="int") */

--- a/tests/Documents/Book.php
+++ b/tests/Documents/Book.php
@@ -18,10 +18,10 @@ class Book
     /** @ODM\Field(type="int") @ODM\Version */
     public $version = 1;
 
-    /** @ODM\EmbedMany(targetDocument="Chapter", strategy="atomicSet") */
+    /** @ODM\EmbedMany(targetDocument=Chapter::class, strategy="atomicSet") */
     public $chapters;
 
-    /** @ODM\EmbedMany(targetDocument="IdentifiedChapter", strategy="atomicSet") */
+    /** @ODM\EmbedMany(targetDocument=IdentifiedChapter::class, strategy="atomicSet") */
     public $identifiedChapters;
 
     public function __construct()

--- a/tests/Documents/BrowseNode.php
+++ b/tests/Documents/BrowseNode.php
@@ -16,10 +16,10 @@ class BrowseNode
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\ReferenceOne(targetDocument="BrowseNode", inversedBy="children", cascade={"all"}) */
+    /** @ODM\ReferenceOne(targetDocument=BrowseNode::class, inversedBy="children", cascade={"all"}) */
     public $parent;
 
-    /** @ODM\ReferenceMany(targetDocument="BrowseNode", mappedBy="parent", cascade={"all"}) */
+    /** @ODM\ReferenceMany(targetDocument=BrowseNode::class, mappedBy="parent", cascade={"all"}) */
     public $children;
 
     public function __construct($name = null)

--- a/tests/Documents/Cart.php
+++ b/tests/Documents/Cart.php
@@ -15,6 +15,6 @@ class Cart
     /** @ODM\Field(type="int") */
     public $numItems = 0;
 
-    /** @ODM\ReferenceOne(targetDocument="Customer", inversedBy="cart") */
+    /** @ODM\ReferenceOne(targetDocument=Customer::class, inversedBy="cart") */
     public $customer;
 }

--- a/tests/Documents/Chapter.php
+++ b/tests/Documents/Chapter.php
@@ -16,7 +16,7 @@ class Chapter
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\EmbedMany(targetDocument="Page") */
+    /** @ODM\EmbedMany(targetDocument=Page::class) */
     public $pages;
 
     /** @ODM\Field(type="int") */

--- a/tests/Documents/CmsAddress.php
+++ b/tests/Documents/CmsAddress.php
@@ -26,7 +26,7 @@ class CmsAddress
     /** @ODM\Field(type="string") */
     public $city;
 
-    /** @ODM\ReferenceOne(targetDocument="CmsUser") */
+    /** @ODM\ReferenceOne(targetDocument=CmsUser::class) */
     public $user;
 
     public function getId()

--- a/tests/Documents/CmsArticle.php
+++ b/tests/Documents/CmsArticle.php
@@ -20,9 +20,9 @@ class CmsArticle
     public $topic;
     /** @ODM\Field(type="string") */
     public $text;
-    /** @ODM\ReferenceOne(targetDocument="CmsUser") */
+    /** @ODM\ReferenceOne(targetDocument=CmsUser::class) */
     public $user;
-    /** @ODM\ReferenceMany(targetDocument="CmsComment") */
+    /** @ODM\ReferenceMany(targetDocument=CmsComment::class) */
     public $comments;
 
     public function setAuthor(CmsUser $author)

--- a/tests/Documents/CmsComment.php
+++ b/tests/Documents/CmsComment.php
@@ -20,7 +20,7 @@ class CmsComment
     public $topic;
     /** @ODM\Field */
     public $text;
-    /** @ODM\ReferenceOne(targetDocument="CmsArticle") */
+    /** @ODM\ReferenceOne(targetDocument=CmsArticle::class) */
     public $article;
 
     /** @ODM\Field(name="ip", type="string") */

--- a/tests/Documents/CmsGroup.php
+++ b/tests/Documents/CmsGroup.php
@@ -15,7 +15,7 @@ class CmsGroup
     public $id;
     /** @ODM\Field(type="string") */
     public $name;
-    /** @ODM\ReferenceMany(targetDocument="CmsUser") */
+    /** @ODM\ReferenceMany(targetDocument=CmsUser::class) */
     public $users;
 
     public function setName($name)

--- a/tests/Documents/CmsPhonenumber.php
+++ b/tests/Documents/CmsPhonenumber.php
@@ -14,7 +14,7 @@ class CmsPhonenumber
     /** @ODM\Id(strategy="NONE", type="custom_id") */
     public $phonenumber;
 
-    /** @ODM\ReferenceOne(targetDocument="CmsUser", cascade={"merge"}) */
+    /** @ODM\ReferenceOne(targetDocument=CmsUser::class, cascade={"merge"}) */
     public $user;
 
     public function setUser(CmsUser $user)

--- a/tests/Documents/CmsUser.php
+++ b/tests/Documents/CmsUser.php
@@ -24,16 +24,16 @@ class CmsUser
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\ReferenceMany(targetDocument="CmsPhonenumber", mappedBy="user", cascade={"persist", "remove", "merge"}) */
+    /** @ODM\ReferenceMany(targetDocument=CmsPhonenumber::class, mappedBy="user", cascade={"persist", "remove", "merge"}) */
     public $phonenumbers;
 
-    /** @ODM\ReferenceMany(targetDocument="CmsArticle") */
+    /** @ODM\ReferenceMany(targetDocument=CmsArticle::class) */
     public $articles;
 
-    /** @ODM\ReferenceOne(targetDocument="CmsAddress", cascade={"persist"}) */
+    /** @ODM\ReferenceOne(targetDocument=CmsAddress::class, cascade={"persist"}) */
     public $address;
 
-    /** @ODM\ReferenceMany(targetDocument="CmsGroup", cascade={"persist", "merge"}) */
+    /** @ODM\ReferenceMany(targetDocument=CmsGroup::class, cascade={"persist", "merge"}) */
     public $groups;
 
     public function __construct()

--- a/tests/Documents/Comment.php
+++ b/tests/Documents/Comment.php
@@ -7,7 +7,7 @@ namespace Documents;
 use DateTime;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(repositoryClass="Documents\CommentRepository") */
+/** @ODM\Document(repositoryClass=CommentRepository::class) */
 class Comment
 {
     /** @ODM\Id */
@@ -16,10 +16,10 @@ class Comment
     /** @ODM\Field(type="string") */
     public $text;
 
-    /** @ODM\ReferenceOne(targetDocument="User", cascade={"all"}) */
+    /** @ODM\ReferenceOne(targetDocument=User::class, cascade={"all"}) */
     public $author;
 
-    /** @ODM\ReferenceOne(targetDocument="BlogPost", inversedBy="comments", cascade={"all"}) */
+    /** @ODM\ReferenceOne(targetDocument=BlogPost::class, inversedBy="comments", cascade={"all"}) */
     public $parent;
 
     /** @ODM\Field(type="date") @ODM\Index(order="1") */

--- a/tests/Documents/CustomUser.php
+++ b/tests/Documents/CustomUser.php
@@ -18,7 +18,7 @@ class CustomUser
     /** @ODM\Field(type="string") */
     protected $password;
 
-    /** @ODM\ReferenceOne(targetDocument="Account", cascade={"all"}) */
+    /** @ODM\ReferenceOne(targetDocument=Account::class, cascade={"all"}) */
     protected $account;
 
     public function getId()

--- a/tests/Documents/Customer.php
+++ b/tests/Documents/Customer.php
@@ -18,6 +18,6 @@ class Customer
     /** @ODM\Field(name="cart", type="string") */
     public $cartTest;
 
-    /** @ODM\ReferenceOne(targetDocument="Cart", mappedBy="customer") */
+    /** @ODM\ReferenceOne(targetDocument=Cart::class, mappedBy="customer") */
     public $cart;
 }

--- a/tests/Documents/Developer.php
+++ b/tests/Documents/Developer.php
@@ -19,7 +19,7 @@ class Developer
     /** @ODM\Field(type="string") */
     private $name;
 
-    /** @ODM\ReferenceMany(targetDocument="Documents\Project", cascade="all") */
+    /** @ODM\ReferenceMany(targetDocument=Project::class, cascade="all") */
     private $projects;
 
     public function __construct($name, ?Collection $projects = null)

--- a/tests/Documents/Employee.php
+++ b/tests/Documents/Employee.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\Document */
 class Employee extends BaseEmployee
 {
-    /** @ODM\ReferenceOne(targetDocument="Documents\Manager") */
+    /** @ODM\ReferenceOne(targetDocument=Manager::class) */
     private $manager;
 
     public function getManager()

--- a/tests/Documents/Event.php
+++ b/tests/Documents/Event.php
@@ -12,7 +12,7 @@ class Event
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\ReferenceOne(targetDocument="Documents\User") */
+    /** @ODM\ReferenceOne(targetDocument=User::class) */
     private $user;
 
     /** @ODM\Field(type="string") */

--- a/tests/Documents/Feature.php
+++ b/tests/Documents/Feature.php
@@ -15,7 +15,7 @@ class Feature
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\ReferenceOne(targetDocument="Product", inversedBy="features", cascade={"all"}) */
+    /** @ODM\ReferenceOne(targetDocument=Product::class, inversedBy="features", cascade={"all"}) */
     public $product;
 
     public function __construct($name)

--- a/tests/Documents/ForumUser.php
+++ b/tests/Documents/ForumUser.php
@@ -15,7 +15,7 @@ class ForumUser
     /** @ODM\Field(type="string") */
     public $username;
 
-    /** @ODM\ReferenceOne(targetDocument="ForumAvatar", cascade={"persist"}) */
+    /** @ODM\ReferenceOne(targetDocument=ForumAvatar::class, cascade={"persist"}) */
     public $avatar;
 
     public function getId()

--- a/tests/Documents/FriendUser.php
+++ b/tests/Documents/FriendUser.php
@@ -16,10 +16,10 @@ class FriendUser
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\ReferenceMany(targetDocument="FriendUser", mappedBy="myFriends", cascade={"all"}) */
+    /** @ODM\ReferenceMany(targetDocument=FriendUser::class, mappedBy="myFriends", cascade={"all"}) */
     public $friendsWithMe;
 
-    /** @ODM\ReferenceMany(targetDocument="FriendUser", inversedBy="friendsWithMe", cascade={"all"}) */
+    /** @ODM\ReferenceMany(targetDocument=FriendUser::class, inversedBy="friendsWithMe", cascade={"all"}) */
     public $myFriends;
 
     public function __construct($name)

--- a/tests/Documents/Functional/EmbedNamed.php
+++ b/tests/Documents/Functional/EmbedNamed.php
@@ -12,9 +12,9 @@ class EmbedNamed
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument="EmbeddedWhichReferences", name="embedded_doc") */
+    /** @ODM\EmbedOne(targetDocument=EmbeddedWhichReferences::class, name="embedded_doc") */
     public $embeddedDoc;
 
-    /** @ODM\EmbedMany(targetDocument="EmbeddedWhichReferences", name="embedded_docs") */
+    /** @ODM\EmbedMany(targetDocument=EmbeddedWhichReferences::class, name="embedded_docs") */
     public $embeddedDocs = [];
 }

--- a/tests/Documents/Functional/EmbeddedTestLevel0.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel0.php
@@ -13,6 +13,6 @@ class EmbeddedTestLevel0
     public $id;
     /** @ODM\Field(type="string") */
     public $name;
-    /** @ODM\EmbedMany(targetDocument="EmbeddedTestLevel1") */
+    /** @ODM\EmbedMany(targetDocument=EmbeddedTestLevel1::class) */
     public $level1 = [];
 }

--- a/tests/Documents/Functional/EmbeddedTestLevel0b.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel0b.php
@@ -13,8 +13,8 @@ class EmbeddedTestLevel0b
     public $id;
     /** @ODM\Field(type="string") */
     public $name;
-    /** @ODM\EmbedOne(targetDocument="EmbeddedTestLevel1") */
+    /** @ODM\EmbedOne(targetDocument=EmbeddedTestLevel1::class) */
     public $oneLevel1;
-    /** @ODM\EmbedMany(targetDocument="EmbeddedTestLevel1") */
+    /** @ODM\EmbedMany(targetDocument=EmbeddedTestLevel1::class) */
     public $level1 = [];
 }

--- a/tests/Documents/Functional/EmbeddedTestLevel1.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel1.php
@@ -11,7 +11,7 @@ class EmbeddedTestLevel1
 {
     /** @ODM\Field(type="string") */
     public $name;
-    /** @ODM\EmbedMany(targetDocument="EmbeddedTestLevel2") */
+    /** @ODM\EmbedMany(targetDocument=EmbeddedTestLevel2::class) */
     public $level2 = [];
 
     public $preRemove = false;

--- a/tests/Documents/Functional/EmbeddedWhichReferences.php
+++ b/tests/Documents/Functional/EmbeddedWhichReferences.php
@@ -9,9 +9,9 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\EmbeddedDocument */
 class EmbeddedWhichReferences
 {
-    /** @ODM\ReferenceOne(targetDocument="Reference", name="reference_doc") */
+    /** @ODM\ReferenceOne(targetDocument=Reference::class, name="reference_doc") */
     public $referencedDoc;
 
-    /** @ODM\ReferenceMany(targetDocument="Reference", name="reference_docs") */
+    /** @ODM\ReferenceMany(targetDocument=Reference::class, name="reference_docs") */
     public $referencedDocs = [];
 }

--- a/tests/Documents/Functional/NotSaved.php
+++ b/tests/Documents/Functional/NotSaved.php
@@ -18,6 +18,6 @@ class NotSaved
     /** @ODM\NotSaved */
     public $notSaved;
 
-    /** @ODM\EmbedOne(targetDocument="NotSavedEmbedded") */
+    /** @ODM\EmbedOne(targetDocument=NotSavedEmbedded::class) */
     public $embedded;
 }

--- a/tests/Documents/Functional/PreUpdateTestProduct.php
+++ b/tests/Documents/Functional/PreUpdateTestProduct.php
@@ -17,7 +17,7 @@ class PreUpdateTestProduct
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\EmbedOne(targetDocument="PreUpdateTestSellable") */
+    /** @ODM\EmbedOne(targetDocument=PreUpdateTestSellable::class) */
     public $sellable;
 
     public function getName()

--- a/tests/Documents/Functional/PreUpdateTestSellable.php
+++ b/tests/Documents/Functional/PreUpdateTestSellable.php
@@ -11,10 +11,10 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  */
 class PreUpdateTestSellable
 {
-    /** @ODM\ReferenceOne(targetDocument="PreUpdateTestProduct") */
+    /** @ODM\ReferenceOne(targetDocument=PreUpdateTestProduct::class) */
     public $product;
 
-    /** @ODM\ReferenceOne(targetDocument="PreUpdateTestSeller") */
+    /** @ODM\ReferenceOne(targetDocument=PreUpdateTestSeller::class) */
     public $seller;
 
     public function getProduct()

--- a/tests/Documents/Functional/SimpleEmbedAndReference.php
+++ b/tests/Documents/Functional/SimpleEmbedAndReference.php
@@ -12,15 +12,15 @@ class SimpleEmbedAndReference
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\EmbedMany(targetDocument="Embedded") */
+    /** @ODM\EmbedMany(targetDocument=Embedded::class) */
     public $embedMany = [];
 
-    /** @ODM\ReferenceMany(targetDocument="Reference") */
+    /** @ODM\ReferenceMany(targetDocument=Reference::class) */
     public $referenceMany = [];
 
-    /** @ODM\EmbedOne(targetDocument="Embedded") */
+    /** @ODM\EmbedOne(targetDocument=Embedded::class) */
     public $embedOne;
 
-    /** @ODM\ReferenceOne(targetDocument="Reference") */
+    /** @ODM\ReferenceOne(targetDocument=Reference::class) */
     public $referenceOne;
 }

--- a/tests/Documents/Functional/Ticket/GH683/AbstractEmbedded.php
+++ b/tests/Documents/Functional/Ticket/GH683/AbstractEmbedded.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /**
  * @ODM\EmbeddedDocument
  * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"e1"="EmbeddedSubDocument1", "e2"="EmbeddedSubDocument2"})
+ * @ODM\DiscriminatorMap({"e1"=EmbeddedSubDocument1::class, "e2"=EmbeddedSubDocument2::class})
  */
 class AbstractEmbedded
 {

--- a/tests/Documents/Functional/Ticket/GH683/ParentDocument.php
+++ b/tests/Documents/Functional/Ticket/GH683/ParentDocument.php
@@ -13,8 +13,8 @@ class ParentDocument
     public $id;
     /** @ODM\Field(type="string") */
     public $name;
-    /** @ODM\EmbedOne(targetDocument="AbstractEmbedded") */
+    /** @ODM\EmbedOne(targetDocument=AbstractEmbedded::class) */
     public $embedOne;
-    /** @ODM\EmbedMany(targetDocument="AbstractEmbedded") */
+    /** @ODM\EmbedMany(targetDocument=AbstractEmbedded::class) */
     public $embedMany;
 }

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayCollectionLevel0.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayCollectionLevel0.php
@@ -14,7 +14,7 @@ class EmbedManyInArrayCollectionLevel0
     public $id;
     /** @ODM\Field(type="string") */
     public $name;
-    /** @ODM\EmbedMany(targetDocument="EmbedManyInArrayCollectionLevel1") */
+    /** @ODM\EmbedMany(targetDocument=EmbedManyInArrayCollectionLevel1::class) */
     public $level1;
 
     public function __construct()

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayCollectionLevel1.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayCollectionLevel1.php
@@ -12,7 +12,7 @@ class EmbedManyInArrayCollectionLevel1
 {
     /** @ODM\Field(type="string") */
     public $name;
-    /** @ODM\EmbedMany(targetDocument="MODM160Level2") */
+    /** @ODM\EmbedMany(targetDocument=MODM160Level2::class) */
     public $level2;
 
     public function __construct()

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayLevel0.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayLevel0.php
@@ -13,6 +13,6 @@ class EmbedManyInArrayLevel0
     public $id;
     /** @ODM\Field(type="string") */
     public $name;
-    /** @ODM\EmbedMany(targetDocument="EmbedManyInArrayLevel1") */
+    /** @ODM\EmbedMany(targetDocument=EmbedManyInArrayLevel1::class) */
     public $level1 = [];
 }

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayLevel1.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayLevel1.php
@@ -11,6 +11,6 @@ class EmbedManyInArrayLevel1
 {
     /** @ODM\Field(type="string") */
     public $name;
-    /** @ODM\EmbedMany(targetDocument="MODM160Level2") */
+    /** @ODM\EmbedMany(targetDocument=MODM160Level2::class) */
     public $level2 = [];
 }

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedOneLevel0.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedOneLevel0.php
@@ -13,6 +13,6 @@ class EmbedOneLevel0
     public $id;
     /** @ODM\Field(type="string") */
     public $name;
-    /** @ODM\EmbedOne(targetDocument="EmbedOneLevel1") */
+    /** @ODM\EmbedOne(targetDocument=EmbedOneLevel1::class) */
     public $level1;
 }

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedOneLevel1.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedOneLevel1.php
@@ -11,6 +11,6 @@ class EmbedOneLevel1
 {
     /** @ODM\Field(type="string") */
     public $name;
-    /** @ODM\EmbedOne(targetDocument="MODM160Level2") */
+    /** @ODM\EmbedOne(targetDocument=MODM160Level2::class) */
     public $level2;
 }

--- a/tests/Documents/IdentifiedChapter.php
+++ b/tests/Documents/IdentifiedChapter.php
@@ -16,7 +16,7 @@ class IdentifiedChapter
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\EmbedMany(targetDocument="Page") */
+    /** @ODM\EmbedMany(targetDocument=Page::class) */
     public $pages;
 
     public function __construct($name = null)

--- a/tests/Documents/IndirectlyReferencedUser.php
+++ b/tests/Documents/IndirectlyReferencedUser.php
@@ -14,7 +14,7 @@ class IndirectlyReferencedUser
     /**
      * @var User
      *
-     * @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="ref")
+     * @ODM\ReferenceOne(targetDocument=User::class, storeAs="ref")
      */
     public $user;
 }

--- a/tests/Documents/Manager.php
+++ b/tests/Documents/Manager.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\Document */
 class Manager extends BaseEmployee
 {
-    /** @ODM\ReferenceMany(targetDocument="Documents\Project") */
+    /** @ODM\ReferenceMany(targetDocument=Project::class) */
     private $projects = [];
 
     public function getProjects()

--- a/tests/Documents/Phonebook.php
+++ b/tests/Documents/Phonebook.php
@@ -13,7 +13,7 @@ class Phonebook
     /** @ODM\Field(type="string") */
     private $title;
 
-    /** @ODM\EmbedMany(targetDocument="Phonenumber") */
+    /** @ODM\EmbedMany(targetDocument=Phonenumber::class) */
     private $phonenumbers;
 
     public function __construct($title)

--- a/tests/Documents/Phonenumber.php
+++ b/tests/Documents/Phonenumber.php
@@ -12,7 +12,7 @@ class Phonenumber
     /** @ODM\Field(type="string") */
     private $phonenumber;
 
-    /** @ODM\ReferenceOne(targetDocument="User", cascade={"persist"}) */
+    /** @ODM\ReferenceOne(targetDocument=User::class, cascade={"persist"}) */
     private $lastCalledBy;
 
     public function __construct($phonenumber = null, ?User $lastCalledBy = null)

--- a/tests/Documents/Product.php
+++ b/tests/Documents/Product.php
@@ -16,7 +16,7 @@ class Product
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\ReferenceMany(targetDocument="Feature", mappedBy="product", cascade={"all"}) */
+    /** @ODM\ReferenceMany(targetDocument=Feature::class, mappedBy="product", cascade={"all"}) */
     public $features;
 
     public function __construct($name)

--- a/tests/Documents/Profile.php
+++ b/tests/Documents/Profile.php
@@ -18,7 +18,7 @@ class Profile
     /** @ODM\Field */
     private $lastName;
 
-    /** @ODM\ReferenceOne(targetDocument="File", cascade={"all"}) */
+    /** @ODM\ReferenceOne(targetDocument=File::class, cascade={"all"}) */
     private $image;
 
     public function getProfileId()

--- a/tests/Documents/ProfileNotify.php
+++ b/tests/Documents/ProfileNotify.php
@@ -21,10 +21,10 @@ class ProfileNotify implements NotifyPropertyChanged
     /** @ODM\Field */
     private $lastName;
 
-    /** @ODM\ReferenceOne(targetDocument="File", cascade={"all"}) */
+    /** @ODM\ReferenceOne(targetDocument=File::class, cascade={"all"}) */
     private $image;
 
-    /** @ODM\ReferenceMany(targetDocument="File", cascade={"all"}, collectionClass="ProfileNotifyImagesCollection") */
+    /** @ODM\ReferenceMany(targetDocument=File::class, cascade={"all"}, collectionClass=ProfileNotifyImagesCollection::class) */
     private $images;
 
     /** @var PropertyChangedListener[] */

--- a/tests/Documents/Project.php
+++ b/tests/Documents/Project.php
@@ -22,10 +22,10 @@ class Project
     /** @ODM\Field(type="string") */
     private $name;
 
-    /** @ODM\EmbedOne(targetDocument="Address") */
+    /** @ODM\EmbedOne(targetDocument=Address::class) */
     private $address;
 
-    /** @ODM\ReferenceMany(targetDocument="SubProject", cascade="all") */
+    /** @ODM\ReferenceMany(targetDocument=SubProject::class, cascade="all") */
     private $subProjects;
 
     public function __construct($name, ?Collection $subProjects = null)

--- a/tests/Documents/ReferenceUser.php
+++ b/tests/Documents/ReferenceUser.php
@@ -17,56 +17,56 @@ class ReferenceUser
     public $id;
 
     /**
-     * @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="id")
+     * @ODM\ReferenceOne(targetDocument=User::class, storeAs="id")
      *
      * @var User
      */
     public $user;
 
     /**
-     * @ODM\ReferenceMany(targetDocument="Documents\User", storeAs="id")
+     * @ODM\ReferenceMany(targetDocument=User::class, storeAs="id")
      *
      * @var User[]
      */
     public $users = [];
 
     /**
-     * @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="dbRef")
+     * @ODM\ReferenceOne(targetDocument=User::class, storeAs="dbRef")
      *
      * @var User
      */
     public $parentUser;
 
     /**
-     * @ODM\ReferenceMany(targetDocument="Documents\User", storeAs="dbRef")
+     * @ODM\ReferenceMany(targetDocument=User::class, storeAs="dbRef")
      *
      * @var User[]
      */
     public $parentUsers = [];
 
     /**
-     * @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="dbRefWithDb")
+     * @ODM\ReferenceOne(targetDocument=User::class, storeAs="dbRefWithDb")
      *
      * @var User
      */
     public $otherUser;
 
     /**
-     * @ODM\ReferenceMany(targetDocument="Documents\User", storeAs="dbRefWithDb")
+     * @ODM\ReferenceMany(targetDocument=User::class, storeAs="dbRefWithDb")
      *
      * @var User[]
      */
     public $otherUsers = [];
 
     /**
-     * @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="ref")
+     * @ODM\ReferenceOne(targetDocument=User::class, storeAs="ref")
      *
      * @var User
      */
     public $referencedUser;
 
     /**
-     * @ODM\ReferenceMany(targetDocument="Documents\User", storeAs="ref")
+     * @ODM\ReferenceMany(targetDocument=User::class, storeAs="ref")
      *
      * @var User[]
      */

--- a/tests/Documents/Server.php
+++ b/tests/Documents/Server.php
@@ -11,8 +11,8 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  * @ODM\InheritanceType("SINGLE_COLLECTION")
  * @ODM\DiscriminatorField("stype")
  * @ODM\DiscriminatorMap({
- * "server"="Server",
- * "server_guest"="GuestServer"
+ * "server"=Server::class,
+ * "server_guest"=GuestServer::class
  * })
  */
 class Server

--- a/tests/Documents/SimpleReferenceUser.php
+++ b/tests/Documents/SimpleReferenceUser.php
@@ -14,10 +14,10 @@ class SimpleReferenceUser
     /** @ODM\Id */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument="Documents\User", storeAs="id", name="userId") @ODM\Index */
+    /** @ODM\ReferenceOne(targetDocument=User::class, storeAs="id", name="userId") @ODM\Index */
     public $user;
 
-    /** @ODM\ReferenceMany(targetDocument="Documents\User", storeAs="id") */
+    /** @ODM\ReferenceMany(targetDocument=User::class, storeAs="id") */
     public $users = [];
 
     /** @ODM\Field(type="string") */

--- a/tests/Documents/Strategy.php
+++ b/tests/Documents/Strategy.php
@@ -15,9 +15,9 @@ class Strategy
     /** @ODM\Field(type="collection") */
     public $logs = [];
 
-    /** @ODM\EmbedMany(targetDocument="Message", strategy="set") */
+    /** @ODM\EmbedMany(targetDocument=Message::class, strategy="set") */
     public $messages = [];
 
-    /** @ODM\ReferenceMany(targetDocument="Task", strategy="set") */
+    /** @ODM\ReferenceMany(targetDocument=Task::class, strategy="set") */
     public $tasks = [];
 }

--- a/tests/Documents/SubProject.php
+++ b/tests/Documents/SubProject.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\Document */
 class SubProject extends Project
 {
-    /** @ODM\EmbedMany(targetDocument="Documents\Issue") */
+    /** @ODM\EmbedMany(targetDocument=Issue::class) */
     private $issues;
 
     public function getIssues()

--- a/tests/Documents/Tag.php
+++ b/tests/Documents/Tag.php
@@ -15,7 +15,7 @@ class Tag
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\ReferenceMany(targetDocument="BlogPost", mappedBy="tags") */
+    /** @ODM\ReferenceMany(targetDocument=BlogPost::class, mappedBy="tags") */
     public $blogPosts;
 
     public function __construct($name)

--- a/tests/Documents/Tournament/Participant.php
+++ b/tests/Documents/Tournament/Participant.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /**
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODm\DiscriminatorMap({"solo"="ParticipantSolo", "team"="ParticipantTeam"})
+ * @ODm\DiscriminatorMap({"solo"=ParticipantSolo::class, "team"=ParticipantTeam::class})
  */
 class Participant
 {
@@ -19,7 +19,7 @@ class Participant
     /** @ODM\Field */
     private $name;
 
-    /** @ODM\ReferenceOne(targetDocument="Tournament", cascade={"all"}) */
+    /** @ODM\ReferenceOne(targetDocument=Tournament::class, cascade={"all"}) */
     protected $tournament;
 
     public function __construct($name)

--- a/tests/Documents/Tournament/Tournament.php
+++ b/tests/Documents/Tournament/Tournament.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /**
  * @ODM\Document
  * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorMap({"football"="TournamentFootball","tennis": "TournamentTennis"})
+ * @ODM\DiscriminatorMap({"football"=TournamentFootball::class,"tennis": TournamentTennis::class})
  */
 class Tournament
 {
@@ -19,7 +19,7 @@ class Tournament
     /** @ODM\Field */
     private $name;
 
-    /** @ODM\ReferenceMany(targetDocument="Participant", cascade={"all"}) */
+    /** @ODM\ReferenceMany(targetDocument=Participant::class, cascade={"all"}) */
     protected $participants = [];
 
     public function __construct($name)

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -25,40 +25,40 @@ class User extends BaseDocument
     /** @ODM\Field(type="date") */
     protected $createdAt;
 
-    /** @ODM\EmbedOne(targetDocument="Address", nullable=true) */
+    /** @ODM\EmbedOne(targetDocument=Address::class, nullable=true) */
     protected $address;
 
-    /** @ODM\ReferenceOne(targetDocument="Profile", cascade={"all"}) */
+    /** @ODM\ReferenceOne(targetDocument=Profile::class, cascade={"all"}) */
     protected $profile;
 
-    /** @ODM\ReferenceOne(targetDocument="ProfileNotify", cascade={"all"}) */
+    /** @ODM\ReferenceOne(targetDocument=ProfileNotify::class, cascade={"all"}) */
     protected $profileNotify;
 
-    /** @ODM\EmbedMany(targetDocument="Phonenumber") */
+    /** @ODM\EmbedMany(targetDocument=Phonenumber::class) */
     protected $phonenumbers;
 
-    /** @ODM\EmbedMany(targetDocument="Phonebook") */
+    /** @ODM\EmbedMany(targetDocument=Phonebook::class) */
     protected $phonebooks;
 
-    /** @ODM\ReferenceMany(targetDocument="Group", cascade={"all"}) */
+    /** @ODM\ReferenceMany(targetDocument=Group::class, cascade={"all"}) */
     protected $groups;
 
-    /** @ODM\ReferenceMany(targetDocument="Group", storeAs="id", cascade={"all"}) */
+    /** @ODM\ReferenceMany(targetDocument=Group::class, storeAs="id", cascade={"all"}) */
     protected $groupsSimple;
 
-    /** @ODM\ReferenceMany(targetDocument="Group", cascade={"all"}, strategy="addToSet") */
+    /** @ODM\ReferenceMany(targetDocument=Group::class, cascade={"all"}, strategy="addToSet") */
     protected $uniqueGroups;
 
-    /** @ODM\ReferenceMany(targetDocument="Group", name="groups", sort={"name"="asc"}, strategy="setArray") */
+    /** @ODM\ReferenceMany(targetDocument=Group::class, name="groups", sort={"name"="asc"}, strategy="setArray") */
     protected $sortedAscGroups;
 
-    /** @ODM\ReferenceMany(targetDocument="Group", name="groups", sort={"name"="desc"}, strategy="setArray") */
+    /** @ODM\ReferenceMany(targetDocument=Group::class, name="groups", sort={"name"="desc"}, strategy="setArray") */
     protected $sortedDescGroups;
 
-    /** @ODM\ReferenceOne(targetDocument="Account", cascade={"all"}) */
+    /** @ODM\ReferenceOne(targetDocument=Account::class, cascade={"all"}) */
     protected $account;
 
-    /** @ODM\ReferenceOne(targetDocument="Account", storeAs="id", cascade={"all"}) */
+    /** @ODM\ReferenceOne(targetDocument=Account::class, storeAs="id", cascade={"all"}) */
     protected $accountSimple;
 
     /** @ODM\Field(type="int") */
@@ -73,19 +73,19 @@ class User extends BaseDocument
     /** @ODM\Field(type="float", strategy="increment") */
     protected $floatCount;
 
-    /** @ODM\ReferenceMany(targetDocument="BlogPost", mappedBy="user", nullable=true) */
+    /** @ODM\ReferenceMany(targetDocument=BlogPost::class, mappedBy="user", nullable=true) */
     protected $posts;
 
-    /** @ODM\ReferenceOne(targetDocument="Documents\SimpleReferenceUser", mappedBy="user") */
+    /** @ODM\ReferenceOne(targetDocument=SimpleReferenceUser::class, mappedBy="user") */
     protected $simpleReferenceOneInverse;
 
-    /** @ODM\ReferenceMany(targetDocument="Documents\SimpleReferenceUser", mappedBy="users") */
+    /** @ODM\ReferenceMany(targetDocument=SimpleReferenceUser::class, mappedBy="users") */
     protected $simpleReferenceManyInverse;
 
-    /** @ODM\ReferenceOne(targetDocument="Documents\ReferenceUser", mappedBy="referencedUser") */
+    /** @ODM\ReferenceOne(targetDocument=ReferenceUser::class, mappedBy="referencedUser") */
     protected $embeddedReferenceOneInverse;
 
-    /** @ODM\ReferenceMany(targetDocument="Documents\ReferenceUser", mappedBy="referencedUsers") */
+    /** @ODM\ReferenceMany(targetDocument=ReferenceUser::class, mappedBy="referencedUsers") */
     protected $embeddedReferenceManyInverse;
 
     /** @ODM\Field(type="collection") */

--- a/tests/Documents/UserUpsert.php
+++ b/tests/Documents/UserUpsert.php
@@ -29,7 +29,7 @@ class UserUpsert
     /** @ODM\Field(type="int", strategy="increment") */
     public $count;
 
-    /** @ODM\ReferenceMany(targetDocument="Group", cascade={"all"}) */
+    /** @ODM\ReferenceMany(targetDocument=Group::class, cascade={"all"}) */
     public $groups;
 
     /** @ODM\Field(type="string", nullable=true) */

--- a/tests/Documents/UserUpsertIdStrategyNone.php
+++ b/tests/Documents/UserUpsertIdStrategyNone.php
@@ -28,7 +28,7 @@ class UserUpsertIdStrategyNone
     /** @ODM\Field(type="int", strategy="increment") */
     public $count;
 
-    /** @ODM\ReferenceMany(targetDocument="Group", cascade={"all"}) */
+    /** @ODM\ReferenceMany(targetDocument=Group::class, cascade={"all"}) */
     public $groups;
 
     /** @ODM\Field(type="string", nullable=true) */

--- a/tools/sandbox/Documents/User.php
+++ b/tools/sandbox/Documents/User.php
@@ -20,13 +20,13 @@ class User
     /** @ODM\Field(type="string") */
     protected $password;
 
-    /** @ODM\EmbedOne(targetDocument="Address") */
+    /** @ODM\EmbedOne(targetDocument=Address::class) */
     protected $address;
 
-    /** @ODM\ReferenceOne(targetDocument="Account") */
+    /** @ODM\ReferenceOne(targetDocument=Account::class) */
     protected $account;
 
-    /** @ODM\EmbedMany(targetDocument="Phonenumber") */
+    /** @ODM\EmbedMany(targetDocument=Phonenumber::class) */
     protected $phonenumbers;
 
     public function __construct()


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | #1795 

#### Summary

Drop namespace property from ClassMetadata and same-namespace resolution magic.
