### PR TITLE
Optimized nested collections deletion in DocumentPersister

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Persisters;
 
+use Closure;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\LockException;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
@@ -12,7 +13,10 @@ use Doctrine\ODM\MongoDB\UnitOfWork;
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 use LogicException;
 use UnexpectedValueException;
+use function array_diff_key;
 use function array_fill_keys;
+use function array_flip;
+use function array_intersect_key;
 use function array_keys;
 use function array_map;
 use function array_reverse;
@@ -37,7 +41,19 @@ use function strpos;
  */
 class CollectionPersister
 {
-    /** @var DocumentManager */
+    /**
+     * Validation map that is used for strategy validation in insertCollections method.
+     */
+    public const INSERT_STRATEGIES_MAP = [
+        ClassMetadata::STORAGE_STRATEGY_PUSH_ALL => true,
+        ClassMetadata::STORAGE_STRATEGY_ADD_TO_SET => true,
+    ];
+
+    /**
+     * The DocumentManager instance.
+     *
+     * @var DocumentManager
+     */
     private $dm;
 
     /** @var PersistenceBuilder */
@@ -137,6 +153,54 @@ class CollectionPersister
     }
 
     /**
+     * Updates a list PersistentCollection instances deleting removed rows and inserting new rows.
+     *
+     * @param PersistentCollectionInterface[] $collections
+     * @param array                           $options
+     */
+    public function updateAll(array $collections, array $options) : void
+    {
+        $setStrategyColls     = [];
+        $addPushStrategyColls = [];
+
+        foreach ($collections as $coll) {
+            $mapping = $coll->getMapping();
+
+            if ($mapping['isInverseSide']) {
+                continue; // ignore inverse side
+            }
+            switch ($mapping['strategy']) {
+                case ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET:
+                case ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET_ARRAY:
+                    throw new UnexpectedValueException($mapping['strategy'] . ' update collection strategy should have been handled by DocumentPersister. Please report a bug in issue tracker');
+
+                case ClassMetadata::STORAGE_STRATEGY_SET:
+                case ClassMetadata::STORAGE_STRATEGY_SET_ARRAY:
+                    $setStrategyColls[] = $coll;
+                    break;
+
+                case ClassMetadata::STORAGE_STRATEGY_ADD_TO_SET:
+                case ClassMetadata::STORAGE_STRATEGY_PUSH_ALL:
+                    $addPushStrategyColls[] = $coll;
+                    break;
+
+                default:
+                    throw new UnexpectedValueException('Unsupported collection strategy: ' . $mapping['strategy']);
+            }
+        }
+
+        if (! empty($setStrategyColls)) {
+            $this->setCollections($setStrategyColls, $options);
+        }
+        if (empty($addPushStrategyColls)) {
+            return;
+        }
+
+        $this->deleteCollections($addPushStrategyColls, $options);
+        $this->insertCollections($addPushStrategyColls, $options); // TODO
+    }
+
+    /**
      * Sets a PersistentCollection instance.
      *
      * This method is intended to be used with the "set" or "setArray"
@@ -152,6 +216,53 @@ class CollectionPersister
         $setData = $this->pb->prepareAssociatedCollectionValue($coll, CollectionHelper::usesSet($mapping['strategy']));
         $query   = ['$set' => [$propertyPath => $setData]];
         $this->executeQuery($parent, $query, $options);
+    }
+
+    /**
+     * Sets a list of PersistentCollection instances.
+     *
+     * This method is intended to be used with the "set" or "setArray"
+     * strategies. The "setArray" strategy will ensure that the collection is
+     * set as a BSON array, which means the collection elements will be
+     * reindexed numerically before storage.
+     *
+     * @param PersistentCollectionInterface[] $collections
+     * @param array                           $options
+     */
+    private function setCollections(array $collections, array $options) : void
+    {
+        $parents     = [];
+        $pathCollMap = [];
+        $pathsMap    = [];
+        foreach ($collections as $coll) {
+            [$propertyPath, $parent]          = $this->getPathAndParent($coll);
+            $oid                              = spl_object_hash($parent);
+            $parents[$oid]                    = $parent;
+            $pathCollMap[$oid][$propertyPath] = $coll;
+            $pathsMap[$oid][]                 = $propertyPath;
+        }
+
+        foreach ($pathsMap as $oid => $paths) {
+            $paths = $this->excludeSubPaths($paths);
+            /** @var PersistentCollectionInterface[] $setColls */
+            $setColls   = array_intersect_key($pathCollMap[$oid], array_flip($paths));
+            $setPayload = [];
+            foreach ($setColls as $propertyPath => $coll) {
+                $coll->initialize();
+                $mapping                   = $coll->getMapping();
+                $setData                   = $this->pb->prepareAssociatedCollectionValue(
+                    $coll,
+                    CollectionHelper::usesSet($mapping['strategy'])
+                );
+                $setPayload[$propertyPath] = $setData;
+            }
+            if (empty($setPayload)) {
+                continue;
+            }
+
+            $query = ['$set' => $setPayload];
+            $this->executeQuery($parents[$oid], $query, $options);
+        }
     }
 
     /**
@@ -185,6 +296,70 @@ class CollectionPersister
          * null values.
          */
         $this->executeQuery($parent, ['$pull' => [$propertyPath => null]], $options);
