### PR TITLE
Fix IDE warning about store-as deprecation warning

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -158,7 +158,8 @@
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="fieldName" type="xs:NMTOKEN" />
-    <xs:attribute name="simple" type="xs:boolean" /><!-- deprecated -->
+    <!-- deprecated -->
+    <xs:attribute name="simple" type="xs:boolean" />
     <xs:attribute name="store-as" type="odm:reference-store-as" default="dbRefWithDb" />
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />
     <xs:attribute name="mapped-by" type="xs:NMTOKEN" />
@@ -183,7 +184,8 @@
     <xs:attribute name="collection-class" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="fieldName" type="xs:NMTOKEN" />
-    <xs:attribute name="simple" type="xs:boolean" /><!-- deprecated -->
+    <!-- deprecated -->
+    <xs:attribute name="simple" type="xs:boolean" />
     <xs:attribute name="store-as" type="odm:reference-store-as" default="dbRefWithDb" />
     <xs:attribute name="strategy" type="xs:NMTOKEN" default="pushAll" />
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />


### PR DESCRIPTION
Fix IDE warning about store-as deprecation warning

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

<!-- Provide a summary your change. -->

"Fixing" the deprecation warning in PHPStorm on `store-as` attribute (instead of `simple` attribute) as discussed in #1895 