### PR TITLE
[2.0] Test update: ODM no longer supports PHP < 7.2

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/DefaultPersistentCollectionGeneratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/DefaultPersistentCollectionGeneratorTest.php
@@ -7,8 +7,6 @@ namespace Doctrine\ODM\MongoDB\Tests\PersistentCollection;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\PersistentCollection\DefaultPersistentCollectionGenerator;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
-use const PHP_VERSION_ID;
-use function sprintf;
 
 /**
  * Tests aims to check if classes generated for various PHP versions are correct (i.e. parses).

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/DefaultPersistentCollectionGeneratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/DefaultPersistentCollectionGeneratorTest.php
@@ -43,10 +43,6 @@ class DefaultPersistentCollectionGeneratorTest extends BaseTest
 
     public function testWithNullableReturnType()
     {
-        if (PHP_VERSION_ID < 70100) {
-            $this->markTestSkipped(sprintf('%s requires at least PHP 7.1', __METHOD__));
-        }
-
         $class = $this->generator->loadClass(CollWithNullableReturnType::class, Configuration::AUTOGENERATE_EVAL);
         $coll = new $class(new CollWithNullableReturnType(), $this->dm, $this->uow);
         $this->assertInstanceOf(CollWithNullableReturnType::class, $coll);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | partial #1791
