### PR TITLE
Added more strict types for docs (Issue #1783)

### DIFF
--- a/docs/en/cookbook/blending-orm-and-mongodb-odm.rst
+++ b/docs/en/cookbook/blending-orm-and-mongodb-odm.rst
@@ -86,7 +86,7 @@ Next create the `Order` entity that has a `$product` and `$productId` property l
             return $this->productId;
         }
 
-        public function setProduct(Product $product)
+        public function setProduct(Product $product): void
         {
             $this->productId = $product->getId();
             $this->product = $product;
@@ -109,7 +109,7 @@ Now we need to setup an event subscriber that will set the `$product` property o
 
     $eventManager = $em->getEventManager();
     $eventManager->addEventListener(
-        array(\Doctrine\ORM\Events::postLoad), new MyEventSubscriber($dm)
+        [\Doctrine\ORM\Events::postLoad], new MyEventSubscriber($dm)
     );
 
 So now we need to define a class named `MyEventSubscriber` and pass a dependency to the `DocumentManager`. It will have a `postLoad()` method that sets the product document reference:
@@ -174,7 +174,7 @@ Later we can retrieve the entity and lazily load the reference to the document i
 
     <?php
 
-    $order = $em->find('Order', $order->getId());
+    $order = $em->find(Order::class, $order->getId());
 
     // Instance of an uninitialized product proxy
     $product = $order->getProduct();

--- a/docs/en/cookbook/implementing-the-notify-changetracking-policy.rst
+++ b/docs/en/cookbook/implementing-the-notify-changetracking-policy.rst
@@ -28,7 +28,7 @@ implement the ``NotifyPropertyChanged`` interface from the
 
     abstract class DomainObject implements NotifyPropertyChanged
     {
-        private $_listeners = array();
+        private $_listeners = [];
 
         public function addPropertyChangedListener(PropertyChangedListener $listener): void
         {
@@ -38,7 +38,7 @@ implement the ``NotifyPropertyChanged`` interface from the
         /** Notifies listeners of a change. */
         protected function _onPropertyChanged($propName, $oldValue, $newValue): void
         {
-            if ($this->_listeners) {
+            if (!empty($this->_listeners)) {
                 foreach ($this->_listeners as $listener) {
                     $listener->propertyChanged($this, $propName, $oldValue, $newValue);
                 }

--- a/docs/en/cookbook/implementing-wakeup-or-clone.rst
+++ b/docs/en/cookbook/implementing-wakeup-or-clone.rst
@@ -29,7 +29,7 @@ implementation code in an identity check as follows:
         public function __wakeup()
         {
             // If the document has an identity, proceed as normal.
-            if ($this->id) {
+            if (null !== $this->id) {
                 // ... Your code here as normal ...
             }
             // otherwise do nothing, do NOT throw an exception!
@@ -54,7 +54,7 @@ Safely implementing ``__clone`` is pretty much the same:
         public function __clone()
         {
             // If the document has an identity, proceed as normal.
-            if ($this->id) {
+            if (null !== $this->id) {
                 // ... Your code here as normal ...
             }
             // otherwise do nothing, do NOT throw an exception!

--- a/docs/en/cookbook/implementing-wakeup-or-clone.rst
+++ b/docs/en/cookbook/implementing-wakeup-or-clone.rst
@@ -29,7 +29,7 @@ implementation code in an identity check as follows:
         public function __wakeup()
         {
             // If the document has an identity, proceed as normal.
-            if (null !== $this->id) {
+            if ($this->id !== null) {
                 // ... Your code here as normal ...
             }
             // otherwise do nothing, do NOT throw an exception!
@@ -54,7 +54,7 @@ Safely implementing ``__clone`` is pretty much the same:
         public function __clone()
         {
             // If the document has an identity, proceed as normal.
-            if (null !== $this->id) {
+            if ($this->id !== null) {
                 // ... Your code here as normal ...
             }
             // otherwise do nothing, do NOT throw an exception!

--- a/docs/en/cookbook/mapping-classes-to-orm-and-odm.rst
+++ b/docs/en/cookbook/mapping-classes-to-orm-and-odm.rst
@@ -95,7 +95,7 @@ You can find the blog post:
 
     <?php
 
-    $blogPost = $em->getRepository('Documents\BlogPost')->findOneBy(array('title' => 'test'));
+    $blogPost = $em->getRepository(Documents\BlogPost::class)->findOneBy(['title' => 'test']);
 
 MongoDB ODM
 ~~~~~~~~~~~
@@ -158,7 +158,7 @@ You can find the blog post:
 
     <?php
 
-    $blogPost = $dm->getRepository('Documents\BlogPost')->findOneBy(array('title' => 'test'));
+    $blogPost = $dm->getRepository(Documents\BlogPost::class)->findOneBy(['title' => 'test']);
 
 Repository Classes
 ------------------
@@ -178,7 +178,7 @@ You can implement the same repository interface for the ORM and MongoDB ODM easi
     {
         public function findPostById(int $id): ?BlogPost
         {
-            return $this->findOneBy(array('id' => $id));
+            return $this->findOneBy(['id' => $id]);
         }
     }
 
@@ -197,7 +197,7 @@ Now define the same repository methods for the MongoDB ODM:
     {
         public function findPostById(string $id): ?BlogPost
         {
-            return $this->findOneBy(array('id' => $id));
+            return $this->findOneBy(['id' => $id]);
         }
     }
 

--- a/docs/en/cookbook/resolve-target-document-listener.rst
+++ b/docs/en/cookbook/resolve-target-document-listener.rst
@@ -115,14 +115,14 @@ you cannot be guaranteed that the targetDocument resolution will occur reliably:
 .. code-block:: php
 
     <?php
-    $evm  = new \Doctrine\Common\EventManager;
-    $rtdl = new \Doctrine\ODM\MongoDB\Tools\ResolveTargetDocumentListener;
+    $evm  = new \Doctrine\Common\EventManager();
+    $rtdl = new \Doctrine\ODM\MongoDB\Tools\ResolveTargetDocumentListener();
 
     // Adds a target-document class
     $rtdl->addResolveTargetDocument(
-        'Acme\\InvoiceModule\\Model\\InvoiceSubjectInterface',
-        'Acme\\CustomerModule\\Document\\Customer',
-        array()
+        \Acme\InvoiceModule\Model\InvoiceSubjectInterface::class,
+        \Acme\CustomerModule\Document\Customer::class,
+        []
     );
 
     // Add the ResolveTargetDocumentListener

--- a/docs/en/cookbook/simple-search-engine.rst
+++ b/docs/en/cookbook/simple-search-engine.rst
@@ -28,7 +28,7 @@ setup a document like the following with a ``$keywords`` property that is mapped
         private $title;
 
         /** @Field(type="collection") @Index */
-        private $keywords = array();
+        private $keywords = [];
 
         // ...
     }
@@ -68,9 +68,9 @@ to find documents that have at least one of the keywords:
 
     <?php
 
-    $keywords = array('nike shoes', 'air jordan');
+    $keywords = ['nike shoes', 'air jordan'];
 
-    $qb = $dm->createQueryBuilder('Product')
+    $qb = $dm->createQueryBuilder(Product::class)
         ->field('keywords')->in($keywords);
 
 You can make the query more strict by using the ``all()`` method instead of ``in()``:
@@ -79,9 +79,9 @@ You can make the query more strict by using the ``all()`` method instead of ``in
 
     <?php
 
-    $keywords = array('nike shoes', 'air jordan');
+    $keywords = ['nike shoes', 'air jordan'];
 
-    $qb = $dm->createQueryBuilder('Product')
+    $qb = $dm->createQueryBuilder(Product::class)
         ->field('keywords')->all($keywords);
 
 The above query would only return products that have both of the keywords!
@@ -99,7 +99,7 @@ the results to your query. Here is an example:
     $queryString = $_REQUEST['q'];
     $keywords = explode(' ', $queryString);
 
-    $qb = $dm->createQueryBuilder('Product')
+    $qb = $dm->createQueryBuilder(Product::class)
         ->field('keywords')->all($keywords);
 
 Embedded Documents

--- a/docs/en/cookbook/soft-delete-extension.rst
+++ b/docs/en/cookbook/soft-delete-extension.rst
@@ -71,16 +71,17 @@ An implementation might look like this in a ``User`` document:
     <?php
 
     use Doctrine\ODM\MongoDB\SoftDelete\SoftDeleteable;
+    use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-    /** @mongodb:Document */
+    /** @ODM\Document */
     class User implements SoftDeleteable
     {
         // ...
 
-        /** @mongodb:Date @mongodb:Index */
+        /** @ODM\Field(type="date") @ODM\Index */
         private $deletedAt;
 
-        public function getDeletedAt()
+        public function getDeletedAt(): ?\DateTime
         {
             return $this->deletedAt;
         }
@@ -97,8 +98,8 @@ Once you have the ``$sdm`` you can start managing the soft delete state of your 
 
     <?php
 
-    $jwage = $dm->getRepository('User')->findOneBy(array('username' => 'jwage'));
-    $fabpot = $dm->getRepository('User')->findOneBy(array('username' => 'fabpot'));
+    $jwage = $dm->getRepository(User::class)->findOneBy(['username' => 'jwage']);
+    $fabpot = $dm->getRepository(User::class)->findOneBy(['username' => 'fabpot']);
     $sdm->delete($jwage);
     $sdm->delete($fabpot);
     $sdm->flush();
@@ -151,7 +152,7 @@ Using the events is easy, just define a class like the following:
 
         public function getSubscribedEvents(): array
         {
-            return array(Events::preSoftDelete);
+            return [Events::preSoftDelete];
         }
     }
 
@@ -196,7 +197,7 @@ You just need to setup an event listener like the following:
             $sdm = $args->getSoftDeleteManager();
             $document = $args->getDocument();
             if ($document instanceof User) {
-                $sdm->deleteBy('Post', array('user.id' => $document->getId()));
+                $sdm->deleteBy(Post:class, ['user.id' => $document->getId()]);
             }
         }
 
@@ -205,16 +206,16 @@ You just need to setup an event listener like the following:
             $sdm = $args->getSoftDeleteManager();
             $document = $args->getDocument();
             if ($document instanceof User) {
-                $sdm->restoreBy('Post', array('user.id' => $document->getId()));
+                $sdm->restoreBy(Post::class, ['user.id' => $document->getId()]);
             }
         }
 
         public function getSubscribedEvents(): array
         {
-            return array(
+            return [
                 Events::preSoftDelete,
                 Events::preRestore
-            );
+            ];
         }
     }
 

--- a/docs/en/cookbook/validation-of-documents.rst
+++ b/docs/en/cookbook/validation-of-documents.rst
@@ -107,7 +107,7 @@ validation callbacks.
                 throw new ValidateException();
             }
 
-            if ($this->customer == null) {
+            if ($this->customer === null) {
                 throw new OrderRequiresCustomerException();
             }
         }

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -30,7 +30,7 @@ will be invoked with the first value found as its single argument.
     <?php
 
     /** @AlsoLoad({"name", "fullName"}) */
-    public function populateFirstAndLastName($name)
+    public function populateFirstAndLastName(string $name): void
     {
         list($this->firstName, $this->lastName) = explode(' ', $name);
     }
@@ -225,7 +225,7 @@ Optional attributes:
      *     defaultDiscriminatorValue="book"
      * )
      */
-    private $tags = array();
+    private $tags = [];
 
 Depending on the embedded document's class, a value of ``user`` or ``author``
 will be stored in the ``type`` field and used to reconstruct the proper class
@@ -299,9 +299,9 @@ relationship.
         /** @Field(type="float") */
         private $amount;
 
-        public function __construct($amount)
+        public function __construct(float $amount)
         {
-            $this->amount = (float) $amount;
+            $this->amount = $amount;
         }
         //...
     }
@@ -312,7 +312,7 @@ relationship.
         /** @EmbedOne(targetDocument=Money::class) */
         private $money;
 
-        public function setMoney(Money $money)
+        public function setMoney(Money $money): void
         {
             $this->money = $money;
         }
@@ -477,7 +477,7 @@ annotation will cause Doctrine to ignore the callbacks.
     class User
     {
         /** @PostPersist */
-        public function sendWelcomeEmail() {}
+        public function sendWelcomeEmail(): void {}
     }
 
 @Id
@@ -663,7 +663,7 @@ method to be registered.
         // ...
 
         /** @PostLoad */
-        public function postLoad()
+        public function postLoad(): void
         {
             // ...
         }
@@ -688,7 +688,7 @@ the method to be registered.
         // ...
 
         /** @PostPersist */
-        public function postPersist()
+        public function postPersist(): void
         {
             // ...
         }
@@ -713,7 +713,7 @@ the method to be registered.
         // ...
 
         /** @PostRemove */
-        public function postRemove()
+        public function postRemove(): void
         {
             // ...
         }
@@ -738,7 +738,7 @@ the method to be registered.
         // ...
 
         /** @PostUpdate */
-        public function postUpdate()
+        public function postUpdate(): void
         {
             // ...
         }
@@ -763,7 +763,7 @@ method to be registered.
         // ...
 
         /** @PreFlush */
-        public function preFlush()
+        public function preFlush(): void
         {
             // ...
         }
@@ -790,7 +790,7 @@ method to be registered.
         // ...
 
         /** @PreLoad */
-        public function preLoad(PreLoadEventArgs $eventArgs)
+        public function preLoad(PreLoadEventArgs $eventArgs): void
         {
             // ...
         }
@@ -815,7 +815,7 @@ the method to be registered.
         // ...
 
         /** @PrePersist */
-        public function prePersist()
+        public function prePersist(): void
         {
             // ...
         }
@@ -840,7 +840,7 @@ the method to be registered.
         // ...
 
         /** @PreRemove */
-        public function preRemove()
+        public function preRemove(): void
         {
             // ...
         }
@@ -865,7 +865,7 @@ the method to be registered.
         // ...
 
         /** @PreUpdate */
-        public function preUpdated()
+        public function preUpdated(): void
         {
             // ...
         }

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -262,7 +262,7 @@ Here is an example how to manually set a string identifier for your documents:
             /** @Id(strategy="NONE", type="string") */
             private $id;
 
-            public function setId($id)
+            public function setId(string $id): void
             {
                 $this->id = $id;
             }
@@ -303,7 +303,7 @@ Now you can retrieve the document later:
 
     //...
 
-    $document = $dm->find('MyPersistentClass', 'my_unique_identifier');
+    $document = $dm->find(MyPersistentClass::class, 'my_unique_identifier');
 
 You can define your own ID generator by extending the
 ``Doctrine\ODM\MongoDB\Id\AbstractIdGenerator`` class and specifying the class
@@ -321,7 +321,7 @@ as an option for the ``CUSTOM`` strategy:
             /** @Id(strategy="CUSTOM", type="string", options={"class"="Vendor\Specific\Generator"}) */
             private $id;
 
-            public function setId(string $id)
+            public function setId(string $id): void
             {
                 $this->id = $id;
             }
@@ -482,7 +482,7 @@ Here is an example:
     // ...
 
     // Register my type
-    Type::addType('mytype', 'My\Project\Types\MyType');
+    Type::addType('mytype', \My\Project\Types\MyType::class);
 
 As can be seen above, when registering the custom types in the
 configuration you specify a unique name for the mapping type and
@@ -549,7 +549,7 @@ may pass an array of document class names when creating a query builder:
 
     <?php
 
-    $query = $dm->createQuery(array('Article', 'Album'));
+    $query = $dm->createQuery([Article::class, Album::class]);
     $documents = $query->execute();
 
 The above will return a cursor that will allow you to iterate over all

--- a/docs/en/reference/best-practices.rst
+++ b/docs/en/reference/best-practices.rst
@@ -59,12 +59,16 @@ Example:
 
     class User
     {
+
+        /** @var ArrayCollection  */
         private $addresses;
+
+        /** @var ArrayCollection  */
         private $articles;
 
         public function __construct()
         {
-            $this->addresses = new ArrayCollection;
-            $this->articles = new ArrayCollection;
+            $this->addresses = new ArrayCollection();
+            $this->articles = new ArrayCollection();
         }
     }

--- a/docs/en/reference/bidirectional-references.rst
+++ b/docs/en/reference/bidirectional-references.rst
@@ -97,7 +97,7 @@ And we retrieve the ``User`` later to access the posts for that user:
 
     <?php
 
-    $user = $dm->find('User', $user->id);
+    $user = $dm->find(User::class, $user->id);
 
     $posts = $user->getPosts();
     foreach ($posts as $post) {

--- a/docs/en/reference/capped-collections.rst
+++ b/docs/en/reference/capped-collections.rst
@@ -65,7 +65,7 @@ that can be acquired from your ``DocumentManager`` instance:
 
     <?php
 
-    $documentManager->getSchemaManager()->createDocumentCollection('Category');
+    $documentManager->getSchemaManager()->createDocumentCollection(Category::class);
 
 You can drop the collection too if it already exists:
 
@@ -73,4 +73,4 @@ You can drop the collection too if it already exists:
 
     <?php
 
-    $documentManager->getSchemaManager()->dropDocumentCollection('Category');
+    $documentManager->getSchemaManager()->dropDocumentCollection(Category::class);

--- a/docs/en/reference/change-tracking-policies.rst
+++ b/docs/en/reference/change-tracking-policies.rst
@@ -84,7 +84,7 @@ follows:
     {
         // ...
 
-        private $_listeners = array();
+        private $_listeners = [];
 
         public function addPropertyChangedListener(PropertyChangedListener $listener): void
         {
@@ -107,9 +107,9 @@ behavior:
     {
         // ...
 
-        protected function _onPropertyChanged($propName, $oldValue, $newValue): void
+        protected function _onPropertyChanged(string $propName, $oldValue, $newValue): void
         {
-            if ($this->_listeners) {
+            if (!empty($this->_listeners)) {
                 foreach ($this->_listeners as $listener) {
                     $listener->propertyChanged($this, $propName, $oldValue, $newValue);
                 }

--- a/docs/en/reference/console-commands.rst
+++ b/docs/en/reference/console-commands.rst
@@ -26,24 +26,28 @@ console command easily with the following code:
 
     // ... include Composer autoloader and configure DocumentManager instance
 
-    $helperSet = new \Symfony\Component\Console\Helper\HelperSet(array(
-        'dm' => new \Doctrine\ODM\MongoDB\Tools\Console\Helper\DocumentManagerHelper($dm),
-    ));
+    $helperSet = new \Symfony\Component\Console\Helper\HelperSet(
+        [
+            'dm' => new \Doctrine\ODM\MongoDB\Tools\Console\Helper\DocumentManagerHelper($dm),
+        ]
+    );
 
     $app = new Application('Doctrine MongoDB ODM');
     $app->setHelperSet($helperSet);
-    $app->addCommands(array(
-        new \Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateDocumentsCommand(),
-        new \Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateHydratorsCommand(),
-        new \Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateProxiesCommand(),
-        new \Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateRepositoriesCommand(),
-        new \Doctrine\ODM\MongoDB\Tools\Console\Command\QueryCommand(),
-        new \Doctrine\ODM\MongoDB\Tools\Console\Command\ClearCache\MetadataCommand(),
-        new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\CreateCommand(),
-        new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\DropCommand(),
-        new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\UpdateCommand(),
-        new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\ShardCommand(),
-    ));
+    $app->addCommands(
+        [
+            new \Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateDocumentsCommand(),
+            new \Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateHydratorsCommand(),
+            new \Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateProxiesCommand(),
+            new \Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateRepositoriesCommand(),
+            new \Doctrine\ODM\MongoDB\Tools\Console\Command\QueryCommand(),
+            new \Doctrine\ODM\MongoDB\Tools\Console\Command\ClearCache\MetadataCommand(),
+            new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\CreateCommand(),
+            new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\DropCommand(),
+            new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\UpdateCommand(),
+            new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\ShardCommand(),
+        ]
+    );
 
     $app->run();
 

--- a/docs/en/reference/custom-collections.rst
+++ b/docs/en/reference/custom-collections.rst
@@ -108,9 +108,9 @@ Alternatively, you may want to implement the whole class from scratch:
 
     class SectionCollection implements Collection
     {
-        private $elements = array();
+        private $elements = [];
 
-        public function __construct(array $elements = array())
+        public function __construct(array $elements = [])
         {
             $this->elements = $elements;
         }
@@ -146,13 +146,13 @@ You may decide to implement this class from scratch or extend our
             $this->eventDispatcher = $eventDispatcher;
         }
 
-        protected function createCollectionClass($collectionClass)
+        protected function createCollectionClass(string $collectionClass)
         {
             switch ($collectionClass) {
                 case SectionCollection::class:
-                    return new $collectionClass(array(), $this->eventDispatcher);
+                    return new $collectionClass([], $this->eventDispatcher);
                 default:
-                    return new $collectionClass;
+                    return new $collectionClass();
             }
         }
     }

--- a/docs/en/reference/document-repositories.rst
+++ b/docs/en/reference/document-repositories.rst
@@ -145,7 +145,7 @@ In order to change the way Doctrine instantiates repositories, you will need to 
             $this->eventDispatcher = $eventDispatcher;
         }
 
-        protected function instantiateRepository($repositoryClassName, DocumentManager $documentManager, ClassMetadata $metadata)
+        protected function instantiateRepository(string $repositoryClassName, DocumentManager $documentManager, ClassMetadata $metadata)
         {
             switch ($repositoryClassName) {
                 case UserRepository::class:

--- a/docs/en/reference/eager-cursors.rst
+++ b/docs/en/reference/eager-cursors.rst
@@ -22,7 +22,7 @@ Example:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('User')
+    $qb = $dm->createQueryBuilder(User::class)
         ->eagerCursor(true);
     $query = $qb->getQuery();
     $users = $query->execute();

--- a/docs/en/reference/embedded-mapping.rst
+++ b/docs/en/reference/embedded-mapping.rst
@@ -65,7 +65,7 @@ Embed many documents:
             // ...
 
             /** @EmbedMany(targetDocument=Phonenumber::class) */
-            private $phonenumbers = array();
+            private $phonenumbers = [];
 
             // ...
         }
@@ -108,7 +108,7 @@ you can simply omit the ``targetDocument`` option:
             // ..
 
             /** @EmbedMany */
-            private $tasks = array();
+            private $tasks = [];
 
             // ...
         }
@@ -136,7 +136,7 @@ the embedded document. The field name can be customized with the
             /**
              * @EmbedMany(discriminatorField="type")
              */
-            private $tasks = array();
+            private $tasks = [];
 
             // ...
         }
@@ -169,7 +169,7 @@ in each embedded document:
              *   }
              * )
              */
-            private $tasks = array();
+            private $tasks = [];
 
             // ...
         }
@@ -207,7 +207,7 @@ discriminator:
              *   defaultDiscriminatorValue="download"
              * )
              */
-            private $tasks = array();
+            private $tasks = [];
 
             // ...
         }

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -39,7 +39,7 @@ Now we can add some event listeners to the ``$evm``. Let's create a
 
         public function __construct(EventManager $evm)
         {
-            $evm->addEventListener(array(self::preFoo, self::postFoo), $this);
+            $evm->addEventListener([self::preFoo, self::postFoo], $this);
         }
 
         public function preFoo(EventArgs $e): void 
@@ -72,7 +72,7 @@ method.
 
     <?php
 
-    $evm->removeEventListener(array(self::preFoo, self::postFoo), $this);
+    $evm->removeEventListener([self::preFoo, self::postFoo], $this);
 
 The Doctrine event system also has a simple concept of event
 subscribers. We can define a simple ``TestEventSubscriber`` class
@@ -97,7 +97,7 @@ array of events it should be subscribed to.
 
         public function getSubscribedEvents(): array
         {
-            return array(self::preFoo);
+            return [self::preFoo];
         }
     }
 
@@ -314,7 +314,7 @@ EventManager that is passed to the DocumentManager factory:
     <?php
 
     $eventManager = new EventManager();
-    $eventManager->addEventListener(array(Events::preUpdate), new MyEventListener());
+    $eventManager->addEventListener([Events::preUpdate], new MyEventListener());
     $eventManager->addEventSubscriber(new MyEventSubscriber());
 
     $documentManager = DocumentManager::create(null, $config, $eventManager);
@@ -326,7 +326,7 @@ DocumentManager was created:
 
     <?php
 
-    $documentManager->getEventManager()->addEventListener(array(Events::preUpdate), new MyEventListener());
+    $documentManager->getEventManager()->addEventListener([Events::preUpdate], new MyEventListener());
     $documentManager->getEventManager()->addEventSubscriber(new MyEventSubscriber());
 
 Implementing Event Listeners
@@ -708,10 +708,10 @@ this process and manipulate the instance with the ``loadClassMetadata`` event:
         public function loadClassMetadata(\Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs $eventArgs): void
         {
             $classMetadata = $eventArgs->getClassMetadata();
-            $fieldMapping = array(
+            $fieldMapping = [
                 'fieldName' => 'about',
                 'type' => 'string'
-            );
+            ];
             $classMetadata->mapField($fieldMapping);
         }
     }

--- a/docs/en/reference/filters.rst
+++ b/docs/en/reference/filters.rst
@@ -40,10 +40,10 @@ should be accessed via ``BsonFilter::getParameter()``.
         {
             // Check if the entity implements the LocalAware interface
             if ( ! $targetDocument->reflClass->implementsInterface('LocaleAware')) {
-                return array();
+                return [];
             }
 
-            return array('locale' => $this->getParameter('locale'));
+            return ['locale' => $this->getParameter('locale')];
         }
     }
 
@@ -55,7 +55,7 @@ Filter classes are added to the configuration as following:
 
     <?php
 
-    $config->addFilter('locale', '\Vendor\Filter\MyLocaleFilter');
+    $config->addFilter('locale', \Vendor\Filter\MyLocaleFilter::class);
 
 The ``Configuration#addFilter()`` method takes a name for the filter and the
 name of the filter class, which will be constructed as necessary.
@@ -66,7 +66,7 @@ An optional third parameter may be used to set parameters at configuration time:
 
     <?php
 
-    $config->addFilter('locale', '\Vendor\Filter\MyLocaleFilter', array('locale' => 'en'));
+    $config->addFilter('locale', \Vendor\Filter\MyLocaleFilter::class, ['locale' => 'en']);
 
 Disabling/Enabling Filters and Setting Parameters
 -------------------------------------------------
@@ -80,7 +80,7 @@ may be used to enabled and return a filter, after which you may set parameters.
     <?php
 
     $filter = $dm->getFilterCollection()->enable("locale");
-    $filter->setParameter('locale', array('$in' => array('en', 'fr'));
+    $filter->setParameter('locale', ['$in' => ['en', 'fr']]);
 
     // Disable the filter (perhaps temporarily to run an unfiltered query)
     $filter = $dm->getFilterCollection()->disable("locale");

--- a/docs/en/reference/find-and-update.rst
+++ b/docs/en/reference/find-and-update.rst
@@ -22,7 +22,7 @@ For example you can update a job and return it:
 
     <?php
 
-    $job = $dm->createQueryBuilder('Job')
+    $job = $dm->createQueryBuilder(Job::class)
         // Find the job
         ->findAndUpdate()
         ->field('in_progress')->equals(false)
@@ -42,7 +42,7 @@ Here is an example where we return the new updated job document:
 .. code-block:: php
 
     <?php
-    $job = $dm->createQueryBuilder('Job')
+    $job = $dm->createQueryBuilder(Job::class)
         // Find the job
         ->findAndUpdate()
         ->returnNew()
@@ -67,7 +67,7 @@ You can also remove a document and return it:
 
     <?php
 
-    $job = $dm->createQueryBuilder('Job')
+    $job = $dm->createQueryBuilder(Job::class)
         ->findAndRemove()
         ->sort('priority', 'desc')
         ->getQuery()

--- a/docs/en/reference/geospatial-queries.rst
+++ b/docs/en/reference/geospatial-queries.rst
@@ -60,7 +60,7 @@ and latitude with the ``near($longitude, $latitude)`` method:
 
     <?php
 
-    $cities = $this->dm->createQuery('City')
+    $cities = $this->dm->createQuery(City::class)
         ->field('coordinates')->near(-120, 40)
         ->execute();
 

--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -128,7 +128,7 @@ would get an Employee instance back:
     $dm->persist($employee);
     $dm->flush();
 
-    $employee = $dm->find('Person', $employee->getId()); // instanceof Employee
+    $employee = $dm->find(Person::class, $employee->getId()); // instanceof Employee
 
 Even though we queried for a Person, Doctrine will know to return an Employee
 instance because of the discriminator map!

--- a/docs/en/reference/introduction.rst
+++ b/docs/en/reference/introduction.rst
@@ -38,7 +38,7 @@ Here is a quick example of some PHP object documents that demonstrates a few of 
         private $changes = 0;
 
         /** @ODM\Field(type="collection") */
-        private $notes = array();
+        private $notes = [];
 
         /** @ODM\Field(type="string") */
         private $name;
@@ -69,10 +69,10 @@ Here is a quick example of some PHP object documents that demonstrates a few of 
         public function getSalary(): ?int { return $this->salary; }
         public function setSalary(int $salary): void { $this->salary = (int) $salary; }
 
-        public function getStarted() { return $this->started; }
+        public function getStarted(): ?DateTime { return $this->started; }
         public function setStarted(DateTime $started) { $this->started = $started; }
 
-        public function getLeft() { return $this->left; }
+        public function getLeft(): ?DateTime { return $this->left; }
         public function setLeft(DateTime $left) { $this->left = $left; }
 
         public function getAddress(): ?Address { return $this->address; }

--- a/docs/en/reference/logging.rst
+++ b/docs/en/reference/logging.rst
@@ -28,4 +28,4 @@ with a object instance and a method to call:
 
     // ...
 
-    $config->setLoggerCallable(array($obj, 'method'));
+    $config->setLoggerCallable([$obj, 'method']);

--- a/docs/en/reference/map-reduce.rst
+++ b/docs/en/reference/map-reduce.rst
@@ -58,7 +58,7 @@ of MongoDB via the ODM's query builder. Here is a simple map reduce example:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('Documents\Event')
+    $qb = $dm->createQueryBuilder(Documents\Event::class)
         ->field('type')
         ->equals('sale')
         ->map('function() { emit(this.user.$id, 1); }')
@@ -102,12 +102,14 @@ PHP driver directly:
         return sum;
     }');
 
-    $result = $db->command(array(
-        'mapreduce' => 'events',
-        'map' => $map,
-        'reduce' => $reduce,
-        'query' => array('type' => 'sale'),
-    ));
+    $result = $db->command(
+        [
+            'mapreduce' => 'events',
+            'map' => $map,
+            'reduce' => $reduce,
+            'query' => ['type' => 'sale'],
+        ]
+    );
 
     foreach ($result['results'] as $user) {
         printf("User %s had %d sale(s).\n", $user['_id'], $user['value']);

--- a/docs/en/reference/metadata-drivers.rst
+++ b/docs/en/reference/metadata-drivers.rst
@@ -180,7 +180,7 @@ the ``ClassMetadataFactory``:
     <?php
 
     $cmf = $em->getMetadataFactory();
-    $class = $cmf->getMetadataFor('MyDocumentName');
+    $class = $cmf->getMetadataFor(MyDocumentName::class);
 
 Now you can learn about the document and use the data stored in the
 ``ClassMetadata`` instance to get all mapped fields for example and

--- a/docs/en/reference/migrating-schemas.rst
+++ b/docs/en/reference/migrating-schemas.rst
@@ -87,7 +87,7 @@ before normal hydration.
         public $lastName;
 
         /** @AlsoLoad({"name", "fullName"}) */
-        public function populateFirstAndLastName($fullName): void
+        public function populateFirstAndLastName(string $fullName): void
         {
             list($this->firstName, $this->lastName) = explode(' ', $fullName);
         }
@@ -150,7 +150,7 @@ Later on, you may want to migrate this data into an embedded Address document:
         /** @Field(type="string") */
         public $city;
 
-        public function __construct($street, $city)
+        public function __construct(string $street, string $city)
         {
             $this->street = $street;
             $this->city = $city;

--- a/docs/en/reference/priming-references.rst
+++ b/docs/en/reference/priming-references.rst
@@ -29,7 +29,7 @@ accounts.
 
     <?php
 
-    $qb = $dm->createQueryBuilder('User')
+    $qb = $dm->createQueryBuilder(User::class)
         ->limit(100);
     $query = $qb->getQuery();
     $users = $query->execute();
@@ -57,7 +57,7 @@ builder's ``prime()`` method allows us to do just that.
 
     <?php
 
-    $qb = $dm->createQueryBuilder('User')
+    $qb = $dm->createQueryBuilder(User::class)
         ->field('accounts')->prime(true)
         ->limit(100);
     $query = $qb->getQuery();

--- a/docs/en/reference/query-builder-api.rst
+++ b/docs/en/reference/query-builder-api.rst
@@ -35,7 +35,7 @@ to find a document by its identifier:
 
     <?php
 
-    $users = $dm->find('User', $id);
+    $users = $dm->find(User::class, $id);
 
 The ``find()`` method is just a convenience shortcut method to:
 
@@ -43,7 +43,7 @@ The ``find()`` method is just a convenience shortcut method to:
 
     <?php
 
-    $user = $dm->getRepository('User')->find($id);
+    $user = $dm->getRepository(User::class)->find($id);
 
 .. note::
 
@@ -59,8 +59,8 @@ On the ``DocumentRepository`` you have a few other methods for finding documents
 
     <?php
 
-    $users = $dm->getRepository('User')->findBy(array('type' => 'employee'));
-    $user = $dm->getRepository('User')->findOneBy(array('username' => 'jwage'));
+    $users = $dm->getRepository(User::class)->findBy(['type' => 'employee']);
+    $user = $dm->getRepository(User::class)->findOneBy(['username' => 'jwage']);
 
 Creating a Query Builder
 ------------------------
@@ -72,7 +72,7 @@ You can easily create a new ``Query\Builder`` object with the
 
     <?php
 
-    $qb = $dm->createQueryBuilder('User');
+    $qb = $dm->createQueryBuilder(User::class);
 
 The first and only argument is optional, you can specify it later
 with the ``find()``, ``update()`` (deprecated), ``updateOne()``,
@@ -86,7 +86,7 @@ with the ``find()``, ``update()`` (deprecated), ``updateOne()``,
 
     // ...
 
-    $qb->find('User');
+    $qb->find(User::class);
 
 Executing Queries
 ~~~~~~~~~~~~~~~~~
@@ -97,7 +97,7 @@ You can execute a query by getting a ``Query`` through the ``getQuery()`` method
 
     <?php
 
-    $qb = $dm->createQueryBuilder('User');
+    $qb = $dm->createQueryBuilder(User::class);
     $query = $qb->getQuery();
 
 Now you can ``execute()`` that query and it will return a cursor for you to iterate over the results:
@@ -119,7 +119,7 @@ you are not sure if your the query constructed with Builder is in fact correct y
 
     <?php
 
-    $qb = $dm->createQueryBuilder('User');
+    $qb = $dm->createQueryBuilder(User::class);
     $query = $qb->getQuery();
     $debug = $query->debug();
 
@@ -137,7 +137,7 @@ You can configure queries to return an eager cursor instead of a normal mongodb 
 
     <?php
 
-    $qb = $dm->createQueryBuilder('User')
+    $qb = $dm->createQueryBuilder(User::class)
         ->eagerCursor(true);
     $query = $qb->getQuery();
     $cursor = $query->execute(); // instanceof Doctrine\ODM\MongoDB\EagerCursor
@@ -162,7 +162,7 @@ If you want to just get a single result you can use the ``Query#getSingleResult(
 
     <?php
 
-    $user = $dm->createQueryBuilder('User')
+    $user = $dm->createQueryBuilder(User::class)
         ->field('username')->equals('jwage')
         ->getQuery()
         ->getSingleResult();
@@ -177,7 +177,7 @@ the ``select()`` method:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('User')
+    $qb = $dm->createQueryBuilder(User::class)
         ->select('username', 'password');
     $query = $qb->getQuery();
     $users = $query->execute();
@@ -194,7 +194,7 @@ You can force MongoDB to use a specific index for a query with the ``hint()`` me
 
     <?php
 
-    $qb = $dm->createQueryBuilder('User')
+    $qb = $dm->createQueryBuilder(User::class)
         ->hint('user_pass_idx');
     $query = $qb->getQuery();
     $users = $query->execute();
@@ -215,7 +215,7 @@ method:
 
     <?php
 
-    $ages = $dm->createQueryBuilder('User')
+    $ages = $dm->createQueryBuilder(User::class)
         ->distinct('age')
         ->getQuery()
         ->execute();
@@ -246,7 +246,7 @@ changeset will be reset in the process.
 
     <?php
 
-    $user = $dm->createQueryBuilder('User')
+    $user = $dm->createQueryBuilder(User::class)
         ->field('username')->equals('jwage')
         ->refresh()
         ->getQuery()
@@ -271,7 +271,7 @@ to update fetched documents.
 
     <?php
 
-    $user = $dm->createQueryBuilder('User')
+    $user = $dm->createQueryBuilder(User::class)
         ->field('username')->equals('malarzm')
         ->readOnly()
         ->getQuery()
@@ -307,7 +307,7 @@ get the raw results directly back from mongo by using the
 
     <?php
 
-    $users = $dm->createQueryBuilder('User')
+    $users = $dm->createQueryBuilder(User::class)
         ->hydrate(false)
         ->getQuery()
         ->execute();
@@ -328,7 +328,7 @@ we show twenty at a time:
 
     <?php
 
-    $blogPosts = $dm->createQueryBuilder('BlogPost')
+    $blogPosts = $dm->createQueryBuilder(BlogPost::class)
         ->limit(20)
         ->skip(40)
         ->getQuery()
@@ -343,7 +343,7 @@ You can sort the results by using the ``sort()`` method:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('Article')
+    $qb = $dm->createQueryBuilder(Article::class)
         ->sort('createdAt', 'desc');
 
 If you want to an additional sort you can call ``sort()`` again. The calls are stacked and ordered
@@ -365,7 +365,7 @@ object:
 
     <?php
 
-    $qb = $this->dm->createQueryBuilder('Event')
+    $qb = $this->dm->createQueryBuilder(Event::class)
         ->field('type')->equals('sale')
         ->map('function() { emit(this.userId, 1); }')
         ->reduce("function(k, vals) {
@@ -391,7 +391,7 @@ you can just call the ``where()`` method:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('User')
+    $qb = $dm->createQueryBuilder(User::class)
         ->where("function() { return this.type == 'admin'; }");
 
 You can read more about the `$where operator <https://docs.mongodb.com/manual/reference/operator/query/where/>`_ in the Mongo docs.
@@ -426,7 +426,7 @@ Query for active administrator users:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('User')
+    $qb = $dm->createQueryBuilder(User::class)
         ->field('type')->equals('admin')
         ->field('active')->equals(true);
 
@@ -436,8 +436,8 @@ Query for articles that have some tags:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('Article')
-        ->field('tags.name')->in(array('tag1', 'tag2'));
+    $qb = $dm->createQueryBuilder(Article::class)
+        ->field('tags.name')->in(['tag1', 'tag2']);
 
 Read more about the
 `$in operator <https://docs.mongodb.com/manual/reference/operator/query/in/>`_
@@ -449,8 +449,8 @@ Query for articles that do not have some tags:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('Article')
-        ->field('tags.name')->notIn(array('tag3'));
+    $qb = $dm->createQueryBuilder(Article::class)
+        ->field('tags.name')->notIn(['tag3']);
 
 Read more about the
 `$nin operator <https://docs.mongodb.com/manual/reference/operator/query/nin/>`_
@@ -460,7 +460,7 @@ in the Mongo docs.
 
     <?php
 
-    $qb = $dm->createQueryBuilder('User')
+    $qb = $dm->createQueryBuilder(User::class)
         ->field('type')->notEqual('admin');
 
 Read more about the
@@ -473,7 +473,7 @@ Query for accounts with an amount due greater than 30:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('Account')
+    $qb = $dm->createQueryBuilder(Account::class)
         ->field('amount_due')->gt(30);
 
 Query for accounts with an amount due greater than or equal to 30:
@@ -482,7 +482,7 @@ Query for accounts with an amount due greater than or equal to 30:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('Account')
+    $qb = $dm->createQueryBuilder(Account::class)
         ->field('amount_due')->gte(30);
 
 Query for accounts with an amount due less than 30:
@@ -491,7 +491,7 @@ Query for accounts with an amount due less than 30:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('Account')
+    $qb = $dm->createQueryBuilder(Account::class)
         ->field('amount_due')->lt(30);
 
 Query for accounts with an amount due less than or equal to 30:
@@ -500,7 +500,7 @@ Query for accounts with an amount due less than or equal to 30:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('Account')
+    $qb = $dm->createQueryBuilder(Account::class)
         ->field('amount_due')->lte(30);
 
 Query for accounts with an amount due between 10 and 20:
@@ -509,7 +509,7 @@ Query for accounts with an amount due between 10 and 20:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('Account')
+    $qb = $dm->createQueryBuilder(Account::class)
         ->field('amount_due')->range(10, 20);
 
 Read more about
@@ -522,7 +522,7 @@ Query for articles with no comments:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('Article')
+    $qb = $dm->createQueryBuilder(Article::class)
         ->field('comments')->size(0);
 
 Read more about the
@@ -536,7 +536,7 @@ username:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('User')
+    $qb = $dm->createQueryBuilder(User::class)
         ->field('login')->exists(true);
 
 Read more about the
@@ -550,7 +550,7 @@ type:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('User')
+    $qb = $dm->createQueryBuilder(User::class)
         ->field('type')->type('integer');
 
 Read more about the
@@ -563,8 +563,8 @@ Query for users that are in all the specified Groups:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('User')
-        ->field('groups')->all(array('Group 1', 'Group 2'));
+    $qb = $dm->createQueryBuilder(User::class)
+        ->field('groups')->all(['Group 1', 'Group 2']);
 
 Read more about the
 `$all operator <https://docs.mongodb.com/manual/reference/operator/query/all/>`_
@@ -574,8 +574,8 @@ in the Mongo docs.
 
     <?php
 
-    $qb = $dm->createQueryBuilder('Transaction')
-        ->field('field')->mod('field', array(10, 1));
+    $qb = $dm->createQueryBuilder(Transaction::class)
+        ->field('field')->mod('field', [10, 1]);
 
 Read more about the
 `$mod operator <https://docs.mongodb.com/manual/reference/operator/query/mod/>`_ in the Mongo docs.
@@ -586,7 +586,7 @@ Query for users who have subscribed or are in a trial.
 
     <?php
 
-    $qb = $dm->createQueryBuilder('User');
+    $qb = $dm->createQueryBuilder(User::class);
     $qb->addOr($qb->expr()->field('subscriber')->equals(true));
     $qb->addOr($qb->expr()->field('inTrial')->equals(true));
 
@@ -602,7 +602,7 @@ following example, we query for all articles written by a particular user.
     <?php
 
     // Suppose $user has already been fetched from the database
-    $qb = $dm->createQueryBuilder('Article')
+    $qb = $dm->createQueryBuilder(Article::class)
         ->field('user')->references($user);
 
 The ``includesReferenceTo()`` method may be used to query the owning side of a
@@ -615,7 +615,7 @@ account.
     <?php
 
     // Suppose $account has already been fetched from the database
-    $qb = $dm->createQueryBuilder('User')
+    $qb = $dm->createQueryBuilder(User::class)
         ->field('accounts')->includesReferenceTo($account);
 
 Text Search
@@ -653,7 +653,7 @@ You can then run queries using the text operator:
     <?php
 
     // Run a text search against the index
-    $qb = $dm->createQueryBuilder('Document')
+    $qb = $dm->createQueryBuilder(Document::class)
         ->text('words you are looking for');
 
 To fetch the calculated score for the text search, use the ``selectMeta()``
@@ -664,7 +664,7 @@ method:
     <?php
 
     // Run a text search against the index
-    $qb = $dm->createQueryBuilder('Document')
+    $qb = $dm->createQueryBuilder(Document::class)
         ->selectMeta('score', 'textScore')
         ->text('words you are looking for');
 
@@ -676,7 +676,7 @@ method:
     <?php
 
     // Run a text search against the index
-    $qb = $dm->createQueryBuilder('Document')
+    $qb = $dm->createQueryBuilder(Document::class)
         ->language('it')
         ->text('parole che stai cercando');
 
@@ -713,7 +713,7 @@ In ODM the distinction is done by explicitly calling ``updateMany()`` method of 
 
     <?php
 
-    $dm->createQueryBuilder('User')
+    $dm->createQueryBuilder(User::class)
         ->updateMany()
         ->field('someField')->set('newValue')
         ->field('username')->equals('sgoettschkes')
@@ -729,7 +729,7 @@ Change a users password:
 
     <?php
 
-    $dm->createQueryBuilder('User')
+    $dm->createQueryBuilder(User::class)
         ->updateOne()
         ->field('password')->set('newpassword')
         ->field('username')->equals('jwage')
@@ -744,7 +744,7 @@ tell it the update is not an atomic one:
 
     <?php
 
-    $dm->createQueryBuilder('User')
+    $dm->createQueryBuilder(User::class)
         ->updateOne()
         ->field('username')->set('jwage', false)
         ->field('password')->set('password', false)
@@ -763,12 +763,14 @@ You can set an entirely new object to update as well:
 
     <?php
 
-    $dm->createQueryBuilder('User')
-        ->setNewObj(array(
-            'username' => 'jwage',
-            'password' => 'password',
-            // ... other fields
-        ))
+    $dm->createQueryBuilder(User::class)
+        ->setNewObj(
+           [
+               'username' => 'jwage',
+               'password' => 'password',
+               // ... other fields
+           ]
+        )
         ->field('username')->equals('jwage')
         ->getQuery()
         ->execute();
@@ -779,7 +781,7 @@ Increment the value of a document:
 
     <?php
 
-    $dm->createQueryBuilder('Package')
+    $dm->createQueryBuilder(Package::class)
         ->field('id')->equals('theid')
         ->field('downloads')->inc(1)
         ->getQuery()
@@ -796,7 +798,7 @@ exists:
 
     <?php
 
-    $dm->createQueryBuilder('User')
+    $dm->createQueryBuilder(User::class)
         ->updateMany()
         ->field('login')->unsetField()->exists(true)
         ->getQuery()
@@ -812,7 +814,7 @@ Append new tag to the tags array:
 
     <?php
 
-    $dm->createQueryBuilder('Article')
+    $dm->createQueryBuilder(Article::class)
         ->updateOne()
         ->field('tags')->push('tag5')
         ->field('id')->equals('theid')
@@ -829,9 +831,9 @@ Append new tags to the tags array:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('Article');
+    $qb = $dm->createQueryBuilder(Article::class);
     $qb->updateOne()
-        ->field('tags')->push($qb->expr()->each(array('tag6', 'tag7')))
+        ->field('tags')->push($qb->expr()->each(['tag6', 'tag7']))
         ->field('id')->equals('theid')
         ->getQuery()
         ->execute();
@@ -842,7 +844,7 @@ Add value to array only if its not in the array already:
 
     <?php
 
-    $dm->createQueryBuilder('Article')
+    $dm->createQueryBuilder(Article::class)
         ->updateOne()
         ->field('tags')->addToSet('tag1')
         ->field('id')->equals('theid')
@@ -860,9 +862,9 @@ already:
 
     <?php
 
-    $qb = $dm->createQueryBuilder('Article');
+    $qb = $dm->createQueryBuilder(Article::class);
     $qb->updateOne()
-        ->field('tags')->addToSet($qb->expr()->each(array('tag6', 'tag7')))
+        ->field('tags')->addToSet($qb->expr()->each(['tag6', 'tag7']))
         ->field('id')->equals('theid')
         ->getQuery()
         ->execute();
@@ -873,7 +875,7 @@ Remove first element in an array:
 
     <?php
 
-    $dm->createQueryBuilder('Article')
+    $dm->createQueryBuilder(Article::class)
         ->updateOne()
         ->field('tags')->popFirst()
         ->field('id')->equals('theid')
@@ -886,7 +888,7 @@ Remove last element in an array:
 
     <?php
 
-    $dm->createQueryBuilder('Article')
+    $dm->createQueryBuilder(Article::class)
         ->updateOne()
         ->field('tags')->popLast()
         ->field('id')->equals('theid')
@@ -903,7 +905,7 @@ Remove all occurrences of value from array:
 
     <?php
 
-    $dm->createQueryBuilder('Article')
+    $dm->createQueryBuilder(Article::class)
         ->updateMany()
         ->field('tags')->pull('tag1')
         ->getQuery()
@@ -917,9 +919,9 @@ in the Mongo docs.
 
     <?php
 
-    $dm->createQueryBuilder('Article')
+    $dm->createQueryBuilder(Article::class)
         ->updateMany()
-        ->field('tags')->pullAll(array('tag1', 'tag2'))
+        ->field('tags')->pullAll(['tag1', 'tag2'])
         ->getQuery()
         ->execute();
 
@@ -941,7 +943,7 @@ Here is an example where we remove users who have never logged in:
 
     <?php
 
-    $dm->createQueryBuilder('User')
+    $dm->createQueryBuilder(User::class)
         ->remove()
         ->field('num_logins')->equals(0)
         ->getQuery()
@@ -964,8 +966,8 @@ operation similar to SQL's GROUP BY command.
 
     <?php
 
-    $result = $this->dm->createQueryBuilder('Documents\User')
-        ->group(array(), array('count' => 0))
+    $result = $this->dm->createQueryBuilder(\Documents\User::class)
+        ->group([], ['count' => 0])
         ->reduce('function (obj, prev) { prev.count++; }')
         ->field('a')->gt(1)
         ->getQuery()
@@ -979,5 +981,5 @@ code:
     <?php
 
     $reduce = 'function (obj, prev) { prev.count++; }';
-    $condition = array('a' => array( '$gt' => 1));
-    $result = $collection->group(array(), array('count' => 0), $reduce, $condition);
+    $condition = ['a' => ['$gt' => 1]];
+    $result = $collection->group([], ['count' => 0], $reduce, $condition);

--- a/docs/en/reference/reference-mapping.rst
+++ b/docs/en/reference/reference-mapping.rst
@@ -99,7 +99,7 @@ Reference many documents:
             /**
              * @ReferenceMany(targetDocument=Account::class)
              */
-            private $accounts = array();
+            private $accounts = [];
 
             // ...
         }
@@ -142,7 +142,7 @@ omit the ``targetDocument`` option:
             // ..
 
             /** @ReferenceMany */
-            private $favorites = array();
+            private $favorites = [];
 
             // ...
         }
@@ -180,7 +180,7 @@ The name of the field within the DBRef object can be customized via the
             /**
              * @ReferenceMany(discriminatorField="type")
              */
-            private $favorites = array();
+            private $favorites = [];
 
             // ...
         }
@@ -213,7 +213,7 @@ in each `DBRef`_ object:
              *   }
              * )
              */
-            private $favorites = array();
+            private $favorites = [];
 
             // ...
         }
