### PR TITLE
[2.0] Validate mapping files against schema

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -14,12 +14,12 @@
 
   <xs:element name="doctrine-mongo-mapping">
     <xs:complexType>
-      <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:element name="document" type="odm:document" minOccurs="0" maxOccurs="unbounded" />
         <xs:element name="embedded-document" type="odm:document" minOccurs="0" maxOccurs="unbounded" />
         <xs:element name="mapped-superclass" type="odm:document" minOccurs="0" maxOccurs="unbounded" />
         <xs:element name="query-result-document" type="odm:document" minOccurs="0" maxOccurs="unbounded" />
-      </xs:sequence>
+      </xs:choice>
     </xs:complexType>
   </xs:element>
 
@@ -36,7 +36,7 @@
   </xs:complexType>
 
   <xs:complexType name="document">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="id" type="odm:id" minOccurs="0" maxOccurs="1"/>
       <xs:element name="field" type="odm:field" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="embed-one" type="odm:embed-one" minOccurs="0" maxOccurs="unbounded"/>
@@ -51,7 +51,7 @@
       <xs:element name="indexes" type="odm:indexes" minOccurs="0"/>
       <xs:element name="shard-key" type="odm:shard-key" minOccurs="0"/>
       <xs:element name="read-preference" type="odm:read-preference" minOccurs="0" maxOccurs="1"/>
-    </xs:sequence>
+    </xs:choice>
     <xs:attribute name="db" type="xs:NMTOKEN" />
     <xs:attribute name="name" type="xs:string" />
     <xs:attribute name="writeConcern" type="xs:string" />
@@ -66,9 +66,9 @@
   </xs:complexType>
 
   <xs:complexType name="read-preference">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="tag-set" type="odm:read-preference-tag-set" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
+    </xs:choice>
     <xs:attribute name="mode" type="odm:read-preference-values"/>
   </xs:complexType>
 
@@ -95,9 +95,9 @@
   </xs:complexType>
 
   <xs:complexType name="id">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="generator-option" type="odm:id-generator-option" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
+    </xs:choice>
     <xs:attribute name="type" type="xs:NMTOKEN" />
     <xs:attribute name="strategy" type="xs:NMTOKEN" default="auto" />
     <xs:attribute name="fieldName" type="xs:NMTOKEN" default="id" />
@@ -109,11 +109,11 @@
   </xs:complexType>
 
   <xs:complexType name="embed-one">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
       <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
       <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
-    </xs:sequence>
+    </xs:choice>
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="fieldName" type="xs:NMTOKEN" />
@@ -123,11 +123,11 @@
   </xs:complexType>
 
   <xs:complexType name="embed-many">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
       <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
       <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
-    </xs:sequence>
+    </xs:choice>
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="collection-class" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
@@ -148,14 +148,14 @@
   </xs:simpleType>
 
   <xs:complexType name="reference-one">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="cascade" type="odm:cascade-type" minOccurs="0" />
       <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
       <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
       <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
       <xs:element name="sort" type="odm:sort-map" minOccurs="0" />
       <xs:element name="criteria" type="odm:criteria-map" minOccurs="0" />
-    </xs:sequence>
+    </xs:choice>
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="fieldName" type="xs:NMTOKEN" />
@@ -171,7 +171,7 @@
   </xs:complexType>
 
   <xs:complexType name="reference-many">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="cascade" type="odm:cascade-type" minOccurs="0" />
       <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
       <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
@@ -179,7 +179,7 @@
       <xs:element name="sort" type="odm:sort-map" minOccurs="0" />
       <xs:element name="criteria" type="odm:criteria-map" minOccurs="0" />
       <xs:element name="prime" type="odm:primers" minOccurs="0" />
-    </xs:sequence>
+    </xs:choice>
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="collection-class" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
@@ -204,9 +204,9 @@
   </xs:complexType>
 
   <xs:complexType name="sort-map">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="sort" type="odm:sort-type" minOccurs="1" maxOccurs="unbounded"/>
-    </xs:sequence>
+    </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="criteria-type">
@@ -215,15 +215,15 @@
   </xs:complexType>
 
   <xs:complexType name="criteria-map">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="criteria" type="odm:criteria-type" minOccurs="1" maxOccurs="unbounded"/>
