### PR TITLE
Fix wrong usage of sequence vs. choice in XSD

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -37,7 +37,7 @@
   </xs:complexType>
 
   <xs:complexType name="gridfs-file">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="id" type="odm:id" minOccurs="0" maxOccurs="1"/>
 
       <xs:element name="length" type="odm:gridfs-length-field" minOccurs="0" maxOccurs="1" />
@@ -50,7 +50,7 @@
       <xs:element name="indexes" type="odm:indexes" minOccurs="0"/>
       <xs:element name="shard-key" type="odm:shard-key" minOccurs="0"/>
       <xs:element name="read-preference" type="odm:read-preference" minOccurs="0" maxOccurs="1"/>
-    </xs:sequence>
+    </xs:choice>
 
     <xs:attribute name="name" type="xs:string" />
     <xs:attribute name="db" type="xs:NMTOKEN" />
@@ -152,11 +152,11 @@
   </xs:complexType>
 
   <xs:complexType name="gridfs-metadata-field">
-    <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
       <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
       <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
-    </xs:sequence>
+    </xs:choice>
 
     <xs:attribute name="target-document" type="xs:string" use="required" />
     <xs:attribute name="fieldName" type="xs:NMTOKEN" />

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -38,47 +38,48 @@
 
   <xs:complexType name="gridfs-file">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="id" type="odm:id" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="id" type="odm:id" minOccurs="0" />
 
-      <xs:element name="length" type="odm:gridfs-length-field" minOccurs="0" maxOccurs="1" />
-      <xs:element name="chunk-size" type="odm:gridfs-chunk-size-field" minOccurs="0" maxOccurs="1" />
-      <xs:element name="upload-date" type="odm:gridfs-upload-date-field" minOccurs="0" maxOccurs="1" />
-      <xs:element name="filename" type="odm:gridfs-filename-field" minOccurs="0" maxOccurs="1" />
-      <xs:element name="metadata" type="odm:gridfs-metadata-field" minOccurs="0" maxOccurs="1" />
+      <xs:element name="length" type="odm:gridfs-length-field" minOccurs="0" />
+      <xs:element name="chunk-size" type="odm:gridfs-chunk-size-field" minOccurs="0" />
+      <xs:element name="upload-date" type="odm:gridfs-upload-date-field" minOccurs="0" />
+      <xs:element name="filename" type="odm:gridfs-filename-field" minOccurs="0" />
+      <xs:element name="metadata" type="odm:gridfs-metadata-field" minOccurs="0" />
 
-      <xs:element name="lifecycle-callbacks" type="odm:lifecycle-callbacks" minOccurs="0"/>
-      <xs:element name="indexes" type="odm:indexes" minOccurs="0"/>
-      <xs:element name="shard-key" type="odm:shard-key" minOccurs="0"/>
-      <xs:element name="read-preference" type="odm:read-preference" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lifecycle-callbacks" type="odm:lifecycle-callbacks" minOccurs="0" />
+      <xs:element name="indexes" type="odm:indexes" minOccurs="0" />
+      <xs:element name="shard-key" type="odm:shard-key" minOccurs="0" />
+      <xs:element name="read-preference" type="odm:read-preference" minOccurs="0" />
     </xs:choice>
 
     <xs:attribute name="name" type="xs:string" />
     <xs:attribute name="db" type="xs:NMTOKEN" />
     <xs:attribute name="bucket-name" type="xs:NMTOKEN" default="fs" />
-    <xs:attribute name="repository-class" type="xs:string"/>
+    <xs:attribute name="repository-class" type="xs:string" />
     <xs:attribute name="writeConcern" type="xs:string" />
-    <xs:attribute name="inheritance-type" type="odm:inheritance-type"/>
+    <xs:attribute name="inheritance-type" type="odm:inheritance-type" />
     <xs:attribute name="change-tracking-policy" type="odm:change-tracking-policy" />
     <xs:attribute name="chunk-size-bytes" type="xs:positiveInteger" />
   </xs:complexType>
 
   <xs:complexType name="document">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="id" type="odm:id" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="field" type="odm:field" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="embed-one" type="odm:embed-one" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="embed-many" type="odm:embed-many" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="reference-one" type="odm:reference-one" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="reference-many" type="odm:reference-many" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
