### PR TITLE
Don't dump to stdout in query command

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -24,6 +24,11 @@
   the `create`, `getClient`, `getDocumentDatabase`, `getDocumentCollection`, and
   `getDocumentCollections` methods have been updated to handle classes from
   `mongodb/mongodb` instead of `doctrine/mongodb`.
+  
+## Commands
+
+* The `--depth` option in the `odm:query` command was dropped without
+  replacement.
 
 ## Configuration
 

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
@@ -8,7 +8,8 @@ use LogicException;
 use Symfony\Component\Console;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\VarDumper\VarDumper;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
 use function is_numeric;
 use function json_decode;
 
@@ -89,8 +90,13 @@ EOT
             $qb->limit((int) $limit);
         }
 
+        $cloner = new VarCloner();
+        $dumper = new CliDumper(static function (string $payload) use ($output) : void {
+            $output->write($payload);
+        });
+
         foreach ($qb->getQuery() as $result) {
-            VarDumper::dump($result);
+            $dumper->dump($cloner->cloneVar($result));
         }
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

The query command uses the Symfony VarDumper component to dump query output to the user. By default however, the dumper dumps this to stdout. This PR uses a custom dumper to instead dump to the console output.

This also adds missing documentation for the BC break introduced in #1896 (the `--depth` option was dropped).