### PR TITLE
[2.0] Consistently use kebab-case in XML mappings

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -54,7 +54,7 @@
     </xs:sequence>
     <xs:attribute name="db" type="xs:NMTOKEN" />
     <xs:attribute name="name" type="xs:string" />
-    <xs:attribute name="writeConcern" type="xs:string" />
+    <xs:attribute name="write-concern" type="xs:string" />
     <xs:attribute name="collection" type="xs:NMTOKEN" />
     <xs:attribute name="capped-collection" type="xs:boolean" />
     <xs:attribute name="capped-collection-size" type="xs:integer" />
@@ -76,7 +76,7 @@
     <xs:attribute name="name" type="xs:NMTOKEN" />
     <xs:attribute name="type" type="xs:NMTOKEN" />
     <xs:attribute name="strategy" type="xs:NMTOKEN" default="set" />
-    <xs:attribute name="fieldName" type="xs:NMTOKEN" />
+    <xs:attribute name="field-name" type="xs:NMTOKEN" />
     <xs:attribute name="embed" type="xs:boolean" />
     <xs:attribute name="reference" type="xs:boolean" />
     <xs:attribute name="version" type="xs:boolean" />
@@ -100,7 +100,7 @@
     </xs:sequence>
     <xs:attribute name="type" type="xs:NMTOKEN" />
     <xs:attribute name="strategy" type="xs:NMTOKEN" default="auto" />
-    <xs:attribute name="fieldName" type="xs:NMTOKEN" default="id" />
+    <xs:attribute name="field-name" type="xs:NMTOKEN" default="id" />
   </xs:complexType>
 
   <xs:complexType name="id-generator-option">
@@ -116,7 +116,7 @@
     </xs:sequence>
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
-    <xs:attribute name="fieldName" type="xs:NMTOKEN" />
+    <xs:attribute name="field-name" type="xs:NMTOKEN" />
     <xs:attribute name="not-saved" type="xs:boolean" />
     <xs:attribute name="nullable" type="xs:boolean" />
     <xs:attribute name="also-load" type="xs:NMTOKEN" />
@@ -131,7 +131,7 @@
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="collection-class" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
-    <xs:attribute name="fieldName" type="xs:NMTOKEN" />
+    <xs:attribute name="field-name" type="xs:NMTOKEN" />
     <xs:attribute name="strategy" type="xs:NMTOKEN" default="pushAll" />
     <xs:attribute name="not-saved" type="xs:boolean" />
     <xs:attribute name="nullable" type="xs:boolean" />
@@ -158,7 +158,7 @@
     </xs:sequence>
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
-    <xs:attribute name="fieldName" type="xs:NMTOKEN" />
+    <xs:attribute name="field-name" type="xs:NMTOKEN" />
     <xs:attribute name="simple" type="xs:boolean" /><!-- deprecated -->
     <xs:attribute name="store-as" type="odm:reference-store-as" default="dbRefWithDb" />
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />
@@ -183,7 +183,7 @@
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="collection-class" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
-    <xs:attribute name="fieldName" type="xs:NMTOKEN" />
+    <xs:attribute name="field-name" type="xs:NMTOKEN" />
     <xs:attribute name="simple" type="xs:boolean" /><!-- deprecated -->
     <xs:attribute name="store-as" type="odm:reference-store-as" default="dbRefWithDb" />
     <xs:attribute name="strategy" type="xs:NMTOKEN" default="pushAll" />

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -81,8 +81,8 @@ class XmlDriver extends FileDriver
                 $class->setCollection((string) $xmlRoot['collection']);
             }
         }