@@ -250,7 +250,7 @@ a certain class, you can optionally specify a default discriminator value:
              *   defaultDiscriminatorValue="album"
              * )
              */
-            private $favorites = array();
+            private $favorites = [];
 
             // ...
         }
@@ -419,7 +419,7 @@ Now two examples of what happens when you remove the references:
 
     <?php
 
-    $contact = $dm->find("Addressbook\Contact", $contactId);
+    $contact = $dm->find(Addressbook\Contact::class, $contactId);
     $contact->newStandingData(new StandingData("Firstname", "Lastname", "Street"));
     $contact->removeAddress(1);
 

--- a/docs/en/reference/transactions-and-concurrency.rst
+++ b/docs/en/reference/transactions-and-concurrency.rst
@@ -119,7 +119,7 @@ You can specify the expected version of a document during a query with ``Documen
     /* @var $dm DocumentManager */
 
     try {
-        $document = $dm->find('User', $theDocumentId, LockMode::OPTIMISTIC, $expectedVersion);
+        $document = $dm->find(User::class, $theDocumentId, LockMode::OPTIMISTIC, $expectedVersion);
 
         // do the work
 
@@ -142,7 +142,7 @@ Alternatively, an expected version may be specified for an existing document wit
 
     /* @var $dm DocumentManager */
 
-    $document = $dm->find('User', $theDocumentId);
+    $document = $dm->find(User::class, $theDocumentId);
 
     try {
         // assert version
@@ -196,7 +196,7 @@ The form (GET Request):
 
     /* @var $dm DocumentManager */
 
-    $post = $dm->find('BlogPost', 123456);
+    $post = $dm->find(BlogPost::class, 123456);
 
     echo '<input type="hidden" name="id" value="' . $post->getId() . '" />';
     echo '<input type="hidden" name="version" value="' . $post->getCurrentVersion() . '" />';
@@ -214,7 +214,7 @@ And the change headline action (POST Request):
     $postId = (int)$_POST['id'];
     $postVersion = (int)$_POST['version'];
 
-    $post = $dm->find('BlogPost', $postId, LockMode::OPTIMISTIC, $postVersion);
+    $post = $dm->find(BlogPost::class, $postId, LockMode::OPTIMISTIC, $postVersion);
 
 .. _transactions_and_concurrency_pessimistic_locking:
 

--- a/docs/en/reference/trees.rst
+++ b/docs/en/reference/trees.rst
@@ -24,7 +24,7 @@ Full Tree in Single Document
         private $body;
 
         /** @EmbedMany(targetDocument=Comment::class) */
-        private $comments = array();
+        private $comments = [];
 
         // ...
     }
@@ -39,7 +39,7 @@ Full Tree in Single Document
         private $text;
 
         /** @EmbedMany(targetDocument=Comment::class) */
-        private $replies = array();
+        private $replies = [];
 
         // ...
     }
