### PR TITLE
Fix discriminator handling with partial discriminator maps

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -749,53 +749,42 @@ class DocumentManager implements ObjectManager
     {
         $discriminatorField = null;
         $discriminatorValue = null;
-        $discriminatorData  = [];
+        $discriminatorMap   = null;
 
         if (isset($referenceMapping['discriminatorField'])) {
             $discriminatorField = $referenceMapping['discriminatorField'];
+
             if (isset($referenceMapping['discriminatorMap'])) {
-                $pos = array_search($class->name, $referenceMapping['discriminatorMap']);
+                $discriminatorMap = $referenceMapping['discriminatorMap'];
+            }
+        } else {
+            $discriminatorField = $class->discriminatorField;
+            $discriminatorValue = $class->discriminatorValue;
+            $discriminatorMap   = $class->discriminatorMap;
+        }
+
+        if ($discriminatorField === null) {
+            return [];
+        }
+
+        if ($discriminatorValue === null) {
+            if (! empty($discriminatorMap)) {
+                $pos = array_search($class->name, $discriminatorMap);
+
                 if ($pos !== false) {
                     $discriminatorValue = $pos;
                 }
             } else {
                 $discriminatorValue = $class->name;
             }
-        } else {
-            $discriminatorField = $class->discriminatorField;
-            $discriminatorValue = isset($class->discriminatorValue) ? $class->discriminatorValue : $class->name;
         }
 
-        if ($discriminatorField !== null) {
-            if ($discriminatorValue === null) {
-                @trigger_error(sprintf('Document class "%s" is unlisted in the discriminator map for reference "%s". This is deprecated and will throw an exception in 2.0.', $class->name, $referenceMapping['name']), E_USER_DEPRECATED);
-                $discriminatorValue = $class->name;
-            }
-
-            $discriminatorData = [$discriminatorField => $discriminatorValue];
-        } elseif (! isset($referenceMapping['targetDocument'])) {
-            $discriminatorField = $referenceMapping['discriminatorField'];
-
-            $discriminatorMap = null;
-            if (isset($referenceMapping['discriminatorMap'])) {
-                $discriminatorMap = $referenceMapping['discriminatorMap'];
-            }
-
-            if ($discriminatorMap === null) {
-                $discriminatorValue = $class->name;
-            } else {
-                $discriminatorValue = array_search($class->name, $discriminatorMap);
-
-                if ($discriminatorValue === false) {
-                    @trigger_error(sprintf('Document class "%s" is unlisted in the discriminator map for reference "%s". This is deprecated and will throw an exception in 2.0.', $class->name, $referenceMapping['name']), E_USER_DEPRECATED);
-                    $discriminatorValue = $class->name;
-                }
-            }
-
-            $discriminatorData = [$discriminatorField => $discriminatorValue];
+        if ($discriminatorValue === null) {
+            @trigger_error(sprintf('Document class "%s" is unlisted in the discriminator map for reference "%s". This is deprecated and will throw an exception in doctrine/mongodb-odm 2.0.', $class->name, $referenceMapping['name']), E_USER_DEPRECATED);
+            $discriminatorValue = $class->name;
         }
 
-        return $discriminatorData;
+        return [$discriminatorField => $discriminatorValue];
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
@@ -114,9 +114,17 @@ class PersistenceBuilder
 
         // add discriminator if the class has one
         if (isset($class->discriminatorField)) {
-            $insertData[$class->discriminatorField] = isset($class->discriminatorValue)
-                ? $class->discriminatorValue
-                : $class->name;
+            $discriminatorValue = $class->discriminatorValue;
+
+            if ($discriminatorValue === null) {
+                if (! empty($class->discriminatorMap)) {
+                    @trigger_error(sprintf('Document class "%s" is unlisted in the discriminator map of its inheritance chain. This is deprecated and will throw an exception in doctrine/mongodb-odm 2.0.', $class->name), E_USER_DEPRECATED);
+                }
+
+                $discriminatorValue = $class->name;
+            }
+
+            $insertData[$class->discriminatorField] = $discriminatorValue;
         }
 
         return $insertData;
@@ -293,9 +301,17 @@ class PersistenceBuilder
 
         // add discriminator if the class has one
         if (isset($class->discriminatorField)) {
-            $updateData['$set'][$class->discriminatorField] = isset($class->discriminatorValue)
-                ? $class->discriminatorValue
-                : $class->name;
+            $discriminatorValue = $class->discriminatorValue;
+
+            if ($discriminatorValue === null) {
+                if (! empty($class->discriminatorMap)) {
+                    @trigger_error(sprintf('Document class "%s" is unlisted in the discriminator map of its inheritance chain. This is deprecated and will throw an exception in doctrine/mongodb-odm 2.0.', $class->name), E_USER_DEPRECATED);
+                }
+
+                $discriminatorValue = $class->name;
+            }
+
+            $updateData['$set'][$class->discriminatorField] = $discriminatorValue;
         }
 
         return $updateData;
@@ -416,9 +432,17 @@ class PersistenceBuilder
          * discriminator field and no value, so default to the full class name.
          */
         if (isset($class->discriminatorField)) {
-            $embeddedDocumentValue[$class->discriminatorField] = isset($class->discriminatorValue)
-                ? $class->discriminatorValue
-                : $class->name;
+            $discriminatorValue = $class->discriminatorValue;
+
+            if ($discriminatorValue === null) {
+                if (! empty($class->discriminatorMap)) {
+                    @trigger_error(sprintf('Document class "%s" is unlisted in the discriminator map of its inheritance chain. This is deprecated and will throw an exception in doctrine/mongodb-odm 2.0.', $class->name), E_USER_DEPRECATED);
+                }
+
+                $discriminatorValue = $class->name;
+            }
+
+            $embeddedDocumentValue[$class->discriminatorField] = $discriminatorValue;
         }
 
         // Ensure empty embedded documents are stored as BSON objects

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2002Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2002Test.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class GH2002Test extends BaseTest
+{
+    /**
+     * @dataProvider getReferenceData
+     */
+    public function testBuildingReferenceCreatesCorrectStructure(array $expectedReference, $document)
+    {
+        $this->dm->persist($document);
+
+        $metadata = $this->dm->getClassMetadata(get_class($document));
+        $this->dm->getUnitOfWork()->computeChangeSet($metadata, $document);
+
+        $data = $this->dm->getUnitOfWork()->getPersistenceBuilder()->prepareInsertData($document);
+
+        self::assertArraySubset($expectedReference, $data['parentDocument']);
+    }
+
+    public function getReferenceData()
+    {
+        return [
+            'discriminatedDocument' => [
+                'expectedReference' => ['$ref' => 'GH2002DocumentA', 'class' => GH2002DocumentA::class],
+                'document' => new GH2002DocumentB(new GH2002DocumentA()),
+            ],
+            'referenceWithoutTargetDocument' => [
+                'expectedReference' => ['$ref' => 'GH2002DocumentA', '_doctrine_class_name' => GH2002DocumentA::class],
+                'document' => new GH2002ReferenceWithoutTargetDocument(new GH2002DocumentA()),
+            ],
+            'referenceWithoutTargetDocumentWithDiscriminatorField' => [
+                'expectedReference' => ['$ref' => 'GH2002DocumentA', 'referencedClass' => GH2002DocumentA::class],
+                'document' => new GH2002ReferenceWithoutTargetDocumentWithDiscriminatorField(new GH2002DocumentA()),
+            ],
+            'referenceWithDiscriminatorField' => [
+                'expectedReference' => ['$ref' => 'GH2002DocumentA', 'referencedClass' => GH2002DocumentA::class],
+                'document' => new GH2002ReferenceWithDiscriminatorField(new GH2002DocumentA()),
+            ],
+            'referenceWithPartialDiscriminatorMapUnlistedDocument' => [
+                'expectedReference' => ['$ref' => 'GH2002DocumentA', 'referencedClass' => GH2002DocumentA::class],
+                'document' => new GH2002ReferenceWithPartialDiscriminatorMap(new GH2002DocumentA()),
+            ],
+            'referenceWithPartialDiscriminatorMapListedDocument' => [
+                'expectedReference' => ['$ref' => 'GH2002DocumentA', 'referencedClass' => 'B'],
+                'document' => new GH2002ReferenceWithPartialDiscriminatorMap(new GH2002DocumentB()),
+            ],
+            'documentWithDiscriminatorMapListedDocument' => [
+                'expectedReference' => ['$ref' => 'GH2002DocumentWithDiscriminatorMapA', 'type' => 'A'],
+                'document' => new GH2002DocumentWithDiscriminatorMapA(new GH2002DocumentWithDiscriminatorMapA()),
+            ],
+            'documentWithDiscriminatorMapUnlistedDocument' => [
+                'expectedReference' => ['$ref' => 'GH2002DocumentWithDiscriminatorMapA', 'type' => GH2002DocumentWithDiscriminatorMapB::class],
+                'document' => new GH2002DocumentWithDiscriminatorMapA(new GH2002DocumentWithDiscriminatorMapB()),
+            ],
+        ];
+    }
+}
+
+/**
+ * @ODM\Document
+ * @ODM\InheritanceType("SINGLE_COLLECTION")
+ * @ODM\DiscriminatorField("class")
+ */
+class GH2002DocumentA
+{
+    /**
+     * @ODM\Id
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * @ODM\ReferenceOne(targetDocument=GH2002DocumentA::class, cascade="all")
+     *
+     * @var GH2002DocumentA
+     */
+    public $parentDocument;
+
+    public function __construct(GH2002DocumentA $parentDocument = null)
+    {
+        $this->parentDocument = $parentDocument;
+    }
+}
+
+/**
+ * @ODM\Document
+ */
+class GH2002DocumentB extends GH2002DocumentA
+{
+}
+
+/**
+ * @ODM\Document
+ */
+class GH2002ReferenceWithoutTargetDocument
+{
+    /**
+     * @ODM\Id
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * @ODM\ReferenceOne(cascade="all")
+     *
+     * @var GH2002DocumentA
+     */
+    public $parentDocument;
+
+    public function __construct(GH2002DocumentA $parentDocument = null)
+    {
+        $this->parentDocument = $parentDocument;
+    }
+}
+
+/**
+ * @ODM\Document
+ */
+class GH2002ReferenceWithoutTargetDocumentWithDiscriminatorField
+{
+    /**
+     * @ODM\Id
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * @ODM\ReferenceOne(discriminatorField="referencedClass", cascade="all")
+     *
+     * @var GH2002DocumentA
+     */
+    public $parentDocument;
+
+    public function __construct(GH2002DocumentA $parentDocument = null)
+    {
+        $this->parentDocument = $parentDocument;
+    }
+}
+
+/**
+ * @ODM\Document
+ */
+class GH2002ReferenceWithDiscriminatorField
+{
+    /**
+     * @ODM\Id
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * @ODM\ReferenceOne(targetDocument=GH2002DocumentA::class, discriminatorField="referencedClass", cascade="all")
+     *
+     * @var GH2002DocumentA
+     */
+    public $parentDocument;
+
+    public function __construct(GH2002DocumentA $parentDocument = null)
+    {
+        $this->parentDocument = $parentDocument;
+    }
+}
+
+/**
+ * @ODM\Document
+ */
+class GH2002ReferenceWithPartialDiscriminatorMap
+{
+    /**
+     * @ODM\Id
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * @ODM\ReferenceOne(discriminatorField="referencedClass", discriminatorMap={"B"=GH2002DocumentB::class}, cascade="all")
+     *
+     * @var GH2002DocumentA
+     */
+    public $parentDocument;
+
+    public function __construct(GH2002DocumentA $parentDocument = null)
+    {
+        $this->parentDocument = $parentDocument;
+    }
+}
+
+/**
+ * @ODM\Document
+ * @ODM\InheritanceType("SINGLE_COLLECTION")
+ * @ODM\DiscriminatorField("type")
+ * @ODM\DiscriminatorMap({"A"=GH2002DocumentWithDiscriminatorMapA::class})
+ */
+class GH2002DocumentWithDiscriminatorMapA
+{
+    /**
+     * @ODM\Id
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * @ODM\ReferenceOne(targetDocument=GH2002DocumentWithDiscriminatorMapA::class, cascade="all")
+     *
+     * @var GH2002DocumentWithDiscriminatorMapA
+     */
+    public $parentDocument;
+
+    public function __construct(GH2002DocumentWithDiscriminatorMapA $parentDocument = null)
+    {
+        $this->parentDocument = $parentDocument;
+    }
+}
+
+/**
+ * @ODM\Document
+ */
+class GH2002DocumentWithDiscriminatorMapB extends GH2002DocumentWithDiscriminatorMapA
+{
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

While working on #2002, I noticed that the detection logic wasn't quite right. So I expanded the failing test submitted by @josefsabl to cover more use cases to make sure we're getting the discriminator logic correct.

Note that this doesn't fix this bug for 2.0, as we need to adapt the logic there a little bit to cover for the (expected) exceptions. While debugging, I also noticed an issue where the `PersistenceBuilder` modifies the ClassMetadata which definitely shouldn't happen.