### PR TITLE
Test against supported versions of MongoDB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - DOCTRINE_MONGODB_SERVER="mongodb://localhost:27017"
     - KEY_SERVER="hkp://keyserver.ubuntu.com:80"
     - MONGO_REPO_URI="https://repo.mongodb.org/apt/ubuntu"
-    - MONGO_REPO_TYPE="precise/mongodb-org/"
+    - MONGO_REPO_TYPE="xenial/mongodb-org/"
     - SOURCES_LOC="/etc/apt/sources.list.d/mongodb.list"
     - DRIVER_VERSION="stable"
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,16 @@ env:
     - SOURCES_LOC="/etc/apt/sources.list.d/mongodb.list"
     - DRIVER_VERSION="stable"
   matrix:
-    - SERVER_VERSION="3.2" KEY_ID="EA312927"
     - SERVER_VERSION="3.4" KEY_ID="0C49F3730359A14518585931BC711F9BA15703C6"
     - SERVER_VERSION="3.6" KEY_ID="2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
+    - SERVER_VERSION="4.0" KEY_ID="9DA31620334BD75D9DCB49F368818C72E52529D4"
 
 jobs:
   include:
     # Test against lowest dependencies, including driver and server versions
     - stage: Test
       php: 7.2
-      env: SERVER_VERSION="3.2" KEY_ID="EA312927" DRIVER_VERSION="1.5.0"
+      env: SERVER_VERSION="3.4" KEY_ID="0C49F3730359A14518585931BC711F9BA15703C6" DRIVER_VERSION="1.5.0"
       install:
         - composer update --prefer-lowest
 
@@ -36,7 +36,7 @@ jobs:
     # Run tests with coverage
     - stage: Code Quality
       php: 7.2
-      env: COVERAGE SERVER_VERSION="3.6" KEY_ID="2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
+      env: SERVER_VERSION="4.0" KEY_ID="9DA31620334BD75D9DCB49F368818C72E52529D4"
       before_script:
         - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}
         - if [[ ! $(php -m | grep -si xdebug) ]]; then echo "xdebug required for coverage"; exit 1; fi
@@ -48,13 +48,13 @@ jobs:
 
     - stage: Code Quality
       php: 7.2
-      env: STATIC_ANALYSIS SERVER_VERSION="3.6" KEY_ID="2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
+      env: SERVER_VERSION="4.0" KEY_ID="9DA31620334BD75D9DCB49F368818C72E52529D4"
       script:
         - vendor/bin/phpstan analyse
 
     - stage: Code Quality
       php: 7.2
-      env: CODING_STANDARDS SERVER_VERSION="3.6" KEY_ID="2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
+      env: SERVER_VERSION="4.0" KEY_ID="9DA31620334BD75D9DCB49F368818C72E52529D4"
       script:
         - vendor/bin/phpcs
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

Support for MongoDB 3.2 ran out in September 2018 while we forgot to add 4.0 to the build pipeline. This PR corrects this and will also be applied to the 1.3 branch.
