### PR TITLE
Fix raw mongo data loss during serialization.

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -574,6 +574,7 @@ trait PersistentCollectionTrait
      */
     public function __sleep()
     {
+        $this->initialize();
         return ['coll', 'initialized'];
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1864 

#### Summary

Added `initialize` method call in `PersistentCollection::__sleep` method for avoiding raw data loss.
