### PR TITLE
Improvements

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
@@ -1311,7 +1311,7 @@ class Expr
      */
     public function stdDevPop($expression1, ...$expressions)
     {
-        $expression = (empty($expressions)) ? $expression1 : func_get_args();
+        $expression = empty($expressions) ? $expression1 : func_get_args();
 
         return $this->operator('$stdDevPop', $expression);
     }
@@ -1329,7 +1329,7 @@ class Expr
      */
     public function stdDevSamp($expression1, ...$expressions)
     {
-        $expression = (empty($expressions)) ? $expression1 : func_get_args();
+        $expression = empty($expressions) ? $expression1 : func_get_args();
 
         return $this->operator('$stdDevSamp', $expression);
     }

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -133,7 +133,7 @@ class Configuration
     {
         $reader = new AnnotationReader();
 
-        return new AnnotationDriver($reader, (array) $paths);
+        return new AnnotationDriver($reader, $paths);
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1365,7 +1365,7 @@ class DocumentPersister
         }
 
         // If a defaultDiscriminatorValue is set and it is among the discriminators being queries, add NULL to the list
-        if ($metadata->defaultDiscriminatorValue && array_search($metadata->defaultDiscriminatorValue, $discriminatorValues) !== false) {
+        if ($metadata->defaultDiscriminatorValue && in_array($metadata->defaultDiscriminatorValue, $discriminatorValues)) {
             $discriminatorValues[] = null;
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -14,9 +14,9 @@ use MongoDB\Collection;
 use MongoDB\Driver\ReadPreference;
 use function array_filter;
 use function array_key_exists;
-use function array_search;
 use function count;
 use function func_get_args;
+use function in_array;
 use function is_array;
 use function is_bool;
 use function is_callable;
@@ -1833,7 +1833,7 @@ class Builder
             $discriminatorValues = $this->getDiscriminatorValues($documentNames);
 
             // If a defaultDiscriminatorValue is set and it is among the discriminators being queries, add NULL to the list
-            if ($metadata->defaultDiscriminatorValue && array_search($metadata->defaultDiscriminatorValue, $discriminatorValues) !== false) {
+            if ($metadata->defaultDiscriminatorValue && in_array($metadata->defaultDiscriminatorValue, $discriminatorValues)) {
                 $discriminatorValues[] = null;
             }
 

--- a/lib/Doctrine/ODM/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Expr.php
@@ -189,7 +189,7 @@ class Expr
      */
     public function all(array $values)
     {
-        return $this->operator('$all', (array) $values);
+        return $this->operator('$all', $values);
     }
 
     /**
@@ -698,7 +698,7 @@ class Expr
         $this->requiresCurrentField();
         $mapping = $this->getReferenceMapping();
         $reference = $this->dm->createReference($document, $mapping);
-        $storeAs = array_key_exists('storeAs', $mapping) ? $mapping['storeAs'] : null;
+        $storeAs = $mapping['storeAs'] ?? null;
         $keys = [];
 
         switch ($storeAs) {
@@ -1096,7 +1096,7 @@ class Expr
         $this->requiresCurrentField();
         $mapping = $this->getReferenceMapping();
         $reference = $this->dm->createReference($document, $mapping);
-        $storeAs = array_key_exists('storeAs', $mapping) ? $mapping['storeAs'] : null;
+        $storeAs = $mapping['storeAs'] ?? null;
         $keys = [];
 
         switch ($storeAs) {

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
@@ -61,7 +61,7 @@ class CreateCommand extends AbstractCommand
                     'Created <comment>%s%s</comment> for <info>%s</info>',
                     $option,
                     (isset($class) ? ($option === self::INDEX ? '(es)' : '') : ($option === self::INDEX ? 'es' : 's')),
-                    ($class ?? 'all classes')
+                    $class ?? 'all classes'
                 ));
             } catch (\Throwable $e) {
                 $output->writeln('<error>' . $e->getMessage() . '</error>');

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
@@ -53,7 +53,7 @@ class DropCommand extends AbstractCommand
                     'Dropped <comment>%s%s</comment> for <info>%s</info>',
                     $option,
                     (isset($class) ? ($option === self::INDEX ? '(es)' : '') : ($option === self::INDEX ? 'es' : 's')),
-                    ($class ?? 'all classes')
+                    $class ?? 'all classes'
                 ));
             } catch (\Throwable $e) {
                 $output->writeln('<error>' . $e->getMessage() . '</error>');

--- a/lib/Doctrine/ODM/MongoDB/Types/CustomIdType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/CustomIdType.php
@@ -6,18 +6,17 @@ namespace Doctrine\ODM\MongoDB\Types;
 
 /**
  * The Id type.
- *
  */
 class CustomIdType extends Type
 {
     public function convertToDatabaseValue($value)
     {
-        return $value !== null ? $value : null;
+        return $value;
     }
 
     public function convertToPHPValue($value)
     {
-        return $value !== null ? $value : null;
+        return $value;
     }
 
     public function closureToMongo()

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2064,7 +2064,7 @@ class UnitOfWork implements PropertyChangedListener
                 continue;
             }
             $relatedDocuments = $class->reflFields[$mapping['fieldName']]->getValue($document);
-            if (($relatedDocuments instanceof Collection || is_array($relatedDocuments))) {
+            if ($relatedDocuments instanceof Collection || is_array($relatedDocuments)) {
                 if ($relatedDocuments instanceof PersistentCollectionInterface) {
                     // Unwrap so that foreach() does not initialize
                     $relatedDocuments = $relatedDocuments->unwrap();


### PR DESCRIPTION

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

Together with PHPStorm and https://github.com/kalessil/phpinspectionsea, here are some improvements that we can make to MongoDB ODM, such as unnecessaries parentheses, casts; null coalesce operator usage; in_array instead of array_search + comparison, etc