### PR TITLE
Rework index equivalency checks

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -649,6 +649,12 @@ class SchemaManagerTest extends BaseTest
                 'mongoIndex' => [],
                 'documentIndex' => ['keys' => ['foo' => 'text', 'bar' => 'text']],
             ],
+            // geoHaystack index options
+            'geoHaystackOptionsDifferent' => [
+                'expected' => false,
+                'mongoIndex' => [],
+                'documentIndex' => ['options' => ['bucketSize' => 16]],
+            ],
         ];
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -23,6 +23,7 @@ use MongoDB\Collection;
 use MongoDB\Database;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\GridFS\Bucket;
+use MongoDB\Model\IndexInfo;
 use MongoDB\Model\IndexInfoIteratorIterator;
 use PHPUnit\Framework\Constraint\ArraySubset;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -500,7 +501,7 @@ class SchemaManagerTest extends BaseTest
         $mongoIndex    += $defaultMongoIndex;
         $documentIndex += $defaultDocumentIndex;
 
-        $this->assertSame($expected, $this->schemaManager->isMongoIndexEquivalentToDocumentIndex($mongoIndex, $documentIndex));
+        $this->assertSame($expected, $this->schemaManager->isMongoIndexEquivalentToDocumentIndex(new IndexInfo($mongoIndex), $documentIndex));
     }
 
     public function dataIsMongoIndexEquivalentToDocumentIndex()
@@ -671,7 +672,7 @@ class SchemaManagerTest extends BaseTest
         $mongoIndex    += $defaultMongoIndex;
         $documentIndex += $defaultDocumentIndex;
 
-        $this->assertSame($expected, $this->schemaManager->isMongoIndexEquivalentToDocumentIndex($mongoIndex, $documentIndex));
+        $this->assertSame($expected, $this->schemaManager->isMongoIndexEquivalentToDocumentIndex(new IndexInfo($mongoIndex), $documentIndex));
     }
 
     public function dataIsMongoTextIndexEquivalentToDocumentIndex()


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #841 

#### Summary

This was extracted from #1910 to allow for a more in-depth discussion. This PR reworks index equivalency checks. Previously, when encountering an unknown index option, we would always consider the indexes equivalent even though they weren't. This PR reverses this behaviour and considers indexes different if they have a different set of options. We exclude some options from this check (e.g. `unique`) to consider indexes equivalent when one specifies the option with the default value while the other one doesn't specify the option at all.