@@ -50,7 +50,7 @@ Retrieve a blog post and only select the first 10 comments:
 
     <?php
 
-    $post = $dm->createQueryBuilder('BlogPost')
+    $post = $dm->createQueryBuilder(BlogPost::class)
         ->selectSlice('replies', 0, 10)
         ->getQuery()
         ->getSingleResult();
@@ -91,7 +91,7 @@ Query for children by a specific parent id:
 
     <?php
 
-    $children = $dm->createQueryBuilder('Category')
+    $children = $dm->createQueryBuilder(Category::class)
         ->field('parent.id')->equals('theid')
         ->getQuery()
         ->execute();
@@ -119,7 +119,7 @@ Child Reference
          * @ReferenceMany(targetDocument=Category::class)
          * @Index
          */
-        private $children = array();
+        private $children = [];
 
         // ...
     }
@@ -130,7 +130,7 @@ Query for immediate children of a category:
 
     <?php
 
-    $category = $dm->createQueryBuilder('Category')
+    $category = $dm->createQueryBuilder(Category::class)
         ->field('id')->equals('theid')
         ->getQuery()
         ->getSingleResult();
@@ -143,7 +143,7 @@ Query for immediate parent of a category:
 
     <?php
 
-    $parent = $dm->createQueryBuilder('Category')
+    $parent = $dm->createQueryBuilder(Category::class)
         ->field('children.id')->equals('theid')
         ->getQuery()
         ->getSingleResult();
