### PR TITLE
Fix incorrect schema commands behaviour

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
@@ -25,6 +25,8 @@ class CreateCommand extends AbstractCommand
 
     protected function configure()
     {
+        parent::configure();
+
         $this
             ->setName('odm:schema:create')
             ->addOption('class', 'c', InputOption::VALUE_REQUIRED, 'Document class to process (default: all classes)')

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
@@ -22,6 +22,8 @@ class DropCommand extends AbstractCommand
 
     protected function configure()
     {
+        parent::configure();
+
         $this
             ->setName('odm:schema:drop')
             ->addOption('class', 'c', InputOption::VALUE_REQUIRED, 'Document class to process (default: all classes)')

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ShardCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ShardCommand.php
@@ -36,10 +36,10 @@ class ShardCommand extends AbstractCommand
 
         try {
             if (is_string($class)) {
-                $this->processDocumentIndex($sm, $class);
+                $this->processDocumentIndex($sm, $class, null, $this->getWriteConcernFromInput($input));
                 $output->writeln(sprintf('Enabled sharding for <info>%s</info>', $class));
             } else {
-                $this->processIndex($sm);
+                $this->processIndex($sm, null, $this->getWriteConcernFromInput($input));
                 $output->writeln('Enabled sharding for <info>all classes</info>');
             }
         } catch (Throwable $e) {
@@ -52,12 +52,12 @@ class ShardCommand extends AbstractCommand
 
     protected function processDocumentIndex(SchemaManager $sm, string $document, ?int $maxTimeMs = null, ?WriteConcern $writeConcern = null)
     {
-        $sm->ensureDocumentSharding($document);
+        $sm->ensureDocumentSharding($document, $writeConcern);
     }
 
     protected function processIndex(SchemaManager $sm, ?int $maxTimeMs = null, ?WriteConcern $writeConcern = null)
     {
-        $sm->ensureSharding();
+        $sm->ensureSharding($writeConcern);
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
@@ -18,6 +18,8 @@ class UpdateCommand extends AbstractCommand
 {
     protected function configure()
     {
+        parent::configure();
+
         $this
             ->setName('odm:schema:update')
             ->addOption('class', 'c', InputOption::VALUE_OPTIONAL, 'Document class to process (default: all classes)')


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1916
#### Summary

Fixes for broken schema commands, that did not use `parent::configure()` call, which is needed to steup all command options. Changed also `ShardCommand` and `SchemaManager` to allow using writeConcern when sharding.
