### PR TITLE
Always use dump method from VarDumper component

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
@@ -8,7 +8,7 @@ use LogicException;
 use Symfony\Component\Console;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
-use function dump;
+use Symfony\Component\VarDumper\VarDumper;
 use function is_numeric;
 use function json_decode;
 
@@ -90,7 +90,7 @@ EOT
         }
 
         foreach ($qb->getQuery() as $result) {
-            dump($result);
+            VarDumper::dump($result);
         }
     }
 }


### PR DESCRIPTION
The `dump` function from the root namespace may conflict with other packages, e.g. `nette/tracy`. Thus, we always use the `VarDumper::dump` method to ensure we're calling what we expect to call.