-        if (isset($xmlRoot['writeConcern'])) {
-            $class->setWriteConcern((string) $xmlRoot['writeConcern']);
+        if (isset($xmlRoot['write-concern'])) {
+            $class->setWriteConcern((string) $xmlRoot['write-concern']);
         }
         if (isset($xmlRoot['inheritance-type'])) {
             $inheritanceType = (string) $xmlRoot['inheritance-type'];
@@ -93,12 +93,7 @@ class XmlDriver extends FileDriver
         }
         if (isset($xmlRoot->{'discriminator-field'})) {
             $discrField = $xmlRoot->{'discriminator-field'};
-            /* XSD only allows for "name", which is consistent with association
-             * configurations, but fall back to "fieldName" for BC.
-             */
-            $class->setDiscriminatorField(
-                (string) ($discrField['name'] ?? $discrField['fieldName'])
-            );
+            $class->setDiscriminatorField((string) $discrField['name']);
         }
         if (isset($xmlRoot->{'discriminator-map'})) {
             $map = [];
@@ -170,6 +165,10 @@ class XmlDriver extends FileDriver
 
                 if (isset($attributes['not-saved'])) {
                     $mapping['notSaved'] = ((string) $attributes['not-saved'] === 'true');
+                }
+
+                if (isset($attributes['field-name'])) {
+                    $mapping['fieldName'] = (string) $attributes['field-name'];
                 }
 
                 if (isset($attributes['also-load'])) {
@@ -268,8 +267,8 @@ class XmlDriver extends FileDriver
             'name'            => (string) $attributes['field'],
             'strategy'        => (string) ($attributes['strategy'] ?? $defaultStrategy),
         ];
-        if (isset($attributes['fieldName'])) {
-            $mapping['fieldName'] = (string) $attributes['fieldName'];
+        if (isset($attributes['field-name'])) {
+            $mapping['fieldName'] = (string) $attributes['field-name'];
         }
         if (isset($embed->{'discriminator-field'})) {
             $attr = $embed->{'discriminator-field'};
@@ -319,8 +318,8 @@ class XmlDriver extends FileDriver
             'prime'            => [],
         ];
 
-        if (isset($attributes['fieldName'])) {
-            $mapping['fieldName'] = (string) $attributes['fieldName'];
+        if (isset($attributes['field-name'])) {
+            $mapping['fieldName'] = (string) $attributes['field-name'];
         }
         if (isset($reference->{'discriminator-field'})) {
             $attr = $reference->{'discriminator-field'};

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
@@ -5,7 +5,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-    <document name="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser" collection="cms_users" writeConcern="1" read-only="true">
+    <document name="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser" collection="cms_users" write-concern="1" read-only="true">
         <discriminator-field name="discr" />
         <discriminator-map>
             <discriminator-mapping value="default" class="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser" />
@@ -20,14 +20,14 @@
             </tag-set>
             <tag-set />
         </read-preference>
-        <id fieldName="id" />
-        <field fieldName="version" version="true" type="int" />
-        <field fieldName="lock" lock="true" type="int" />
-        <field fieldName="name" name="username" type="string" />
-        <field fieldName="email" type="string" unique="true" drop-dups="true" order="desc" />
-        <field fieldName="mysqlProfileId" type="integer" unique="true" drop-dups="true" order="desc" />
-        <field fieldName="createdAt" type="date" />
-        <field fieldName="roles" type="collection" />
+        <id field-name="id" />
+        <field field-name="version" version="true" type="int" />
+        <field field-name="lock" lock="true" type="int" />
+        <field field-name="name" name="username" type="string" />
+        <field field-name="email" type="string" unique="true" drop-dups="true" order="desc" />
+        <field field-name="mysqlProfileId" type="integer" unique="true" drop-dups="true" order="desc" />
+        <field field-name="createdAt" type="date" />
+        <field field-name="roles" type="collection" />
         <indexes>
             <index unique="true">
                 <key name="username" order="desc" />
@@ -66,9 +66,9 @@
                 <all />
             </cascade>
         </reference-many>
-        <reference-many target-document="Phonenumber" fieldName="morePhoneNumbers" field="more_phone_numbers">
+        <reference-many target-document="Phonenumber" field-name="morePhoneNumbers" field="more_phone_numbers">
         </reference-many>
-        <embed-one target-document="Phonenumber" fieldName="embeddedPhonenumber" field="embedded_phone_number">
+        <embed-one target-document="Phonenumber" field-name="embeddedPhonenumber" field="embedded_phone_number">
         </embed-one>
         <embed-many target-document="Phonenumber" collection-class="PhonenumberCollection" field="otherPhonenumbers">
             <discriminator-field name="discr" />


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes

#### Summary

I've noticed this while reviewing GridFS changes ([reference](
https://github.com/doctrine/mongodb-odm/pull/1790#discussion_r203134914)) and decided to update the names consistently. We'll create a BC layer for this introducing the `field-name` and `write-concern` attributes preferring them over the old names if both are set. Additionally, using `fieldName` and `writeConcern` will cause a deprecation warning to be thrown in 1.3.