### PR TITLE
Fix type hint: createDocument(array $result)

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -470,6 +470,10 @@ class DocumentPersister
             }
         }
 
+        if ($result === null) {
+            return null;
+        }
+
         return $this->createDocument($result, $document, $hints);
     }
 
@@ -580,18 +584,14 @@ class DocumentPersister
     /**
      * Creates or fills a single document object from an query result.
      *
-     * @param array|null $result The query result.
-     * @param object $document   The document object to fill, if any.
-     * @param array  $hints      Hints for document creation.
+     * @param array  $result   The query result.
+     * @param object $document The document object to fill, if any.
+     * @param array  $hints    Hints for document creation.
      *
      * @return object The filled and managed document object or NULL, if the query result is empty.
      */
-    private function createDocument(?array $result, ?object $document = null, array $hints = []) : ?object
+    private function createDocument(array $result, ?object $document = null, array $hints = []) : ?object
     {
-        if ($result === null) {
-            return null;
-        }
-
         if ($document !== null) {
             $hints[Query::HINT_REFRESH] = true;
             $id                         = $this->class->getPHPIdentifierValue($result['_id']);

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -580,13 +580,13 @@ class DocumentPersister
     /**
      * Creates or fills a single document object from an query result.
      *
-     * @param object $result   The query result.
-     * @param object $document The document object to fill, if any.
-     * @param array  $hints    Hints for document creation.
+     * @param array|null $result The query result.
+     * @param object $document   The document object to fill, if any.
+     * @param array  $hints      Hints for document creation.
      *
      * @return object The filled and managed document object or NULL, if the query result is empty.
      */
-    private function createDocument($result, ?object $document = null, array $hints = []) : ?object
+    private function createDocument(?array $result, ?object $document = null, array $hints = []) : ?object
     {
         if ($result === null) {
             return null;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug/improvement
| BC Break     | no
| Related issues | https://github.com/doctrine/mongodb-odm/issues/1869

#### Summary

I found out the hard way that the implementation only works if the MongoDB client is configured to convert `root` and `document` types to array. Therefore, I believe the type hint of the `$result` parameter of the `createDocument()` method should be `?array` instead of `object`.

I also added a commit that moves the type check to the caller method as to avoid an necessary method call. This change also allows narrowing the type hint of the `$result` parameter to `array`.