### PR TITLE
Add docker-compose for controlled local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM php:7.2-alpine3.8
+
+RUN apk add --no-cache make && \
+    apk add --no-cache --virtual .php-ext-deps autoconf g++ pcre-dev && \
+    pecl channel-update pecl.php.net && \
+    pecl install mongodb && \
+    docker-php-ext-install bcmath && \
+    docker-php-ext-enable mongodb && \
+    docker-php-source delete && \
+    apk del .php-ext-deps
+
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+RUN curl -o /tmp/composer-setup.php https://getcomposer.org/installer && \
+    curl -o /tmp/composer-setup.sig https://composer.github.io/installer.sig && \
+    php -r "if (hash('SHA384', file_get_contents('/tmp/composer-setup.php')) !== trim(file_get_contents('/tmp/composer-setup.sig'))) { unlink('/tmp/composer-setup.php'); echo 'Invalid installer' . PHP_EOL; exit(1); }" && \
+    php /tmp/composer-setup.php && \
+    mv composer.phar /usr/local/bin/composer && \
+    composer global require hirak/prestissimo --no-interaction --no-progress

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+test-container:
+	@docker-compose run --rm tests sh
+	@docker-compose down
+
+test: vendor
+	@vendor/bin/phpunit -d memory_limit=-1
+
+vendor:
+	@composer install

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "require": {
         "php": "^7.2",
         "ext-mongodb": "^1.5",
+        "ext-bcmath": "*",
         "symfony/console": "^3.4|^4.1",
         "doctrine/annotations": "^1.6",
         "doctrine/collections": "^1.5",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+---
+version: "2.1"
+services:
+  tests:
+    build: .
+    depends_on:
+    - mongodb
+    environment:
+      DOCTRINE_MONGODB_SERVER: "mongodb://mongodb:27017"
+    volumes:
+    - .:/tests:delegated
+    - ~/.composer:/root/.composer
+    working_dir: /tests
+
+  mongodb:
+    image: mongo:3.6


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no

Hi,

This PR adds Docker support to help with local development.

Run `make test-container` to create the container and its MongoDB dependency. A terminal is opened once the container is ready, run `make test` to run the test suite. When you're done with the tests just enter `exit` and the container will be destroyed and it's dependency shutdown.

The container image is built from the [official PHP 7.2 image](https://hub.docker.com/_/php/), and includes the MongoDB driver, the `bcmath` extension, and Composer (to install packages from within the container).

I also added `ext-bcmath` to `composer.json` since the extension is required by the `AlnumGenerator` class, but I didn't indicate a version because I didn't know which one to pick.

I hope this helps.