### PR TITLE
Make addStage Aggregation Builder method public

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -20,6 +20,7 @@
 namespace Doctrine\ODM\MongoDB\Aggregation;
 
 use Doctrine\MongoDB\Aggregation\Builder as BaseBuilder;
+use Doctrine\MongoDB\Aggregation\Stage;
 use Doctrine\MongoDB\Aggregation\Stage\GeoNear;
 use Doctrine\MongoDB\CommandCursor as BaseCommandCursor;
 use Doctrine\ODM\MongoDB\CommandCursor;
@@ -222,6 +223,17 @@ class Builder extends BaseBuilder
         }
 
         return $pipeline;
+    }
+
+    /**
+     * Extend visibility of parent's method to public
+     *
+     * @param Stage $stage
+     * @return Stage
+     */
+    public function addStage(Stage $stage)
+    {
+        return parent::addStage($stage);
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

Makes `addStage` method public to allow easier usage of "custom" `Stage` class objects.

Following discussion in https://doctrine.slack.com/archives/CAAE6T66B/p1552300833003900 / https://doctrine.slack.com/messages/CAAE6T66B/convo/CAAE6T66B-1552300833.003900/
