### PR TITLE
[2.0] Fix serialisation of uninitialised PersistentCollection instances

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -566,15 +566,15 @@ trait PersistentCollectionTrait
     }
 
     /**
-     * Called by PHP when this collection is serialized. Ensures that only the
-     * elements are properly serialized.
+     * Called by PHP when this collection is serialized. Ensures that the
+     * internal state of the collection can be reproduced after serialization
      *
      * @internal Tried to implement Serializable first but that did not work well
      *           with circular references. This solution seems simpler and works well.
      */
     public function __sleep()
     {
-        return ['coll', 'initialized'];
+        return ['coll', 'initialized', 'mongoData', 'snapshot', 'isDirty', 'hints'];
     }
 
     /* ArrayAccess implementation */


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1864 

#### Summary

Ports #1929 to ODM 2.0.