### PR TITLE
Fix wrong type hint for generator type in ClassMetadata

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -307,7 +307,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
     /**
      * READ-ONLY: The Id generator type used by the class.
      *
-     * @var string
+     * @var int
      */
     public $generatorType = self::GENERATOR_TYPE_AUTO;
 
@@ -1943,7 +1943,7 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
     /**
      * Sets the type of Id generator to use for the mapped class.
      *
-     * @param string $generatorType Generator type.
+     * @param int $generatorType Generator type.
      */
     public function setIdGeneratorType($generatorType)
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

This causes PHPStan errors when using strict type comparison on the `generatorType` property. This is already fixed in 2.0 and has been like this for a while, so we can safely fix the type hint.

// cc @venyii