### PR TITLE
Deprecate more features in preparation for 2.0

### DIFF
--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -91,3 +91,5 @@ set.
  * The `timeout` option in the `odm:schema:create` and `odm:schema:update`
    commands was deprecated and will be dropped in 2.0. Use the `maxTimeMs`
    option instead.
+ * The `indexOptions` argument in the `ensureSharding` and
+   `ensureDocumentSharding` methods was deprecated and will be dropped in 2.0.

--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -42,6 +42,12 @@ The `Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo` class has been deprecated
 in favor of `Doctrine\ODM\MongoDB\Mapping\ClassMetadata` and will be dropped in
 2.0.
 
+### Annotation mappings
+
+ * The `@NotSaved` annotation was deprecated and will be dropped in 2.0. Use the
+   `notSaved` option on the `@Field`, `@ReferenceOne`, `@ReferenceMany`,
+   `@EmbedOne` or `@EmbedMany` annotations instead.
+
 ### XML mappings
 
  * The `writeConcern` attribute in document mappings has been deprecated and

--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -47,6 +47,9 @@ in favor of `Doctrine\ODM\MongoDB\Mapping\ClassMetadata` and will be dropped in
  * The `@NotSaved` annotation was deprecated and will be dropped in 2.0. Use the
    `notSaved` option on the `@Field`, `@ReferenceOne`, `@ReferenceMany`,
    `@EmbedOne` or `@EmbedMany` annotations instead.
+ * Using more than one class-level document annotation (e.g. `@Document`,
+   `@MappedSuperclass`) is deprecated and will throw an exception in 2.0.
+   Classes should only be annotated with a single document annotation.
 
 ### XML mappings
 

--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -79,3 +79,9 @@ set.
    available.
  * The `eager` option in `Doctrine\ODM\MongoDB\Query\Query` was deprecated and
    will be dropped in 2.0. This functionality is no longer available.
+   
+## Schema manager
+
+ * The `timeout` option in the `odm:schema:create` and `odm:schema:update`
+   commands was deprecated and will be dropped in 2.0. Use the `maxTimeMs`
+   option instead.

--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -55,3 +55,11 @@ When using a discriminator map on a reference or embedded relationship,
 persisting or loading a class that is not in the map is deprecated and will
 cause an exception in 2.0. The discriminator map must contain all possible
 classes that can be referenced or be omitted completely.
+
+## Queries
+
+ * The `eagerCursor` method in `Doctrine\ODM\MongoDB\Query\Builder` was
+   deprecated and will be dropped in 2.0. This functionality is no longer
+   available.
+ * The `eager` option in `Doctrine\ODM\MongoDB\Query\Query` was deprecated and
+   will be dropped in 2.0. This functionality is no longer available.

--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -62,6 +62,13 @@ persisting or loading a class that is not in the map is deprecated and will
 cause an exception in 2.0. The discriminator map must contain all possible
 classes that can be referenced or be omitted completely.
 
+### Duplicate field names in mappings
+
+Mapping two fields with the same name in the database is deprecated and will
+cause an exception in 2.0. It is possible to have multiple fields with the same
+name in the database as long as all but one of them have the `notSaved` option
+set.
+
 ## Queries
 
  * The `eagerCursor` method in `Doctrine\ODM\MongoDB\Query\Builder` was

--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -50,6 +50,9 @@ in favor of `Doctrine\ODM\MongoDB\Mapping\ClassMetadata` and will be dropped in
  * Using more than one class-level document annotation (e.g. `@Document`,
    `@MappedSuperclass`) is deprecated and will throw an exception in 2.0.
    Classes should only be annotated with a single document annotation.
+ * The `dropDups` option on the `@Index` annotation was deprecated and will be 
+   dropped without replacement in 2.0. This functionality is no longer
+   available.
 
 ### XML mappings
 
@@ -57,6 +60,9 @@ in favor of `Doctrine\ODM\MongoDB\Mapping\ClassMetadata` and will be dropped in
    will be dropped in 2.0. Use `write-concern` instead.
  * The `fieldName` attribute in field mappings has been deprecated and will be
    dropped in 2.0. Use `field-name` instead.
+ * The `drop-dups` attribute in the `index` element was deprecated and will be
+   dropped without replacement in 2.0. This functionality is no longer
+   available.
    
 ### Full discriminator maps required
 