-      <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
-      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
-      <xs:element name="lifecycle-callbacks" type="odm:lifecycle-callbacks" minOccurs="0"/>
-      <xs:element name="also-load-methods" type="odm:also-load-methods" minOccurs="0"/>
-      <xs:element name="indexes" type="odm:indexes" minOccurs="0"/>
-      <xs:element name="shard-key" type="odm:shard-key" minOccurs="0"/>
-      <xs:element name="read-preference" type="odm:read-preference" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="id" type="odm:id" minOccurs="0" />
+      <xs:element name="field" type="odm:field" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="embed-one" type="odm:embed-one" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="embed-many" type="odm:embed-many" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="reference-one" type="odm:reference-one" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="reference-many" type="odm:reference-many" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0" />
+      <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0" />
+      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0" />
+      <xs:element name="lifecycle-callbacks" type="odm:lifecycle-callbacks" minOccurs="0" />
+      <xs:element name="also-load-methods" type="odm:also-load-methods" minOccurs="0" />
+      <xs:element name="indexes" type="odm:indexes" minOccurs="0" />
+      <xs:element name="shard-key" type="odm:shard-key" minOccurs="0" />
+      <xs:element name="read-preference" type="odm:read-preference" minOccurs="0" />
     </xs:choice>
+
     <xs:attribute name="db" type="xs:NMTOKEN" />
     <xs:attribute name="name" type="xs:string" />
     <xs:attribute name="write-concern" type="xs:string" />
@@ -86,8 +87,8 @@
     <xs:attribute name="capped-collection" type="xs:boolean" />
     <xs:attribute name="capped-collection-size" type="xs:integer" />
     <xs:attribute name="capped-collection-max" type="xs:integer" />
-    <xs:attribute name="repository-class" type="xs:string"/>
-    <xs:attribute name="inheritance-type" type="odm:inheritance-type"/>
+    <xs:attribute name="repository-class" type="xs:string" />
+    <xs:attribute name="inheritance-type" type="odm:inheritance-type" />
     <xs:attribute name="change-tracking-policy" type="odm:change-tracking-policy" />
     <xs:attribute name="read-only" type="xs:boolean" />
   </xs:complexType>
@@ -96,7 +97,8 @@
     <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="tag-set" type="odm:read-preference-tag-set" minOccurs="0" maxOccurs="unbounded" />
     </xs:choice>
-    <xs:attribute name="mode" type="odm:read-preference-values"/>
+
+    <xs:attribute name="mode" type="odm:read-preference-values" />
   </xs:complexType>
 
   <xs:complexType name="field">
@@ -111,6 +113,7 @@
     <xs:attribute name="not-saved" type="xs:boolean" />
     <xs:attribute name="nullable" type="xs:boolean" />
     <xs:attribute name="also-load" type="xs:NMTOKEN" />
+
     <!-- index options -->
     <xs:attribute name="background" type="xs:boolean" />
     <xs:attribute name="drop-dups" type="xs:boolean" />
@@ -125,14 +128,15 @@
     <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="generator-option" type="odm:id-generator-option" minOccurs="0" maxOccurs="unbounded" />
     </xs:choice>
+
     <xs:attribute name="type" type="xs:NMTOKEN" />
     <xs:attribute name="strategy" type="xs:NMTOKEN" default="auto" />
     <xs:attribute name="field-name" type="xs:NMTOKEN" default="id" />
   </xs:complexType>
 
   <xs:complexType name="id-generator-option">
-    <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
-    <xs:attribute name="value" type="xs:string" use="required"/>
+    <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
+    <xs:attribute name="value" type="xs:string" use="required" />
   </xs:complexType>
 
   <xs:complexType name="gridfs-length-field">
@@ -153,9 +157,9 @@
 
   <xs:complexType name="gridfs-metadata-field">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
-      <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
-      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
+      <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0" />
+      <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0" />
+      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0" />
     </xs:choice>
 
     <xs:attribute name="target-document" type="xs:string" use="required" />
