### PR TITLE
Optimizations for documents loading

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -144,6 +144,9 @@ class DocumentManager implements ObjectManager
     /** @var ClassNameResolver */
     private $classNameResolver;
 
+    /** @var ClassMetadata[]  */
+    private $classMetadataCache = [];
+
     /**
      * Creates a new Document that operates on the given Mongo connection
      * and uses the given Configuration.
@@ -279,7 +282,11 @@ class DocumentManager implements ObjectManager
      */
     public function getClassMetadata($className) : ClassMetadata
     {
-        return $this->metadataFactory->getMetadataFor($className);
+        if (empty($this->classMetadataCache[$className])) {
+            $this->classMetadataCache[$className] = $this->metadataFactory->getMetadataFor($className);
+        }
+
+        return $this->classMetadataCache[$className];
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2671,13 +2671,13 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function propertyChanged($document, $propertyName, $oldValue, $newValue)
     {
-        $oid   = spl_object_hash($document);
         $class = $this->dm->getClassMetadata(get_class($document));
 
         if (! isset($class->fieldMappings[$propertyName])) {
             return; // ignore non-persistent fields
         }
 
+        $oid = spl_object_hash($document);
         // Update changeset and mark document for synchronization
         $this->documentChangeSets[$oid][$propertyName] = [$oldValue, $newValue];
         if (isset($this->scheduledForDirtyCheck[$class->name][$oid])) {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes/no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary
I am profiled library with XHProf and find out next:
1. Class metadata extraction from metadata factory is slow even when it is already loaded to process memory. 
2. Hydrators can work more efficiently if their logic will be slightly changed.

For speeding up metadata extraction I added field to `DocumentManager` in which all previously extracted metadata will be cached with class name as index. This approach allow me to hugely increase documents population speed.
For speeding up hydrators work I added to them fields for storing directly inside reflection fields, field mappings and persistent collection factory. Also I slightly updated conditions for checking if field should be populated (this not bring much but perfectionist inside of me was satisfied by that:) ).

As a result of my manipulations ODM in "documents reading mode" is on 45-50% faster than it was previously. Hydrators  now approximately on 10% faster (here major role played storing required information inside hydrator). 

In PR all changes that was made by me. Also you can check it by yourself - I created [repository](https://github.com/watari/mongodb-odm-benchmarks) with command. In it `composer.json.opt` contain dependency for fork with my changes.





