### PR TITLE
Finish renaming dirtyCheck methods

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -270,3 +270,6 @@ ocramius. If you are checking for proxies, the following changed:
   exception. This would usually happen if you flushed the document manager from
   within a lifecycle event handler. Since data integrity can't be guaranteed, it
   is no longer allowed to nest flushes to the database.
+* The `isScheduledForDirtyCheck` and `scheduleForDirtyCheck` methods have been
+  renamed to `isScheduledForSynchronization` and `scheduleForSynchronization`,
+  respectively.

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/DefaultPersistentCollectionGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/DefaultPersistentCollectionGenerator.php
@@ -198,7 +198,7 @@ CODE;
     public function {$method->name}($parametersString){$this->getMethodReturnType($method)}
     {
         \$this->initialize();
-        if (\$this->needsSchedulingForDirtyCheck()) {
+        if (\$this->needsSchedulingForSynchronization()) {
             \$this->changed();
         }
         return \$this->coll->{$method->name}($callParamsString);

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -171,7 +171,7 @@ trait PersistentCollectionTrait
 
         $this->isDirty = true;
 
-        if (! $this->needsSchedulingForDirtyCheck() || $this->owner === null) {
+        if (! $this->needsSchedulingForSynchronization() || $this->owner === null) {
             return;
         }
 
@@ -775,7 +775,7 @@ trait PersistentCollectionTrait
      *
      * @return bool
      */
-    private function needsSchedulingForDirtyCheck()
+    private function needsSchedulingForSynchronization()
     {
         return $this->owner && $this->dm && ! empty($this->mapping['isOwningSide'])
             && $this->dm->getClassMetadata(get_class($this->owner))->isChangeTrackingNotify();

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1251,7 +1251,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Checks whether a document is registered to be checked in the unit of work.
      */
-    public function isScheduledForDirtyCheck(object $document) : bool
+    public function isScheduledForSynchronization(object $document) : bool
     {
         $class = $this->dm->getClassMetadata(get_class($document));
         return isset($this->scheduledForSynchronization[$class->name][spl_object_hash($document)]);

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -220,14 +220,14 @@ class UnitOfWorkTest extends BaseTest
 
         $this->assertCount(1, $persister->getUpserts());
         $this->assertTrue($this->uow->isInIdentityMap($entity));
-        $this->assertFalse($this->uow->isScheduledForDirtyCheck($entity));
+        $this->assertFalse($this->uow->isScheduledForSynchronization($entity));
 
         $persister->reset();
 
         $entity->setData('newdata');
         $entity->setTransient('newtransientvalue');
 
-        $this->assertTrue($this->uow->isScheduledForDirtyCheck($entity));
+        $this->assertTrue($this->uow->isScheduledForSynchronization($entity));
         $this->assertEquals(['data' => ['thedata', 'newdata']], $this->uow->getDocumentChangeSet($entity));
 
         $item = new NotifyChangedRelatedItem();
@@ -240,7 +240,7 @@ class UnitOfWorkTest extends BaseTest
 
         $this->assertCount(1, $itemPersister->getUpserts());
         $this->assertTrue($this->uow->isInIdentityMap($item));
-        $this->assertFalse($this->uow->isScheduledForDirtyCheck($item));
+        $this->assertFalse($this->uow->isScheduledForSynchronization($item));
 
         $persister->reset();
         $itemPersister->reset();


### PR DESCRIPTION
Finishes work started in #1938. ORM may not have renamed that method yet, but it makes sense to keep method names similar instead of having multiple names for the same functionality.