### PR TITLE
Optimized handling of scheduled collections for update and removal.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -40,6 +40,15 @@ use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
  */
 class CollectionPersister
 {
+
+    /**
+     * Validation map that is used for strategy validation in insertCollections method.
+     */
+    const INSERT_STRATEGIES_MAP = [
+        ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL => true,
+        ClassMetadataInfo::STORAGE_STRATEGY_ADD_TO_SET => true,
+    ];
+
     /**
      * The DocumentManager instance.
      *
@@ -159,6 +168,53 @@ class CollectionPersister
     }
 
     /**
+     * Updates a list PersistentCollection instances deleting removed rows and inserting new rows.
+     *
+     * @param PersistentCollectionInterface[] $collections
+     * @param array                           $options
+     */
+    public function updateAll(array $collections, array $options)
+    {
+
+        $setStrategyColls = [];
+        $addPushStrategyColls = [];
+
+        foreach ($collections as $coll) {
+            $mapping = $coll->getMapping();
+
+            if ($mapping['isInverseSide']) {
+                continue; // ignore inverse side
+            }
+            switch ($mapping['strategy']) {
+                case ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET:
+                case ClassMetadataInfo::STORAGE_STRATEGY_ATOMIC_SET_ARRAY:
+                    throw new \UnexpectedValueException($mapping['strategy'] . ' update collection strategy should have been handled by DocumentPersister. Please report a bug in issue tracker');
+
+                case ClassMetadataInfo::STORAGE_STRATEGY_SET:
+                case ClassMetadataInfo::STORAGE_STRATEGY_SET_ARRAY:
+                    $setStrategyColls[] = $coll;
+                    break;
+
+                case ClassMetadataInfo::STORAGE_STRATEGY_ADD_TO_SET:
+                case ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL:
+                    $addPushStrategyColls[] = $coll;
+                    break;
+
+                default:
+                    throw new \UnexpectedValueException('Unsupported collection strategy: ' . $mapping['strategy']);
+            }
+        }
+
+        if (!empty($setStrategyColls)) {
+            $this->setCollections($setStrategyColls, $options);
+        }
+        if (!empty($addPushStrategyColls)) {
+            $this->deleteCollections($addPushStrategyColls, $options);
+            $this->insertCollections($addPushStrategyColls, $options); // TODO
+        }
+    }
+
+    /**
      * Sets a PersistentCollection instance.
      *
      * This method is intended to be used with the "set" or "setArray"
@@ -177,6 +233,49 @@ class CollectionPersister
         $setData = $this->pb->prepareAssociatedCollectionValue($coll, CollectionHelper::usesSet($mapping['strategy']));
         $query = array('$set' => array($propertyPath => $setData));
         $this->executeQuery($parent, $query, $options);
+    }
+
+    /**
+     * Sets a list of PersistentCollection instances.
+     *
+     * This method is intended to be used with the "set" or "setArray"
+     * strategies. The "setArray" strategy will ensure that the collection is
+     * set as a BSON array, which means the collection elements will be
+     * reindexed numerically before storage.
+     *
+     * @param PersistentCollectionInterface[] $collections
+     * @param array                           $options
+     */
+    private function setCollections(array $collections, array $options)
+    {
+        $parents = [];
+        $pathCollMap = [];
+        $pathsMap = [];
+        foreach ($collections as $coll) {
+            list($propertyPath, $parent) = $this->getPathAndParent($coll);
+            $oid = \spl_object_hash($parent);
+            $parents[$oid] = $parent;
+            $pathCollMap[$oid][$propertyPath] = $coll;
+            $pathsMap[$oid][] = $propertyPath;
+        }
+
+        foreach ($pathsMap as $oid => $paths) {
+            $paths = $this->excludeSubPaths($paths);
+            /** @var PersistentCollectionInterface[] $setColls */
+            $setColls = \array_intersect_key($pathCollMap[$oid], \array_flip($paths));
+            $setPayload = [];
+            foreach ($setColls as $propertyPath => $coll) {
+                $coll->initialize();
+                $mapping = $coll->getMapping();
+                $setData = $this->pb->prepareAssociatedCollectionValue($coll,
+                    CollectionHelper::usesSet($mapping['strategy']));
+                $setPayload[$propertyPath] = $setData;
+            }
+            if (!empty($setPayload)) {
+                $query = ['$set' => $setPayload];
+                $this->executeQuery($parents[$oid], $query, $options);
+            }
+        }
     }
 
     /**
@@ -213,6 +312,69 @@ class CollectionPersister
          * null values.
          */
         $this->executeQuery($parent, array('$pull' => array($propertyPath => null)), $options);
+    }
+
+    /**
+     * Deletes removed elements from a list of PersistentCollection instances.
+     *
+     * This method is intended to be used with the "pushAll" and "addToSet" strategies.
+     *
+     * @param PersistentCollectionInterface[] $collections
+     * @param array                           $options
+     */
+    private function deleteCollections(array $collections, array $options)
+    {
+        $parents = [];
+        $pathCollMap = [];
+        $pathsMap = [];
+        $deleteDiffMap = [];
+
+        foreach ($collections as $coll) {
+            $coll->initialize();
+            if (!$this->uow->isCollectionScheduledForUpdate($coll)) {
+                continue;
+            }
+            $deleteDiff = $coll->getDeleteDiff();
+
+            if (empty($deleteDiff)) {
+                continue;
+            }
+            list($propertyPath, $parent) = $this->getPathAndParent($coll);
+
+            $oid = \spl_object_hash($parent);
+            $parents[$oid] = $parent;
+            $pathCollMap[$oid][$propertyPath] = $coll;
+            $pathsMap[$oid][] = $propertyPath;
+            $deleteDiffMap[$oid][$propertyPath] = $deleteDiff;
+        }
+
+        foreach ($pathsMap as $oid => $paths) {
+            $paths = $this->excludeSubPaths($paths);
+            $deleteColls = \array_intersect_key($pathCollMap[$oid], \array_flip($paths));
+            $unsetPayload = [];
+            $pullPayload = [];
+            foreach ($deleteColls as $propertyPath => $coll) {
+                $deleteDiff = $deleteDiffMap[$oid][$propertyPath];
+                foreach ($deleteDiff as $key => $document) {
+                    $unsetPayload[$propertyPath . '.' . $key] = true;
+                }
+                $pullPayload[$propertyPath] = null;
+            }
+
+            if (!empty($unsetPayload)) {
+                $this->executeQuery($parents[$oid], ['$unset' => $unsetPayload], $options);
+            }
+            if (!empty($pullPayload)) {
+                /**
+                 * @todo This is a hack right now because we don't have a proper way to
+                 * remove an element from an array by its key. Unsetting the key results
+                 * in the element being left in the array as null so we have to pull
+                 * null values.
+                 */
+                $this->executeQuery($parents[$oid], ['$pull' => $pullPayload], $options);
+            }
+
+        }
     }
 
     /**
@@ -258,6 +420,167 @@ class CollectionPersister
         $query = ['$' . $operator => [$propertyPath => ['$each' => $value]]];
 
         $this->executeQuery($parent, $query, $options);
+    }
+
+    /**
+     * Inserts new elements for a list of PersistentCollection instances.
+     *
+     * This method is intended to be used with the "pushAll" and "addToSet" strategies.
+     *
+     * @param PersistentCollectionInterface[] $collections
+     * @param array                           $options
+     */
+    private function insertCollections(array $collections, array $options)
+    {
+        $parents = [];
+        $pushAllPathCollMap = [];
+        $addToSetPathCollMap = [];
+        $pushAllPathsMap = [];
+        $addToSetPathsMap = [];
+        $diffsMap = [];
+
+        foreach ($collections as $coll) {
+            $coll->initialize();
+            if (!$this->uow->isCollectionScheduledForUpdate($coll)) {
+                continue;
+            }
+            $insertDiff = $coll->getInsertDiff();
+
+            if (empty($insertDiff)) {
+                continue;
+            }
+
+            $mapping = $coll->getMapping();
+            $strategy = $mapping['strategy'];
+
+            if (empty(self::INSERT_STRATEGIES_MAP[$strategy])) {
+                throw new \LogicException("Invalid strategy {$strategy} given for insertCollections");
+            }
+
+            list($propertyPath, $parent) = $this->getPathAndParent($coll);
+            $oid = \spl_object_hash($parent);
+            $parents[$oid] = $parent;
+            $diffsMap[$oid][$propertyPath] = $insertDiff;
+
+            switch ($strategy) {
+                case ClassMetadataInfo::STORAGE_STRATEGY_PUSH_ALL:
+                    $pushAllPathCollMap[$oid][$propertyPath] = $coll;
+                    $pushAllPathsMap[$oid][] = $propertyPath;
+                    break;
+
+                case ClassMetadataInfo::STORAGE_STRATEGY_ADD_TO_SET:
+                    $addToSetPathCollMap[$oid][$propertyPath] = $coll;
+                    $addToSetPathsMap[$oid][] = $propertyPath;
+                    break;
+
+                default:
+                    throw new \LogicException("Invalid strategy {$strategy} given for insertCollections");
+            }
+        }
+
+        foreach ($parents as $oid => $parent) {
+            if(!empty($pushAllPathsMap[$oid])) {
+                $this->pushAllCollections(
+                    $parent,
+                    $pushAllPathsMap[$oid],
+                    $pushAllPathCollMap[$oid],
+                    $diffsMap[$oid],
+                    $options
+                );
+            }
+            if(!empty($addToSetPathsMap[$oid])) {
+                $this->addToSetCollections(
+                    $parent,
+                    $addToSetPathsMap[$oid],
+                    $addToSetPathCollMap[$oid],
+                    $diffsMap[$oid],
+                    $options
+                );
+            }
+        }
+    }
+
+    /**
+     * Perform collections update for 'pushAll' strategy.
+     *
+     * @param object $parent Parent object to which passed collections is belong.
+     * @param array  $collsPaths Paths of collections that is passed.
+     * @param array  $pathCollsMap List of collections indexed by their paths.
+     * @param array  $diffsMap List of collection diffs indexed by collections paths.
+     * @param array  $options
+     */
+    private function pushAllCollections($parent, array $collsPaths, array $pathCollsMap, array $diffsMap, array $options)
+    {
+        $pushAllPaths = $this->excludeSubPaths($collsPaths);
+        /** @var PersistentCollectionInterface[] $pushAllColls */
+        $pushAllColls = \array_intersect_key($pathCollsMap, \array_flip($pushAllPaths));
+        $pushAllPayload = [];
+        foreach ($pushAllColls as $propertyPath => $coll) {
+            $callback = $this->getValuePrepareCallback($coll);
+            $value = \array_values(\array_map($callback, $diffsMap[$propertyPath]));
+            $pushAllPayload[$propertyPath] = ['$each' => $value];
+        }
+
+        if (!empty($pushAllPayload)) {
+            $this->executeQuery($parent, ['$push' => $pushAllPayload], $options);
+        }
+
+        $pushAllColls = \array_diff_key($pathCollsMap, \array_flip($pushAllPaths));
+        foreach ($pushAllColls as $propertyPath => $coll) {
+            $callback = $this->getValuePrepareCallback($coll);
+            $value = \array_values(\array_map($callback, $diffsMap[$propertyPath]));
+            $query = ['$push' => [$propertyPath => ['$each' => $value]]];
+            $this->executeQuery($parent, $query, $options);
+        }
+    }
+
+    /**
+     * Perform collections update by 'addToSet' strategy.
+     *
+     * @param object $parent Parent object to which passed collections is belong.
+     * @param array  $collsPaths Paths of collections that is passed.
+     * @param array  $pathCollsMap List of collections indexed by their paths.
+     * @param array  $diffsMap List of collection diffs indexed by collections paths.
+     * @param array  $options
+     */
+    private function addToSetCollections($parent, array $collsPaths, array $pathCollsMap, array $diffsMap, array $options)
+    {
+        $addToSetPaths = $this->excludeSubPaths($collsPaths);
+        /** @var PersistentCollectionInterface[] $addToSetColls */
+        $addToSetColls = \array_intersect_key($pathCollsMap, \array_flip($addToSetPaths));
+
+        $addToSetPayload = [];
+        foreach ($addToSetColls as $propertyPath => $coll) {
+            $callback = $this->getValuePrepareCallback($coll);
+            $value = \array_values(\array_map($callback, $diffsMap[$propertyPath]));
+            $addToSetPayload[$propertyPath] = ['$each' => $value];
+        }
+
+        if (!empty($addToSetPayload)) {
+            $this->executeQuery($parent, ['$addToSet' => $addToSetPayload], $options);
+        }
+    }
+
+    /**
+     * Return callback instance for specified collection. This callback will prepare values for query from documents
+     * that collection contain.
+     *
+     * @param PersistentCollectionInterface $coll
+     *
+     * @return \Closure
+     */
+    private function getValuePrepareCallback(PersistentCollectionInterface $coll)
+    {
+        $mapping = $coll->getMapping();
+        if(isset($mapping['embedded'])) {
+            return function ($v) use ($mapping) {
+                return $this->pb->prepareEmbeddedDocumentValue($mapping, $v);
+            };
+        } else {
+            return function ($v) use ($mapping) {
+                return $this->pb->prepareReferencedDocumentValue($mapping, $v);
+            };
+        }
     }
 
     /**
@@ -318,16 +641,23 @@ class CollectionPersister
         }
     }
 
+    /**
+     * Remove from passed paths list all sub-paths.
+     *
+     * @param string[] $paths
+     *
+     * @return string[]
+     */
     private function excludeSubPaths(array $paths)
     {
         $checkedPaths = [];
-        $pathsAmount  = count($paths);
-        $paths        = array_unique($paths);
+        $pathsAmount = \count($paths);
+        $paths = \array_unique($paths);
         for ($i = 0; $i < $pathsAmount; $i++) {
             $isSubPath = false;
-            $j         = $i;
+            $j         = 0;
             for (; $j < $pathsAmount; $j++) {
-                if ($i !== $j && strpos($paths[$i], $paths[$j]) === 0) {
+                if ($i !== $j && \strpos($paths[$i], $paths[$j]) === 0) {
                     $isSubPath = true;
                     break;
                 }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -69,6 +69,38 @@ class CollectionPersister
     }
 
     /**
+     * Deletes a PersistentCollection instances completely from a document using $unset. Collections can belong to
+     * different parents. Collections that is belong to one parent will be deleted in one query.
+     *
+     * @param PersistentCollectionInterface[] $collections
+     * @param array $options
+     */
+    public function deleteAll(array $collections, array $options)
+    {
+        $parents = [];
+        $unsetPathsMap = [];
+
+        foreach ($collections as $coll) {
+            $mapping = $coll->getMapping();
+            if ($mapping['isInverseSide']) {
+                continue; // ignore inverse side
+            }
+            if (CollectionHelper::isAtomic($mapping['strategy'])) {
+                throw new \UnexpectedValueException($mapping['strategy'] . ' delete collection strategy should have been handled by DocumentPersister. Please report a bug in issue tracker');
+            }
+            list($propertyPath, $parent) = $this->getPathAndParent($coll);
+            $oid = \spl_object_hash($parent);
+            $parents[$oid] = $parent;
+            $unsetPathsMap[$oid][$propertyPath] = true;
+        }
+
+        foreach ($unsetPathsMap as $oid => $unsetPaths) {
+            $query = array('$unset' => $unsetPaths);
+            $this->executeQuery($parents[$oid], $query, $options);
+        }
+    }
+
+    /**
      * Deletes a PersistentCollection instance completely from a document using $unset.
      *
      * @param PersistentCollectionInterface $coll

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1356,8 +1356,8 @@ class DocumentPersister
 
     private function handleCollections($document, $options)
     {
-        $collections = [];
         // Collection deletions (deletions of complete collections)
+        $collections = [];
         foreach ($this->uow->getScheduledCollections($document) as $coll) {
             if ($this->uow->isCollectionScheduledForDeletion($coll)) {
                 $collections[] = $coll;
@@ -1367,10 +1367,14 @@ class DocumentPersister
             $this->cp->deleteAll($collections, $options);
         }
         // Collection updates (deleteRows, updateRows, insertRows)
+        $collections = [];
         foreach ($this->uow->getScheduledCollections($document) as $coll) {
             if ($this->uow->isCollectionScheduledForUpdate($coll)) {
-                $this->cp->update($coll, $options);
+                $collections[] = $coll;
             }
+        }
+        if (!empty($collections)) {
+            $this->cp->updateAll($collections, $options);
         }
         // Take new snapshots from visited collections
         foreach ($this->uow->getVisitedCollections($document) as $coll) {

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -22,7 +22,6 @@ namespace Doctrine\ODM\MongoDB\Persisters;
 use Doctrine\Common\EventManager;
 use Doctrine\Common\Persistence\Mapping\MappingException;
 use Doctrine\MongoDB\CursorInterface;
-use Doctrine\MongoDB\EagerCursor;
 use Doctrine\ODM\MongoDB\Cursor;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
@@ -1357,11 +1356,15 @@ class DocumentPersister
 
     private function handleCollections($document, $options)
     {
+        $collections = [];
         // Collection deletions (deletions of complete collections)
         foreach ($this->uow->getScheduledCollections($document) as $coll) {
             if ($this->uow->isCollectionScheduledForDeletion($coll)) {
-                $this->cp->delete($coll, $options);
+                $collections[] = $coll;
             }
+        }
+        if (!empty($collections)) {
+            $this->cp->deleteAll($collections, $options);
         }
         // Collection updates (deleteRows, updateRows, insertRows)
         foreach ($this->uow->getScheduledCollections($document) as $coll) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -104,6 +104,25 @@ class CollectionPersisterTest extends BaseTest
         $this->assertTrue(isset($check['categories'][1]), 'Test that the category with the children still exists');
     }
 
+    public function testDeleteAllNestedEmbedManyAndNestedParent()
+    {
+        $persister = $this->getCollectionPersister();
+        $user      = $this->getTestUser('jwage');
+        $persister->deleteAll(
+            [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
+            []
+        );
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
+        $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
+        $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
+        $persister->deleteAll(
+            [$user->categories[0]->children, $user->categories[0]->children[1]->children, $user->categories],
+            []
+        );
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(['username' => 'jwage']);
+        $this->assertFalse(isset($check['categories']), 'Test that the nested categories field was deleted');
+    }
+
     public function testDeleteRows()
     {
         $persister = $this->getCollectionPersister();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -54,6 +54,56 @@ class CollectionPersisterTest extends BaseTest
         $this->assertTrue(isset($check['categories'][1]), 'Test that the category with the children still exists');
     }
 
+    public function testDeleteAllEmbedMany()
+    {
+        $persister = $this->getCollectionPersister();
+        $user = $this->getTestUser('jwage');
+        $persister->deleteAll([$user->categories], array());
+
+        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $this->assertArrayNotHasKey('categories', $user, 'Test that the categories field was deleted');
+    }
+
+    public function testDeleteAllReferenceMany()
+    {
+        $persister = $this->getCollectionPersister();
+        $user = $this->getTestUser('jwage');
+        $persister->deleteAll([$user->phonenumbers], array());
+
+        $user = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+        $this->assertArrayNotHasKey('phonenumbers', $user, 'Test that the phonenumbers field was deleted');
+    }
+
+
+    public function testDeleteAllNestedEmbedMany()
+    {
+        $persister = $this->getCollectionPersister();
+        $user = $this->getTestUser('jwage');
+
+        $persister->deleteAll(
+            [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
+            array()
+        );
+
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+
+        $this->assertFalse(isset($check['categories']['0']['children'][0]['children']));
+        $this->assertFalse(isset($check['categories']['0']['children'][1]['children']));
+
+        $persister->deleteAll(
+            [$user->categories[0]->children, $user->categories[1]->children],
+            array()
+        );
+
+        $check = $this->dm->getDocumentCollection(__NAMESPACE__ . '\CollectionPersisterUser')->findOne(array('username' => 'jwage'));
+
+        $this->assertFalse(isset($check['categories'][0]['children']), 'Test that the nested children categories field was deleted');
+        $this->assertTrue(isset($check['categories'][0]), 'Test that the category with the children still exists');
+
+        $this->assertFalse(isset($check['categories'][1]['children']), 'Test that the nested children categories field was deleted');
+        $this->assertTrue(isset($check['categories'][1]), 'Test that the category with the children still exists');
+    }
+
     public function testDeleteRows()
     {
         $persister = $this->getCollectionPersister();


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature/improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Was updated handling of scheduled collections for update and delete. Added to CollectionPersister methods `deleteAll` and `updateAll`. In added methods query "per-collection" replaced on query "per-parent" where it is was possible.

I added tests only for `deleteAll` method of CollectionPersister. Functional tests is covers `updateAll` method. Should I also add separate functional tests for `deleteAll` method?
