### PR TITLE
Finalize sharding support for 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
     # Test against lowest dependencies, including driver and server versions
     - stage: Test
       php: 7.2
-      env: SERVER_VERSION="3.2" KEY_ID="EA312927" DRIVER_VERSION="1.3.0"
+      env: SERVER_VERSION="3.2" KEY_ID="EA312927" DRIVER_VERSION="1.5.0"
       install:
         - composer update --prefer-lowest
         

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^7.2",
+        "ext-mongodb": "^1.5",
         "symfony/console": "^3.4|^4.1",
         "doctrine/annotations": "^1.6",
         "doctrine/collections": "^1.5",

--- a/docs/en/reference/sharding.rst
+++ b/docs/en/reference/sharding.rst
@@ -9,7 +9,7 @@ about sharding, please refer to the `MongoDB docs <https://docs.mongodb.com/manu
 
 Once you have a `sharded cluster <https://docs.mongodb.com/manual/core/sharded-cluster-architectures-production/>`_,
 you can enable sharding for a document. You can do this by defining a shard key in
-the document:
+the document as well as an appropriate index:
 
 .. configuration-block::
 
@@ -19,6 +19,7 @@ the document:
 
         /**
          * @Document
+         * @Indexes(@Index(keys={"username"="asc"}))
          * @ShardKey(keys={"username"="asc"})
          */
         class User
@@ -44,6 +45,11 @@ the document:
                 <shard-key>
                     <key name="username" order="asc"/>
                 </shard-key>
+                <indexes>
+                    <index>
+                        <key name="username" order="asc" />
+                    </index>
+                </indexes>
             </document>
         </doctrine-mongo-mapping>
 

--- a/tests/Documents/Developer.php
+++ b/tests/Documents/Developer.php
@@ -25,7 +25,7 @@ class Developer
     public function __construct($name, ?Collection $projects = null)
     {
         $this->name = $name;
-        $this->projects = $projects === null ? new ArrayCollection() : $projects;
+        $this->projects = $projects ?? new ArrayCollection();
     }
 
     public function getId()

--- a/tests/Documents/Sharded/ShardedOne.php
+++ b/tests/Documents/Sharded/ShardedOne.php
@@ -8,6 +8,9 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
  * @ODM\Document(collection="sharded.one")
+ * @ODM\Indexes(
+ *     @ODM\Index(keys={"k"="asc"})
+ * )
  * @ODM\ShardKey(keys={"k"="asc"})
  */
 class ShardedOne

--- a/tests/Documents/Sharded/ShardedOneWithDifferentKey.php
+++ b/tests/Documents/Sharded/ShardedOneWithDifferentKey.php
@@ -10,6 +10,9 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  * Note: this document intentially collides with ShardedOne to test shard key changes
  *
  * @ODM\Document(collection="sharded.one")
+ * @ODM\Indexes(
+ *     @ODM\Index(keys={"v"="asc"})
+ * )
  * @ODM\ShardKey(keys={"v"="asc"})
  */
 class ShardedOneWithDifferentKey


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | #1698 

#### Summary

This PR re-introduces full sharding support to ODM 2.0. Due to changes in the server, the implementation now requires the user to map an index covering the shard key. Previously, this index was created automatically by ODM based on an index suggestion returned by the server as a response to the `shardCollection` command. Since this is no longer returned, we can't implicitly create an index without duplicating the index check logic in the server. Thus, we require the user to create the index themselves.

A compat layer for 1.3 should ideally warn the user about the change when an index is implicitly created when enabling sharding for a collection.