### PR TITLE
[2.0] Removed QueryLogger from tests

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
-use Doctrine\ODM\MongoDB\Tests\QueryLogger;
 use Documents\Book;
 use Documents\Chapter;
 use Documents\IdentifiedChapter;
@@ -24,29 +23,12 @@ use function get_class;
  */
 class AtomicSetTest extends BaseTest
 {
-    /** @var QueryLogger */
-    private $ql;
-
-    protected function getConfiguration()
-    {
-        $this->markTestSkipped('mongodb-driver: query logging does not exist');
-        if (! isset($this->ql)) {
-            $this->ql = new QueryLogger();
-        }
-
-        $config = parent::getConfiguration();
-        $config->setLoggerCallable($this->ql);
-
-        return $config;
-    }
-
     public function testAtomicInsertAndUpdate()
     {
         $user = new AtomicSetUser('Maciej');
         $user->phonenumbers[] = new Phonenumber('12345678');
         $this->dm->persist($user);
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Inserting a document with an embed-many collection requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -56,9 +38,7 @@ class AtomicSetTest extends BaseTest
 
         $user->surname = 'Malarz';
         $user->phonenumbers[] = new Phonenumber('87654321');
-        $this->ql->clear();
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Updating a document and its embed-many collection requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -76,7 +56,6 @@ class AtomicSetTest extends BaseTest
         $user->phonenumbers[] = new Phonenumber('12345678');
         $this->dm->persist($user);
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Upserting a document with an embed-many collection requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -94,7 +73,6 @@ class AtomicSetTest extends BaseTest
         $user->phonenumbers[] = new Phonenumber('12345678');
         $this->dm->persist($user);
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Inserting a document with an embed-many collection requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -104,9 +82,7 @@ class AtomicSetTest extends BaseTest
 
         $user->surname = 'Malarz';
         $user->phonenumbers = $clearWith;
-        $this->ql->clear();
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Updating a document and unsetting its embed-many collection requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -130,15 +106,12 @@ class AtomicSetTest extends BaseTest
         $user->phonenumbers[] = new Phonenumber('12345678');
         $this->dm->persist($user);
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Inserting a document with an embed-many collection requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
         $user->phonenumbers->clear();
         $user->phonenumbers[] = new Phonenumber('87654321');
-        $this->ql->clear();
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Updating emptied collection requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -153,15 +126,12 @@ class AtomicSetTest extends BaseTest
         $user->phonenumbers[] = new Phonenumber('12345678');
         $this->dm->persist($user);
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Inserting a document with an embed-many collection requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
         $user->phonenumbers = new ArrayCollection();
         $user->phonenumbers[] = new Phonenumber('87654321');
-        $this->ql->clear();
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Updating emptied collection requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -177,7 +147,6 @@ class AtomicSetTest extends BaseTest
         $user->phonenumbersArray[2] = new Phonenumber('87654321');
         $this->dm->persist($user);
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Inserting a document with an embed-many collection requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -187,9 +156,7 @@ class AtomicSetTest extends BaseTest
         $this->assertEquals('87654321', $user->phonenumbersArray[1]->getPhonenumber());
 
         unset($user->phonenumbersArray[0]);
-        $this->ql->clear();
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Unsetting an element within an embed-many collection requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -206,7 +173,6 @@ class AtomicSetTest extends BaseTest
         $user->phonebooks[] = $privateBook;
         $this->dm->persist($user);
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Inserting a document with a nested embed-many collection requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -221,9 +187,7 @@ class AtomicSetTest extends BaseTest
         $publicBook = new Phonebook('Public');
         $publicBook->addPhonenumber(new Phonenumber('10203040'));
         $user->phonebooks[] = $publicBook;
-        $this->ql->clear();
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Updating multiple, nested embed-many collections requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -239,9 +203,7 @@ class AtomicSetTest extends BaseTest
         $this->assertEquals('10203040', $publicBook->getPhonenumbers()->get(0)->getPhonenumber());
 
         $privateBook->getPhonenumbers()->clear();
-        $this->ql->clear();
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Clearing a nested embed-many collection requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -266,7 +228,6 @@ class AtomicSetTest extends BaseTest
         $user->inception[0]->one->one->many[0]->many[] = new AtomicSetInception('start.one.one.many.0.many.0');
         $this->dm->persist($user);
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Inserting a document with nested embed-many collections requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -287,9 +248,7 @@ class AtomicSetTest extends BaseTest
         unset($user->inception[0]->one->many[0]);
         $user->inception[0]->one->many[] = new AtomicSetInception('start.one.many.2');
         $user->inception[0]->one->one->many[0]->many[] = new AtomicSetInception('start.one.one.many.0.many.1');
-        $this->ql->clear();
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Updating nested collections on various levels requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -324,7 +283,6 @@ class AtomicSetTest extends BaseTest
         $user->inception[0]->many[1]->many[0] = new AtomicSetInception('start.many.1.many.0');
         $this->dm->persist($user);
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Inserting a document with nested embed-many collections requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -344,9 +302,7 @@ class AtomicSetTest extends BaseTest
         $user->inception[0]->many[1]->many[1] = new AtomicSetInception('start.many.1.many.1');
         $user->inception[0]->many[1] = new AtomicSetInception('start.many.1');
         $user->inception[0]->many[1]->many[0] = new AtomicSetInception('start.many.1.many.0-new');
-        $this->ql->clear();
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Updating nested collections while deleting parents requires one query');
         $this->dm->clear();
 
         $user = $this->dm->getRepository(get_class($user))->find($user->id);
@@ -370,11 +326,9 @@ class AtomicSetTest extends BaseTest
         $this->dm->persist($jmikola);
         $this->dm->persist($jonwage);
         $this->dm->flush();
-        $this->ql->clear();
 
         $malarzm->friends[] = $jmikola;
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Updating empty atomic reference many requires one query');
         $this->dm->clear();
 
         $malarzm = $this->dm->find(get_class($malarzm), $malarzm->id);
@@ -383,9 +337,7 @@ class AtomicSetTest extends BaseTest
 
         $jonwage = $this->dm->find(get_class($jonwage), $jonwage->id);
         $malarzm->friends[] = $jonwage;
-        $this->ql->clear();
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Updating existing atomic reference many requires one query');
         $this->dm->clear();
 
         $malarzm = $this->dm->find(get_class($malarzm), $malarzm->id);
@@ -394,10 +346,11 @@ class AtomicSetTest extends BaseTest
         $this->assertEquals('Jon', $malarzm->friends[1]->name);
 
         $malarzm->friends->clear();
-        $this->ql->clear();
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Clearing atomic reference many requires one query');
         $this->dm->clear();
+
+        $malarzm = $this->dm->find(get_class($malarzm), $malarzm->id);
+        $this->assertCount(0, $malarzm->friends);
     }
 
     public function testAtomicSetUpdatesAllNestedCollectionsInOneQuery()
@@ -412,7 +365,6 @@ class AtomicSetTest extends BaseTest
 
         // Saving this book should result in 1 query since we use strategy="atomicSet"
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Inserting a book with one chapter and page requires one query');
 
         // Simulate another PHP request which loads this record and tries to add an embedded document two levels deep...
         $this->dm->clear();
@@ -423,9 +375,7 @@ class AtomicSetTest extends BaseTest
         $firstChapter->pages->add(new Page(2));
 
         // Updating this book should result in 1 query since we use strategy="atomicSet"
-        $this->ql->clear();
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Adding a page to the first chapter of the book requires one query');
 
         // this is failing if lifecycle callback postUpdate is recomputing change set
         $book = $this->dm->getRepository(Book::CLASSNAME)->findOneBy(['_id' => $book->id]);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
@@ -8,7 +8,6 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\LockException;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
-use Doctrine\ODM\MongoDB\Tests\QueryLogger;
 use Documents\Phonebook;
 use Documents\Phonenumber;
 use Documents\User;
@@ -17,22 +16,6 @@ use function get_class;
 
 class CommitImprovementTest extends BaseTest
 {
-    /** @var Doctrine\ODM\MongoDB\Tests\QueryLogger */
-    private $ql;
-
-    protected function getConfiguration()
-    {
-        $this->markTestSkipped('mongodb-driver: query logging does not exist');
-        if (! isset($this->ql)) {
-            $this->ql = new QueryLogger();
-        }
-
-        $config = parent::getConfiguration();
-        $config->setLoggerCallable($this->ql);
-
-        return $config;
-    }
-
     public function testInsertIncludesAllNestedCollections()
     {
         $user = new User();
@@ -42,7 +25,6 @@ class CommitImprovementTest extends BaseTest
         $user->addPhonebook($privateBook);
         $this->dm->persist($user);
         $this->dm->flush();
-        $this->assertCount(1, $this->ql, 'Inserting a document includes all nested collections and requires one query');
         $this->dm->clear();
 
         $user = $this->dm->find(get_class($user), $user->getId());
@@ -128,7 +110,6 @@ class CommitImprovementTest extends BaseTest
         $this->uow->computeChangeSet($this->dm->getClassMetadata(get_class($user)), $user);
         $this->assertFalse($this->uow->isCollectionScheduledForUpdate($user->getPhonenumbers()));
         $this->assertTrue($this->uow->isCollectionScheduledForDeletion($user->getPhonenumbers()));
-        $this->ql->clear();
         $this->dm->flush();
         $this->dm->clear();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1138Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1138Test.php
@@ -8,26 +8,9 @@ use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
-use Doctrine\ODM\MongoDB\Tests\QueryLogger;
 
 class GH1138Test extends BaseTest
 {
-    /** @var Doctrine\ODM\MongoDB\Tests\QueryLogger */
-    private $ql;
-
-    protected function getConfiguration()
-    {
-        $this->markTestSkipped('mongodb-driver: query logging does not exist');
-        if (! isset($this->ql)) {
-            $this->ql = new QueryLogger();
-        }
-
-        $config = parent::getConfiguration();
-        $config->setLoggerCallable($this->ql);
-
-        return $config;
-    }
-
     public function testUpdatingDocumentBeforeItsInsertionShouldNotEntailMultipleQueries()
     {
         $listener = new GH1138Listener();
@@ -39,7 +22,6 @@ class GH1138Test extends BaseTest
         $this->dm->persist($doc);
         $this->dm->flush();
 
-        $this->assertCount(1, $this->ql, 'Changing a document before its insertion requires one query');
         $this->assertEquals('foo-changed', $doc->name);
         $this->assertEquals(1, $listener->inserts);
         $this->assertEquals(0, $listener->updates);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #1791 

#### Summary

There is still one test file left: tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php. I'm not sure how to update the tests in that file. Some hints would be appreciated.
