### PR TITLE
Drop "simple" attribute from references in XML schema

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -213,7 +213,6 @@
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="field-name" type="xs:NMTOKEN" />
-    <xs:attribute name="simple" type="xs:boolean" /><!-- deprecated -->
     <xs:attribute name="store-as" type="odm:reference-store-as" default="dbRefWithDb" />
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />
     <xs:attribute name="mapped-by" type="xs:NMTOKEN" />
@@ -238,7 +237,6 @@
     <xs:attribute name="collection-class" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="field-name" type="xs:NMTOKEN" />
-    <xs:attribute name="simple" type="xs:boolean" /><!-- deprecated -->
     <xs:attribute name="store-as" type="odm:reference-store-as" default="dbRefWithDb" />
     <xs:attribute name="strategy" type="xs:NMTOKEN" default="pushAll" />
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -116,12 +116,12 @@ class MappingException extends BaseMappingException
 
     public static function simpleReferenceRequiresTargetDocument(string $className, string $fieldName) : self
     {
-        return new self(sprintf('Target document must be specified for simple reference: %s::%s', $className, $fieldName));
+        return new self(sprintf('Target document must be specified for identifier reference: %s::%s', $className, $fieldName));
     }
 
     public static function simpleReferenceMustNotTargetDiscriminatedDocument(string $targetDocument) : self
     {
-        return new self(sprintf('Simple reference must not target document using Single Collection Inheritance, %s targeted.', $targetDocument));
+        return new self(sprintf('Identifier reference must not target document using Single Collection Inheritance, %s targeted.', $targetDocument));
     }
 
     public static function atomicCollectionStrategyNotAllowed(string $strategy, string $className, string $fieldName) : self

--- a/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
@@ -115,7 +115,7 @@ class ReferencePrimer
          * the priming query.
          */
         if ($mapping['storeAs'] === ClassMetadata::REFERENCE_STORE_AS_ID && empty($mapping['targetDocument'])) {
-            throw new LogicException(sprintf('Field "%s" is a simple reference without a target document class in class "%s"', $fieldName, $class->name));
+            throw new LogicException(sprintf('Field "%s" is an identifier reference without a target document class in class "%s"', $fieldName, $class->name));
         }
 
         if ($primer !== null && ! is_callable($primer)) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -189,7 +189,7 @@ class DocumentManagerTest extends BaseTest
 
     /**
      * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
-     * @expectedExceptionMessage Simple reference must not target document using Single Collection Inheritance, Documents\Tournament\Participant targeted.
+     * @expectedExceptionMessage Identifier reference must not target document using Single Collection Inheritance, Documents\Tournament\Participant targeted.
      */
     public function testDisriminatedSimpleReferenceFails()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -465,7 +465,7 @@ class ClassMetadataTest extends BaseTest
 
     /**
      * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
-     * @expectedExceptionMessage Target document must be specified for simple reference: stdClass::assoc
+     * @expectedExceptionMessage Target document must be specified for identifier reference: stdClass::assoc
      */
     public function testSimpleReferenceRequiresTargetDocument()
     {
@@ -481,7 +481,7 @@ class ClassMetadataTest extends BaseTest
 
     /**
      * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
-     * @expectedExceptionMessage Target document must be specified for simple reference: stdClass::assoc
+     * @expectedExceptionMessage Target document must be specified for identifier reference: stdClass::assoc
      */
     public function testSimpleAsStringReferenceRequiresTargetDocument()
     {
@@ -523,7 +523,7 @@ class ClassMetadataTest extends BaseTest
 
     /**
      * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
-     * @expectedExceptionMessage Target document must be specified for simple reference: stdClass::assoc
+     * @expectedExceptionMessage Target document must be specified for identifier reference: stdClass::assoc
      */
     public function testStoreAsIdReferenceRequiresTargetDocument()
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | #1854 

#### Summary

The `simple` option for references has been dropped in favour of the `storeAs` directive, so it makes sense to drop this from the schema. This PR also updates the wording in some exception messages to no longer refer to these references as "simple" but rather "identifier references".