### PR TITLE
Fix tests against php 7.4snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ jobs:
     # Test against the upcoming PHP version
     - stage: Test
       php: 7.4snapshot
+      addons:
+        apt:
+          packages:
+            - libonig-dev
 
 before_install:
   - sudo apt-key adv --keyserver ${KEY_SERVER} --recv ${KEY_ID}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

* Install libonig-dev as it is temporarily required for snapshot and nighly tests (see https://github.com/travis-ci/php-src-builder/pull/36)