@@ -164,10 +168,11 @@
 
   <xs:complexType name="embed-one">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
-      <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
-      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
+      <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0" />
+      <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0" />
+      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0" />
     </xs:choice>
+
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="field-name" type="xs:NMTOKEN" />
@@ -178,10 +183,11 @@
 
   <xs:complexType name="embed-many">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
-      <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
-      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
+      <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0" />
+      <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0" />
+      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0" />
     </xs:choice>
+
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="collection-class" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
@@ -194,22 +200,23 @@
 
   <xs:simpleType name="reference-store-as">
     <xs:restriction base="xs:token">
-      <xs:enumeration value="id"/>
-      <xs:enumeration value="ref"/>
-      <xs:enumeration value="dbRef"/>
-      <xs:enumeration value="dbRefWithDb"/>
+      <xs:enumeration value="id" />
+      <xs:enumeration value="ref" />
+      <xs:enumeration value="dbRef" />
+      <xs:enumeration value="dbRefWithDb" />
     </xs:restriction>
   </xs:simpleType>
 
   <xs:complexType name="reference-one">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="cascade" type="odm:cascade-type" minOccurs="0" />
-      <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
-      <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
-      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
+      <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0" />
+      <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0" />
+      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0" />
       <xs:element name="sort" type="odm:sort-map" minOccurs="0" />
       <xs:element name="criteria" type="odm:criteria-map" minOccurs="0" />
     </xs:choice>
+
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="field-name" type="xs:NMTOKEN" />
@@ -226,13 +233,14 @@
   <xs:complexType name="reference-many">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="cascade" type="odm:cascade-type" minOccurs="0" />
-      <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0"/>
-      <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0"/>
-      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0"/>
+      <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0" />
+      <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0" />
+      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0" />
       <xs:element name="sort" type="odm:sort-map" minOccurs="0" />
       <xs:element name="criteria" type="odm:criteria-map" minOccurs="0" />
       <xs:element name="prime" type="odm:primers" minOccurs="0" />
     </xs:choice>
+
     <xs:attribute name="target-document" type="xs:string" />
     <xs:attribute name="collection-class" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
@@ -251,127 +259,127 @@
   </xs:complexType>
 
   <xs:complexType name="sort-type">
-    <xs:attribute name="field" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="order" type="xs:NMTOKEN" default="asc" />
   </xs:complexType>
 
   <xs:complexType name="sort-map">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="sort" type="odm:sort-type" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="sort" type="odm:sort-type" maxOccurs="unbounded" />
     </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="criteria-type">
-    <xs:attribute name="field" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="value" type="xs:NMTOKEN" use="required" />
   </xs:complexType>
 
   <xs:complexType name="criteria-map">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="criteria" type="odm:criteria-type" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="criteria" type="odm:criteria-type" maxOccurs="unbounded" />
     </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="primers">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="field" type="odm:primer-field" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="field" type="odm:primer-field" maxOccurs="unbounded" />
     </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="primer-field">
-    <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
   </xs:complexType>
 
-  <xs:complexType name="emptyType"/>
+  <xs:complexType name="emptyType" />
 
   <xs:complexType name="cascade-type">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="all" type="odm:emptyType" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="persist" type="odm:emptyType" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="merge" type="odm:emptyType" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="remove" type="odm:emptyType" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="refresh" type="odm:emptyType" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="detach" type="odm:emptyType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="all" type="odm:emptyType" minOccurs="0" />
+      <xs:element name="persist" type="odm:emptyType" minOccurs="0" />
+      <xs:element name="merge" type="odm:emptyType" minOccurs="0" />
+      <xs:element name="remove" type="odm:emptyType" minOccurs="0" />
+      <xs:element name="refresh" type="odm:emptyType" minOccurs="0" />
+      <xs:element name="detach" type="odm:emptyType" minOccurs="0" />
     </xs:choice>
   </xs:complexType>
 
   <xs:simpleType name="inheritance-type">
     <xs:restriction base="xs:token">
