### PR TITLE
Removed PHP 5.5 workaround

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1013,9 +1013,7 @@ class DocumentPersister
             }
 
             // No further preparation unless we're dealing with a simple reference
-            // We can't have expressions in empty() with PHP < 5.5, so store it in a variable
-            $arrayValue = (array) $value;
-            if (empty($mapping['reference']) || $mapping['storeAs'] !== ClassMetadata::REFERENCE_STORE_AS_ID || empty($arrayValue)) {
+            if (empty($mapping['reference']) || $mapping['storeAs'] !== ClassMetadata::REFERENCE_STORE_AS_ID || empty((array) $value)) {
                 return [[$fieldName, $value]];
             }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | no

#### Summary

This line is not required anymore as we now have PHP 7.2 as min. version.
I did not test this apart from making sure the file can still be parsed. Not sure if that is required or how to accomplish that.
