### PR TITLE
Fix metadata storage when uploading GridFS files

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Repository/DefaultGridFSRepository.php
+++ b/lib/Doctrine/ODM/MongoDB/Repository/DefaultGridFSRepository.php
@@ -96,10 +96,13 @@ class DefaultGridFSRepository extends DocumentRepository implements GridFSReposi
             'chunkSizeBytes' => $uploadOptions->chunkSizeBytes ?: $this->class->getChunkSizeBytes(),
         ];
 
-        if (is_object($uploadOptions->metadata)) {
-            $options += ['metadata' => (object) $this->uow->getPersistenceBuilder()->prepareInsertData($uploadOptions->metadata)];
+        if (! is_object($uploadOptions->metadata)) {
+            return $options;
         }
 
-        return $options;
+        $metadataMapping = $this->class->getFieldMappingByDbFieldName('metadata');
+        $metadata        = $this->uow->getPersistenceBuilder()->prepareEmbeddedDocumentValue($metadataMapping, $uploadOptions->metadata, true);
+
+        return $options + ['metadata' => (object) $metadata];
     }
 }

--- a/tests/Documents/FileMetadata.php
+++ b/tests/Documents/FileMetadata.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Documents\Functional\Embedded;
 
 /** @ODM\EmbeddedDocument */
 final class FileMetadata
@@ -16,6 +17,14 @@ final class FileMetadata
      */
     private $owner;
 
+    /** @ODM\EmbedOne(targetDocument=Embedded::class) */
+    private $embedOne;
+
+    public function __construct()
+    {
+        $this->embedOne = new Embedded();
+    }
+
     public function getOwner() : ?User
     {
         return $this->owner;
@@ -24,5 +33,10 @@ final class FileMetadata
     public function setOwner(?User $owner) : void
     {
         $this->owner = $owner;
+    }
+
+    public function getEmbedOne() : Embedded
+    {
+        return $this->embedOne;
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fixes #1985 

#### Summary

This fixes a bug where metadata submitted while uploading a file to GridFS would not be stored correctly. The test only checked for the existence of the metadata object but did not check whether its information was stored correctly.

Unfortunately, due to the mechanics of GridFS uploads not all operations work as you'd normally expect. For example, uploading a file to GridFS with a metadata object that contains a reference will not cascade any operations to the referenced object as the UnitOfWork is not flushed during the update operation.