### PR TITLE
Fix generation of proxy classes

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Proxy/Factory/StaticProxyFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Factory/StaticProxyFactory.php
@@ -77,7 +77,9 @@ class StaticProxyFactory implements ProxyFactory
                     static function () {
                         // empty closure, serves its purpose, for now
                     },
-                    $this->skippedFieldsFqns($metadata)
+                    [
+                        'skippedProperties' => $this->skippedFieldsFqns($metadata),
+                    ]
                 );
         }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1990Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1990Test.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class GH1990Test extends BaseTest
+{
+    public function testInitialisationOfInverseProxy() : void
+    {
+        // Generate proxy class using generateProxyClasses to ensure it is
+        // consistent with other proxy classes
+        $metadata = $this->dm->getClassMetadata(GH1990Document::class);
+        $this->dm->getProxyFactory()->generateProxyClasses([$metadata]);
+
+        $parent = new GH1990Document(null);
+        $child  = new GH1990Document($parent);
+        $this->dm->persist($parent);
+        $this->dm->persist($child);
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $this->dm->find(GH1990Document::class, $child->getId());
+
+        self::assertInstanceOf(GH1990Document::class, $child);
+    }
+}
+
+/** @ODM\Document */
+class GH1990Document
+{
+    /** @ODM\Id */
+    private $id;
+
+    /** @ODM\ReferenceOne(targetDocument=GH1990Document::class) */
+    private $parent;
+
+    public function __construct(?GH1990Document $parent)
+    {
+        $this->parent = $parent;
+    }
+
+    public function getId() : ?string
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fixes #1990 

#### Summary

This took a little longer to figure out. The issue was neither with inverse references, repository methods, discriminators or anything else but only appears when proxy objects have been generated through the `generateProxyClasses` method due to invalid configuration of skipped properties.