@@ -177,7 +177,7 @@ Array of Ancestors
          * @ReferenceMany(targetDocument=Category::class)
          * @Index
          */
-        private $ancestors = array();
+        private $ancestors = [];
 
         /**
          * @ReferenceOne(targetDocument=Category::class)
@@ -199,7 +199,7 @@ Query for all descendants of a category:
 
     <?php
 
-    $categories = $dm->createQueryBuilder('Category')
+    $categories = $dm->createQueryBuilder(Category::class)
         ->field('ancestors.id')->equals('theid')
         ->getQuery()
         ->execute();
@@ -210,7 +210,7 @@ Query for all ancestors of a category:
 
     <?php
 
-    $category = $dm->createQuery('Category')
+    $category = $dm->createQuery(Category::class)
         ->field('id')->equals('theid')
         ->getQuery()
         ->getSingleResult();
@@ -248,7 +248,7 @@ Query for the entire tree:
 
     <?php
 
-    $categories = $dm->createQuery('Category')
+    $categories = $dm->createQuery(Category::class)
         ->sort('path', 'asc')
         ->getQuery()
         ->execute();
@@ -258,7 +258,7 @@ Query for the node 'b' and all its descendants:
 .. code-block:: php
 
     <?php
-    $categories = $dm->createQuery('Category')
+    $categories = $dm->createQuery(Category::class)
         ->field('path')->equals('/^a,b,/')
         ->getQuery()
         ->execute();

--- a/docs/en/reference/upserting-documents.rst
+++ b/docs/en/reference/upserting-documents.rst
@@ -24,9 +24,9 @@ The above would result in an operation like the following:
     <?php
 
     $articleCollection->update(
-        array('_id' => new MongoDB\BSON\ObjectId($articleId)),
-        array('$inc' => array('numViews' => 1)),
-        array('upsert' => true, 'safe' => true)
+        ['_id' => new MongoDB\BSON\ObjectId($articleId)],
+        ['$inc' => ['numViews' => 1]],
+        ['upsert' => true, 'safe' => true]
     );
 
 The extra benefit is the fact that you don't have to fetch the ``$article`` in order

--- a/docs/en/reference/working-with-objects.rst
+++ b/docs/en/reference/working-with-objects.rst
@@ -142,10 +142,10 @@ Example:
 
     <?php
 
-    $user = $dm->getRepository('User')->find($userId);
+    $user = $dm->getRepository(User::class)->find($userId);
     // ...
     $user->setPassword('changeme');
-    $dm->flush(null, array('safe' => true, 'fsync' => true));
+    $dm->flush(null, ['safe' => true, 'fsync' => true]);
 
 You can configure the default flush options on your ``Configuration`` object
 if you want to set them globally for all flushes.
@@ -156,10 +156,12 @@ Example:
 
     <?php
 
-    $config->setDefaultCommitOptions(array(
+    $config->setDefaultCommitOptions(
+      [
         'safe' => true,
         'fsync' => true
-    ));
+      ]
+    );
 
 .. note::
 
@@ -458,7 +460,7 @@ example:
 
     <?php
 
-    $user = $dm->find('User', $id);
+    $user = $dm->find(User::class, $id);
 
 The return value is either the found document instance or null if
 no instance could be found with the given identifier.
@@ -470,7 +472,7 @@ following:
 
     <?php
 
-    $user = $dm->getRepository('User')->find($id);
+    $user = $dm->getRepository(User::class)->find($id);
 
 ``DocumentManager#getRepository($documentName)`` returns a
 repository object which provides many ways to retrieve documents of
@@ -490,13 +492,13 @@ methods on a repository as follows:
     <?php
 
     // All users that are 20 years old
-    $users = $dm->getRepository('User')->findBy(array('age' => 20));
+    $users = $dm->getRepository(User::class)->findBy(['age' => 20]);
 
     // All users that are 20 years old and have a surname of 'Miller'
-    $users = $dm->getRepository('User')->findBy(array('age' => 20, 'surname' => 'Miller'));
+    $users = $dm->getRepository(User::class)->findBy(['age' => 20, 'surname' => 'Miller']);
 
     // A single user by its nickname
-    $user = $dm->getRepository('User')->findOneBy(array('nickname' => 'romanb'));
+    $user = $dm->getRepository(User::class)->findOneBy(['nickname' => 'romanb']);
 
 .. note::
 
@@ -526,7 +528,7 @@ simple example:
     <?php
 
     // All users with an age between 20 and 30 (inclusive).
-    $qb = $dm->createQueryBuilder('User')
+    $qb = $dm->createQueryBuilder(User::class)
         ->field('age')->range(20, 30);
     $q = $qb->getQuery()
     $users = $q->execute();
@@ -540,8 +542,8 @@ To query documents with a ReferenceOne association to another document, use the 
 
     <?php
 
-    $group = $dm->find('Group', $id);
-    $usersWithGroup = $dm->createQueryBuilder('User')
+    $group = $dm->find(Group::class, $id);
+    $usersWithGroup = $dm->createQueryBuilder(User::class)
         ->field('group')->references($group)
         ->getQuery()->execute();
 
@@ -551,6 +553,6 @@ To find documents with a ReferenceMany association that includes a certain docum
 
     <?php
 
-    $users = $dm->createQueryBuilder('User')
+    $users = $dm->createQueryBuilder(User::class)
         ->field('groups')->includesReferenceTo($group)
         ->getQuery()->execute();

--- a/docs/en/reference/xml-mapping.rst
+++ b/docs/en/reference/xml-mapping.rst
@@ -66,7 +66,7 @@ of the constructor, like this:
     <?php
 
     // $config instanceof Doctrine\ODM\MongoDB\Configuration
-    $driver = new XmlDriver(array('/path/to/files'));
+    $driver = new XmlDriver(['/path/to/files']);
     $config->setMetadataDriverImpl($driver);
 
 Simplified XML Driver
@@ -84,10 +84,10 @@ Configuration of this client works a little bit different:
 .. code-block:: php
 
     <?php
-    $namespaces = array(
+    $namespaces = [
         'MyProject\Documents' => '/path/to/files1',
         'OtherProject\Documents' => '/path/to/files2'
-    );
+    ];
     $driver = new \Doctrine\ODM\MongoDB\Mapping\Driver\SimplifiedXmlDriver($namespaces);
     $driver->setGlobalBasename('global'); // global.mongodb-odm.xml
 

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -33,7 +33,7 @@ First define the ``User`` document:
     {
         private $name;
         private $email;
-        private $posts = array();
+        private $posts = [];
 
         // ...
     }
@@ -83,7 +83,7 @@ You can provide your mapping information in Annotations or XML:
             private $email;
 
             /** @ODM\ReferenceMany(targetDocument=BlogPost::class, cascade="all") */
-            private $posts = array();
+            private $posts = [];
 
             // ...
         }
@@ -248,7 +248,7 @@ You can retrieve the user later by its identifier:
     // ...
 
     $userId = '....';
-    $user = $dm->find('User', $userId);
+    $user = $dm->find(User::class, $userId);
 
 Or you can find the user by name even:
 
@@ -256,7 +256,7 @@ Or you can find the user by name even:
 
     <?php
 
-    $user = $dm->getRepository('User')->findOneBy(array('name' => 'Bulat S.'));
+    $user = $dm->getRepository(User::class)->findOneBy(['name' => 'Bulat S.']);
 
 If you want to iterate over the posts the user references it is as easy as the following:
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Updated ODM docs (https://github.com/doctrine/mongodb-odm/issues/1783 related):

-  added missing type-hints for method params and return types; 
-  replaced class names literals by class constant '::class'; 
-  replaced array() with short syntax [];
-  updated if expressions to use strict checks.