-      <xs:enumeration value="SINGLE_COLLECTION"/>
-      <xs:enumeration value="COLLECTION_PER_CLASS"/>
+      <xs:enumeration value="SINGLE_COLLECTION" />
+      <xs:enumeration value="COLLECTION_PER_CLASS" />
     </xs:restriction>
   </xs:simpleType>
 
   <xs:simpleType name="change-tracking-policy">
     <xs:restriction base="xs:token">
       <xs:enumeration value="DEFERRED_IMPLICIT" />
-      <xs:enumeration value="DEFERRED_EXPLICIT"/>
-      <xs:enumeration value="NOTIFY"/>
+      <xs:enumeration value="DEFERRED_EXPLICIT" />
+      <xs:enumeration value="NOTIFY" />
     </xs:restriction>
   </xs:simpleType>
 
   <xs:complexType name="discriminator-mapping">
-    <xs:attribute name="value" type="xs:NMTOKEN" use="required"/>
-    <xs:attribute name="class" type="xs:string" use="required"/>
+    <xs:attribute name="value" type="xs:NMTOKEN" use="required" />
+    <xs:attribute name="class" type="xs:string" use="required" />
   </xs:complexType>
 
   <xs:complexType name="discriminator-map">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="discriminator-mapping" type="odm:discriminator-mapping" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="discriminator-mapping" type="odm:discriminator-mapping" maxOccurs="unbounded" />
     </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="discriminator-field">
-    <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
   </xs:complexType>
 
   <xs:complexType name="default-discriminator-value">
-    <xs:attribute name="value" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="value" type="xs:NMTOKEN" use="required" />
   </xs:complexType>
 
   <xs:simpleType name="lifecycle-callback-type">
     <xs:restriction base="xs:token">
-      <xs:enumeration value="prePersist"/>
-      <xs:enumeration value="postPersist"/>
-      <xs:enumeration value="preUpdate"/>
-      <xs:enumeration value="postUpdate"/>
-      <xs:enumeration value="preRemove"/>
-      <xs:enumeration value="postRemove"/>
-      <xs:enumeration value="preLoad"/>
-      <xs:enumeration value="postLoad"/>
+      <xs:enumeration value="prePersist" />
+      <xs:enumeration value="postPersist" />
+      <xs:enumeration value="preUpdate" />
+      <xs:enumeration value="postUpdate" />
+      <xs:enumeration value="preRemove" />
+      <xs:enumeration value="postRemove" />
+      <xs:enumeration value="preLoad" />
+      <xs:enumeration value="postLoad" />
     </xs:restriction>
   </xs:simpleType>
 
   <xs:complexType name="lifecycle-callback">
-    <xs:attribute name="type" type="odm:lifecycle-callback-type" use="required"/>
-    <xs:attribute name="method" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="type" type="odm:lifecycle-callback-type" use="required" />
+    <xs:attribute name="method" type="xs:NMTOKEN" use="required" />
   </xs:complexType>
 
   <xs:complexType name="lifecycle-callbacks">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="lifecycle-callback" type="odm:lifecycle-callback" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="lifecycle-callback" type="odm:lifecycle-callback" maxOccurs="unbounded" />
     </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="index-key">
-    <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="order" type="xs:NMTOKEN" default="asc" />
   </xs:complexType>
 
   <xs:complexType name="index-option">
-    <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="value" type="xs:NMTOKEN" use="required" />
   </xs:complexType>
 
   <xs:simpleType name="partial-filter-expression-operator">
     <xs:restriction base="xs:token">
-      <xs:enumeration value="eq"/>
-      <xs:enumeration value="exists"/>
-      <xs:enumeration value="gt"/>
-      <xs:enumeration value="gte"/>
-      <xs:enumeration value="lt"/>
-      <xs:enumeration value="lte"/>
-      <xs:enumeration value="type"/>
+      <xs:enumeration value="eq" />
+      <xs:enumeration value="exists" />
+      <xs:enumeration value="gt" />
+      <xs:enumeration value="gte" />
+      <xs:enumeration value="lt" />
+      <xs:enumeration value="lte" />
+      <xs:enumeration value="type" />
     </xs:restriction>
   </xs:simpleType>
 
