### PR TITLE
[1.2] Fix failing build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/cache": "~1.0",
         "doctrine/inflector": "~1.0",
         "doctrine/instantiator": "^1.0.1",
-        "doctrine/mongodb": "^1.6.1"
+        "doctrine/mongodb": "^1.6.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.21|^6.4",

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -179,7 +179,7 @@ class ExprTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->field('address.subAddress.subAddress.subAddress.test')->popFirst();
         $query = $qb->getQuery();
         $query = $query->getQuery();
-        $this->assertEquals(array('$pop' => array('address.subAddress.subAddress.subAddress.testFieldName' => 1)), $query['newObj']);
+        $this->assertEquals(array('$pop' => array('address.subAddress.subAddress.subAddress.testFieldName' => -1)), $query['newObj']);
     }
 
     public function testReferencesUsesMinimalKeys()

--- a/tests/Documents/IndirectlyReferencedUser.php
+++ b/tests/Documents/IndirectlyReferencedUser.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;


### PR DESCRIPTION
Fixes failing build due to a broken test and an invalid `strict_types` declaration.