### PR TITLE
Fix wrong capitalisation of attributes for GridFS mappings

### DIFF
--- a/docs/en/cookbook/mapping-classes-to-orm-and-odm.rst
+++ b/docs/en/cookbook/mapping-classes-to-orm-and-odm.rst
@@ -134,9 +134,9 @@ Now map the same class to the Doctrine MongoDB ODM:
                                   http://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
             <document name="Documents\BlogPost" repository-class="Doctrine\Blog\ODM\MongoDB\BlogPostRepository">
-                <field fieldName="id" type="id" />
-                <field fieldName="name" type="string" />
-                <field fieldName="email" type="text" />
+                <field field-name="id" type="id" />
+                <field field-name="name" type="string" />
+                <field field-name="email" type="text" />
             </document>
         </doctrine-mongo-mapping>
 

--- a/docs/en/reference/aggregation-builder.rst
+++ b/docs/en/reference/aggregation-builder.rst
@@ -152,8 +152,8 @@ they can't be persisted to the database.
                           xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                           http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
             <query-result-document name="Documents\UserPurchases">
-                <field fieldName="numPurchases" type="int" />
-                <field fieldName="amount" type="float" />
+                <field field-name="numPurchases" type="int" />
+                <field field-name="amount" type="float" />
                 <reference-one field="user" target-document="Documents\User" name="_id" />
             </query-result-document>
         </doctrine-mongo-mapping>

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -381,7 +381,7 @@ Example:
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
           <document name="Documents\User">
                 <id />
-                <field fieldName="username" type="string" />
+                <field field-name="username" type="string" />
           </document>
         </doctrine-mongo-mapping>
 
@@ -404,7 +404,7 @@ as follows:
 
     .. code-block:: xml
 
-        <field fieldName="name" name="db_name" />
+        <field field-name="name" name="db_name" />
 
 Custom Mapping Types
 --------------------
@@ -503,7 +503,7 @@ type in your mapping like this:
 
     .. code-block:: xml
 
-        <field fieldName="field" type="mytype" />
+        <field field-name="field" type="mytype" />
 
 Multiple Document Types in a Collection
 ---------------------------------------

--- a/docs/en/reference/capped-collections.rst
+++ b/docs/en/reference/capped-collections.rst
@@ -48,7 +48,7 @@ the ``@Document`` annotation:
                           http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
             <document name="Documents\Category" collection="collname" capped-collection="true" capped-collection-size="100000" capped-collection-max="1000">
                 <id />
-                <field fieldName="name" type="string" />
+                <field field-name="name" type="string" />
             </document>
         </doctrine-mongo-mapping>
 

--- a/docs/en/reference/indexes.rst
+++ b/docs/en/reference/indexes.rst
@@ -93,7 +93,7 @@ Unique Index
 
     .. code-block:: xml
 
-        <field fieldName="username" index="true" unique="true" order="asc" />
+        <field field-name="username" index="true" unique="true" order="asc" />
 
 For your convenience you can quickly specify a unique index with
 ``@UniqueIndex``:
@@ -118,7 +118,7 @@ For your convenience you can quickly specify a unique index with
 
     .. code-block:: xml
 
-        <field fieldName="username" unique="true" order="asc" />
+        <field field-name="username" unique="true" order="asc" />
 
 If you want to specify an index that consists of multiple fields
 you can specify them on the class doc block:

--- a/docs/en/reference/reference-mapping.rst
+++ b/docs/en/reference/reference-mapping.rst
@@ -149,7 +149,7 @@ omit the ``targetDocument`` option:
 
     .. code-block:: xml
 
-        <field fieldName="favorites" />
+        <field field-name="favorites" />
 
 Now the ``$favorites`` property can store a reference to any type of document!
 The class name will be automatically stored in a field named
@@ -187,7 +187,7 @@ The name of the field within the DBRef object can be customized via the
 
     .. code-block:: xml
 
-        <reference-many fieldName="favorites">
+        <reference-many field-name="favorites">
             <discriminator-field name="type" />
         </reference-many>
 
@@ -220,7 +220,7 @@ in each `DBRef`_ object:
 
     .. code-block:: xml
 
-        <reference-many fieldName="favorites">
+        <reference-many field-name="favorites">
             <discriminator-map>
                 <discriminator-mapping value="album" class="Documents\Album" />
                 <discriminator-mapping value="song" class="Documents\Song" />
@@ -257,7 +257,7 @@ a certain class, you can optionally specify a default discriminator value:
 
     .. code-block:: xml
 
-        <reference-many fieldName="favorites">
+        <reference-many field-name="favorites">
             <discriminator-map>
                 <discriminator-mapping value="album" class="Documents\Album" />
                 <discriminator-mapping value="song" class="Documents\Song" />

--- a/docs/en/reference/storing-files-with-mongogridfs.rst
+++ b/docs/en/reference/storing-files-with-mongogridfs.rst
@@ -113,7 +113,7 @@ look like this:
             <length />
             <chunk-size />
             <upload-date />
-            <filename fieldName="name" />
+            <filename field-name="name" />
 
             <metadata target-document="Documents\ImageMetadata" />
         </gridfs-file>

--- a/docs/en/reference/transactions-and-concurrency.rst
+++ b/docs/en/reference/transactions-and-concurrency.rst
@@ -67,7 +67,7 @@ The following example designates a version field using the ``int`` type:
 
     .. code-block:: xml
 
-        <field fieldName="version" version="true" type="int" />
+        <field field-name="version" version="true" type="int" />
 
 Alternatively, the ``date`` type may be used:
 
@@ -81,7 +81,7 @@ Alternatively, the ``date`` type may be used:
 
     .. code-block:: xml
 
