### PR TITLE
Remove obsolete syntaxCheck option in PHPUnit config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="tests/bootstrap.php"
 >
     <testsuites>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

When running the test suite locally, I noticed the following warning:

```
  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 12:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.
```

This option is no longer documented for [PHPUnit 7.0](https://phpunit.de/manual/7.0/en/appendixes.configuration.html) and appears to be obsolete. See: https://stackoverflow.com/a/44331140/162228
