### PR TITLE
Fix wrong usage of discriminator map in complex document inheritance chains

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -784,6 +784,10 @@ class ClassMetadataInfo implements \Doctrine\Common\Persistence\Mapping\ClassMet
      */
     public function setDiscriminatorMap(array $map)
     {
+        $this->subClasses = [];
+        $this->discriminatorMap = [];
+        $this->discriminatorValue = null;
+
         foreach ($map as $value => $className) {
             if (strpos($className, '\\') === false && strlen($this->namespace)) {
                 $className = $this->namespace . '\\' . $className;

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -944,27 +944,35 @@ class DocumentPersister
     }
 
     /**
-     * Adds discriminator criteria to an already-prepared query.
+     * Adds a discriminator criteria to an already-prepared query if necessary.
+     *
+     * If the class we're querying has a discriminator field set, we add all
+     * possible discriminator values to the query. The list of possible
+     * discriminator values is based on the discriminatorValue of the class
+     * itself as well as those of all its subclasses.
      *
      * This method should be used once for query criteria and not be used for
      * nested expressions. It should be called before
      * {@link DocumentPerister::addFilterToPreparedQuery()}.
      *
-     * @param array $preparedQuery
      * @return array
      */
     public function addDiscriminatorToPreparedQuery(array $preparedQuery)
     {
-        /* If the class has a discriminator field, which is not already in the
-         * criteria, inject it now. The field/values need no preparation.
-         */
-        if ($this->class->hasDiscriminator() && ! isset($preparedQuery[$this->class->discriminatorField])) {
-            $discriminatorValues = $this->getClassDiscriminatorValues($this->class);
-            if (count($discriminatorValues) === 1) {
-                $preparedQuery[$this->class->discriminatorField] = $discriminatorValues[0];
-            } else {
-                $preparedQuery[$this->class->discriminatorField] = array('$in' => $discriminatorValues);
-            }
+        if (isset($preparedQuery[$this->class->discriminatorField]) || $this->class->discriminatorField === null) {
+            return $preparedQuery;
+        }
+
+        $discriminatorValues = $this->getClassDiscriminatorValues($this->class);
+
+        if ($discriminatorValues === []) {
+            return $preparedQuery;
+        }
+
+        if (count($discriminatorValues) === 1) {
+            $preparedQuery[$this->class->discriminatorField] = $discriminatorValues[0];
+        } else {
+            $preparedQuery[$this->class->discriminatorField] = ['$in' => $discriminatorValues];
         }
 
         return $preparedQuery;
@@ -1333,14 +1341,19 @@ class DocumentPersister
     }
 
     /**
-     * Gets the array of discriminator values for the given ClassMetadata
+     * Returns the list of discriminator values for the given ClassMetadata
      *
      * @param ClassMetadata $metadata
      * @return array
      */
     private function getClassDiscriminatorValues(ClassMetadata $metadata)
     {
-        $discriminatorValues = array($metadata->discriminatorValue);
+        $discriminatorValues = [];
+
+        if ($metadata->discriminatorValue !== null) {
+            $discriminatorValues[] = $metadata->discriminatorValue;
+        }
+
         foreach ($metadata->subClasses as $className) {
             if ($key = array_search($className, $metadata->discriminatorMap)) {
                 $discriminatorValues[] = $key;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1962Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1962Test.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class GH1962Test extends BaseTest
+{
+    public function testDiscriminatorMaps()
+    {
+        $metadata = $this->dm->getClassMetadata(GH1962Superclass::class);
+        self::assertCount(3, $metadata->discriminatorMap);
+
+        $metadata = $this->dm->getClassMetadata(GH1962BarSuperclass::class);
+        self::assertCount(2, $metadata->discriminatorMap);
+    }
+
+    public function testFetchingDiscriminatedDocuments()
+    {
+        $foo = new GH1962FooDocument();
+        $bar = new GH1962BarDocument();
+        $baz = new GH1962BazDocument();
+
+        $this->dm->persist($foo);
+        $this->dm->persist($bar);
+        $this->dm->persist($baz);
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        self::assertCount(3, $this->dm->getRepository(GH1962Superclass::class)->findAll());
+        self::assertCount(2, $this->dm->getRepository(GH1962BarSuperclass::class)->findAll());
+
+        self::assertCount(1, $this->dm->getRepository(GH1962FooDocument::class)->findAll());
+        self::assertCount(1, $this->dm->getRepository(GH1962BarDocument::class)->findAll());
+        self::assertCount(1, $this->dm->getRepository(GH1962BazDocument::class)->findAll());
+    }
+}
+
+/**
+ * @ODM\MappedSuperclass()
+ * @ODM\DiscriminatorField("type")
+ * @ODM\InheritanceType("SINGLE_COLLECTION")
+ * @ODM\DiscriminatorMap({
+ *     "foo"=GH1962FooDocument::class,
+ *     "bar"=GH1962BarDocument::class,
+ *     "baz"=GH1962BazDocument::class
+ * })
+ */
+class GH1962Superclass
+{
+    /** @ODM\Id */
+    public $id;
+}
+
+/** @ODM\Document */
+class GH1962FooDocument extends GH1962Superclass
+{
+}
+
+/**
+ * @ODM\MappedSuperclass()
+ * @ODM\DiscriminatorMap({
+ *     "bar"=GH1962BarDocument::class,
+ *     "baz"=GH1962BazDocument::class
+ * })
+ */
+class GH1962BarSuperclass extends GH1962Superclass
+{
+}
+
+/** @ODM\Document */
+class GH1962BarDocument extends GH1962BarSuperclass
+{
+}
+
+/** @ODM\Document */
+class GH1962BazDocument extends GH1962BarSuperclass
+{
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -25,13 +25,25 @@ class BuilderTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->field('featureFull')->references($f)
             ->getQuery()->debug();
 
-        $this->assertEquals([ 'featureFull.$id' => new \MongoId($f->id) ], $q1['query']);
+        $this->assertEquals(
+            [
+                'featureFull.$id' => new \MongoId($f->id),
+                'type' => ['$in' => ['ca', 'cb', 'cc']],
+            ],
+            $q1['query']
+        );
 
         $q2 = $this->dm->createQueryBuilder(ParentClass::class)
             ->field('featureSimple')->references($f)
             ->getQuery()->debug();
 
-        $this->assertEquals([ 'featureSimple' => new \MongoId($f->id) ], $q2['query']);
+        $this->assertEquals(
+            [
+                'featureSimple' => new \MongoId($f->id),
+                'type' => ['$in' => ['ca', 'cb', 'cc']],
+            ],
+            $q2['query']
+        );
 
         $q3 = $this->dm->createQueryBuilder(ParentClass::class)
             ->field('featurePartial')->references($f)
@@ -41,6 +53,7 @@ class BuilderTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             [
                 'featurePartial.$id' => new \MongoId($f->id),
                 'featurePartial.$ref' => 'Feature',
+                'type' => ['$in' => ['ca', 'cb', 'cc']],
             ],
             $q3['query']
         );
@@ -83,13 +96,27 @@ class BuilderTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->field('featureFullMany')->includesReferenceTo($f)
             ->getQuery()->debug();
 
-        $this->assertEquals([ 'featureFullMany' => [ '$elemMatch' => [ '$id' => new \MongoId($f->id) ] ] ], $q1['query']);
+        $this->assertEquals(
+            [
+                'featureFullMany' => [
+                    '$elemMatch' => ['$id' => new \MongoId($f->id)],
+                ],
+                'type' => ['$in' => ['ca', 'cb', 'cc']],
+            ],
+            $q1['query']
+        );
 
         $q2 = $this->dm->createQueryBuilder(ParentClass::class)
             ->field('featureSimpleMany')->includesReferenceTo($f)
             ->getQuery()->debug();
 
-        $this->assertEquals([ 'featureSimpleMany' => new \MongoId($f->id) ], $q2['query']);
+        $this->assertEquals(
+            [
+                'featureSimpleMany' => new \MongoId($f->id),
+                'type' => ['$in' => ['ca', 'cb', 'cc']],
+            ],
+            $q2['query']
+        );
 
         $q3 = $this->dm->createQueryBuilder(ParentClass::class)
             ->field('featurePartialMany')->includesReferenceTo($f)
@@ -101,8 +128,9 @@ class BuilderTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                     '$elemMatch' => [
                         '$id' => new \MongoId($f->id),
                         '$ref' => 'Feature',
-                    ]
-                ]
+                    ],
+                ],
+                'type' => ['$in' => ['ca', 'cb', 'cc']],
             ],
             $q3['query']
         );


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | Maybe
| Fixed issues | 

#### Summary

When having multiple levels of inheritance in your document structure, discriminator maps are inherited incorrectly. They are currently inherited from their parent class and cannot be overridden. As highlighted in the attached tests, fetching all documents from the `GH1962BarSuperclass` repository should only yield subclasses of that superclass but also returns an unrelated `GH1962FooDocument`, which should not happen.

In my opinion, discriminator maps should be overridable in a child class (as showcased in the test). Optionally, me may want to invert inheritance completely, where a discriminator map is not passed on to child classes but to parent classes; that way, a class will always contain all possible classes in its discriminator map.