--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -48,3 +48,10 @@ in favor of `Doctrine\ODM\MongoDB\Mapping\ClassMetadata` and will be dropped in
    will be dropped in 2.0. Use `write-concern` instead.
  * The `fieldName` attribute in field mappings has been deprecated and will be
    dropped in 2.0. Use `field-name` instead.
+   
+### Full discriminator maps required
+
+When using a discriminator map on a reference or embedded relationship,
+persisting or loading a class that is not in the map is deprecated and will
+cause an exception in 2.0. The discriminator map must contain all possible
+classes that can be referenced or be omitted completely.

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -456,6 +456,9 @@ Optional attributes:
 -
     collectionClass - A |FQCN| of class that implements ``Collection`` interface
     and is used to hold documents. Doctrine's ``ArrayCollection`` is used by default.
+-
+    ``notSaved`` - The property is loaded if it exists in the database; however,
+    ODM will not save the property value back to the database.
 
 .. code-block:: php
 
@@ -507,6 +510,9 @@ Optional attributes:
 -
     defaultDiscriminatorValue - A default value for discriminatorField if no value
     has been set in the embedded document.
+-
+    ``notSaved`` - The property is loaded if it exists in the database; however,
+    ODM will not save the property value back to the database.
 
 .. code-block:: php
 
@@ -600,6 +606,9 @@ Optional attributes:
    nullable - By default, ODM will ``$unset`` fields in MongoDB if the PHP value
    is null. Specify true for this option to force ODM to store a null value in
    the database instead of unsetting the field.
+-
+   ``notSaved`` - The property is loaded if it exists in the database; however,
+   ODM will not save the property value back to the database.
 
 Examples:
 
@@ -642,11 +651,11 @@ persisted, ODM will convert it to GridFSFile object automatically.
     private $file;
 
 Additional fields can be mapped in GridFS documents like any other, but metadata
-fields set by the driver (e.g. ``length``) should be mapped with `@NotSaved`_ so
-as not to inadvertently overwrite them. Some metadata fields, such as
-``filename`` may be modified and do not require `@NotSaved`_. In the following
-example, we also add a custom field to refer to the corresponding User document
-that created the file.
+fields set by the driver (e.g. ``length``) should be mapped with the
+``NotSaved`` option so as not to inadvertently overwrite them. Some metadata
+fields, such as ``filename`` may be modified and do not require ``NotSaved``. In
+the following example, we also add a custom field to refer to the corresponding
+User document that created the file.
 
 .. code-block:: php
 
@@ -655,13 +664,13 @@ that created the file.
     /** @Field(type="string") */
     private $filename;
 
-    /** @NotSaved(type="int") */
+    /** @Field(type="int", notSaved=true) */
     private $length;
 
-    /** @NotSaved(type="string") */
+    /** @Field(type="string", notSaved=true) */
     private $md5;
 
-    /** @NotSaved(type="date") */
+    /** @Field(type="date", notSaved=true) */
     private $uploadDate;
 
     /** @ReferenceOne(targetDocument="Documents\User") */
@@ -977,8 +986,22 @@ MongoDB; however, ODM will not save the property value back to the database.
 
     <?php
 
-    /** @NotSaved */
+    /**
+     * Legacy notation
+     * @NotSaved
+     */
+    public $legacyField;
+
+    /**
+     * ODM 2.0 compatible notation
+     * @Field(notSaved=true)
+     */
     public $field;
+
+.. note::
+
+    This annotation is deprecated. Use the `@Field`_ annotation with the
+    ``notSaved`` option instead.
 
 @PostLoad
 ---------
@@ -1292,6 +1315,9 @@ Optional attributes:
     prime - A list of references contained in the target document that will be
     initialized when the collection is loaded. Only allowed for inverse
     references.
+-
+    ``notSaved`` - The property is loaded if it exists in the database; however,
+    ODM will not save the property value back to the database.
 
 .. code-block:: php
 
@@ -1357,6 +1383,9 @@ Optional attributes:
     limit - Limit for the query that loads the reference.
 -
     skip - Skip for the query that loads the reference.
+-
+    ``notSaved`` - The property is loaded if it exists in the database; however,
+    ODM will not save the property value back to the database.
 
 .. code-block:: php
 

--- a/docs/en/reference/indexes.rst
+++ b/docs/en/reference/indexes.rst
@@ -49,7 +49,8 @@ You can customize the index with some additional options:
    too long.
 - 
    **dropDups** - If a unique index is being created and duplicate
-   values exist, drop all but one duplicate value.
+   values exist, drop all but one duplicate value. This option is deprecated and
+   will be dropped without replacement in 2.0.
 - 
    **background** - Create indexes in the background while other
    operations are taking place. By default, index creation happens

