### PR TITLE
Replace the deprecated comment

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -158,7 +158,8 @@
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="fieldName" type="xs:NMTOKEN" />
-    <xs:attribute name="simple" type="xs:boolean" /><!-- deprecated -->
+    <!-- deprecated -->
+    <xs:attribute name="simple" type="xs:boolean" />
     <xs:attribute name="store-as" type="odm:reference-store-as" default="dbRefWithDb" />
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />
     <xs:attribute name="mapped-by" type="xs:NMTOKEN" />
@@ -183,7 +184,8 @@
     <xs:attribute name="collection-class" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="fieldName" type="xs:NMTOKEN" />
-    <xs:attribute name="simple" type="xs:boolean" /><!-- deprecated -->
+    <!-- deprecated -->
+    <xs:attribute name="simple" type="xs:boolean" />
     <xs:attribute name="store-as" type="odm:reference-store-as" default="dbRefWithDb" />
     <xs:attribute name="strategy" type="xs:NMTOKEN" default="pushAll" />
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | --

#### Summary

<!-- Provide a summary your change. -->
The deprecated comment should be placed before the deprecated element.
In PhpStorm with the old placement, the `store-as` attribute was marked as deprecated instead of the `simple` attribute.

as discussed in #1895 and #1917 