### PR TITLE
Make addStage Aggregation Builder method public

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -503,7 +503,12 @@ class Builder
         return $stage;
     }
 
-    protected function addStage(Stage $stage) : Stage
+    /**
+     * Allows adding an arbitrary stage to the pipeline
+     *
+     * @return Stage The method returns the stage given as an argument
+     */
+    public function addStage(Stage $stage) : Stage
     {
         $this->stages[] = $stage;
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -323,4 +323,14 @@ abstract class Stage
     {
         return $this->builder->unwind($fieldName);
     }
+
+    /**
+     * Allows adding an arbitrary stage to the pipeline
+     *
+     * @return Stage The method returns the stage given as an argument
+     */
+    public function addStage(Stage $stage) : Stage
+    {
+        return $this->builder->addStage($stage);
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation;
 
 use DateTimeImmutable;
+use Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Article;
@@ -102,6 +103,7 @@ class BuilderTest extends BaseTest
             ['$sort' => ['numOrders' => -1, 'avgAmount' => 1]],
             ['$limit' => 5],
             ['$skip' => 2],
+            ['$foo' => 'bar'],
             ['$out' => 'collectionName'],
         ];
 
@@ -160,6 +162,7 @@ class BuilderTest extends BaseTest
             ->sort(['numOrders' => 'desc', 'avgAmount' => 'asc']) // Multiple subsequent sorts are combined into a single stage
             ->limit(5)
             ->skip(2)
+            ->addStage(new TestStage($builder))
             ->out('collectionName');
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
@@ -368,5 +371,13 @@ class BuilderTest extends BaseTest
 
         $this->dm->flush();
         $this->dm->clear();
+    }
+}
+
+class TestStage extends Stage
+{
+    public function getExpression() : array
+    {
+        return ['$foo' => 'bar'];
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

This takes work done by @Steveb-p in #1974 and applies it to the master branch. As explained in https://github.com/doctrine/mongodb-odm/pull/1974#issuecomment-482083234, without a public `addStage` method in the pipeline stages we can't really make it public in the builder either since it would break the fluent interface, which might confuse people. In order to avoid having to do a new minor release of `doctrine/mongodb` just to make the method public, we move the feature to the 2.0 release.