### PR TITLE
Allow increment strategy for not defined types

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -1234,7 +1234,7 @@ class ClassMetadata implements BaseClassMetadata
 
             default:
                 $defaultStrategy = self::STORAGE_STRATEGY_SET;
-                $allowedStrategies = [self::STORAGE_STRATEGY_SET];
+                $allowedStrategies = [self::STORAGE_STRATEGY_SET, self::STORAGE_STRATEGY_INCREMENT];
         }
 
         if (! isset($mapping['strategy'])) {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/improvement
| BC Break     | no

#### Summary

<!-- Provide a summary your change. -->

As decimal128 is not provided by doctrine types, it may be created as custom type. But even if mongo allows to use increment strategy with decimal128, doctrine throws an exception, that increment storage strategy is not allowed. Only doctrine restriction is to deal with. No other implementation is needed.
