### PR TITLE
Documenting Lookup not working on ref which are in embedded doc.

### DIFF
--- a/docs/en/reference/aggregation-builder.rst
+++ b/docs/en/reference/aggregation-builder.rst
@@ -495,6 +495,9 @@ pipeline stages. Take the following relationship for example:
         ->lookup('items')
             ->alias('items');
 
+In MongoDB 3.2, the resulting array will be empty for a one-to-many relationship,
+you need to unwind your field at first and use a group stage afterwards.
+
 The resulting array will contain all matched item documents in an array. This has
 to be considered when looking up one-to-one relationships:
 
@@ -524,6 +527,10 @@ to be considered when looking up one-to-one relationships:
 MongoDB will always return an array, even if the lookup only returned a single
 document. Thus, when looking up one-to-one references the result must be flattened
 using the ``$unwind`` operator.
+
+Looking up  a reference nested in an embedded document (like ``->lookup('embedDoc.refDocs')``)
+is not supported. You'll need to make your lookup as if your Reference was not mapped
+See below for more.
 
 .. note::
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

Lookup is not working with `embedDoc.refDocs`. (ReferenceOne and Many) It's not really a problem because when passing refDoc::class in lookup and manually setting localField, foreignField, it's working great.
I just wrote some documentation for it and added an Exception (thrown error wasn't understandable)

Plus, the simple `lookup()->alias()` with ReferenceMany seems not to work with Mongo 3.2. Which seems to be confirmed by the tests (https://github.com/doctrine/mongodb-odm/blob/1.2.x/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LookupTest.php#L191) but not indicated in doc, I added a line about that.
