### PR TITLE
[1.3] Deprecate proxies from doctrine/common

### DIFF
--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -78,6 +78,18 @@ cause an exception in 2.0. It is possible to have multiple fields with the same
 name in the database as long as all but one of them have the `notSaved` option
 set.
 
+## Proxies
+
+ * The usage of proxies from Doctrine Common was deprecated and will be replaced
+   with `ocramius/proxy-manager` in 2.0.
+ * Using the `AUTOGENERATE_ALWAYS` and `AUTOGENERATE_NEVER` strategies is
+   deprecated and will be dropped in 2.0. Use `AUTOGENERATE_FILE_NOT_EXISTS` and
+   `AUTOGENERATE_EVAL` instead.
+ * The `Doctrine\ODM\MongoDB\Proxy\ProxyFactory` class was deprecated and will
+   be dropped in 2.0.
+ * The `Doctrine\ODM\MongoDB\Proxy\Proxy` interface was deprecated and will be
+   dropped in 2.0.
+
 ## Queries
 
  * The `eagerCursor` method in `Doctrine\ODM\MongoDB\Query\Builder` was

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -228,17 +228,25 @@ class Configuration extends \Doctrine\MongoDB\Configuration
      * Sets a boolean flag that indicates whether proxy classes should always be regenerated
      * during each script execution.
      *
-     * @param boolean|int $bool Possible values are constants of Doctrine\Common\Proxy\AbstractProxyFactory
+     * @param boolean|int $autoGenerateProxyClasses Possible values are constants of Doctrine\Common\Proxy\AbstractProxyFactory
      */
-    public function setAutoGenerateProxyClasses($bool)
+    public function setAutoGenerateProxyClasses($autoGenerateProxyClasses)
     {
-        if (is_bool($bool)) {
+        if (is_bool($autoGenerateProxyClasses)) {
             @trigger_error(
                 sprintf('Passing boolean value to %s is deprecated, please use constants of %s instead.', __METHOD__, AbstractProxyFactory::class),
                 E_USER_DEPRECATED
             );
         }
-        $this->attributes['autoGenerateProxyClasses'] = $bool;
+
+        if ($autoGenerateProxyClasses === AbstractProxyFactory::AUTOGENERATE_ALWAYS || $autoGenerateProxyClasses === AbstractProxyFactory::AUTOGENERATE_NEVER) {
+            @trigger_error(
+                sprintf('The "AUTOGENERATE_ALWAYS" and "AUTOGENERATE_NEVER" strategies for proxy generation are deprecated and will be dropped in 2.0. Please use "AUTOGENERATE_FILE_NOT_EXISTS" and "AUTOGENERATE_EVAL".'),
+                E_USER_DEPRECATED
+            );
+        }
+
+        $this->attributes['autoGenerateProxyClasses'] = $autoGenerateProxyClasses;
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Proxy/Proxy.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Proxy.php
@@ -25,5 +25,6 @@ use Doctrine\Common\Proxy\Proxy as BaseProxy;
  * Document Proxy interface.
  *
  * @since       1.0
+ * @deprecated The proxy interface is deprecated and will be removed in 2.0.
  */
 interface Proxy extends BaseProxy {}

--- a/lib/Doctrine/ODM/MongoDB/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/ProxyFactory.php
@@ -37,6 +37,7 @@ use ReflectionProperty;
  * This factory is used to create proxy objects for documents at runtime.
  *
  * @since       1.0
+ * @deprecated The proxy factory is deprecated and will be removed in 2.0.
  */
 class ProxyFactory extends AbstractProxyFactory
 {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

This drops the proxy classes related to `doctrine/common`. Unfortunately we won't be able to provide a BC layer due to `ocramius/proxy-manager` 2.0 needing PHP 7.0. To avoid deprecation notices that users can't do anything about (see #1675) I didn't add any `trigger_error` calls to deprecated interfaces but those could certainly be added to `ProxyFactory` and `Proxy`.