### PR TITLE
Dump xdebug filter to improve code coverage build performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,9 @@ jobs:
       before_script:
         - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}
         - if [[ ! $(php -m | grep -si xdebug) ]]; then echo "xdebug required for coverage"; exit 1; fi
+        - vendor/bin/phpunit --dump-xdebug-filter xdebug-filter.php
       script:
-        - vendor/bin/phpunit --coverage-clover=coverage.clover
+        - vendor/bin/phpunit --prepend xdebug-filter.php --coverage-clover=coverage.clover
       after_script:
         - wget https://scrutinizer-ci.com/ocular.phar
         - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "doctrine/coding-standard": "^5.0",
         "jmikola/geojson": "^1.0",
         "phpstan/phpstan": "^0.10.3",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.4"
     },
     "autoload": {
         "psr-4": { "Doctrine\\ODM\\MongoDB\\": "lib/Doctrine/ODM/MongoDB" }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

This makes use of a PHPUnit feature which dumps the code coverage whitelist in a format understandable by Xdebug, which in turn greatly speeds up code coverage builds. Locally, I was able to get build times with coverage from ~17 minutes down to ~11 minutes.

I've bumped the required PHPUnit version to the lowest version supporting the feature and have not checked if we may drop some more versions due to the PHP requirement.