### PR TITLE
Optimized nested collections deletion in DocumentPersister

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -69,6 +69,38 @@ class CollectionPersister
     }
 
     /**
+     * Deletes a PersistentCollection instances completely from a document using $unset. Collections can belong to
+     * different parents. Collections that is belong to one parent will be deleted in one query.
+     *
+     * @param PersistentCollectionInterface[] $collections
+     * @param array $options
+     */
+    public function deleteAll(array $collections, array $options)
+    {
+        $parents = [];
+        $unsetPathsMap = [];
+
+        foreach ($collections as $coll) {
+            $mapping = $coll->getMapping();
+            if ($mapping['isInverseSide']) {
+                continue; // ignore inverse side
+            }
+            if (CollectionHelper::isAtomic($mapping['strategy'])) {
+                throw new \UnexpectedValueException($mapping['strategy'] . ' delete collection strategy should have been handled by DocumentPersister. Please report a bug in issue tracker');
+            }
+            list($propertyPath, $parent) = $this->getPathAndParent($coll);
+            $oid = \spl_object_hash($parent);
+            $parents[$oid] = $parent;
+            $unsetPathsMap[$oid][$propertyPath] = true;
+        }
+
+        foreach ($unsetPathsMap as $oid => $unsetPaths) {
+            $query = array('$unset' => $unsetPaths);
+            $this->executeQuery($parents[$oid], $query, $options);
+        }
+    }
+
+    /**
      * Deletes a PersistentCollection instance completely from a document using $unset.
      *
      * @param PersistentCollectionInterface $coll

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -22,7 +22,6 @@ namespace Doctrine\ODM\MongoDB\Persisters;
 use Doctrine\Common\EventManager;
 use Doctrine\Common\Persistence\Mapping\MappingException;
 use Doctrine\MongoDB\CursorInterface;
-use Doctrine\MongoDB\EagerCursor;
 use Doctrine\ODM\MongoDB\Cursor;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
@@ -1357,11 +1356,15 @@ class DocumentPersister
 
     private function handleCollections($document, $options)
     {
+        $collections = [];
         // Collection deletions (deletions of complete collections)
         foreach ($this->uow->getScheduledCollections($document) as $coll) {
             if ($this->uow->isCollectionScheduledForDeletion($coll)) {
-                $this->cp->delete($coll, $options);
+                $collections[] = $coll;
             }
+        }
+        if (!empty($collections)) {
+            $this->cp->deleteAll($collections, $options);
         }
         // Collection updates (deleteRows, updateRows, insertRows)
         foreach ($this->uow->getScheduledCollections($document) as $coll) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -104,6 +104,25 @@ class CollectionPersisterTest extends BaseTest
         $this->assertTrue(isset($check['categories'][1]), 'Test that the category with the children still exists');
     }
 
+    public function testDeleteAllNestedEmbedManyAndNestedParent()
+    {
+        $persister = $this->getCollectionPersister();
+        $user      = $this->getTestUser('jwage');
+        $persister->deleteAll(
+            [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
+            []
+        );
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
+        $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
+        $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
+        $persister->deleteAll(
+            [$user->categories[0]->children, $user->categories[0]->children[1]->children, $user->categories],
+            []
+        );
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
+        $this->assertFalse(isset($check['categories']), 'Test that the nested categories field was deleted');
+    }
+
     public function testDeleteRows()
     {
         $persister = $this->getCollectionPersister();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -54,6 +54,56 @@ class CollectionPersisterTest extends BaseTest
         $this->assertTrue(isset($check['categories'][1]), 'Test that the category with the children still exists');
     }
 
+    public function testDeleteAllEmbedMany()
+    {
+        $persister = $this->getCollectionPersister();
+        $user = $this->getTestUser('jwage');
+        $persister->deleteAll([$user->categories], array());
+
+        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $this->assertArrayNotHasKey('categories', $user, 'Test that the categories field was deleted');
+    }
+
+    public function testDeleteAllReferenceMany()
+    {
+        $persister = $this->getCollectionPersister();
+        $user = $this->getTestUser('jwage');
+        $persister->deleteAll([$user->phonenumbers], array());
+
+        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $this->assertArrayNotHasKey('phonenumbers', $user, 'Test that the phonenumbers field was deleted');
+    }
+
+
+    public function testDeleteAllNestedEmbedMany()
+    {
+        $persister = $this->getCollectionPersister();
+        $user = $this->getTestUser('jwage');
+
+        $persister->deleteAll(
+            [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
+            array()
+        );
+
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+
+        $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
+        $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
+
+        $persister->deleteAll(
+            [$user->categories[0]->children, $user->categories[1]->children],
+            array()
+        );
+
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+
+        $this->assertFalse(isset($check['categories'][0]['children']), 'Test that the nested children categories field was deleted');
+        $this->assertTrue(isset($check['categories'][0]), 'Test that the category with the children still exists');
+
+        $this->assertFalse(isset($check['categories'][1]['children']), 'Test that the nested children categories field was deleted');
+        $this->assertTrue(isset($check['categories'][1]), 'Test that the category with the children still exists');
+    }
+
     public function testDeleteRows()
     {
         $persister = $this->getCollectionPersister();


### PR DESCRIPTION
Implemented CollectionPersister::deleteAll method for simultaneous deletion of collections that is belong to one document.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary
Improved removal of scheduled for removal collections. Now all collections that is belong to one parent is deleted in one query.