--- a/docs/en/reference/migrating-schemas.rst
+++ b/docs/en/reference/migrating-schemas.rst
@@ -109,7 +109,7 @@ Migrating your schema can be a difficult task, but Doctrine provides a few
 different methods for dealing with it:
 
 -  **@AlsoLoad** - load values from old fields or transform data through methods
--  **@NotSaved** - load values into fields without saving them again
+-  **@Field(notSaved=true)** - load values into fields without saving them again
 -  **@PostLoad** - execute code after all fields have been loaded
 -  **@PrePersist** - execute code before your document gets saved
 
@@ -166,10 +166,10 @@ Later on, you may want to migrate this data into an embedded Address document:
         /** @Field(type="string") */
         public $name;
     
-        /** @NotSaved */
+        /** @Field(notSaved=true) */
         public $street;
     
-        /** @NotSaved */
+        /** @Field(notSaved=true) */
         public $city;
     
         /** @EmbedOne(targetDocument="Address") */

--- a/docs/en/reference/query-builder-api.rst
+++ b/docs/en/reference/query-builder-api.rst
@@ -642,7 +642,7 @@ document with a text index:
             /** @Field(type="string") */
             public $description;
 
-            /** @Field(type="float") @NotSaved */
+            /** @Field(type="float", notSaved=true) */
             public $score;
         }
 

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -377,6 +377,7 @@
       <xs:element name="partial-filter-expression" type="odm:partial-filter-expression" minOccurs="0" maxOccurs="1"/>
     </xs:choice>
     <xs:attribute name="name" type="xs:NMTOKEN"/>
+    <!-- deprecated -->
     <xs:attribute name="drop-dups" type="xs:boolean"/>
     <xs:attribute name="background" type="xs:boolean"/>
     <xs:attribute name="safe" type="xs:boolean"/>

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractField.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractField.php
@@ -29,6 +29,9 @@ abstract class AbstractField extends Annotation
     public $options = array();
     public $strategy;
 
+    /** @var bool */
+    public $notSaved = false;
+
     /**
      * Gets deprecation message. The method *WILL* be removed in 2.0.
      *

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractIndex.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractIndex.php
@@ -25,6 +25,7 @@ abstract class AbstractIndex extends Annotation
 {
     public $keys = array();
     public $name;
+    /** @deprecated  */
     public $dropDups;
     public $background;
     public $safe;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/NotSaved.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/NotSaved.php
@@ -23,8 +23,19 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
  * Specifies that a field will not be written to the database
  *
  * @Annotation
