### PR TITLE
[1.2] Fix sharding commands for MongoDB 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - DOCTRINE_MONGODB_SERVER="mongodb://localhost:27017"
     - KEY_SERVER="hkp://keyserver.ubuntu.com:80"
     - MONGO_REPO_URI="https://repo.mongodb.org/apt/ubuntu"
-    - MONGO_REPO_TYPE="precise/mongodb-org/"
+    - MONGO_REPO_TYPE="trusty/mongodb-org/"
     - SOURCES_LOC="/etc/apt/sources.list.d/mongodb.list"
     - DRIVER_VERSION="stable"
     - ADAPTER_VERSION="^1.0.0"
@@ -26,6 +26,8 @@ matrix:
       env: DRIVER_VERSION="1.6.7" COMPOSER_FLAGS="--prefer-lowest" SERVER_VERSION="3.2" KEY_ID="EA312927"
     - php: 7.2
       env: SERVER_VERSION="3.6" KEY_ID="2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
+    - php: 7.3
+      env: SERVER_VERSION="4.0" KEY_ID="9DA31620334BD75D9DCB49F368818C72E52529D4"
 
 before_install:
   - sudo apt-key adv --keyserver ${KEY_SERVER} --recv ${KEY_ID}

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -22,6 +22,7 @@ namespace Doctrine\ODM\MongoDB;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
+use function in_array;
 use function sprintf;
 
 class SchemaManager
@@ -650,9 +651,10 @@ class SchemaManager
             }
         } while (! $done && $try < 2);
 
-        // Starting with MongoDB 3.2, this command returns code 20 when a collection is already sharded.
-        // For older MongoDB versions, check the error message
-        if ($result['ok'] == 1 || (isset($result['code']) && $result['code'] == 20) || $result['errmsg'] == 'already sharded') {
+        // For MongoDB 3.2 and newer, this command returns code 20 when a collection is already sharded.
+        // For MongoDB 4.0 and newer, this command returns code 23 when a collection is already sharded.
+        // For older MongoDB versions, we check the error message
+        if ($result['ok'] == 1 || (isset($result['code']) && in_array($result['code'], [20, 23])) || $result['errmsg'] == 'already sharded') {
             return;
         }
 

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -28,6 +28,16 @@ use function sprintf;
 class SchemaManager
 {
     /**
+     * @internal For internal use only. This constant will be private in 2.0.
+     */
+    const MONGODB_ERROR_ILLEGAL_OPERATION = 20;
+
+    /**
+     * @internal For internal use only. This constant will be private in 2.0.
+     */
+    const MONGODB_ERROR_ALREADY_INITIALIZED = 23;
+
+    /**
      * @var DocumentManager
      */
     protected $dm;
@@ -654,7 +664,7 @@ class SchemaManager
         // For MongoDB 3.2 and newer, this command returns code 20 when a collection is already sharded.
         // For MongoDB 4.0 and newer, this command returns code 23 when a collection is already sharded.
         // For older MongoDB versions, we check the error message
-        if ($result['ok'] == 1 || (isset($result['code']) && in_array($result['code'], [20, 23])) || $result['errmsg'] == 'already sharded') {
+        if ($result['ok'] == 1 || (isset($result['code']) && in_array($result['code'], [self::MONGODB_ERROR_ILLEGAL_OPERATION, self::MONGODB_ERROR_ALREADY_INITIALIZED])) || $result['errmsg'] == 'already sharded') {
             return;
         }
 
@@ -676,7 +686,7 @@ class SchemaManager
 
         // Error code is only available with MongoDB 3.2. MongoDB 3.0 only returns a message
         // Thus, check code if it exists and fall back on error message
-        if ($result['ok'] == 1 || (isset($result['code']) && $result['code'] == 23) || $result['errmsg'] == 'already enabled') {
+        if ($result['ok'] == 1 || (isset($result['code']) && $result['code'] == self::MONGODB_ERROR_ALREADY_INITIALIZED) || $result['errmsg'] == 'already enabled') {
             return;
         }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
@@ -38,6 +38,7 @@ class EnsureShardingTest extends BaseTest
         $doc = array('title' => 'hey', 'k' => 'hi');
         $collection->insert($doc);
 
+        $this->dm->getSchemaManager()->ensureDocumentIndexes($class);
         $this->dm->getSchemaManager()->ensureDocumentSharding($class);
 
         $indexes = $collection->getIndexInfo();
@@ -71,6 +72,7 @@ class EnsureShardingTest extends BaseTest
         $this->dm->flush();
 
         $class = \Documents\Sharded\ShardedOne::class;
+        $this->dm->getSchemaManager()->ensureDocumentIndexes($class);
         $this->dm->getSchemaManager()->ensureDocumentSharding($class);
 
         $collection = $this->dm->getDocumentCollection($class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
@@ -5,6 +5,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
+/**
+ * @group sharding
+ */
 class EnsureShardingTest extends BaseTest
 {
     public function setUp()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
@@ -7,6 +7,9 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Tests\QueryLogger;
 use Documents\Sharded\ShardedOne;
 
+/**
+ * @group sharding
+ */
 class ShardKeyTest extends BaseTest
 {
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -7,6 +7,7 @@ use Doctrine\ODM\MongoDB\SchemaManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\MongoDB\Tests\Mocks\DocumentManagerMock;
+use Documents\Sharded\ShardedOne;
 use PHPUnit\Framework\TestCase;
 
 class SchemaManagerTest extends TestCase
@@ -18,6 +19,7 @@ class SchemaManagerTest extends TestCase
         \Documents\CmsProduct::class,
         \Documents\Comment::class,
         \Documents\SimpleReferenceUser::class,
+        ShardedOne::class,
     );
 
     private $someNonIndexedClasses = array(

--- a/tests/Documents/Sharded/ShardedOne.php
+++ b/tests/Documents/Sharded/ShardedOne.php
@@ -6,6 +6,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
  * @ODM\Document(collection="sharded.one")
+ * @ODM\Index(keys={"k"="asc"})
  * @ODM\ShardKey(keys={"k"="asc"})
  */
 class ShardedOne


### PR DESCRIPTION
Discovered this while working on #1972: the root problem is also present in 1.2, where we should also fix it.