### PR TITLE
Loosen naming rules for discriminator values

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -285,7 +285,7 @@
   </xs:simpleType>
 
   <xs:complexType name="discriminator-mapping">
-    <xs:attribute name="value" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="value" type="xs:string" use="required"/>
     <xs:attribute name="class" type="xs:string" use="required"/>
   </xs:complexType>
 
@@ -300,7 +300,7 @@
   </xs:complexType>
 
   <xs:complexType name="default-discriminator-value">
-    <xs:attribute name="value" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="value" type="xs:string" use="required"/>
   </xs:complexType>
 
   <xs:simpleType name="lifecycle-callback-type">


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | Fixes #1980 

#### Summary

With 2.0, loading mapping files that don't validate against the provided XSD file are no longer loaded and cause an exception. In 1.3, such files will trigger a deprecation notice to inform the user of the upcoming restriction. However, some of the values that were accepted before are not considered valid, most notably discriminator values. This PR loosens the restriction for those types.

Technically, we can most likely do the same for many other attributes that use `NMTOKEN` right now, especially since those checks are not done for annotation mappings. However, I'd rather not completely open up the types for field names, as we'd most likely want to restrict them to what MongoDB allows. Thus, only discriminator values are loosened right now.