### PR TITLE
[docs] Fix RST directive syntax / code blocks

### DIFF
--- a/docs/en/reference/indexes.rst
+++ b/docs/en/reference/indexes.rst
@@ -317,14 +317,14 @@ It will create the indexes from the ``BlogPost`` document but will also create t
 defined on the ``Comment`` embedded document. The following would be executed on the underlying MongoDB
 database:
 
-..
+::
 
     db.BlogPost.ensureIndexes({ 'slug' : 1, 'comments.date': 1 })
 
 Also, for your convenience you can create the indexes for your mapped documents from the
 :doc:`console <console-commands>`:
 
-..
+::
 
     $ php mongodb.php mongodb:schema:create --index
 

--- a/docs/en/reference/reference-mapping.rst
+++ b/docs/en/reference/reference-mapping.rst
@@ -371,7 +371,7 @@ The ``storeAs`` option has the following possible values:
 .. note::
 
     For backwards compatibility ``storeAs=dbRefWithDb`` is the default, but
-    ``storeAs=ref`` is the recommended setting.
+    ``storeAs=ref`` is the recommended setting.
 
 
 Cascading Operations


### PR DESCRIPTION
Note:
the syntax fix applies to `1.2.x`, `1.3.x` and `master`;
the space fix applies to `1.2.x` and `1.3.x` (not `master`).