+    }
+
+    /**
+     * Deletes removed elements from a list of PersistentCollection instances.
+     *
+     * This method is intended to be used with the "pushAll" and "addToSet" strategies.
+     *
+     * @param PersistentCollectionInterface[] $collections
+     * @param array                           $options
+     */
+    private function deleteCollections(array $collections, array $options) : void
+    {
+        $parents       = [];
+        $pathCollMap   = [];
+        $pathsMap      = [];
+        $deleteDiffMap = [];
+
+        foreach ($collections as $coll) {
+            $coll->initialize();
+            if (! $this->uow->isCollectionScheduledForUpdate($coll)) {
+                continue;
+            }
+            $deleteDiff = $coll->getDeleteDiff();
+
+            if (empty($deleteDiff)) {
+                continue;
+            }
+            [$propertyPath, $parent] = $this->getPathAndParent($coll);
+
+            $oid                                = spl_object_hash($parent);
+            $parents[$oid]                      = $parent;
+            $pathCollMap[$oid][$propertyPath]   = $coll;
+            $pathsMap[$oid][]                   = $propertyPath;
+            $deleteDiffMap[$oid][$propertyPath] = $deleteDiff;
+        }
+
+        foreach ($pathsMap as $oid => $paths) {
+            $paths        = $this->excludeSubPaths($paths);
+            $deleteColls  = array_intersect_key($pathCollMap[$oid], array_flip($paths));
+            $unsetPayload = [];
+            $pullPayload  = [];
+            foreach ($deleteColls as $propertyPath => $coll) {
+                $deleteDiff = $deleteDiffMap[$oid][$propertyPath];
+                foreach ($deleteDiff as $key => $document) {
+                    $unsetPayload[$propertyPath . '.' . $key] = true;
+                }
+                $pullPayload[$propertyPath] = null;
+            }
+
+            if (! empty($unsetPayload)) {
+                $this->executeQuery($parents[$oid], ['$unset' => $unsetPayload], $options);
+            }
+            if (empty($pullPayload)) {
+                continue;
+            }
+
+            /**
+             * @todo This is a hack right now because we don't have a proper way to
+             * remove an element from an array by its key. Unsetting the key results
+             * in the element being left in the array as null so we have to pull
+             * null values.
+             */
+            $this->executeQuery($parents[$oid], ['$pull' => $pullPayload], $options);
+        }
     }
 
     /**
@@ -231,6 +406,167 @@ class CollectionPersister
         $query = ['$' . $operator => [$propertyPath => ['$each' => $value]]];
 
         $this->executeQuery($parent, $query, $options);
+    }
+
+    /**
+     * Inserts new elements for a list of PersistentCollection instances.
+     *
+     * This method is intended to be used with the "pushAll" and "addToSet" strategies.
+     *
+     * @param PersistentCollectionInterface[] $collections
+     * @param array                           $options
+     */
+    private function insertCollections(array $collections, array $options) : void
+    {
+        $parents             = [];
+        $pushAllPathCollMap  = [];
+        $addToSetPathCollMap = [];
+        $pushAllPathsMap     = [];
+        $addToSetPathsMap    = [];
+        $diffsMap            = [];
+
+        foreach ($collections as $coll) {
+            $coll->initialize();
+            if (! $this->uow->isCollectionScheduledForUpdate($coll)) {
+                continue;
+            }
+            $insertDiff = $coll->getInsertDiff();
+
+            if (empty($insertDiff)) {
+                continue;
+            }
+
+            $mapping  = $coll->getMapping();
+            $strategy = $mapping['strategy'];
+
+            if (empty(self::INSERT_STRATEGIES_MAP[$strategy])) {
+                throw new LogicException('Invalid strategy ' . $strategy . ' given for insertCollections');
+            }
+
+            [$propertyPath, $parent]       = $this->getPathAndParent($coll);
+            $oid                           = spl_object_hash($parent);
+            $parents[$oid]                 = $parent;
+            $diffsMap[$oid][$propertyPath] = $insertDiff;
+
+            switch ($strategy) {
+                case ClassMetadata::STORAGE_STRATEGY_PUSH_ALL:
+                    $pushAllPathCollMap[$oid][$propertyPath] = $coll;
+                    $pushAllPathsMap[$oid][]                 = $propertyPath;
+                    break;
+
+                case ClassMetadata::STORAGE_STRATEGY_ADD_TO_SET:
+                    $addToSetPathCollMap[$oid][$propertyPath] = $coll;
+                    $addToSetPathsMap[$oid][]                 = $propertyPath;
+                    break;
+
+                default:
+                    throw new LogicException('Invalid strategy ' . $strategy . ' given for insertCollections');
+            }
+        }
+
+        foreach ($parents as $oid => $parent) {
+            if (! empty($pushAllPathsMap[$oid])) {
+                $this->pushAllCollections(
+                    $parent,
+                    $pushAllPathsMap[$oid],
+                    $pushAllPathCollMap[$oid],
+                    $diffsMap[$oid],
+                    $options
+                );
+            }
+            if (empty($addToSetPathsMap[$oid])) {
+                continue;
+            }
+
+            $this->addToSetCollections(
+                $parent,
+                $addToSetPathsMap[$oid],
+                $addToSetPathCollMap[$oid],
+                $diffsMap[$oid],
+                $options
+            );
+        }
+    }
+
+    /**
+     * Perform collections update for 'pushAll' strategy.
+     *
+     * @param object $parent       Parent object to which passed collections is belong.
+     * @param array  $collsPaths   Paths of collections that is passed.
+     * @param array  $pathCollsMap List of collections indexed by their paths.
+     * @param array  $diffsMap     List of collection diffs indexed by collections paths.
+     * @param array  $options
+     */
+    private function pushAllCollections(object $parent, array $collsPaths, array $pathCollsMap, array $diffsMap, array $options) : void
+    {
+        $pushAllPaths = $this->excludeSubPaths($collsPaths);
+        /** @var PersistentCollectionInterface[] $pushAllColls */
+        $pushAllColls   = array_intersect_key($pathCollsMap, array_flip($pushAllPaths));
+        $pushAllPayload = [];
+        foreach ($pushAllColls as $propertyPath => $coll) {
+            $callback                      = $this->getValuePrepareCallback($coll);
+            $value                         = array_values(array_map($callback, $diffsMap[$propertyPath]));
+            $pushAllPayload[$propertyPath] = ['$each' => $value];
+        }
+
+        if (! empty($pushAllPayload)) {
+            $this->executeQuery($parent, ['$push' => $pushAllPayload], $options);
+        }
+
+        $pushAllColls = array_diff_key($pathCollsMap, array_flip($pushAllPaths));
+        foreach ($pushAllColls as $propertyPath => $coll) {
+            $callback = $this->getValuePrepareCallback($coll);
+            $value    = array_values(array_map($callback, $diffsMap[$propertyPath]));
+            $query    = ['$push' => [$propertyPath => ['$each' => $value]]];
+            $this->executeQuery($parent, $query, $options);
+        }
+    }
+
+    /**
+     * Perform collections update by 'addToSet' strategy.
+     *
+     * @param object $parent       Parent object to which passed collections is belong.
+     * @param array  $collsPaths   Paths of collections that is passed.
+     * @param array  $pathCollsMap List of collections indexed by their paths.
+     * @param array  $diffsMap     List of collection diffs indexed by collections paths.
+     * @param array  $options
+     */
+    private function addToSetCollections(object $parent, array $collsPaths, array $pathCollsMap, array $diffsMap, array $options) : void
+    {
+        $addToSetPaths = $this->excludeSubPaths($collsPaths);
+        /** @var PersistentCollectionInterface[] $addToSetColls */
+        $addToSetColls = array_intersect_key($pathCollsMap, array_flip($addToSetPaths));
+
+        $addToSetPayload = [];
+        foreach ($addToSetColls as $propertyPath => $coll) {
+            $callback                       = $this->getValuePrepareCallback($coll);
+            $value                          = array_values(array_map($callback, $diffsMap[$propertyPath]));
+            $addToSetPayload[$propertyPath] = ['$each' => $value];
+        }
+
+        if (empty($addToSetPayload)) {
+            return;
+        }
+
+        $this->executeQuery($parent, ['$addToSet' => $addToSetPayload], $options);
+    }
+
+    /**
+     * Return callback instance for specified collection. This callback will prepare values for query from documents
+     * that collection contain.
+     */
+    private function getValuePrepareCallback(PersistentCollectionInterface $coll) : Closure
+    {
+        $mapping = $coll->getMapping();
+        if (isset($mapping['embedded'])) {
+            return function ($v) use ($mapping) {
+                return $this->pb->prepareEmbeddedDocumentValue($mapping, $v);
+            };
+        }
+
+        return function ($v) use ($mapping) {
+            return $this->pb->prepareReferencedDocumentValue($mapping, $v);
+        };
     }
 
     /**
@@ -284,6 +620,13 @@ class CollectionPersister
         }
     }
 
+    /**
+     * Remove from passed paths list all sub-paths.
+     *
+     * @param string[] $paths
+     *
+     * @return string[]
+     */
     private function excludeSubPaths(array $paths) : array
     {
         $checkedPaths = [];

--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -81,15 +81,15 @@ class CollectionPersister
         $parents       = [];
         $unsetPathsMap = [];
 
-        foreach ($collections as $coll) {
-            $mapping = $coll->getMapping();
+        foreach ($collections as $collection) {
+            $mapping = $collection->getMapping();
             if ($mapping['isInverseSide']) {
                 continue; // ignore inverse side
             }
             if (CollectionHelper::isAtomic($mapping['strategy'])) {
                 throw new UnexpectedValueException($mapping['strategy'] . ' delete collection strategy should have been handled by DocumentPersister. Please report a bug in issue tracker');
             }
-            [$propertyPath, $parent]            = $this->getPathAndParent($coll);
+            [$propertyPath, $parent]            = $this->getPathAndParent($collection);
             $oid                                = spl_object_hash($parent);
             $parents[$oid]                      = $parent;
             $unsetPathsMap[$oid][$propertyPath] = true;
@@ -635,7 +635,7 @@ class CollectionPersister
         }
         sort($paths);
         $uniquePaths = [$paths[0]];
-        for ($i = 1; $i < count($paths); ++$i) {
+        for ($i = 1, $count = count($paths); $i < $count; ++$i) {
             if (strpos($paths[$i], end($uniquePaths)) === 0) {
                 continue;
             }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -12,12 +12,18 @@ use Doctrine\ODM\MongoDB\UnitOfWork;
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 use LogicException;
 use UnexpectedValueException;
+use function array_fill_keys;
+use function array_keys;
 use function array_map;
 use function array_reverse;
+use function array_unique;
 use function array_values;
+use function count;
 use function get_class;
 use function implode;
+use function spl_object_hash;
 use function sprintf;
+use function strpos;
 
 /**
  * The CollectionPersister is responsible for persisting collections of embedded
@@ -51,11 +57,11 @@ class CollectionPersister
      * Deletes a PersistentCollection instances completely from a document using $unset. If collections belong to the different
      *
      * @param PersistentCollectionInterface[] $collections
-     * @param array $options
+     * @param array                           $options
      */
-    public function deleteAll(array $collections, array $options)
+    public function deleteAll(array $collections, array $options) : void
     {
-        $parents = [];
+        $parents       = [];
         $unsetPathsMap = [];
 
         foreach ($collections as $coll) {
@@ -64,16 +70,17 @@ class CollectionPersister
                 continue; // ignore inverse side
             }
             if (CollectionHelper::isAtomic($mapping['strategy'])) {
-                throw new \UnexpectedValueException($mapping['strategy'] . ' delete collection strategy should have been handled by DocumentPersister. Please report a bug in issue tracker');
+                throw new UnexpectedValueException($mapping['strategy'] . ' delete collection strategy should have been handled by DocumentPersister. Please report a bug in issue tracker');
             }
-            list($propertyPath, $parent) = $this->getPathAndParent($coll);
-            $oid = \spl_object_hash($parent);
-            $parents[$oid] = $parent;
+            [$propertyPath, $parent]            = $this->getPathAndParent($coll);
+            $oid                                = spl_object_hash($parent);
+            $parents[$oid]                      = $parent;
             $unsetPathsMap[$oid][$propertyPath] = true;
         }
 
-        foreach ($unsetPathsMap as $oid => $unsetPaths) {
-            $query = array('$unset' => $unsetPaths);
+        foreach ($unsetPathsMap as $oid => $paths) {
+            $unsetPaths = array_fill_keys($this->excludeSubPaths(array_keys($paths)), true);
+            $query      = ['$unset' => $unsetPaths];
             $this->executeQuery($parents[$oid], $query, $options);
         }
     }
@@ -275,5 +282,29 @@ class CollectionPersister
         if ($class->isVersioned && ! $result->getMatchedCount()) {
             throw LockException::lockFailed($document);
         }
+    }
+
+    private function excludeSubPaths(array $paths) : array
+    {
+        $checkedPaths = [];
+        $pathsAmount  = count($paths);
+        $paths        = array_unique($paths);
+        for ($i = 0; $i < $pathsAmount; $i++) {
+            $isSubPath = false;
+            $j         = 0;
+            for (; $j < $pathsAmount; $j++) {
+                if ($i !== $j && strpos($paths[$i], $paths[$j]) === 0) {
+                    $isSubPath = true;
+                    break;
+                }
+            }
+            if ($isSubPath) {
+                continue;
+            }
+
+            $checkedPaths[] = $paths[$i];
+        }
+
+        return $checkedPaths;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -20,11 +20,12 @@ use function array_intersect_key;
 use function array_keys;
 use function array_map;
 use function array_reverse;
-use function array_unique;
 use function array_values;
 use function count;
+use function end;
 use function get_class;
 use function implode;
+use function sort;
 use function spl_object_hash;
 use function sprintf;
 use function strpos;
@@ -629,25 +630,19 @@ class CollectionPersister
      */
     private function excludeSubPaths(array $paths) : array
     {
-        $checkedPaths = [];
-        $pathsAmount  = count($paths);
-        $paths        = array_unique($paths);
-        for ($i = 0; $i < $pathsAmount; $i++) {
-            $isSubPath = false;
-            $j         = 0;
-            for (; $j < $pathsAmount; $j++) {
-                if ($i !== $j && strpos($paths[$i], $paths[$j]) === 0) {
-                    $isSubPath = true;
-                    break;
-                }
-            }
-            if ($isSubPath) {
+        if (empty($paths)) {
+            return $paths;
+        }
+        sort($paths);
+        $uniquePaths = [$paths[0]];
+        for ($i = 1; $i < count($paths); ++$i) {
+            if (strpos($paths[$i], end($uniquePaths)) === 0) {
                 continue;
             }
 
-            $checkedPaths[] = $paths[$i];
+            $uniquePaths[] = $paths[$i];
         }
 
-        return $checkedPaths;
+        return $uniquePaths;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1269,8 +1269,8 @@ class DocumentPersister
 
     private function handleCollections(object $document, array $options) : void
     {
-        $collections = [];
         // Collection deletions (deletions of complete collections)
+        $collections = [];
         foreach ($this->uow->getScheduledCollections($document) as $coll) {
             if (! $this->uow->isCollectionScheduledForDeletion($coll)) {
                 continue;
@@ -1282,12 +1282,16 @@ class DocumentPersister
             $this->cp->deleteAll($collections, $options);
         }
         // Collection updates (deleteRows, updateRows, insertRows)
+        $collections = [];
         foreach ($this->uow->getScheduledCollections($document) as $coll) {
             if (! $this->uow->isCollectionScheduledForUpdate($coll)) {
                 continue;
             }
 
-            $this->cp->update($coll, $options);
+            $collections[] = $coll;
+        }
+        if (! empty($collections)) {
+            $this->cp->updateAll($collections, $options);
         }
         // Take new snapshots from visited collections
         foreach ($this->uow->getVisitedCollections($document) as $coll) {

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1272,11 +1272,13 @@ class DocumentPersister
         $collections = [];
         // Collection deletions (deletions of complete collections)
         foreach ($this->uow->getScheduledCollections($document) as $coll) {
-            if ($this->uow->isCollectionScheduledForDeletion($coll)) {
-                $collections[] = $coll;
+            if (! $this->uow->isCollectionScheduledForDeletion($coll)) {
+                continue;
             }
+
+            $collections[] = $coll;
         }
-        if (!empty($collections)) {
+        if (! empty($collections)) {
             $this->cp->deleteAll($collections, $options);
         }
         // Collection updates (deleteRows, updateRows, insertRows)

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1279,7 +1279,7 @@ class DocumentPersister
             $collections[] = $coll;
         }
         if (! empty($collections)) {
-            $this->cp->deleteAll($document, $collections, $options);
+            $this->cp->delete($document, $collections, $options);
         }
         // Collection updates (deleteRows, updateRows, insertRows)
         $collections = [];
@@ -1291,7 +1291,7 @@ class DocumentPersister
             $collections[] = $coll;
         }
         if (! empty($collections)) {
-            $this->cp->updateAll($document, $collections, $options);
+            $this->cp->update($document, $collections, $options);
         }
         // Take new snapshots from visited collections
         foreach ($this->uow->getVisitedCollections($document) as $coll) {

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1279,7 +1279,7 @@ class DocumentPersister
             $collections[] = $coll;
         }
         if (! empty($collections)) {
-            $this->cp->deleteAll($collections, $options);
+            $this->cp->deleteAll($document, $collections, $options);
         }
         // Collection updates (deleteRows, updateRows, insertRows)
         $collections = [];
@@ -1291,7 +1291,7 @@ class DocumentPersister
             $collections[] = $coll;
         }
         if (! empty($collections)) {
-            $this->cp->updateAll($collections, $options);
+            $this->cp->updateAll($document, $collections, $options);
         }
         // Take new snapshots from visited collections
         foreach ($this->uow->getVisitedCollections($document) as $coll) {

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1269,13 +1269,15 @@ class DocumentPersister
 
     private function handleCollections(object $document, array $options) : void
     {
+        $collections = [];
         // Collection deletions (deletions of complete collections)
         foreach ($this->uow->getScheduledCollections($document) as $coll) {
-            if (! $this->uow->isCollectionScheduledForDeletion($coll)) {
-                continue;
+            if ($this->uow->isCollectionScheduledForDeletion($coll)) {
+                $collections[] = $coll;
             }
-
-            $this->cp->delete($coll, $options);
+        }
+        if (!empty($collections)) {
+            $this->cp->deleteAll($collections, $options);
         }
         // Collection updates (deleteRows, updateRows, insertRows)
         foreach ($this->uow->getScheduledCollections($document) as $coll) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -36,20 +36,20 @@ class CollectionPersisterTest extends BaseTest
     {
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
-        $persister->delete($user->phonenumbers, []);
+        $persister->delete($user, [$user->categories], []);
 
         $user = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
-        $this->assertArrayNotHasKey('phonenumbers', $user, 'Test that the phonenumbers field was deleted');
+        $this->assertArrayNotHasKey('categories', $user, 'Test that the categories field was deleted');
     }
 
     public function testDeleteEmbedMany() : void
     {
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
-        $persister->delete($user->categories, []);
+        $persister->delete($user, [$user->phonenumbers], []);
 
         $user = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
-        $this->assertArrayNotHasKey('categories', $user, 'Test that the categories field was deleted');
+        $this->assertArrayNotHasKey('phonenumbers', $user, 'Test that the phonenumbers field was deleted');
     }
 
     public function testDeleteNestedEmbedMany() : void
@@ -57,94 +57,64 @@ class CollectionPersisterTest extends BaseTest
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
 
-        $persister->delete($user->categories[0]->children[0]->children, []);
-        $persister->delete($user->categories[0]->children[1]->children, []);
-
-        $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
-
-        $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
-        $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
-
-        $persister->delete($user->categories[0]->children, []);
-        $persister->delete($user->categories[1]->children, []);
-
-        $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
-
-        $this->assertFalse(isset($check['categories'][0]['children']), 'Test that the nested children categories field was deleted');
-        $this->assertTrue(isset($check['categories'][0]), 'Test that the category with the children still exists');
-
-        $this->assertFalse(isset($check['categories'][1]['children']), 'Test that the nested children categories field was deleted');
-        $this->assertTrue(isset($check['categories'][1]), 'Test that the category with the children still exists');
-    }
-
-    public function testDeleteAllEmbedMany() : void
-    {
-        $persister = $this->getCollectionPersister();
-        $user      = $this->getTestUser('jwage');
-        $persister->deleteAll($user, [$user->categories], []);
-        $user = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
-        $this->assertArrayNotHasKey('categories', $user, 'Test that the categories field was deleted');
-    }
-
-    public function testDeleteAllReferenceMany() : void
-    {
-        $persister = $this->getCollectionPersister();
-        $user      = $this->getTestUser('jwage');
-        $persister->deleteAll($user, [$user->phonenumbers], []);
-        $user = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
-        $this->assertArrayNotHasKey('phonenumbers', $user, 'Test that the phonenumbers field was deleted');
-    }
-
-    public function testDeleteAllNestedEmbedMany() : void
-    {
-        $persister = $this->getCollectionPersister();
-        $user      = $this->getTestUser('jwage');
         $this->logger->clear();
-        $persister->deleteAll(
+        $persister->delete(
             $user,
             [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
             []
         );
         $this->assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
+
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
+
         $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
         $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
+
         $this->logger->clear();
-        $persister->deleteAll(
+        $persister->delete(
             $user,
             [$user->categories[0]->children, $user->categories[1]->children],
             []
         );
         $this->assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
+
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
+
         $this->assertFalse(isset($check['categories'][0]['children']), 'Test that the nested children categories field was deleted');
         $this->assertTrue(isset($check['categories'][0]), 'Test that the category with the children still exists');
+
         $this->assertFalse(isset($check['categories'][1]['children']), 'Test that the nested children categories field was deleted');
         $this->assertTrue(isset($check['categories'][1]), 'Test that the category with the children still exists');
     }
 
-    public function testDeleteAllNestedEmbedManyAndNestedParent() : void
+    public function testDeleteNestedEmbedManyAndNestedParent() : void
     {
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
+
         $this->logger->clear();
-        $persister->deleteAll(
+        $persister->delete(
             $user,
             [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
             []
         );
         $this->assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
+
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
+
         $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
         $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
+
         $this->logger->clear();
-        $persister->deleteAll(
+        $persister->delete(
             $user,
             [$user->categories[0]->children, $user->categories[0]->children[1]->children, $user->categories],
             []
         );
         $this->assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
+
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
+
         $this->assertFalse(isset($check['categories']), 'Test that the nested categories field was deleted');
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -58,6 +58,47 @@ class CollectionPersisterTest extends BaseTest
         $this->assertTrue(isset($check['categories'][1]), 'Test that the category with the children still exists');
     }
 
+    public function testDeleteAllEmbedMany()
+    {
+        $persister = $this->getCollectionPersister();
+        $user = $this->getTestUser('jwage');
+        $persister->deleteAll([$user->categories], array());
+        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $this->assertArrayNotHasKey('categories', $user, 'Test that the categories field was deleted');
+    }
+
+    public function testDeleteAllReferenceMany()
+    {
+        $persister = $this->getCollectionPersister();
+        $user = $this->getTestUser('jwage');
+        $persister->deleteAll([$user->phonenumbers], array());
+        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $this->assertArrayNotHasKey('phonenumbers', $user, 'Test that the phonenumbers field was deleted');
+    }
+
+    public function testDeleteAllNestedEmbedMany()
+    {
+        $persister = $this->getCollectionPersister();
+        $user = $this->getTestUser('jwage');
+        $persister->deleteAll(
+            [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
+            array()
+        );
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
+        $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
+        $persister->deleteAll(
+            [$user->categories[0]->children, $user->categories[1]->children],
+            array()
+        );
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $this->assertFalse(isset($check['categories'][0]['children']), 'Test that the nested children categories field was deleted');
+        $this->assertTrue(isset($check['categories'][0]), 'Test that the category with the children still exists');
+        $this->assertFalse(isset($check['categories'][1]['children']), 'Test that the nested children categories field was deleted');
+        $this->assertTrue(isset($check['categories'][1]), 'Test that the category with the children still exists');
+    }
+
+
     public function testDeleteRows()
     {
         $persister = $this->getCollectionPersister();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -63,7 +63,7 @@ class CollectionPersisterTest extends BaseTest
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
         $persister->deleteAll([$user->categories], []);
-        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
+        $user = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         $this->assertArrayNotHasKey('categories', $user, 'Test that the categories field was deleted');
     }
 
@@ -72,7 +72,7 @@ class CollectionPersisterTest extends BaseTest
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
         $persister->deleteAll([$user->phonenumbers], []);
-        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
+        $user = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         $this->assertArrayNotHasKey('phonenumbers', $user, 'Test that the phonenumbers field was deleted');
     }
 
@@ -84,14 +84,14 @@ class CollectionPersisterTest extends BaseTest
             [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
             []
         );
-        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
+        $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
         $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
         $persister->deleteAll(
             [$user->categories[0]->children, $user->categories[1]->children],
             []
         );
-        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
+        $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         $this->assertFalse(isset($check['categories'][0]['children']), 'Test that the nested children categories field was deleted');
         $this->assertTrue(isset($check['categories'][0]), 'Test that the category with the children still exists');
         $this->assertFalse(isset($check['categories'][1]['children']), 'Test that the nested children categories field was deleted');
@@ -106,14 +106,14 @@ class CollectionPersisterTest extends BaseTest
             [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
             []
         );
-        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
+        $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
         $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
         $persister->deleteAll(
             [$user->categories[0]->children, $user->categories[0]->children[1]->children, $user->categories],
             []
         );
-        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
+        $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         $this->assertFalse(isset($check['categories']), 'Test that the nested categories field was deleted');
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -62,7 +62,7 @@ class CollectionPersisterTest extends BaseTest
     {
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
-        $persister->deleteAll([$user->categories], []);
+        $persister->deleteAll($user, [$user->categories], []);
         $user = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         $this->assertArrayNotHasKey('categories', $user, 'Test that the categories field was deleted');
     }
@@ -71,7 +71,7 @@ class CollectionPersisterTest extends BaseTest
     {
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
-        $persister->deleteAll([$user->phonenumbers], []);
+        $persister->deleteAll($user, [$user->phonenumbers], []);
         $user = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         $this->assertArrayNotHasKey('phonenumbers', $user, 'Test that the phonenumbers field was deleted');
     }
@@ -81,6 +81,7 @@ class CollectionPersisterTest extends BaseTest
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
         $persister->deleteAll(
+            $user,
             [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
             []
         );
@@ -88,6 +89,7 @@ class CollectionPersisterTest extends BaseTest
         $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
         $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
         $persister->deleteAll(
+            $user,
             [$user->categories[0]->children, $user->categories[1]->children],
             []
         );
@@ -103,6 +105,7 @@ class CollectionPersisterTest extends BaseTest
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
         $persister->deleteAll(
+            $user,
             [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
             []
         );
@@ -110,6 +113,7 @@ class CollectionPersisterTest extends BaseTest
         $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
         $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
         $persister->deleteAll(
+            $user,
             [$user->categories[0]->children, $user->categories[0]->children[1]->children, $user->categories],
             []
         );

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\APM\CommandLogger;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Persisters\CollectionPersister;
 use Doctrine\ODM\MongoDB\Persisters\PersistenceBuilder;
@@ -13,7 +14,25 @@ use function get_class;
 
 class CollectionPersisterTest extends BaseTest
 {
-    public function testDeleteReferenceMany()
+    /** @var CommandLogger */
+    private $logger;
+
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        $this->logger = new CommandLogger();
+        $this->logger->register();
+    }
+
+    public function tearDown() : void
+    {
+        $this->logger->unregister();
+
+        parent::tearDown();
+    }
+
+    public function testDeleteReferenceMany() : void
     {
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
@@ -23,7 +42,7 @@ class CollectionPersisterTest extends BaseTest
         $this->assertArrayNotHasKey('phonenumbers', $user, 'Test that the phonenumbers field was deleted');
     }
 
-    public function testDeleteEmbedMany()
+    public function testDeleteEmbedMany() : void
     {
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
@@ -33,7 +52,7 @@ class CollectionPersisterTest extends BaseTest
         $this->assertArrayNotHasKey('categories', $user, 'Test that the categories field was deleted');
     }
 
-    public function testDeleteNestedEmbedMany()
+    public function testDeleteNestedEmbedMany() : void
     {
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
@@ -58,7 +77,7 @@ class CollectionPersisterTest extends BaseTest
         $this->assertTrue(isset($check['categories'][1]), 'Test that the category with the children still exists');
     }
 
-    public function testDeleteAllEmbedMany()
+    public function testDeleteAllEmbedMany() : void
     {
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
@@ -67,7 +86,7 @@ class CollectionPersisterTest extends BaseTest
         $this->assertArrayNotHasKey('categories', $user, 'Test that the categories field was deleted');
     }
 
-    public function testDeleteAllReferenceMany()
+    public function testDeleteAllReferenceMany() : void
     {
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
@@ -76,23 +95,27 @@ class CollectionPersisterTest extends BaseTest
         $this->assertArrayNotHasKey('phonenumbers', $user, 'Test that the phonenumbers field was deleted');
     }
 
-    public function testDeleteAllNestedEmbedMany()
+    public function testDeleteAllNestedEmbedMany() : void
     {
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
+        $this->logger->clear();
         $persister->deleteAll(
             $user,
             [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
             []
         );
+        $this->assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
         $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
+        $this->logger->clear();
         $persister->deleteAll(
             $user,
             [$user->categories[0]->children, $user->categories[1]->children],
             []
         );
+        $this->assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         $this->assertFalse(isset($check['categories'][0]['children']), 'Test that the nested children categories field was deleted');
         $this->assertTrue(isset($check['categories'][0]), 'Test that the category with the children still exists');
@@ -100,32 +123,35 @@ class CollectionPersisterTest extends BaseTest
         $this->assertTrue(isset($check['categories'][1]), 'Test that the category with the children still exists');
     }
 
-    public function testDeleteAllNestedEmbedManyAndNestedParent()
+    public function testDeleteAllNestedEmbedManyAndNestedParent() : void
     {
         $persister = $this->getCollectionPersister();
         $user      = $this->getTestUser('jwage');
+        $this->logger->clear();
         $persister->deleteAll(
             $user,
             [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
             []
         );
+        $this->assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
         $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
+        $this->logger->clear();
         $persister->deleteAll(
             $user,
             [$user->categories[0]->children, $user->categories[0]->children[1]->children, $user->categories],
             []
         );
+        $this->assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         $this->assertFalse(isset($check['categories']), 'Test that the nested categories field was deleted');
     }
 
 
-    public function testDeleteRows()
+    public function testDeleteRows() : void
     {
-        $persister = $this->getCollectionPersister();
-        $user      = $this->getTestUser('jwage');
+        $user = $this->getTestUser('jwage');
 
         unset($user->phonenumbers[0]);
         unset($user->phonenumbers[1]);
@@ -136,7 +162,9 @@ class CollectionPersisterTest extends BaseTest
         unset($user->categories[0]->children[1]->children[0]);
         unset($user->categories[0]->children[1]->children[1]);
 
+        $this->logger->clear();
         $this->dm->flush();
+        $this->assertCount(2, $this->logger, 'Modification of several embedded-many collections of one document requires two queries');
 
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
 
@@ -151,19 +179,23 @@ class CollectionPersisterTest extends BaseTest
 
         unset($user->categories[0]);
         unset($user->categories[1]);
+        $this->logger->clear();
         $this->dm->flush();
+        $this->assertCount(2, $this->logger, 'Modification of embedded-many collection of one document requires two queries');
 
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         $this->assertFalse(isset($check['categories'][0]));
         $this->assertFalse(isset($check['categories'][1]));
     }
 
-    public function testInsertRows()
+    public function testInsertRows() : void
     {
         $user                 = $this->getTestUser('jwage');
         $user->phonenumbers[] = new CollectionPersisterPhonenumber('6155139185');
         $user->phonenumbers[] = new CollectionPersisterPhonenumber('6155139185');
+        $this->logger->clear();
         $this->dm->flush();
+        $this->assertCount(2, $this->logger, 'Modification of embedded-many collection of one document requires two queries');
 
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         $this->assertCount(4, $check['phonenumbers']);
@@ -172,7 +204,13 @@ class CollectionPersisterTest extends BaseTest
 
         $user->categories[] = new CollectionPersisterCategory('Test');
         $user->categories[] = new CollectionPersisterCategory('Test');
+        $this->logger->clear();
         $this->dm->flush();
+        $this->assertCount(
+            1,
+            $this->logger,
+            'Modification of embedded-many collection of one document requires one query since no existing collection elements was removed'
+        );
 
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         $this->assertCount(4, $check['categories']);
@@ -181,14 +219,20 @@ class CollectionPersisterTest extends BaseTest
         $user->categories[3]->children[1]              = new CollectionPersisterCategory('Test');
         $user->categories[3]->children[1]->children[0] = new CollectionPersisterCategory('Test');
         $user->categories[3]->children[1]->children[1] = new CollectionPersisterCategory('Test');
+        $this->logger->clear();
         $this->dm->flush();
+        $this->assertCount(
+            1,
+            $this->logger,
+            'Modification of embedded-many collection of one document requires one query since no existing collection elements was removed'
+        );
 
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         $this->assertCount(2, $check['categories'][3]['children']);
         $this->assertCount(2, $check['categories'][3]['children']['1']['children']);
     }
 
-    private function getTestUser($username)
+    private function getTestUser(string $username) : CollectionPersisterUser
     {
         $user                  = new CollectionPersisterUser();
         $user->username        = $username;
@@ -215,14 +259,14 @@ class CollectionPersisterTest extends BaseTest
         return $user;
     }
 
-    private function getCollectionPersister()
+    private function getCollectionPersister() : CollectionPersister
     {
         $uow = $this->dm->getUnitOfWork();
         $pb  = new PersistenceBuilder($this->dm, $uow);
         return new CollectionPersister($this->dm, $pb, $uow);
     }
 
-    public function testNestedEmbedManySetStrategy()
+    public function testNestedEmbedManySetStrategy() : void
     {
         $post      = new CollectionPersisterPost('postA');
         $commentA  = new CollectionPersisterComment('commentA', 'userA');
@@ -234,7 +278,13 @@ class CollectionPersisterTest extends BaseTest
         $commentA->comments->set('b', $commentAB);
 
         $this->dm->persist($post);
+        $this->logger->clear();
         $this->dm->flush();
+        $this->assertCount(
+            1,
+            $this->logger,
+            'Insertion of embedded-many collection of one document requires no additional queries'
+        );
 
         $doc = $this->dm->getDocumentCollection(CollectionPersisterPost::class)->findOne(['post' => 'postA']);
 
@@ -255,7 +305,13 @@ class CollectionPersisterTest extends BaseTest
         $commentB->comments->set('a', $commentBA);
 
         $this->dm->persist($post);
+        $this->logger->clear();
         $this->dm->flush();
+        $this->assertCount(
+            1,
+            $this->logger,
+            'Modification of embedded-many collection of one document requires one query since no existing collection elements was removed'
+        );
 
         $doc = $this->dm->getDocumentCollection(CollectionPersisterPost::class)->findOne(['post' => 'postA']);
 
@@ -275,7 +331,13 @@ class CollectionPersisterTest extends BaseTest
         $commentAB->comment = 'commentAB-modified';
 
         $this->dm->persist($post);
+        $this->logger->clear();
         $this->dm->flush();
+        $this->assertCount(
+            1,
+            $this->logger,
+            'Modification of embedded-many collection of one document requires one query since no existing collection elements was removed'
+        );
 
         $doc = $this->dm->getDocumentCollection(CollectionPersisterPost::class)->findOne(['post' => 'postA']);
 
@@ -292,7 +354,13 @@ class CollectionPersisterTest extends BaseTest
         unset($post->comments['b']);
 
         $this->dm->persist($post);
+        $this->logger->clear();
         $this->dm->flush();
+        $this->assertCount(
+            1,
+            $this->logger,
+            'Modification of embedded-many collection of one document requires one query since collection, from which element was removed, have "set" store strategy.'
+        );
 
         $doc = $this->dm->getDocumentCollection(CollectionPersisterPost::class)->findOne(['post' => 'postA']);
 
@@ -304,7 +372,7 @@ class CollectionPersisterTest extends BaseTest
         $this->assertFalse(isset($doc['comments']['b']));
     }
 
-    public function testFindBySetStrategyKey()
+    public function testFindBySetStrategyKey() : void
     {
         $post      = new CollectionPersisterPost('postA');
         $commentA  = new CollectionPersisterComment('commentA', 'userA');
@@ -318,6 +386,204 @@ class CollectionPersisterTest extends BaseTest
 
         $this->assertSame($post, $this->dm->getRepository(get_class($post))->findOneBy(['comments.a.by' => 'userA']));
         $this->assertSame($post, $this->dm->getRepository(get_class($post))->findOneBy(['comments.a.comments.b.by' => 'userB']));
+    }
+
+    public function testPersistSeveralNestedEmbedManySetStrategy() : void
+    {
+        $structure = new CollectionPersisterStructure();
+        $structure->set->add(new CollectionPersisterNestedStructure('nested1'));
+        $structure->set->add(new CollectionPersisterNestedStructure('nested2'));
+        $structure->set2->add(new CollectionPersisterNestedStructure('nested3'));
+        $structure->set2->add(new CollectionPersisterNestedStructure('nested4'));
+
+        $this->dm->persist($structure);
+        $this->dm->flush();
+        $this->assertCount(
+            1,
+            $this->logger,
+            'Insertion of embedded-many collections of one document by "set" strategy requires no additional queries'
+        );
+
+        $structure->set->clear();
+        $structure->set->add(new CollectionPersisterNestedStructure('nested5'));
+        $structure->set2->add(new CollectionPersisterNestedStructure('nested6'));
+
+        $this->logger->clear();
+        $this->dm->flush();
+        $this->assertCount(
+            1,
+            $this->logger,
+            'Modification of embedded-many collections of one document by "set" strategy requires one query'
+        );
+
+        $this->assertSame($structure, $this->dm->getRepository(get_class($structure))->findOneBy(['id' => $structure->id]));
+    }
+
+    public function testPersistSeveralNestedEmbedManySetArrayStrategy() : void
+    {
+        $structure = new CollectionPersisterStructure();
+        $structure->setArray->add(new CollectionPersisterNestedStructure('nested1'));
+        $structure->setArray->add(new CollectionPersisterNestedStructure('nested2'));
+        $structure->setArray2->add(new CollectionPersisterNestedStructure('nested3'));
+        $structure->setArray2->add(new CollectionPersisterNestedStructure('nested4'));
+
+        $this->dm->persist($structure);
+        $this->dm->flush();
+        $this->assertCount(
+            1,
+            $this->logger,
+            'Insertion of embedded-many collections of one document by "setArray" strategy requires no additional queries'
+        );
+
+        $structure->setArray->clear();
+        $structure->setArray->add(new CollectionPersisterNestedStructure('nested5'));
+        $structure->setArray2->add(new CollectionPersisterNestedStructure('nested6'));
+
+        $this->logger->clear();
+        $this->dm->flush();
+        $this->assertCount(
+            1,
+            $this->logger,
+            'Modification of embedded-many collections of one document by "setArray" strategy requires one query'
+        );
+
+        $this->assertSame($structure, $this->dm->getRepository(get_class($structure))->findOneBy(['id' => $structure->id]));
+    }
+
+    public function testPersistSeveralNestedEmbedManyAddToSetStrategy() : void
+    {
+        $structure = new CollectionPersisterStructure();
+        $structure->addToSet->add(new CollectionPersisterNestedStructure('nested1'));
+        $structure->addToSet->add(new CollectionPersisterNestedStructure('nested2'));
+        $structure->addToSet2->add(new CollectionPersisterNestedStructure('nested3'));
+        $structure->addToSet2->add(new CollectionPersisterNestedStructure('nested4'));
+
+        $this->dm->persist($structure);
+        $this->dm->flush();
+        $this->assertCount(
+            2,
+            $this->logger,
+            'Insertion of embedded-many collections of one document by "addToSet" strategy requires one additional query'
+        );
+
+        $structure->addToSet->clear();
+        $structure->addToSet->add(new CollectionPersisterNestedStructure('nested5'));
+        $structure->addToSet2->add(new CollectionPersisterNestedStructure('nested6'));
+
+        $this->logger->clear();
+        $this->dm->flush();
+        $this->assertCount(
+            2,
+            $this->logger,
+            'Modification of embedded-many collections of one document by "addToSet" strategy requires two queries'
+        );
+
+        $this->assertSame($structure, $this->dm->getRepository(get_class($structure))->findOneBy(['id' => $structure->id]));
+    }
+
+    public function testPersistSeveralNestedEmbedManyPushAllStrategy() : void
+    {
+        $structure = new CollectionPersisterStructure();
+        $structure->pushAll->add(new CollectionPersisterNestedStructure('nested1'));
+        $structure->pushAll->add(new CollectionPersisterNestedStructure('nested2'));
+        $structure->pushAll2->add(new CollectionPersisterNestedStructure('nested3'));
+        $structure->pushAll2->add(new CollectionPersisterNestedStructure('nested4'));
+
+        $this->dm->persist($structure);
+        $this->dm->flush();
+        $this->assertCount(
+            1,
+            $this->logger,
+            'Insertion of embedded-many collections of one document by "pushAll" strategy requires no additional queries'
+        );
+
+        $structure->pushAll->add(new CollectionPersisterNestedStructure('nested5'));
+        $structure->pushAll2->add(new CollectionPersisterNestedStructure('nested6'));
+
+        $this->logger->clear();
+        $this->dm->persist($structure);
+        $this->dm->flush();
+        $this->assertCount(
+            2,
+            $this->logger,
+            'Modification of embedded-many collections of one document by "pushAll" strategy requires two queries'
+        );
+
+        $this->assertSame($structure, $this->dm->getRepository(get_class($structure))->findOneBy(['id' => $structure->id]));
+    }
+
+    public function testPersistSeveralNestedEmbedManyDifferentStrategies() : void
+    {
+        $structure = new CollectionPersisterStructure();
+        $structure->set->add(new CollectionPersisterNestedStructure('nested1'));
+        $structure->setArray->add(new CollectionPersisterNestedStructure('nested2'));
+        $structure->pushAll->add(new CollectionPersisterNestedStructure('nested3'));
+
+        $this->dm->persist($structure);
+        $this->dm->flush();
+        $this->assertCount(
+            1,
+            $this->logger,
+            'Insertion of embedded-many collections of one document by "set", "setArray" and "pushAll" strategies requires no additional queries'
+        );
+
+        $structure->set->remove(0);
+        $structure->set->add(new CollectionPersisterNestedStructure('nested5'));
+        $structure->pushAll->remove(0);
+        $structure->setArray->add(new CollectionPersisterNestedStructure('nested6'));
+        $structure->setArray->remove(0);
+        $structure->pushAll->add(new CollectionPersisterNestedStructure('nested7'));
+
+        $this->logger->clear();
+        $this->dm->persist($structure);
+        $this->dm->flush();
+        $this->assertCount(
+            4,
+            $this->logger,
+            'Modification of embedded-many collections of one document by "set", "setArray" and "pushAll" strategies requires two queries'
+        );
+
+        $this->assertSame($structure, $this->dm->getRepository(get_class($structure))->findOneBy(['id' => $structure->id]));
+    }
+
+    public function testPersistSeveralNestedEmbedManyDifferentStrategiesDeepNesting() : void
+    {
+        $structure = new CollectionPersisterStructure();
+        $nested1   = new CollectionPersisterNestedStructure('nested1');
+        $nested2   = new CollectionPersisterNestedStructure('nested2');
+        $nested3   = new CollectionPersisterNestedStructure('nested3');
+        $nested1->setArray->add(new CollectionPersisterNestedStructure('setArray_nested1'));
+        $nested2->pushAll->add(new CollectionPersisterNestedStructure('pushAll_nested1'));
+        $nested3->set->add(new CollectionPersisterNestedStructure('set_nested1'));
+        $structure->set->add($nested1);
+        $structure->setArray->add($nested2);
+        $structure->pushAll->add($nested3);
+
+        $this->dm->persist($structure);
+        $this->dm->flush();
+        $this->assertCount(
+            1,
+            $this->logger,
+            'Insertion of embedded-many collections of one document by "set", "setArray" and "pushAll" strategies requires no additional queries'
+        );
+
+        $structure->set->remove(0);
+        $structure->set->add(new CollectionPersisterNestedStructure('nested5'));
+        $structure->setArray->get(0)->set->add(new CollectionPersisterNestedStructure('set_nested1'));
+        $structure->pushAll->get(0)->set->clear();
+        $structure->pushAll->add(new CollectionPersisterNestedStructure('nested5'));
+        $structure->pushAll->remove(0);
+
+        $this->logger->clear();
+        $this->dm->persist($structure);
+        $this->dm->flush();
+        $this->assertCount(
+            5,
+            $this->logger,
+            'Modification of embedded-many collections of one document by "set", "setArray" and "pushAll" strategies requires two queries'
+        );
+
+        $this->assertSame($structure, $this->dm->getRepository(get_class($structure))->findOneBy(['id' => $structure->id]));
     }
 }
 
@@ -406,5 +672,94 @@ class CollectionPersisterComment
         $this->comments = new ArrayCollection();
         $this->comment  = $comment;
         $this->by       = $by;
+    }
+}
+
+/** @ODM\Document(collection="structure_collection_persister_test") */
+class CollectionPersisterStructure
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="addToSet") */
+    public $addToSet;
+
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="addToSet") */
+    public $addToSet2;
+
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="set") */
+    public $set;
+
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="set") */
+    public $set2;
+
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="setArray") */
+    public $setArray;
+
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="setArray") */
+    public $setArray2;
+
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="pushAll") */
+    public $pushAll;
+
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="pushAll") */
+    public $pushAll2;
+
+    public function __construct()
+    {
+        $this->addToSet  = new ArrayCollection();
+        $this->addToSet2 = new ArrayCollection();
+        $this->set       = new ArrayCollection();
+        $this->set2      = new ArrayCollection();
+        $this->setArray  = new ArrayCollection();
+        $this->setArray2 = new ArrayCollection();
+        $this->pushAll   = new ArrayCollection();
+        $this->pushAll2  = new ArrayCollection();
+    }
+}
+/** @ODM\EmbeddedDocument */
+class CollectionPersisterNestedStructure
+{
+    /** @ODM\Id */
+    public $id;
+
+    /** @ODM\Field(type="string") */
+    public $field;
+
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="addToSet") */
+    public $addToSet;
+
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="addToSet") */
+    public $addToSet2;
+
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="set") */
+    public $set;
+
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="set") */
+    public $set2;
+
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="setArray") */
+    public $setArray;
+
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="setArray") */
+    public $setArray2;
+
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="pushAll") */
+    public $pushAll;
+
+    /** @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="pushAll") */
+    public $pushAll2;
+
+    public function __construct(string $field)
+    {
+        $this->field     = $field;
+        $this->addToSet  = new ArrayCollection();
+        $this->addToSet2 = new ArrayCollection();
+        $this->set       = new ArrayCollection();
+        $this->set2      = new ArrayCollection();
+        $this->setArray  = new ArrayCollection();
+        $this->setArray2 = new ArrayCollection();
+        $this->pushAll   = new ArrayCollection();
+        $this->pushAll2  = new ArrayCollection();
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -61,41 +61,60 @@ class CollectionPersisterTest extends BaseTest
     public function testDeleteAllEmbedMany()
     {
         $persister = $this->getCollectionPersister();
-        $user = $this->getTestUser('jwage');
-        $persister->deleteAll([$user->categories], array());
-        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $user      = $this->getTestUser('jwage');
+        $persister->deleteAll([$user->categories], []);
+        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
         $this->assertArrayNotHasKey('categories', $user, 'Test that the categories field was deleted');
     }
 
     public function testDeleteAllReferenceMany()
     {
         $persister = $this->getCollectionPersister();
-        $user = $this->getTestUser('jwage');
-        $persister->deleteAll([$user->phonenumbers], array());
-        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $user      = $this->getTestUser('jwage');
+        $persister->deleteAll([$user->phonenumbers], []);
+        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
         $this->assertArrayNotHasKey('phonenumbers', $user, 'Test that the phonenumbers field was deleted');
     }
 
     public function testDeleteAllNestedEmbedMany()
     {
         $persister = $this->getCollectionPersister();
-        $user = $this->getTestUser('jwage');
+        $user      = $this->getTestUser('jwage');
         $persister->deleteAll(
             [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
-            array()
+            []
         );
-        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
         $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
         $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
         $persister->deleteAll(
             [$user->categories[0]->children, $user->categories[1]->children],
-            array()
+            []
         );
-        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
         $this->assertFalse(isset($check['categories'][0]['children']), 'Test that the nested children categories field was deleted');
         $this->assertTrue(isset($check['categories'][0]), 'Test that the category with the children still exists');
         $this->assertFalse(isset($check['categories'][1]['children']), 'Test that the nested children categories field was deleted');
         $this->assertTrue(isset($check['categories'][1]), 'Test that the category with the children still exists');
+    }
+
+    public function testDeleteAllNestedEmbedManyAndNestedParent()
+    {
+        $persister = $this->getCollectionPersister();
+        $user      = $this->getTestUser('jwage');
+        $persister->deleteAll(
+            [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
+            []
+        );
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
+        $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
+        $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
+        $persister->deleteAll(
+            [$user->categories[0]->children, $user->categories[0]->children[1]->children, $user->categories],
+            []
+        );
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
+        $this->assertFalse(isset($check['categories']), 'Test that the nested categories field was deleted');
     }
 
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
@@ -403,7 +403,8 @@ class LockTest extends BaseTest
         );
 
         $d->issues->add(new Issue('oops', 'version mismatch'));
-        $this->uow->getCollectionPersister()->update($d->issues, []);
+        $this->uow->scheduleCollectionUpdate($d->issues);
+        $this->uow->getCollectionPersister()->update($d, [$d->issues], []);
     }
 
     /**
@@ -422,7 +423,7 @@ class LockTest extends BaseTest
             ['$set' => ['version' => 2]]
         );
 
-        $this->uow->getCollectionPersister()->delete($d->issues, []);
+        $this->uow->getCollectionPersister()->delete($d, [$d->issues], []);
     }
 }
 


### PR DESCRIPTION
Implemented CollectionPersister::deleteAll method for simultaneous deletion of collections that is belong to one document.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->
Improved removal of scheduled for removal collections. Now all collections that is belong to one parent is deleted in one query.