-    </xs:sequence>
+    </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="primers">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="field" type="odm:primer-field" minOccurs="1" maxOccurs="unbounded"/>
-    </xs:sequence>
+    </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="primer-field">
@@ -233,14 +233,14 @@
   <xs:complexType name="emptyType"/>
 
   <xs:complexType name="cascade-type">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="all" type="odm:emptyType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="persist" type="odm:emptyType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="merge" type="odm:emptyType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="remove" type="odm:emptyType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="refresh" type="odm:emptyType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="detach" type="odm:emptyType" minOccurs="0" maxOccurs="1"/>
-    </xs:sequence>
+    </xs:choice>
   </xs:complexType>
 
   <xs:simpleType name="inheritance-type">
@@ -264,9 +264,9 @@
   </xs:complexType>
 
   <xs:complexType name="discriminator-map">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="discriminator-mapping" type="odm:discriminator-mapping" minOccurs="1" maxOccurs="unbounded"/>
-    </xs:sequence>
+    </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="discriminator-field">
@@ -296,9 +296,9 @@
   </xs:complexType>
 
   <xs:complexType name="lifecycle-callbacks">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="lifecycle-callback" type="odm:lifecycle-callback" minOccurs="1" maxOccurs="unbounded"/>
-    </xs:sequence>
+    </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="index-key">
@@ -324,33 +324,33 @@
   </xs:simpleType>
 
   <xs:complexType name="partial-filter-expression-field">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="field" type="odm:partial-filter-expression-field" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
+    </xs:choice>
     <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
     <xs:attribute name="operator" type="odm:partial-filter-expression-operator" use="optional" />
     <xs:attribute name="value" type="xs:string" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="partial-filter-expression-and">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="field" type="odm:partial-filter-expression-field" minOccurs="1" maxOccurs="unbounded" />
-    </xs:sequence>
+    </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="partial-filter-expression">
-    <xs:choice>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="and" type="odm:partial-filter-expression-and" minOccurs="1" maxOccurs="unbounded" />
       <xs:element name="field" type="odm:partial-filter-expression-field" minOccurs="1" maxOccurs="unbounded" />
     </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="index">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="key" type="odm:index-key" minOccurs="1" maxOccurs="unbounded"/>
       <xs:element name="option" type="odm:index-option" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="partial-filter-expression" type="odm:partial-filter-expression" minOccurs="0" maxOccurs="1"/>
-    </xs:sequence>
+    </xs:choice>
     <xs:attribute name="name" type="xs:NMTOKEN"/>
     <xs:attribute name="drop-dups" type="xs:boolean"/>
     <xs:attribute name="background" type="xs:boolean"/>
@@ -359,16 +359,16 @@
   </xs:complexType>
 
   <xs:complexType name="indexes">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="index" type="odm:index" minOccurs="1" maxOccurs="unbounded"/>
-    </xs:sequence>
+    </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="shard-key">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="key" type="odm:shard-key-key" minOccurs="1" maxOccurs="unbounded"/>
       <xs:element name="option" type="odm:shard-key-option" minOccurs="0" maxOccurs="unbounded"/>
-    </xs:sequence>
+    </xs:choice>
     <xs:attribute name="unique" type="xs:boolean"/>
     <xs:attribute name="numInitialChunks" type="xs:integer"/>
   </xs:complexType>
@@ -390,9 +390,9 @@
 
 
   <xs:complexType name="also-load-methods">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="also-load-method" type="odm:also-load-method" minOccurs="1" maxOccurs="unbounded"/>
-    </xs:sequence>
+    </xs:choice>
   </xs:complexType>
 
   <xs:simpleType name="read-preference-values">
@@ -406,9 +406,9 @@
   </xs:simpleType>
 
   <xs:complexType name="read-preference-tag-set">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="tag" type="odm:read-preference-tag" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
+    </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="read-preference-tag">

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -407,7 +407,7 @@
 
   <xs:complexType name="read-preference-tag-set">
     <xs:sequence>
