### PR TITLE
Introducing class metadata not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/console": "~2.3|~3.0|^4.0",
         "doctrine/annotations": "~1.2",
         "doctrine/collections": "~1.1",
-        "doctrine/common": "~2.4",
+        "doctrine/common": "^2.5.0",
         "doctrine/cache": "~1.0",
         "doctrine/inflector": "~1.0",
         "doctrine/instantiator": "^1.0.1",

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -166,6 +166,12 @@ the life-time of their registered documents.
    mapping metadata for a class has been loaded from a mapping source
    (annotations/xml/yaml).
 -
+   onClassMetadataNotFound - Loading class metadata for a particular
+   requested class name failed. Manipulating the given event args instance
+   allows providing fallback metadata even when no actual metadata exists
+   or could be found. This event is not a lifecycle callback. Support for this
+   event was added in MongoDB ODM 1.3.
+-
    preFlush - The preFlush event occurs before the change-sets of all
    managed documents are computed. This both a lifecycle call back and
    and listener.

--- a/lib/Doctrine/ODM/MongoDB/Event/OnClassMetadataNotFoundEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/OnClassMetadataNotFoundEventArgs.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Event;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\DocumentManager;
+
+/**
+ * Class that holds event arguments for a `onClassMetadataNotFound` event.
+ *
+ * This object is mutable by design, allowing callbacks having access to it to set the
+ * found metadata in it, and therefore "cancelling" a `onClassMetadataNotFound` event
+ */
+class OnClassMetadataNotFoundEventArgs extends ManagerEventArgs
+{
+    /**
+     * @var string
+     */
+    private $className;
+
+    /**
+     * @var ClassMetadata|null
+     */
+    private $foundMetadata;
+
+    /**
+     * @param string          $className
+     * @param DocumentManager $dm
+     */
+    public function __construct($className, DocumentManager $dm)
+    {
+        $this->className = (string) $className;
+
+        parent::__construct($dm);
+    }
+
+    /**
+     * @param ClassMetadata|null $classMetadata
+     */
+    public function setFoundMetadata(ClassMetadata $classMetadata = null)
+    {
+        $this->foundMetadata = $classMetadata;
+    }
+
+    /**
+     * @return ClassMetadata|null
+     */
+    public function getFoundMetadata()
+    {
+        return $this->foundMetadata;
+    }
+
+    /**
+     * Retrieve class name for which a failed metadata fetch attempt was executed
+     *
+     * @return string
+     */
+    public function getClassName()
+    {
+        return $this->className;
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Events.php
+++ b/lib/Doctrine/ODM/MongoDB/Events.php
@@ -126,6 +126,12 @@ final class Events
     const loadClassMetadata = 'loadClassMetadata';
 
     /**
+     * The onClassMetadataNotFound event occurs whenever loading metadata for a class
+     * failed.
+     */
+    const onClassMetadataNotFound = 'onClassMetadataNotFound';
+
+    /**
      * The preFlush event occurs when the DocumentManager#flush() operation is invoked,
      * but before any changes to managed documents have been calculated. This event is
      * always raised right after DocumentManager#flush() call.

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -25,6 +25,7 @@ use Doctrine\Common\Persistence\Mapping\ReflectionService;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs;
+use Doctrine\ODM\MongoDB\Event\OnClassMetadataNotFoundEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Id\AbstractIdGenerator;
 use Doctrine\ODM\MongoDB\Id\AlnumGenerator;
@@ -84,6 +85,22 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         $this->driver = $this->config->getMetadataDriverImpl();
         $this->evm = $this->dm->getEventManager();
         $this->initialized = true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function onNotFoundMetadata($className)
+    {
+        if (! $this->evm->hasListeners(Events::onClassMetadataNotFound)) {
+            return null;
+        }
+
+        $eventArgs = new OnClassMetadataNotFoundEventArgs($className, $this->dm);
+
+        $this->evm->dispatchEvent(Events::onClassMetadataNotFound, $eventArgs);
+
+        return $eventArgs->getFoundMetadata();
     }
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/OnClassMetadataNotFoundEventArgsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/OnClassMetadataNotFoundEventArgsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Events;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Event\OnClassMetadataNotFoundEventArgs;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use PHPUnit\Framework\TestCase;
+
+class OnClassMetadataNotFoundEventArgsTest extends TestCase
+{
+    public function testEventArgsMutability()
+    {
+        $documentManager = $this->createMock(DocumentManager::class);
+
+        $args = new OnClassMetadataNotFoundEventArgs('foo', $documentManager);
+
+        $this->assertSame('foo', $args->getClassName());
+        $this->assertSame($documentManager, $args->getObjectManager());
+
+        $this->assertNull($args->getFoundMetadata());
+
+        $metadata = $this->createMock(ClassMetadata::class);
+
+        $args->setFoundMetadata($metadata);
+
+        $this->assertSame($metadata, $args->getFoundMetadata());
+
+        $args->setFoundMetadata(null);
+
+        $this->assertNull($args->getFoundMetadata());
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature/improvement
| BC Break     | no
| Fixed issues | #1993 

#### Summary

* Introduce the `onClassMetadataNotFound` event along with its object
* Add support for the `onClassMetadataNotFound` event in `ResolveTargetDocumentListener`
