### PR TITLE
Change `ResolveTargetDocumentListener` to be an event subscriber instead of an event listener

### DIFF
--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -1,5 +1,31 @@
 # UPGRADE FROM 1.2 TO 1.3
 
+## Events
+
+### `onClassMetadataNotFound` event added
+
+The default ClassMetadataFactory now triggers an `onClassMetadataNotFound` event
+when no metadata was found for a given class. The event args contain information
+about the loaded class and can store a metadata object which can be used to load
+custom metadata when none was found.
+
+### `ResolveTargetDocumentListener` is now an event subscriber
+
+The `Doctrine\ODM\MongoDB\Tools\ResolveTargetDocumentListener` class now
+implements the `EventSubscriber` interface. You can still register it as a
+listener as was necessary previously, but in order to use new functionality you
+have to register it as an event subscriber.
+
+### `ResolveTargetDocumentListener` resolves class names on document load
+
+The `Doctrine\ODM\MongoDB\Tools\ResolveTargetDocumentListener` class not only
+resolves class names when looking up the `targetDoccumet` of an association in
+a document, but it also uses the new `onClassMetadataNotFound` event to resolve
+class names and trigger a secondary metadata load cycle if no metadata was found
+for the original class name. To use this functionality, either register an event
+listener for the `onClassMetadataNotFound` event or register the entire class as
+an event subscriber.
+
 ## GridFS
 
 GridFS support will be rewritten for 2.0 and was deprecated in its current form.

--- a/docs/en/cookbook/resolve-target-document-listener.rst
+++ b/docs/en/cookbook/resolve-target-document-listener.rst
@@ -10,7 +10,8 @@ Doctrine MongoDB ODM includes a utility called
 inside Doctrine and rewriting ``targetDocument`` parameters in your metadata
 mapping at runtime. This allows your bundle to use an interface or abstract
 class in its mappings while still allowing the mapping to resolve to a concrete
-document class at runtime.
+document class at runtime. It will also rewrite class names when no mapping
+metadata has been found for the original class name.
 
 This functionality allows you to define relationships between different
 documents without creating hard dependencies.
@@ -126,7 +127,7 @@ you cannot be guaranteed that the targetDocument resolution will occur reliably:
     );
 
     // Add the ResolveTargetDocumentListener
-    $evm->addEventListener(\Doctrine\ODM\MongoDB\Events::loadClassMetadata, $rtdl);
+    $evm->addEventSubscriber($rtdl);
 
     // Create the document manager as you normally would
     $dm = \Doctrine\ODM\MongoDB\DocumentManager::create($connectionOptions, $config, $evm);

--- a/lib/Doctrine/ODM/MongoDB/Tools/ResolveTargetDocumentListener.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/ResolveTargetDocumentListener.php
@@ -2,7 +2,9 @@
 
 namespace Doctrine\ODM\MongoDB\Tools;
 
+use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs;
+use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 
 /**
@@ -10,12 +12,22 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
  *
  * Mechanism to overwrite document interfaces or classes specified as association targets.
  */
-class ResolveTargetDocumentListener
+class ResolveTargetDocumentListener implements EventSubscriber
 {
     /**
      * @var array
      */
     private $resolveTargetDocuments = array();
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSubscribedEvents()
+    {
+        return [
+            Events::loadClassMetadata,
+        ];
+    }
 
     /**
      * Add a target-document class name to resolve to a new class name.

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
@@ -3,9 +3,9 @@
 namespace Doctrine\ODM\MongoDB\Tests\Tools;
 
 use Doctrine\ODM\MongoDB\Events;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\MongoDB\Tools\ResolveTargetDocumentListener;
-use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 class ResolveTargetDocumentListenerTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 {
@@ -69,6 +69,17 @@ class ResolveTargetDocumentListenerTest extends \Doctrine\ODM\MongoDB\Tests\Base
 
         $this->assertSame($this->factory->getMetadataFor(ResolveTargetDocument::class), $cm);
     }
+
+    public function testResolveTargetDocumentListenerCanRetrieveTargetDocumentByAbstractClassName()
+    {
+        $this->listener->addResolveTargetDocument(AbstractResolveTarget::class, ResolveTargetDocument::class, []);
+
+        $this->dm->getEventManager()->addEventSubscriber($this->listener);
+
+        $cm = $this->factory->getMetadataFor(AbstractResolveTarget::class);
+
+        $this->assertSame($this->factory->getMetadataFor(ResolveTargetDocument::class), $cm);
+    }
 }
 
 interface ResolveTargetInterface
@@ -80,10 +91,15 @@ interface TargetInterface extends ResolveTargetInterface
 {
 }
 
+abstract class AbstractResolveTarget implements ResolveTargetInterface
+{
+
+}
+
 /**
  * @ODM\Document
  */
-class ResolveTargetDocument implements ResolveTargetInterface
+class ResolveTargetDocument extends AbstractResolveTarget implements ResolveTargetInterface
 {
     /**
      * @ODM\Id

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\ODM\MongoDB\Tests\Tools;
 
 use Doctrine\ODM\MongoDB\Events;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\MongoDB\Tools\ResolveTargetDocumentListener;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
@@ -18,11 +19,17 @@ class ResolveTargetDocumentListenerTest extends \Doctrine\ODM\MongoDB\Tests\Base
      */
     protected $listener;
 
+    /**
+     * @var ClassMetadataFactory
+     */
+    private $factory;
+
     public function setUp()
     {
         parent::setUp();
 
          $this->listener = new ResolveTargetDocumentListener();
+        $this->factory = $this->dm->getMetadataFactory();
     }
 
     public function testResolveTargetDocumentListenerCanResolveTargetDocument()
@@ -50,6 +57,17 @@ class ResolveTargetDocumentListenerTest extends \Doctrine\ODM\MongoDB\Tests\Base
         $this->assertSame('Doctrine\ODM\MongoDB\Tests\Tools\TargetDocument', $meta['refMany']['targetDocument']);
         $this->assertSame('Doctrine\ODM\MongoDB\Tests\Tools\ResolveTargetDocument', $meta['embedOne']['targetDocument']);
         $this->assertSame('Doctrine\ODM\MongoDB\Tests\Tools\TargetDocument', $meta['embedMany']['targetDocument']);
+    }
+
+    public function testResolveTargetDocumentListenerCanRetrieveTargetDocumentByInterfaceName()
+    {
+        $this->listener->addResolveTargetDocument(ResolveTargetInterface::class, ResolveTargetDocument::class, []);
+
+        $this->dm->getEventManager()->addEventSubscriber($this->listener);
+
+        $cm = $this->factory->getMetadataFor(ResolveTargetInterface::class);
+
+        $this->assertSame($this->factory->getMetadataFor(ResolveTargetDocument::class), $cm);
     }
 }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature/improvement
| BC Break     | yes
| Fixed issues | #1993 

#### Summary

Note: needs changes from #1998. As long as that isn't merged, this PR will be unstable.

Change `ResolveTargetDocumentListener` to be an event subscriber instead of an event listener
