### PR TITLE
Allow specifying generic options for Query find operations

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -401,7 +401,7 @@ class Query implements IteratorAggregate
      *
      * @return Iterator|UpdateResult|InsertOneResult|DeleteResult|array|object|int|null
      */
-    public function runQuery()
+    private function runQuery()
     {
         $options = $this->options;
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | #1808

#### Summary

Previously, find operations were unique in that they did not inherit generic options passed to the `Query::__construct()` via `Builder::getQuery()`. This makes find consistent with other operations and also adds tests for allowing query array options to override these generic options.

This also enabled users to pass driver-specific options to `Collection::find()` that may not be supported by the Builder API.
