### PR TITLE
Renamed scheduledForDirtyCheck

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -175,7 +175,7 @@ trait PersistentCollectionTrait
             return;
         }
 
-        $this->uow->scheduleForDirtyCheck($this->owner);
+        $this->uow->scheduleForSynchronization($this->owner);
     }
 
     /** {@inheritdoc} */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes?
| Fixed issues | no, but TODO in code

#### Summary

Saw this @todo in the code and thought I might aswell just fix it.
These names are now the same as in the ORM.

I guess this is a BC break if people used the UOW directly, should this change be included in the Upgrade/Changelog? (#1696)
