### PR TITLE
Error in group aggregation builder

### DIFF
--- a/docs/en/reference/aggregation-builder.rst
+++ b/docs/en/reference/aggregation-builder.rst
@@ -75,9 +75,9 @@ the aggregation builder.
             ->expression(
                 $builder->expr()
                     ->field('month')
-                    ->month('purchaseDate')
+                    ->month('$purchaseDate')
                     ->field('year')
-                    ->year('purchaseDate')
+                    ->year('$purchaseDate')
             )
             ->field('numPurchases')
             ->sum(1)


### PR DESCRIPTION
After spending some hours trying to figure out why I had the error "can't convert from BSON type string to Date" I founded that there is an error in the doc
"->month('purchaseDate')" and "->year('purchaseDate')" instead of "->month('$purchaseDate')" and "->year('$purchaseDate')"

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| BC Break     | yes/no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->
