### PR TITLE
fix: replace string assertion with array assertion for $filter

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php
@@ -13,8 +13,8 @@ use const PHP_EOL;
 use function assert;
 use function count;
 use function file_exists;
+use function is_array;
 use function is_dir;
-use function is_string;
 use function is_writable;
 use function mkdir;
 use function realpath;
@@ -58,7 +58,7 @@ EOT
     protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output)
     {
         $filter = $input->getOption('filter');
-        assert(is_string($filter));
+        assert(is_array($filter));
 
         $dm = $this->getHelper('documentManager')->getDocumentManager();
 

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GeneratePersistentCollectionsCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GeneratePersistentCollectionsCommand.php
@@ -13,8 +13,8 @@ use const PHP_EOL;
 use function assert;
 use function count;
 use function file_exists;
+use function is_array;
 use function is_dir;
-use function is_string;
 use function is_writable;
 use function mkdir;
 use function realpath;
@@ -58,7 +58,7 @@ EOT
     protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output)
     {
         $filter = $input->getOption('filter');
-        assert(is_string($filter));
+        assert(is_array($filter));
 
         $dm = $this->getHelper('documentManager')->getDocumentManager();
 

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
@@ -16,6 +16,7 @@ use function array_filter;
 use function assert;
 use function count;
 use function file_exists;
+use function is_array;
 use function is_dir;
 use function is_string;
 use function is_writable;
@@ -56,7 +57,7 @@ EOT
     protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output)
     {
         $filter = $input->getOption('filter');
-        assert(is_string($filter));
+        assert(is_array($filter));
 
         /** @var DocumentManager $dm */
         $dm = $this->getHelper('documentManager')->getDocumentManager();


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1943

#### Summary

The $filter input option from the generate commands should be asserted as array instead of string.