### PR TITLE
Fix serialisation of uninitialised PersistentCollection instances

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -574,15 +574,15 @@ trait PersistentCollectionTrait
     }
 
     /**
-     * Called by PHP when this collection is serialized. Ensures that only the
-     * elements are properly serialized.
+     * Called by PHP when this collection is serialized. Ensures that the
+     * internal state of the collection can be reproduced after serialization
      *
      * @internal Tried to implement Serializable first but that did not work well
      *           with circular references. This solution seems simpler and works well.
      */
     public function __sleep()
     {
-        return array('coll', 'initialized');
+        return array('coll', 'initialized', 'mongoData', 'snapshot', 'isDirty', 'hints');
     }
 
     /* ArrayAccess implementation */


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fixes #1864, Replaces #1914

#### Summary

This ensures that any internal data from `PersistentCollection` instances are serialised to have a usable collection instance after serialisation. This affects the `mongoData` and `snapshot` properties along with `isDirty` and `hints`.

Ping @watari