### PR TITLE
Add configuration for stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,27 @@
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 30
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed
+daysUntilClose: 7
+
+# Issues or Pull Requests with these labels will never be considered stale
+exemptLabels:
+  - Bug
+
+# Don't mark Issues or Pull Requests in a project as stale
+exemptProjects: true
+
+# Don't mark Issues or Pull Requests with a milestone as stale
+exemptMilestones: true
+
+staleLabel: Stale
+
+# This comment will be posted when an Issue or Pull Request is marked as stale.
+markComment: >
+  This issue has been automatically marked as stale because it has not had any
+  recent activity. It will be closed in a week if no further activity occurs.
+  Thank you for your contributions.
+
+# Don't post a comment when unmarking or closing a stale Issue or Pull Request
+unmarkComment: false
+closeComment: false


### PR DESCRIPTION
This adds configuration for [stalebot](https://github.com/apps/stale). We mark issues as stale after 30 days and close them after a further 7, with these values being subject to change if we notice it's too aggressive.

Bugs, and Issues/PRs that have been added to a Project or Milestone will not be closed.