@@ -379,71 +387,74 @@
     <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="field" type="odm:partial-filter-expression-field" minOccurs="0" maxOccurs="unbounded" />
     </xs:choice>
-    <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+
+    <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="operator" type="odm:partial-filter-expression-operator" use="optional" />
     <xs:attribute name="value" type="xs:string" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="partial-filter-expression-and">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="field" type="odm:partial-filter-expression-field" minOccurs="1" maxOccurs="unbounded" />
+      <xs:element name="field" type="odm:partial-filter-expression-field" maxOccurs="unbounded" />
     </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="partial-filter-expression">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="and" type="odm:partial-filter-expression-and" minOccurs="1" maxOccurs="unbounded" />
-      <xs:element name="field" type="odm:partial-filter-expression-field" minOccurs="1" maxOccurs="unbounded" />
+      <xs:element name="and" type="odm:partial-filter-expression-and" maxOccurs="unbounded" />
+      <xs:element name="field" type="odm:partial-filter-expression-field" maxOccurs="unbounded" />
     </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="index">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="key" type="odm:index-key" minOccurs="1" maxOccurs="unbounded"/>
-      <xs:element name="option" type="odm:index-option" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="partial-filter-expression" type="odm:partial-filter-expression" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="key" type="odm:index-key" maxOccurs="unbounded" />
+      <xs:element name="option" type="odm:index-option" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="partial-filter-expression" type="odm:partial-filter-expression" minOccurs="0" />
     </xs:choice>
-    <xs:attribute name="name" type="xs:NMTOKEN"/>
-    <xs:attribute name="drop-dups" type="xs:boolean"/>
-    <xs:attribute name="background" type="xs:boolean"/>
-    <xs:attribute name="unique" type="xs:boolean"/>
-    <xs:attribute name="sparse" type="xs:boolean"/>
+
+    <xs:attribute name="name" type="xs:NMTOKEN" />
+    <xs:attribute name="drop-dups" type="xs:boolean" />
+    <xs:attribute name="background" type="xs:boolean" />
+    <xs:attribute name="unique" type="xs:boolean" />
+    <xs:attribute name="sparse" type="xs:boolean" />
   </xs:complexType>
 
   <xs:complexType name="indexes">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="index" type="odm:index" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="index" type="odm:index" maxOccurs="unbounded" />
     </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="shard-key">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="key" type="odm:shard-key-key" minOccurs="1" maxOccurs="unbounded"/>
-      <xs:element name="option" type="odm:shard-key-option" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="key" type="odm:shard-key-key" maxOccurs="unbounded" />
+      <xs:element name="option" type="odm:shard-key-option" minOccurs="0" maxOccurs="unbounded" />
     </xs:choice>
-    <xs:attribute name="unique" type="xs:boolean"/>
-    <xs:attribute name="numInitialChunks" type="xs:integer"/>
+
+    <xs:attribute name="unique" type="xs:boolean" />
+    <xs:attribute name="numInitialChunks" type="xs:integer" />
   </xs:complexType>
 
   <xs:complexType name="shard-key-key">
-    <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="order" type="xs:NMTOKEN" default="asc" />
   </xs:complexType>
 
   <xs:complexType name="shard-key-option">
-    <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="value" type="xs:NMTOKEN" use="required" />
   </xs:complexType>
 
   <xs:complexType name="also-load-method">
-    <xs:attribute name="method" type="xs:NMTOKEN" use="required"/>
-    <xs:attribute name="field" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="method" type="xs:NMTOKEN" use="required" />
+    <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
   </xs:complexType>
 
 
   <xs:complexType name="also-load-methods">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="also-load-method" type="odm:also-load-method" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="also-load-method" type="odm:also-load-method" maxOccurs="unbounded" />
     </xs:choice>
   </xs:complexType>
 
@@ -467,5 +478,4 @@
     <xs:attribute name="name" type="xs:string" use="required" />
     <xs:attribute name="value" type="xs:string" use="required" />
   </xs:complexType>
-
 </xs:schema>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

This fixes two wrong types in the mapping XSD that required people to write child elements in a certain order. This is inconsistent with the rest of the schema file.