-      <xs:element name="tag" type="read-preference-tag" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="tag" type="odm:read-preference-tag" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -169,7 +169,7 @@ class XmlDriver extends FileDriver
                 $attributes = $field->attributes();
                 foreach ($attributes as $key => $value) {
                     $mapping[$key] = (string) $value;
-                    $booleanAttributes = ['id', 'reference', 'embed', 'unique', 'sparse'];
+                    $booleanAttributes = ['reference', 'embed', 'unique', 'sparse'];
                     if (! in_array($key, $booleanAttributes)) {
                         continue;
                     }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -396,4 +396,9 @@ class MappingException extends BaseMappingException
     {
         return new self(sprintf("'repositoryMethod' used on '%s' in class '%s' can not be combined with skip, limit or sort.", $fieldName, $className));
     }
+
+    public static function xmlMappingFileInvalid(string $filename, string $errorDetails): self
+    {
+        return new self(sprintf("The mapping file %s is invalid: \n%s", $filename, $errorDetails));
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -578,3 +578,8 @@ class AbstractMappingDriverUser
 class PhonenumberCollection extends ArrayCollection
 {
 }
+
+class InvalidMappingDocument
+{
+    public $id;
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Mapping\Driver;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
+use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use TestDocuments\CustomIdGenerator;
 use TestDocuments\InvalidPartialFilterDocument;
 use TestDocuments\UserCustomIdGenerator;
@@ -62,22 +63,11 @@ class XmlDriverTest extends AbstractDriverTest
     public function testInvalidPartialFilterExpressions()
     {
         $classMetadata = new ClassMetadata(InvalidPartialFilterDocument::class);
-        $this->driver->loadMetadataForClass(InvalidPartialFilterDocument::class, $classMetadata);
 
-        $this->assertEquals([
-            [
-                'keys' => ['fieldA' => 1],
-                'options' => [
-                    'partialFilterExpression' => [
-                        '$and' => [['discr' => ['$eq' => 'default']]],
-                    ],
-                ],
-            ],
-            [
-                'keys' => ['fieldB' => 1],
-                'options' => [],
-            ],
-        ], $classMetadata->getIndexes());
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessageRegExp('#The mapping file .+ is invalid#');
+
+        $this->driver->loadMetadataForClass(InvalidPartialFilterDocument::class, $classMetadata);
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.UserNonStringOptions.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.UserNonStringOptions.dcm.xml
@@ -8,6 +8,6 @@
     <document name="TestDocuments\UserNonStringOptions">
         <id />
         <reference-one target-document="Documents\Profile" field="profile" store-as="id" orphan-removal="true" />
-        <reference-many target-document="Documents\Group" field="groups" orphan-removal="" limit="0" skip="2" />
+        <reference-many target-document="Documents\Group" field="groups" orphan-removal="false" limit="0" skip="2" />
     </document>
 </doctrine-mongo-mapping>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
+use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Documents\User;
 use const DIRECTORY_SEPARATOR;
 use function get_class;
@@ -46,5 +47,18 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
         $m->invoke($driver, $class, $element, 'many');
 
         $this->assertEquals(PhonenumberCollection::class, $class->getAssociationCollectionClass('phonenumbers'));
+    }
+
+    public function testInvalidMappingFileTriggersException(): void
+    {
+        $className = InvalidMappingDocument::class;
+        $mappingDriver = $this->_loadDriver();
+
+        $class = new ClassMetadata($className);
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessageRegExp("#Element '\{http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping\}field', attribute 'id': The attribute 'id' is not allowed.#");
+
+        $mappingDriver->loadMetadataForClass($className, $class);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.InvalidMappingDocument.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.InvalidMappingDocument.dcm.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping
+    xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+    http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd"
+>
+    <document name="Doctrine\ODM\MongoDB\Tests\Mapping\InvalidMappingDocument">
+        <field fieldName="id" id="true" />
+    </document>
+</doctrine-mongo-mapping>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

#### Summary

With this change, invalid XML mapping files are no longer accepted by the XML driver. It also replaces the pesky `sequence` element in the schema with `choice`, allowing fields in any order the user wants to map them. This mirrors a change done in ORM a while ago.

Last but not least, this removes leftover handling for the `id` attribute in the `field` mapping that should have been removed in #1807.

When backporting this feature to 1.3, we have to introduce a strict mode for mapping files that is disabled by default. When disabled, it will trigger a deprecation warning to inform the user that it will  throw exceptions in 2.0; when enabled, it will behave like the driver in 2.0 and throw exceptions on invalid mapping files.