-        <field fieldName="version" version="true" type="date" />
+        <field field-name="version" version="true" type="date" />
 
 Choosing the Field Type
 """""""""""""""""""""""
@@ -239,7 +239,7 @@ Pessimistic locking requires a document to designate a lock field using the ``in
 
     .. code-block:: xml
 
-        <field fieldName="lock" lock="true" type="int" />
+        <field field-name="lock" lock="true" type="int" />
 
 Lock Modes
 ^^^^^^^^^^

--- a/docs/en/reference/xml-mapping.rst
+++ b/docs/en/reference/xml-mapping.rst
@@ -161,7 +161,7 @@ This is only compatible with the ``int`` field type.
 .. code-block:: xml
 
     <doctrine-mongo-mapping>
-        <field fieldName="lock" lock="true" type="int" />
+        <field field-name="lock" lock="true" type="int" />
     </doctrine-mongo-mapping>
 
 .. _xml_reference_version:
@@ -175,7 +175,7 @@ This is only compatible with ``int`` and ``date`` field types.
 .. code-block:: xml
 
     <doctrine-mongo-mapping>
-        <field fieldName="version" version="true" type="int" />
+        <field field-name="version" version="true" type="int" />
     </doctrine-mongo-mapping>
 
 By default, Doctrine ODM updates :ref:`embed-many <embed_many>` and

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -115,9 +115,9 @@ You can provide your mapping information in Annotations or XML:
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
           <document name="Documents\User">
                 <id />
-                <field fieldName="name" type="string" />
-                <field fieldName="email" type="string" />
-                <reference-many fieldName="posts" targetDocument="Documents\BlogPost">
+                <field field-name="name" type="string" />
+                <field field-name="email" type="string" />
+                <reference-many field-name="posts" targetDocument="Documents\BlogPost">
                     <cascade>
                         <all/>
                     </cascade>
@@ -132,9 +132,9 @@ You can provide your mapping information in Annotations or XML:
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
           <document name="Documents\BlogPost">
                 <id />
-                <field fieldName="title" type="string" />
-                <field fieldName="body" type="string" />
-                <field fieldName="createdAt" type="date" />
+                <field field-name="title" type="string" />
+                <field field-name="body" type="string" />
+                <field field-name="createdAt" type="date" />
           </document>
         </doctrine-mongo-mapping>
 

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -56,7 +56,7 @@
     <xs:attribute name="db" type="xs:NMTOKEN" />
     <xs:attribute name="bucket-name" type="xs:NMTOKEN" default="fs" />
     <xs:attribute name="repository-class" type="xs:string" />
-    <xs:attribute name="writeConcern" type="xs:string" />
+    <xs:attribute name="write-concern" type="xs:string" />
     <xs:attribute name="inheritance-type" type="odm:inheritance-type" />
     <xs:attribute name="change-tracking-policy" type="odm:change-tracking-policy" />
     <xs:attribute name="chunk-size-bytes" type="xs:positiveInteger" />
@@ -140,19 +140,19 @@
   </xs:complexType>
 
   <xs:complexType name="gridfs-length-field">
-    <xs:attribute name="fieldName" type="xs:NMTOKEN" default="length" />
+    <xs:attribute name="field-name" type="xs:NMTOKEN" default="length" />
   </xs:complexType>
 
   <xs:complexType name="gridfs-chunk-size-field">
-    <xs:attribute name="fieldName" type="xs:NMTOKEN" default="chunkSize" />
+    <xs:attribute name="field-name" type="xs:NMTOKEN" default="chunkSize" />
   </xs:complexType>
 
   <xs:complexType name="gridfs-upload-date-field">
-    <xs:attribute name="fieldName" type="xs:NMTOKEN" default="uploadDate" />
+    <xs:attribute name="field-name" type="xs:NMTOKEN" default="uploadDate" />
   </xs:complexType>
 
   <xs:complexType name="gridfs-filename-field">
-    <xs:attribute name="fieldName" type="xs:NMTOKEN" default="filename" />
+    <xs:attribute name="field-name" type="xs:NMTOKEN" default="filename" />
   </xs:complexType>
 
   <xs:complexType name="gridfs-metadata-field">
@@ -163,7 +163,7 @@
     </xs:choice>
 
     <xs:attribute name="target-document" type="xs:string" use="required" />
-    <xs:attribute name="fieldName" type="xs:NMTOKEN" />
+    <xs:attribute name="field-name" type="xs:NMTOKEN" />
   </xs:complexType>
 
   <xs:complexType name="embed-one">

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -628,8 +628,8 @@ class XmlDriver extends FileDriver
                 continue;
             }
 
-            if (isset($xmlRoot->{$name}->attributes()['fieldName'])) {
-                $mapping['fieldName'] = (string) $xmlRoot->{$name}->attributes()['fieldName'];
+            if (isset($xmlRoot->{$name}->attributes()['field-name'])) {
+                $mapping['fieldName'] = (string) $xmlRoot->{$name}->attributes()['field-name'];
             }
 
             $this->addFieldMapping($class, $mapping);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverFile.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverFile.dcm.xml
@@ -7,10 +7,10 @@
 
     <gridfs-file name="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverFile" chunk-size-bytes="12345">
         <id />
-        <length fieldName="size" />
+        <length field-name="size" />
         <chunk-size />
         <upload-date />
-        <filename fieldName="name" />
+        <filename field-name="name" />
 
         <metadata target-document="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverFileMetadata" />
     </gridfs-file>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes

#### Summary

An unfortunate BC break, looks like we didn't properly clean up GridFS attribute names before merging the PR, which is why we have to change some more `writeConcern` and `fieldName` attribute names.

This PR also updates these in the documentation which was omitted before.