### PR TITLE
[2.1] Deprecate AbstractIdGenerator

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -1,0 +1,7 @@
+# UPGRADE FROM 2.0 to 2.1
+
+The `Doctrine\ODM\MongoDB\Id\AbstractIdGenerator` class has been deprecated. Custom ID generators must implement
+the `Doctrine\ODM\MongoDB\Id\IdGenerator` interface.
+
+The `Doctrine\ODM\MongoDB\Mapping\ClassMetadata` class has been marked final. The class will no longer be extendable 
+in ODM 3.0.

--- a/lib/Doctrine/ODM/MongoDB/Id/AbstractIdGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Id/AbstractIdGenerator.php
@@ -4,17 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Id;
 
-use Doctrine\ODM\MongoDB\DocumentManager;
-
 /**
- * AbstractIdGenerator
+ * @deprecated AbstractIdGenerator was deprecated in 2.1 and will be removed in 3.0. Implement IdGenerator interface instead.
  */
-abstract class AbstractIdGenerator
+abstract class AbstractIdGenerator implements IdGenerator
 {
-    /**
-     * Generates an identifier for a document.
-     *
-     * @return mixed
-     */
-    abstract public function generate(DocumentManager $dm, object $document);
 }

--- a/lib/Doctrine/ODM/MongoDB/Id/IdGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Id/IdGenerator.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Id;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+
+interface IdGenerator
+{
+    /**
+     * Generates an identifier for a document.
+     *
+     * @return mixed
+     */
+    public function generate(DocumentManager $dm, object $document);
+}

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -8,7 +8,7 @@ use BadMethodCallException;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata as BaseClassMetadata;
 use Doctrine\Instantiator\Instantiator;
 use Doctrine\Instantiator\InstantiatorInterface;
-use Doctrine\ODM\MongoDB\Id\AbstractIdGenerator;
+use Doctrine\ODM\MongoDB\Id\IdGenerator;
 use Doctrine\ODM\MongoDB\LockException;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
@@ -48,8 +48,10 @@ use function strtoupper;
  * 2) To drastically reduce the size of a serialized instance (private/protected members
  *    get the whole class name, namespace inclusive, prepended to every property in
  *    the serialized representation).
+ *
+ * @final
  */
-class ClassMetadata implements BaseClassMetadata
+/* final */ class ClassMetadata implements BaseClassMetadata
 {
     /* The Id generator types. */
     /**
@@ -80,7 +82,7 @@ class ClassMetadata implements BaseClassMetadata
      * does not exist or if an option was passed for that there is not setter in the new
      * generator class.
      *
-     * The class  will have to be a subtype of AbstractIdGenerator.
+     * The class will have to implement IdGenerator.
      */
     public const GENERATOR_TYPE_CUSTOM = 5;
 
@@ -328,7 +330,7 @@ class ClassMetadata implements BaseClassMetadata
     /**
      * READ-ONLY: The ID generator used for generating IDs for this class.
      *
-     * @var AbstractIdGenerator|null
+     * @var IdGenerator|null
      */
     public $idGenerator;
 
@@ -1370,7 +1372,7 @@ class ClassMetadata implements BaseClassMetadata
     /**
      * Sets the ID generator used to generate IDs for instances of this class.
      */
-    public function setIdGenerator(AbstractIdGenerator $generator) : void
+    public function setIdGenerator(IdGenerator $generator) : void
     {
         $this->idGenerator = $generator;
     }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -15,9 +15,9 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs;
 use Doctrine\ODM\MongoDB\Event\OnClassMetadataNotFoundEventArgs;
 use Doctrine\ODM\MongoDB\Events;
-use Doctrine\ODM\MongoDB\Id\AbstractIdGenerator;
 use Doctrine\ODM\MongoDB\Id\AlnumGenerator;
 use Doctrine\ODM\MongoDB\Id\AutoGenerator;
+use Doctrine\ODM\MongoDB\Id\IdGenerator;
 use Doctrine\ODM\MongoDB\Id\IncrementGenerator;
 use Doctrine\ODM\MongoDB\Id\UuidGenerator;
 use ReflectionException;
@@ -295,7 +295,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
                 $customGenerator = new $idGenOptions['class']();
                 unset($idGenOptions['class']);
-                if (! $customGenerator instanceof AbstractIdGenerator) {
+                if (! $customGenerator instanceof IdGenerator) {
                     throw MappingException::classIsNotAValidGenerator(get_class($customGenerator));
                 }
 


### PR DESCRIPTION
There's no reason to provide an abstract class instead of an interface. Since this is a BC break I propose we do this for 2.0 although I'm eager to deprecate the class in 1.3 and remove the abstract in 2.0 already :)