+ * @deprecated This class will be removed in ODM 2.0. Use `@ODM\Field(notSaved=true)` instead.
  */
 final class NotSaved extends AbstractField
 {
     public $notSaved = true;
+
+    public function isDeprecated()
+    {
+        return true;
+    }
+
+    public function getDeprecationMessage()
+    {
+        return sprintf('%s will be removed in ODM 2.0. Use `@ODM\Field(notSaved="true")` instead.', get_class($this));
+    }
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -889,6 +889,10 @@ class ClassMetadata implements BaseClassMetadata
      */
     public function addIndex($keys, array $options = array())
     {
+        if (isset($options['dropDups'])) {
+            @trigger_error(sprintf('Ths "dropDups" option on indexes is deprecated and will be dropped in 2.0. Remove the "dropDups" options in class "%s".', $this->getName()), E_USER_DEPRECATED);
+        }
+
         $this->indexes[] = array(
             'keys' => array_map(function($value) {
                 if ($value == 1 || $value == -1) {

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -20,8 +20,10 @@
 namespace Doctrine\ODM\MongoDB\Query;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Hydrator;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use const E_USER_DEPRECATED;
+use function sprintf;
+use function trigger_error;
 
 /**
  * Query builder for ODM.
@@ -177,6 +179,8 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
      */
     public function eagerCursor($bool = true)
     {
+        @trigger_error(sprintf('Ths "%s" method is deprecated and will be removed in 2.0.', __METHOD__), E_USER_DEPRECATED);
+
         if ( ! $bool && ! empty($this->primers)) {
             throw new \BadMethodCallException("Can't set eagerCursor to false when using reference primers");
         }

--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -27,6 +27,9 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\EagerCursor;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\MongoDBException;
+use const E_USER_DEPRECATED;
+use function sprintf;
+use function trigger_error;
 
 /**
  * ODM Query wraps the raw Doctrine MongoDB queries to add additional functionality
@@ -104,6 +107,10 @@ class Query extends \Doctrine\MongoDB\Query\Query
     public function __construct(DocumentManager $dm, ClassMetadata $class, Collection $collection, array $query = array(), array $options = array(), $hydrate = true, $refresh = false, array $primers = array(), $requireIndexes = null, $readOnly = false)
     {
         $primers = array_filter($primers);
+
+        if (isset($query['eagerCursor'])) {
+            @trigger_error(sprintf('The "eagerCursor" option for "%s" is deprecated and will be removed in 2.0.', self::class), E_USER_DEPRECATED);
+        }
 
         if ( ! empty($primers)) {
             $query['eagerCursor'] = true;

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -21,6 +21,9 @@ namespace Doctrine\ODM\MongoDB;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
+use const E_USER_DEPRECATED;
+use function sprintf;
+use function trigger_error;
 
 class SchemaManager
 {
@@ -591,6 +594,10 @@ class SchemaManager
      */
     public function ensureSharding(array $indexOptions = array())
     {
+        if (! empty($indexOptions)) {
+            @trigger_error(sprintf('The "indexOptions" argument in "%s" is deprecated and will be removed in 2.0.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         foreach ($this->metadataFactory->getAllMetadata() as $class) {
             if ($class->isMappedSuperclass || !$class->isSharded()) {
                 continue;
@@ -610,6 +617,10 @@ class SchemaManager
      */
     public function ensureDocumentSharding($documentName, array $indexOptions = array())
     {
+        if (! empty($indexOptions)) {
+            @trigger_error(sprintf('The "indexOptions" argument in "%s" is deprecated and will be removed in 2.0.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         $class = $this->dm->getClassMetadata($documentName);
         if ( ! $class->isSharded()) {
             return;

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/AbstractCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/AbstractCommand.php
@@ -21,6 +21,8 @@ namespace Doctrine\ODM\MongoDB\Tools\Console\Command\Schema;
 
 use Doctrine\ODM\MongoDB\SchemaManager;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 
 abstract class AbstractCommand extends Command
 {
@@ -62,5 +64,35 @@ abstract class AbstractCommand extends Command
     protected function getMetadataFactory()
     {
         return $this->getDocumentManager()->getMetadataFactory();
+    }
+
+    protected function addTimeoutOptions()
+    {
+        $this
+            ->addOption('timeout', 't', InputOption::VALUE_OPTIONAL, 'Timeout (ms) for acknowledged commands. This option is deprecated and will be dropped in 2.0. Use the maxTimeMs option instead.')
+            ->addOption('maxTimeMs', null, InputOption::VALUE_REQUIRED, 'An optional maxTimeMs that will be used for all schema operations.');
+
+        return $this;
+    }
+
+    /**
+     * Returns the appropriate timeout value
+     *
+     * @return int|null
+     */
+    protected function getTimeout(InputInterface $input)
+    {
+        $maxTimeMs = $input->getOption('maxTimeMs');
+        $timeout = $input->getOption('timeout');
+
+        if (isset($maxTimeMs)) {
+            return (int) $maxTimeMs;
+        } elseif (! isset($timeout)) {
+            return null;
+        }
+
+        @trigger_error(sprintf('The "timeout" option for command "%s" is deprecated and will be removed in 2.0. Use the maxTimeMs option instead.', static::class), E_USER_DEPRECATED);
+
+        return (int) $timeout;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
@@ -36,7 +36,7 @@ class CreateCommand extends AbstractCommand
         $this
             ->setName('odm:schema:create')
             ->addOption('class', 'c', InputOption::VALUE_REQUIRED, 'Document class to process (default: all classes)')
-            ->addOption('timeout', 't', InputOption::VALUE_OPTIONAL, 'Timeout (ms) for acknowledged index creation')
+            ->addTimeoutOptions()
             ->addOption(self::DB, null, InputOption::VALUE_NONE, 'Create databases')
             ->addOption(self::COLLECTION, null, InputOption::VALUE_NONE, 'Create collections')
             ->addOption(self::INDEX, null, InputOption::VALUE_NONE, 'Create indexes')
@@ -61,8 +61,7 @@ class CreateCommand extends AbstractCommand
 
         $class = $input->getOption('class');
 
-        $timeout = $input->getOption('timeout');
-        $this->timeout = isset($timeout) ? (int) $timeout : null;
+        $this->timeout = $this->getTimeout($input);
 
         $sm = $this->getSchemaManager();
         $isErrored = false;

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
@@ -33,7 +33,7 @@ class UpdateCommand extends AbstractCommand
         $this
             ->setName('odm:schema:update')
             ->addOption('class', 'c', InputOption::VALUE_OPTIONAL, 'Document class to process (default: all classes)')
-            ->addOption('timeout', 't', InputOption::VALUE_OPTIONAL, 'Timeout (ms) for acknowledged index creation')
+            ->addTimeoutOptions()
             ->setDescription('Update indexes for your documents')
         ;
     }
@@ -47,8 +47,7 @@ class UpdateCommand extends AbstractCommand
     {
         $class = $input->getOption('class');
 
-        $timeout = $input->getOption('timeout');
-        $this->timeout = isset($timeout) ? (int) $timeout : null;
+        $this->timeout = $this->getTimeout($input);
 
         $sm = $this->getSchemaManager();
         $isErrored = false;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AlsoLoadTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AlsoLoadTest.php
@@ -220,15 +220,15 @@ class AlsoLoadDocument
     public $foo;
 
     /**
-     * @ODM\NotSaved
+     * @ODM\Field(notSaved=true)
      * @ODM\AlsoLoad({"zip", "bar"})
      */
     public $baz;
 
-    /** @ODM\NotSaved */
+    /** @ODM\Field(notSaved=true) */
     public $bar;
 
-    /** @ODM\NotSaved */
+    /** @ODM\Field(notSaved=true) */
     public $zip;
 
     /**
@@ -237,10 +237,10 @@ class AlsoLoadDocument
      */
     public $zap = 'zap';
 
-    /** @ODM\NotSaved */
+    /** @ODM\Field(notSaved=true) */
     public $name;
 
-    /** @ODM\NotSaved */
+    /** @ODM\Field(notSaved=true) */
     public $fullName;
 
     /** @ODM\Field(type="string") */
@@ -255,13 +255,13 @@ class AlsoLoadDocument
      */
     public $test = 'test';
 
-    /** @ODM\NotSaved */
+    /** @ODM\Field(notSaved=true) */
     public $testNew;
 
-    /** @ODM\NotSaved */
+    /** @ODM\Field(notSaved=true) */
     public $testOld;
 
-    /** @ODM\NotSaved */
+    /** @ODM\Field(notSaved=true) */
     public $testOlder;
 
     /** @ODM\AlsoLoad({"name", "fullName"}) */

--- a/tests/Documents/File.php
+++ b/tests/Documents/File.php
@@ -19,13 +19,13 @@ class File
     /** @ODM\Field(type="string") */
     private $filename;
 
-    /** @ODM\NotSaved(type="int") */
+    /** @ODM\Field(type="int", notSaved=true) */
     private $length;
 
-    /** @ODM\NotSaved(type="string") */
+    /** @ODM\Field(type="string", notSaved=true) */
     private $md5;
 
-    /** @ODM\NotSaved(type="date") */
+    /** @ODM\Field(type="date", notSaved=true) */
     private $uploadDate;
 
     public function getId()

--- a/tests/Documents/Functional/NotSaved.php
+++ b/tests/Documents/Functional/NotSaved.php
@@ -13,7 +13,7 @@ class NotSaved
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\NotSaved */
+    /** @ODM\Field(notSaved=true) */
     public $notSaved;
 
     /** @ODM\EmbedOne(targetDocument="NotSavedEmbedded") */

--- a/tests/Documents/Functional/NotSavedEmbedded.php
+++ b/tests/Documents/Functional/NotSavedEmbedded.php
@@ -10,6 +10,6 @@ class NotSavedEmbedded
     /** @ODM\Field(type="string") */
     public $name;
 
-    /** @ODM\NotSaved */
+    /** @ODM\Field(notSaved=true) */
     public $notSaved;
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

After #1924, this adds some more deprecations for 2.0:
* Deprecate partial discriminator maps; references must now define all possible classes in discriminator maps if they have a map (#1887)
* Deprecate the `eagerCursor` helper in `Query\Builder` and the `eager` option in `Query\Query` (#1902)
* Deprecate the `@NotSaved` annotation (#1903)
* Deprecate multiple fields with the same name in the database (#1903)
* Deprecate using multiple class-level document annotations in mappings (#1906)
* Deprecate `timeout` option in schema commands (#1910)
* Deprecate `dropDups` option in indexes (#1910)
* Deprecate `indexOptions` arguments in SchemaManager (#1910)