### PR TITLE
Enforce typemap

### DIFF
--- a/docs/en/cookbook/resolve-target-document-listener.rst
+++ b/docs/en/cookbook/resolve-target-document-listener.rst
@@ -129,7 +129,7 @@ you cannot be guaranteed that the targetDocument resolution will occur reliably:
     $evm->addEventListener(\Doctrine\ODM\MongoDB\Events::loadClassMetadata, $rtdl);
 
     // Create the document manager as you normally would
-    $dm = \Doctrine\ODM\MongoDB\DocumentManager::create($connectionOptions, $config, $evm);
+    $dm = \Doctrine\ODM\MongoDB\DocumentManager::create(null, $config, $evm);
 
 Final Thoughts
 --------------

--- a/docs/en/reference/eager-cursors.rst
+++ b/docs/en/reference/eager-cursors.rst
@@ -25,7 +25,7 @@ Example:
     $qb = $dm->createQueryBuilder('User')
         ->eagerCursor(true);
     $query = $qb->getQuery();
-    $users = $query->execute(); // returns instance of Doctrine\MongoDB\ODM\EagerCursor
+    $users = $query->execute();
 
 At this point all data is loaded from the database and cursors to MongoDB
 have been closed but hydration of the data in to objects has not begun. Once

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -317,7 +317,7 @@ EventManager that is passed to the DocumentManager factory:
     $eventManager->addEventListener(array(Events::preUpdate), new MyEventListener());
     $eventManager->addEventSubscriber(new MyEventSubscriber());
 
-    $documentManager = DocumentManager::create($mongo, $config, $eventManager);
+    $documentManager = DocumentManager::create(null, $config, $eventManager);
 
 You can also retrieve the event manager instance after the
 DocumentManager was created:

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -148,7 +148,6 @@ instance. Read more about setting up the Doctrine MongoDB ODM in the
     <?php
 
     use Doctrine\Common\Annotations\AnnotationRegistry;
-    use Doctrine\MongoDB\Connection;
     use Doctrine\ODM\MongoDB\Configuration;
     use Doctrine\ODM\MongoDB\DocumentManager;
     use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
@@ -164,7 +163,7 @@ instance. Read more about setting up the Doctrine MongoDB ODM in the
     $config->setHydratorNamespace('Hydrators');
     $config->setMetadataDriverImpl(AnnotationDriver::create('/path/to/document/classes'));
 
-    $dm = DocumentManager::create(new Connection(), $config);
+    $dm = DocumentManager::create(null, $config);
 
 Usage
 -----

--- a/lib/Doctrine/ODM/MongoDB/MongoDBException.php
+++ b/lib/Doctrine/ODM/MongoDB/MongoDBException.php
@@ -132,4 +132,9 @@ class MongoDBException extends Exception
     {
         return new self(sprintf('Cannot open file "%s" for uploading to GridFS.', $filename));
     }
+
+    public static function invalidTypeMap(string $part, string $epectedType) : self
+    {
+        return new self(sprintf('Invalid typemap provided. Type "%s" is required for "%s".', $epectedType, $part));
+    }
 }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -580,13 +580,13 @@ class DocumentPersister
     /**
      * Creates or fills a single document object from an query result.
      *
-     * @param object $result   The query result.
-     * @param object $document The document object to fill, if any.
-     * @param array  $hints    Hints for document creation.
+     * @param array|null $result   The query result.
+     * @param object     $document The document object to fill, if any.
+     * @param array      $hints    Hints for document creation.
      *
      * @return object The filled and managed document object or NULL, if the query result is empty.
      */
-    private function createDocument($result, ?object $document = null, array $hints = []) : ?object
+    private function createDocument(?array $result, ?object $document = null, array $hints = []) : ?object
     {
         if ($result === null) {
             return null;

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -470,6 +470,10 @@ class DocumentPersister
             }
         }
 
+        if ($result === null) {
+            return null;
+        }
+
         return $this->createDocument($result, $document, $hints);
     }
 
@@ -580,18 +584,14 @@ class DocumentPersister
     /**
      * Creates or fills a single document object from an query result.
      *
-     * @param array|null $result   The query result.
-     * @param object     $document The document object to fill, if any.
-     * @param array      $hints    Hints for document creation.
+     * @param array  $result   The query result.
+     * @param object $document The document object to fill, if any.
+     * @param array  $hints    Hints for document creation.
      *
      * @return object The filled and managed document object or NULL, if the query result is empty.
      */
-    private function createDocument(?array $result, ?object $document = null, array $hints = []) : ?object
+    private function createDocument(array $result, ?object $document = null, array $hints = []) : ?object
     {
-        if ($result === null) {
-            return null;
-        }
-
         if ($document !== null) {
             $hints[Query::HINT_REFRESH] = true;
             $id                         = $this->class->getPHPIdentifierValue($result['_id']);

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Tests;
 use Doctrine\Common\EventManager;
 use Doctrine\ODM\MongoDB\Aggregation\Builder as AggregationBuilder;
 use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
@@ -223,6 +224,29 @@ class DocumentManagerTest extends BaseTest
         $dbRef = $this->dm->createReference($r, $class->associationMappings['ref4']);
         $this->assertCount(1, $dbRef);
         $this->assertArrayHasKey('id', $dbRef);
+    }
+
+    /**
+     * @dataProvider dataInvalidTypeMap
+     */
+    public function testThrowsExceptionOnInvalidTypeMap(string $expectedMessage, Client $client) : void
+    {
+        $this->expectException(MongoDBException::class);
+        $this->expectExceptionMessage($expectedMessage);
+        DocumentManager::create($client);
+    }
+
+    public function dataInvalidTypeMap() : array
+    {
+        $noTypeMap              = new Client();
+        $invalidDocumentTypeMap = new Client('mongodb://127.0.0.1', [], ['typeMap' => ['root' => 'array', 'document' => stdClass::class]]);
+        $invalidRootTypeMap     = new Client('mongodb://127.0.0.1', [], ['typeMap' => ['root' => stdClass::class, 'document' => 'array']]);
+
+        return [
+            'No typeMap' => ['Invalid typemap provided. Type "array" is required for "root".', $noTypeMap],
+            'Invalid document' => ['Invalid typemap provided. Type "array" is required for "document".', $invalidDocumentTypeMap],
+            'Invalid root' => ['Invalid typemap provided. Type "array" is required for "root".', $invalidRootTypeMap],
+        ];
     }
 }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | #1869

#### Summary

Fixes #1869 by enforcing the correct typeMap when a client is provided to the document manager. Since the typeMap can't (and most likely, shouldn't) be changed after instantiation of the client, we throw an exception if the typeMap isn't what we expect. For convenience, we also expose the expected typeMap using a constant for people to use. It also includes changes from #1870.

Furthermore, the documentation was updated to remove some legacy types.