### PR TITLE
[2.0] Fix wrong element deletion in popFirst and popLast

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Expr.php
@@ -967,7 +967,7 @@ class Expr
     public function popFirst()
     {
         $this->requiresCurrentField();
-        $this->newObj['$pop'][$this->currentField] = 1;
+        $this->newObj['$pop'][$this->currentField] = -1;
         return $this;
     }
 
@@ -981,7 +981,7 @@ class Expr
     public function popLast()
     {
         $this->requiresCurrentField();
-        $this->newObj['$pop'][$this->currentField] = -1;
+        $this->newObj['$pop'][$this->currentField] = 1;
         return $this;
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
@@ -441,4 +441,56 @@ class QueryTest extends BaseTest
         $this->assertSame($expected, $qb->getQueryArray());
         $this->assertSame($expected, $qb->getQuery()->debug('query'));
     }
+
+    public function testPopFirst(): void
+    {
+        $article = new Article();
+        $article->setTitle('test');
+        $article->setBody('test');
+        $article->setCreatedAt('1985-09-01 00:00:00');
+        $article->addTag(1);
+        $article->addTag(2);
+        $article->addTag(3);
+
+        $this->dm->persist($article);
+        $this->dm->flush();
+
+        $this->dm->createQueryBuilder(Article::class)
+            ->updateOne()
+            ->field('id')
+            ->equals($article->getId())
+            ->field('tags')
+            ->popFirst()
+            ->getQuery()
+            ->execute();
+
+        $this->dm->refresh($article);
+        $this->assertSame([2, 3], $article->getTags());
+    }
+
+    public function testPopLast(): void
+    {
+        $article = new Article();
+        $article->setTitle('test');
+        $article->setBody('test');
+        $article->setCreatedAt('1985-09-01 00:00:00');
+        $article->addTag(1);
+        $article->addTag(2);
+        $article->addTag(3);
+
+        $this->dm->persist($article);
+        $this->dm->flush();
+
+        $this->dm->createQueryBuilder(Article::class)
+            ->updateOne()
+            ->field('id')
+            ->equals($article->getId())
+            ->field('tags')
+            ->popLast()
+            ->getQuery()
+            ->execute();
+
+        $this->dm->refresh($article);
+        $this->assertSame([1, 2], $article->getTags());
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -189,7 +189,7 @@ class ExprTest extends BaseTest
             ->field('address.subAddress.subAddress.subAddress.test')->popFirst();
         $query = $qb->getQuery();
         $query = $query->getQuery();
-        $this->assertEquals(['$pop' => ['address.subAddress.subAddress.subAddress.testFieldName' => 1]], $query['newObj']);
+        $this->assertEquals(['$pop' => ['address.subAddress.subAddress.subAddress.testFieldName' => -1]], $query['newObj']);
     }
 
     public function testReferencesUsesMinimalKeys()


### PR DESCRIPTION
Fixes #1830 and is a port of https://github.com/doctrine/mongodb/pull/326 which fixes this problem for ODM 1.x.