### PR TITLE
Reword most deprecation notices

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
@@ -73,7 +73,7 @@ class Expr extends BaseExpr
     protected function ensureArray($expression)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The "%s" method will be private in MongoDB ODM 2.0. You should not rely on calling this method.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The "%s" method will be private in doctrine/mongodb-odm 2.0. You should not rely on calling this method.', __METHOD__), E_USER_DEPRECATED);
         }
 
         // Convert field names in expressions

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket.php
@@ -48,7 +48,7 @@ class Bucket extends BaseStage\Bucket
     protected function convertExpression($expression)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The "%s" method will be private in MongoDB ODM 2.0. You should not rely on calling this method.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The "%s" method will be private in doctrine/mongodb-odm 2.0. You should not rely on calling this method.', __METHOD__), E_USER_DEPRECATED);
         }
 
         if (is_array($expression)) {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/BucketAuto.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/BucketAuto.php
@@ -48,7 +48,7 @@ class BucketAuto extends BaseStage\BucketAuto
     protected function convertExpression($expression)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The "%s" method will be private in MongoDB ODM 2.0. You should not rely on calling this method.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The "%s" method will be private in doctrine/mongodb-odm 2.0. You should not rely on calling this method.', __METHOD__), E_USER_DEPRECATED);
         }
 
         if (is_array($expression)) {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup.php
@@ -156,7 +156,7 @@ class GraphLookup extends BaseStage\GraphLookup
     protected function convertExpression($expression)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The "%s" method will be private in MongoDB ODM 2.0. You should not rely on calling this method.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The "%s" method will be private in doctrine/mongodb-odm 2.0. You should not rely on calling this method.', __METHOD__), E_USER_DEPRECATED);
         }
 
         if (is_array($expression)) {
@@ -171,7 +171,7 @@ class GraphLookup extends BaseStage\GraphLookup
     protected function convertTargetFieldName($fieldName)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The "%s" method will be private in MongoDB ODM 2.0. You should not rely on calling this method.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The "%s" method will be private in doctrine/mongodb-odm 2.0. You should not rely on calling this method.', __METHOD__), E_USER_DEPRECATED);
         }
 
         if (is_array($fieldName)) {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Match.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Match.php
@@ -60,7 +60,7 @@ class Match extends BaseStage\Match
      */
     public function debug($name = null)
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in MongoDB ODM 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         return parent::debug($name);
     }
@@ -71,7 +71,7 @@ class Match extends BaseStage\Match
     public function geoWithinPolygon()
     {
         if (func_num_args() < 3) {
-            @trigger_error(sprintf('Calling "%s" with fewer than 3 arguments was deprecated in MongoDB ODM 1.3 and will require at least 3 arguments in 2.0.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Calling "%s" with fewer than 3 arguments was deprecated in doctrine/mongodb-odm 1.3 and will require at least 3 arguments in 2.0.', __METHOD__), E_USER_DEPRECATED);
         }
 
         return parent::geoWithinPolygon(...func_get_args());
@@ -84,7 +84,7 @@ class Match extends BaseStage\Match
      */
     public function maxDistance($maxDistance)
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in MongoDB ODM 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         return parent::maxDistance($maxDistance);
     }
@@ -96,7 +96,7 @@ class Match extends BaseStage\Match
      */
     public function minDistance($minDistance)
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in MongoDB ODM 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         return parent::minDistance($minDistance);
     }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceRoot.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceRoot.php
@@ -48,7 +48,7 @@ class ReplaceRoot extends BaseStage\ReplaceRoot
     protected function convertExpression($expression)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The "%s" method will be private in MongoDB ODM 2.0. You should not rely on calling this method.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The "%s" method will be private in doctrine/mongodb-odm 2.0. You should not rely on calling this method.', __METHOD__), E_USER_DEPRECATED);
         }
 
         if (is_array($expression)) {

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -247,14 +247,14 @@ class Configuration extends \Doctrine\MongoDB\Configuration
     {
         if (is_bool($autoGenerateProxyClasses)) {
             @trigger_error(
-                sprintf('Passing boolean value to %s is deprecated, please use constants of %s instead.', __METHOD__, AbstractProxyFactory::class),
+                sprintf('Passing boolean value to "%s" is deprecated, please use constants of "%s" instead.', __METHOD__, AbstractProxyFactory::class),
                 E_USER_DEPRECATED
             );
         }
 
         if ($autoGenerateProxyClasses === AbstractProxyFactory::AUTOGENERATE_ALWAYS || $autoGenerateProxyClasses === AbstractProxyFactory::AUTOGENERATE_NEVER) {
             @trigger_error(
-                sprintf('The "AUTOGENERATE_ALWAYS" and "AUTOGENERATE_NEVER" strategies for proxy generation are deprecated and will be dropped in 2.0. Please use "AUTOGENERATE_FILE_NOT_EXISTS" and "AUTOGENERATE_EVAL".'),
+                sprintf('The "AUTOGENERATE_ALWAYS" and "AUTOGENERATE_NEVER" strategies for proxy generation are deprecated and will be dropped in doctrine/mongodb-odm 2.0. Please use "AUTOGENERATE_FILE_NOT_EXISTS" and "AUTOGENERATE_EVAL".'),
                 E_USER_DEPRECATED
             );
         }
@@ -326,7 +326,7 @@ class Configuration extends \Doctrine\MongoDB\Configuration
     {
         if (is_bool($bool)) {
             @trigger_error(
-                sprintf('Passing boolean value to %s is deprecated, please use AUTOGENERATE_* constants of %s instead.', __METHOD__, self::class),
+                sprintf('Passing boolean value to "%s" is deprecated, please use "AUTOGENERATE_*" constants of "%s" instead.', __METHOD__, self::class),
                 E_USER_DEPRECATED
             );
         }
@@ -545,7 +545,7 @@ class Configuration extends \Doctrine\MongoDB\Configuration
     public function setDefaultRepositoryClassName($className)
     {
         @trigger_error(
-            sprintf('"%s" was deprecated in MongoDB ODM 1.2 and will be removed in 2.0. Please use "%s::setDefaultDocumentRepositoryClassName" instead.', __METHOD__, __CLASS__),
+            sprintf('"%s" was deprecated in doctrine/mongodb-odm 1.2 and will be removed in 2.0. Please use "%s::setDefaultDocumentRepositoryClassName" instead.', __METHOD__, __CLASS__),
             E_USER_DEPRECATED
         );
         $this->setDefaultDocumentRepositoryClassName($className);
@@ -561,7 +561,7 @@ class Configuration extends \Doctrine\MongoDB\Configuration
     public function getDefaultRepositoryClassName()
     {
         @trigger_error(
-            sprintf('"%s" was deprecated in MongoDB ODM 1.2 and will be removed in 2.0. Please use "%s::getDefaultDocumentRepositoryClassName" instead.', __METHOD__, __CLASS__),
+            sprintf('"%s" was deprecated in doctrine/mongodb-odm 1.2 and will be removed in 2.0. Please use "%s::getDefaultDocumentRepositoryClassName" instead.', __METHOD__, __CLASS__),
             E_USER_DEPRECATED
         );
         return $this->getDefaultDocumentRepositoryClassName();
@@ -669,7 +669,7 @@ class Configuration extends \Doctrine\MongoDB\Configuration
      */
     public function getLoggerCallable()
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in MongoDB ODM 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         return parent::getLoggerCallable();
     }
@@ -681,7 +681,7 @@ class Configuration extends \Doctrine\MongoDB\Configuration
      */
     public function setLoggerCallable($loggerCallable)
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in MongoDB ODM 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         parent::setLoggerCallable($loggerCallable);
     }
@@ -693,7 +693,7 @@ class Configuration extends \Doctrine\MongoDB\Configuration
      */
     public function getMongoCmd()
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in MongoDB ODM 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         return parent::getMongoCmd();
     }
@@ -705,7 +705,7 @@ class Configuration extends \Doctrine\MongoDB\Configuration
      */
     public function setMongoCmd($cmd)
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in MongoDB ODM 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         parent::setMongoCmd($cmd);
     }
@@ -717,7 +717,7 @@ class Configuration extends \Doctrine\MongoDB\Configuration
      */
     public function getRetryConnect()
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in MongoDB ODM 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         return parent::getRetryConnect();
     }
@@ -729,7 +729,7 @@ class Configuration extends \Doctrine\MongoDB\Configuration
      */
     public function setRetryConnect($retryConnect)
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in MongoDB ODM 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         parent::setRetryConnect($retryConnect);
     }
@@ -741,7 +741,7 @@ class Configuration extends \Doctrine\MongoDB\Configuration
      */
     public function getRetryQuery()
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in MongoDB ODM 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         return parent::getRetryQuery();
     }
@@ -753,7 +753,7 @@ class Configuration extends \Doctrine\MongoDB\Configuration
      */
     public function setRetryQuery($retryQuery)
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in MongoDB ODM 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         parent::setRetryQuery($retryQuery);
     }

--- a/lib/Doctrine/ODM/MongoDB/Cursor.php
+++ b/lib/Doctrine/ODM/MongoDB/Cursor.php
@@ -559,7 +559,7 @@ class Cursor implements CursorInterface, Iterator
         $ok = (boolean) $ok;
         if ($ok) {
             @trigger_error(
-                sprintf('%s was deprecated in version 1.2 - use setReadPreference on the query instead.', __METHOD__),
+                sprintf('The "%s" method was deprecated in doctrine/mongodb-odm 1.2 and will be removed in 2.0. Use setReadPreference on the query instead.', __METHOD__),
                 E_USER_DEPRECATED
             );
         }

--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -799,7 +799,7 @@ class DocumentManager implements ObjectManager
      */
     public function createDBRef($document, array $referenceMapping = null)
     {
-        @trigger_error('The ' . __METHOD__ . ' method has been deprecated and will be removed in ODM 2.0. Use createReference() instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method has been deprecated and will be removed in doctrine/mongodb-odm 2.0. Use createReference() instead.', __METHOD__), E_USER_DEPRECATED);
 
         if (!isset($referenceMapping['storeAs'])) {
             $referenceMapping['storeAs'] = ClassMetadata::REFERENCE_STORE_AS_DB_REF;

--- a/lib/Doctrine/ODM/MongoDB/DocumentNotFoundException.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentNotFoundException.php
@@ -33,7 +33,7 @@ class DocumentNotFoundException extends MongoDBException
     public function __construct($message = "", $code = 0, Throwable $previous = null)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         parent::__construct($message, $code, $previous);
     }

--- a/lib/Doctrine/ODM/MongoDB/DocumentRepository.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentRepository.php
@@ -9,7 +9,7 @@ use function sprintf;
 use function trigger_error;
 
 if (! class_exists(BaseDocumentRepository::class, false)) {
-    @trigger_error(sprintf('The "%s" class is deprecated and will be removed in 2.0. Use "%s" instead.', DocumentRepository::class, BaseDocumentRepository::class), E_USER_DEPRECATED);
+    @trigger_error(sprintf('The "%s" class is deprecated and will be removed in doctrine/mongodb-odm 2.0. Use "%s" instead.', DocumentRepository::class, BaseDocumentRepository::class), E_USER_DEPRECATED);
 }
 
 class_alias(BaseDocumentRepository::class, DocumentRepository::class);

--- a/lib/Doctrine/ODM/MongoDB/Event/DocumentNotFoundEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/DocumentNotFoundEventArgs.php
@@ -51,7 +51,7 @@ class DocumentNotFoundEventArgs extends LifecycleEventArgs
     public function __construct($document, DocumentManager $dm, $identifier)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         parent::__construct($document, $dm);
         $this->identifier = $identifier;

--- a/lib/Doctrine/ODM/MongoDB/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/LoadClassMetadataEventArgs.php
@@ -34,7 +34,7 @@ class LoadClassMetadataEventArgs extends BaseLoadClassMetadataEventArgs
     public function __construct(ClassMetadata $classMetadata, ObjectManager $objectManager)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         parent::__construct($classMetadata, $objectManager);
     }

--- a/lib/Doctrine/ODM/MongoDB/Event/OnClassMetadataNotFoundEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/OnClassMetadataNotFoundEventArgs.php
@@ -32,7 +32,7 @@ class OnClassMetadataNotFoundEventArgs extends ManagerEventArgs
     public function __construct($className, DocumentManager $dm)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         $this->className = (string) $className;
 

--- a/lib/Doctrine/ODM/MongoDB/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/OnClearEventArgs.php
@@ -32,7 +32,7 @@ class OnClearEventArgs extends BaseOnClearEventArgs
     public function __construct($objectManager, $entityClass = null)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         parent::__construct($objectManager, $entityClass);
     }

--- a/lib/Doctrine/ODM/MongoDB/Event/OnFlushEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/OnFlushEventArgs.php
@@ -32,7 +32,7 @@ class OnFlushEventArgs extends ManagerEventArgs
     public function __construct(ObjectManager $objectManager)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         parent::__construct($objectManager);
     }

--- a/lib/Doctrine/ODM/MongoDB/Event/PostCollectionLoadEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PostCollectionLoadEventArgs.php
@@ -25,7 +25,7 @@ class PostCollectionLoadEventArgs extends ManagerEventArgs
     public function __construct(PersistentCollectionInterface $collection, DocumentManager $dm)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         parent::__construct($dm);
         $this->collection = $collection;

--- a/lib/Doctrine/ODM/MongoDB/Event/PostFlushEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PostFlushEventArgs.php
@@ -32,7 +32,7 @@ class PostFlushEventArgs extends ManagerEventArgs
     public function __construct(ObjectManager $objectManager)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         parent::__construct($objectManager);
     }

--- a/lib/Doctrine/ODM/MongoDB/Event/PreFlushEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PreFlushEventArgs.php
@@ -32,7 +32,7 @@ class PreFlushEventArgs extends ManagerEventArgs
     public function __construct(ObjectManager $objectManager)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         parent::__construct($objectManager);
     }

--- a/lib/Doctrine/ODM/MongoDB/Event/PreLoadEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PreLoadEventArgs.php
@@ -44,7 +44,7 @@ class PreLoadEventArgs extends LifecycleEventArgs
     public function __construct($document, DocumentManager $dm, array &$data)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         parent::__construct($document, $dm);
         $this->data =& $data;

--- a/lib/Doctrine/ODM/MongoDB/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PreUpdateEventArgs.php
@@ -44,7 +44,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
     public function __construct($document, DocumentManager $dm, array $changeSet)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         parent::__construct($document, $dm);
         $this->documentChangeSet = $changeSet;

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorException.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorException.php
@@ -33,7 +33,7 @@ class HydratorException extends MongoDBException
     public function __construct($message = "", $code = 0, Throwable $previous = null)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         parent::__construct($message, $code, $previous);
     }

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -99,7 +99,7 @@ class HydratorFactory
     public function __construct(DocumentManager $dm, EventManager $evm, $hydratorDir, $hydratorNs, $autoGenerate)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         if ( ! $hydratorDir) {
             throw HydratorException::hydratorDirectoryRequired();

--- a/lib/Doctrine/ODM/MongoDB/Id/AlnumGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Id/AlnumGenerator.php
@@ -50,7 +50,7 @@ class AlnumGenerator extends IncrementGenerator
     public function __construct()
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Id/AutoGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Id/AutoGenerator.php
@@ -32,7 +32,7 @@ class AutoGenerator extends AbstractIdGenerator
     public function __construct()
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Id/IncrementGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Id/IncrementGenerator.php
@@ -44,7 +44,7 @@ class IncrementGenerator extends AbstractIdGenerator
     public function __construct()
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Id/UuidGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Id/UuidGenerator.php
@@ -39,7 +39,7 @@ class UuidGenerator extends AbstractIdGenerator
     public function __construct()
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
     }
 

--- a/lib/Doctrine/ODM/MongoDB/LockException.php
+++ b/lib/Doctrine/ODM/MongoDB/LockException.php
@@ -32,7 +32,7 @@ class LockException extends MongoDBException
     public function __construct($msg, $document = null)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         parent::__construct($msg);
         $this->document = $document;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/DoctrineAnnotations.php
@@ -18,7 +18,7 @@
  */
 
 @trigger_error(
-    sprintf('Loading annotations with %s is deprecated - register class loader through AnnotationRegistry::registerLoader instead.', __FILE__),
+    sprintf('Loading annotations with "%s" is deprecated and will be removed in doctrine/mongodb-odm 2.0. Register class loader through AnnotationRegistry::registerLoader instead.', __FILE__),
     E_USER_DEPRECATED
 );
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -640,7 +640,7 @@ class ClassMetadata implements BaseClassMetadata
         }
 
         if ($repositoryClassName && strpos($repositoryClassName, '\\') === false && strlen($this->namespace)) {
-            @trigger_error(sprintf('Class "%s" relies on same-namespace resolution for its repository class. This is deprecated and will be dropped in 2.0. Please use a FQCN instead.', $this->name), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Class "%s" relies on same-namespace resolution for its repository class. This is deprecated and will be dropped in doctrine/mongodb-odm 2.0. Please use a FQCN instead.', $this->name), E_USER_DEPRECATED);
 
             $repositoryClassName = $this->namespace . '\\' . $repositoryClassName;
         }
@@ -805,7 +805,7 @@ class ClassMetadata implements BaseClassMetadata
     {
         foreach ($map as $value => $className) {
             if (strpos($className, '\\') === false && strlen($this->namespace)) {
-                @trigger_error(sprintf('Class "%s" relies on same-namespace resolution in its discriminator map for value "%s". This is deprecated and will be dropped in 2.0. Please use a FQCN instead.', $this->name, $value), E_USER_DEPRECATED);
+                @trigger_error(sprintf('Class "%s" relies on same-namespace resolution in its discriminator map for value "%s". This is deprecated and will be dropped in doctrine/mongodb-odm 2.0. Please use a FQCN instead.', $this->name, $value), E_USER_DEPRECATED);
 
                 $className = $this->namespace . '\\' . $className;
             }
@@ -872,7 +872,7 @@ class ClassMetadata implements BaseClassMetadata
     {
         if ($slaveOkay) {
             @trigger_error(
-                sprintf('%s was deprecated in version 1.2 and will be removed in 2.0.', __METHOD__),
+                sprintf('The "%s" method was deprecated in doctrine/mongodb-odm 1.2 and will be removed in 2.0.', __METHOD__),
                 E_USER_DEPRECATED
             );
         }
@@ -892,7 +892,7 @@ class ClassMetadata implements BaseClassMetadata
     public function addIndex($keys, array $options = array())
     {
         if (isset($options['dropDups'])) {
-            @trigger_error(sprintf('Ths "dropDups" option on indexes is deprecated and will be dropped in 2.0. Remove the "dropDups" options in class "%s".', $this->getName()), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Ths "dropDups" option on indexes is deprecated and will be dropped in doctrine/mongodb-odm 2.0. Remove the "dropDups" option in class "%s".', $this->getName()), E_USER_DEPRECATED);
         }
 
         $this->indexes[] = array(
@@ -925,7 +925,7 @@ class ClassMetadata implements BaseClassMetadata
     {
         if ($requireIndexes) {
             @trigger_error(
-                'requireIndexes was deprecated in version 1.2 and will be removed altogether in 2.0.',
+                'requireIndexes was deprecated in doctrine/mongodb-odm 1.2 and will be removed altogether in 2.0.',
                 E_USER_DEPRECATED
             );
         }
@@ -1145,7 +1145,7 @@ class ClassMetadata implements BaseClassMetadata
      */
     public function getNamespace()
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         return $this->namespace;
     }
@@ -1317,7 +1317,7 @@ class ClassMetadata implements BaseClassMetadata
      */
     public function getDistance()
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in MongoDB ODM 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         return $this->distance;
     }
@@ -1331,7 +1331,7 @@ class ClassMetadata implements BaseClassMetadata
      */
     public function setDistance($distance)
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in MongoDB ODM 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         $this->distance = $distance;
     }
@@ -1363,14 +1363,14 @@ class ClassMetadata implements BaseClassMetadata
             throw MappingException::discriminatorFieldConflict($this->name, $this->discriminatorField);
         }
         if (isset($mapping['targetDocument']) && strpos($mapping['targetDocument'], '\\') === false && strlen($this->namespace)) {
-            @trigger_error(sprintf('Field "%s" in class "%s" relies on same-namespace resolution for the target document. This is deprecated and will be dropped in 2.0. Please use a FQCN instead.', $mapping['name'], $this->name), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Field "%s" in class "%s" relies on same-namespace resolution for the target document. This is deprecated and will be dropped in doctrine/mongodb-odm 2.0. Please use a FQCN instead.', $mapping['name'], $this->name), E_USER_DEPRECATED);
 
             $mapping['targetDocument'] = $this->namespace . '\\' . $mapping['targetDocument'];
         }
 
         if (isset($mapping['collectionClass'])) {
             if (strpos($mapping['collectionClass'], '\\') === false && strlen($this->namespace)) {
-                @trigger_error(sprintf('Field "%s" in class "%s" relies on same-namespace resolution for the collection class. This is deprecated and will be dropped in 2.0. Please use a FQCN instead.', $mapping['name'], $this->name), E_USER_DEPRECATED);
+                @trigger_error(sprintf('Field "%s" in class "%s" relies on same-namespace resolution for the collection class. This is deprecated and will be dropped in doctrine/mongodb-odm 2.0. Please use a FQCN instead.', $mapping['name'], $this->name), E_USER_DEPRECATED);
 
                 $mapping['collectionClass'] = $this->namespace . '\\' . $mapping['collectionClass'];
             }
@@ -1386,7 +1386,7 @@ class ClassMetadata implements BaseClassMetadata
         if (isset($mapping['discriminatorMap'])) {
             foreach ($mapping['discriminatorMap'] as $key => $class) {
                 if (strpos($class, '\\') === false && strlen($this->namespace)) {
-                    @trigger_error(sprintf('Field "%s" in class "%s" relies on same-namespace resolution in its discriminator map for value "%s". This is deprecated and will be dropped in 2.0. Please use a FQCN instead.', $mapping['name'], $this->name, $key), E_USER_DEPRECATED);
+                    @trigger_error(sprintf('Field "%s" in class "%s" relies on same-namespace resolution in its discriminator map for value "%s". This is deprecated and will be dropped in doctrine/mongodb-odm 2.0. Please use a FQCN instead.', $mapping['name'], $this->name, $key), E_USER_DEPRECATED);
 
                     $mapping['discriminatorMap'][$key] = $this->namespace . '\\' . $class;
                 }
@@ -1422,7 +1422,7 @@ class ClassMetadata implements BaseClassMetadata
             $mapping['strategy'] = self::STORAGE_STRATEGY_INCREMENT;
         }
         if (isset($mapping['file']) && $mapping['file'] === true) {
-            @trigger_error(sprintf('The field "%s" for class "%s" is mapped as file. This is deprecated and will not be possible in 2.0. Please read the upgrade notes for GridFS.', $mapping['fieldName'], $this->getName()), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The field "%s" for class "%s" is mapped as file. This is deprecated and will not be possible in doctrine/mongodb-odm 2.0. Please read the upgrade notes for GridFS.', $mapping['fieldName'], $this->getName()), E_USER_DEPRECATED);
             $this->file = $mapping['fieldName'];
             $mapping['name'] = 'file';
         }
@@ -1457,7 +1457,7 @@ class ClassMetadata implements BaseClassMetadata
         // Synchronize the "simple" and "storeAs" mapping information for backwards compatibility
         if (isset($mapping['simple']) && ($mapping['simple'] === true || $mapping['simple'] === 'true')) {
             $mapping['storeAs'] = static::REFERENCE_STORE_AS_ID;
-            @trigger_error('"simple" attribute of a reference is deprecated - use storeAs="id" instead.', E_USER_DEPRECATED);
+            @trigger_error('"simple" attribute of a reference is deprecated and will be removed in doctrine/mongodb-odm 2.0. Use storeAs="id" instead.', E_USER_DEPRECATED);
         }
         // Provide the correct value for the "simple" field for backwards compatibility
         if (isset($mapping['storeAs'])) {
@@ -1484,7 +1484,7 @@ class ClassMetadata implements BaseClassMetadata
         if (isset($mapping['repositoryMethod']) && ! (empty($mapping['skip']) && empty($mapping['limit']) && empty($mapping['sort']))) {
             @trigger_error(
                 sprintf(
-                    "Combining 'repositoryMethod' with skip, limit or sort (used on '%s' in class '%s') was deprecated in 1.3 and will be removed in 2.0. Please include those in the repository method itself.",
+                    "Combining 'repositoryMethod' with skip, limit or sort (used on '%s' in class '%s') was deprecated in doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please include those in the repository method itself.",
                     $mapping['fieldName'],
                     $this->name
                 ),
@@ -1620,7 +1620,7 @@ class ClassMetadata implements BaseClassMetadata
      */
     public function mapFile(array $mapping)
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in 2.0. Please read the upgrade notes for GridFS.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in doctrine/mongodb-odm 2.0. Please read the upgrade notes for GridFS.', __METHOD__), E_USER_DEPRECATED);
 
         $mapping['file'] = true;
         $mapping['type'] = 'file';
@@ -2064,7 +2064,7 @@ class ClassMetadata implements BaseClassMetadata
     {
         foreach ($subclasses as $subclass) {
             if (strpos($subclass, '\\') === false && strlen($this->namespace)) {
-                @trigger_error(sprintf('Subclass "%s" in class "%s" relies on same-namespace resolution. This is deprecated and will be dropped in 2.0. Please use a FQCN instead.', $subclass, $this->name), E_USER_DEPRECATED);
+                @trigger_error(sprintf('Subclass "%s" in class "%s" relies on same-namespace resolution. This is deprecated and will be dropped in doctrine/mongodb-odm 2.0. Please use a FQCN instead.', $subclass, $this->name), E_USER_DEPRECATED);
 
                 $this->subClasses[] = $this->namespace . '\\' . $subclass;
             } else {
@@ -2443,7 +2443,7 @@ class ClassMetadata implements BaseClassMetadata
 
             @trigger_error(
                 sprintf(
-                    'Field "%s" in class "%s" is mapped to field "%s" in the database, but that name is already in use by field "%s". This is deprecated and will cause an exception in 2.0.',
+                    'Field "%s" in class "%s" is mapped to field "%s" in the database, but that name is already in use by field "%s". This is deprecated and will cause an exception in doctrine/mongodb-odm 2.0.',
                     $mapping['fieldName'],
                     $this->getName(),
                     $mapping['name'],

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -60,7 +60,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     public function __construct()
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataInfo.php
@@ -25,7 +25,7 @@ use function sprintf;
 use function trigger_error;
 
 if (! class_exists(ClassMetadata::class, false)) {
-    @trigger_error(sprintf('The "%s" class is deprecated and will be removed in 2.0. Use "%s" instead.', ClassMetadataInfo::class, ClassMetadata::class), E_USER_DEPRECATED);
+    @trigger_error(sprintf('The "%s" class is deprecated and will be removed in doctrine/mongodb-odm 2.0. Use "%s" instead.', ClassMetadataInfo::class, ClassMetadata::class), E_USER_DEPRECATED);
 }
 
 class_alias(ClassMetadata::class, ClassMetadataInfo::class);

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -57,7 +57,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
     public static function registerAnnotationClasses()
     {
         @trigger_error(
-            sprintf('%s is deprecated - register class loader through AnnotationRegistry::registerLoader instead.', __METHOD__),
+            sprintf('The "%s" method is deprecated and will be removed in doctrine/mongodb-odm 2.0. Register class loader through AnnotationRegistry::registerLoader instead.', __METHOD__),
             E_USER_DEPRECATED
         );
         AnnotationRegistry::registerFile(__DIR__ . '/../Annotations/DoctrineAnnotations.php');
@@ -112,13 +112,13 @@ class AnnotationDriver extends AbstractAnnotationDriver
                     $class->setDiscriminatorField($annot->value);
                 } elseif (isset($annot->name)) {
                     @trigger_error(
-                        sprintf('Specifying discriminator\'s name through "name" is deprecated - use @DiscriminatorField("%s") instead', $annot->name),
+                        sprintf('Specifying discriminator\'s name through "name" is deprecated and will be removed in doctrine/mongodb-odm 2.0. Use @DiscriminatorField("%s") instead', $annot->name),
                         E_USER_DEPRECATED
                     );
                     $class->setDiscriminatorField($annot->name);
                 } elseif (isset($annot->fieldName)) {
                     @trigger_error(
-                        sprintf('Specifying discriminator\'s name through "name" is deprecated - use @DiscriminatorField("%s") instead', $annot->fieldName),
+                        sprintf('Specifying discriminator\'s name through "name" is deprecated and will be removed in doctrine/mongodb-odm 2.0. Use @DiscriminatorField("%s") instead', $annot->fieldName),
                         E_USER_DEPRECATED
                     );
                     $class->setDiscriminatorField($annot->fieldName);
@@ -147,7 +147,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
             default:
                 @trigger_error(
-                    sprintf('Class "%s" uses more than one document annotation. This is deprecated and will cause an exception in 2.0.', $className),
+                    sprintf('Class "%s" uses more than one document annotation. This is deprecated and will cause an exception in doctrine/mongodb-odm 2.0.', $className),
                     E_USER_DEPRECATED
                 );
         }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/SimplifiedYamlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/SimplifiedYamlDriver.php
@@ -38,7 +38,7 @@ class SimplifiedYamlDriver extends YamlDriver
      */
     public function __construct($prefixes, $fileExtension = self::DEFAULT_FILE_EXTENSION)
     {
-        @trigger_error(sprintf('The "%s" class is deprecated and will be removed in 2.0. Please switch to XML or annotation mapping.', self::class), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" class is deprecated and will be removed in doctrine/mongodb-odm 2.0. Please switch to XML or annotation mapping.', self::class), E_USER_DEPRECATED);
 
         $locator = new SymfonyFileLocator((array) $prefixes, $fileExtension);
         parent::__construct($locator, $fileExtension);

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -95,7 +95,7 @@ class XmlDriver extends FileDriver
         if (isset($xmlRoot['write-concern'])) {
             $class->setWriteConcern((string) $xmlRoot['write-concern']);
         } elseif (isset($xmlRoot['writeConcern'])) {
-            @trigger_error(sprintf('The "writeConcern" attribute in the mapping file for class "%s" is deprecated and will be dropped in 2.0. Please use "write-concern" instead.', $class->getName()), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The "writeConcern" attribute in the mapping file for class "%s" is deprecated and will be dropped in doctrine/mongodb-odm 2.0. Please use "write-concern" instead.', $class->getName()), E_USER_DEPRECATED);
             $class->setWriteConcern((string) $xmlRoot['writeConcern']);
         }
 
@@ -189,11 +189,11 @@ class XmlDriver extends FileDriver
                 }
 
                 if (! empty($mapping['file'])) {
-                    @trigger_error('The "file" attribute to map GridFS files is deprecated and will be removed in 2.0. Please read the upgrade notes for GridFS.', E_USER_DEPRECATED);
+                    @trigger_error('The "file" attribute to map GridFS files is deprecated and will be removed in doctrine/mongodb-odm 2.0. Please read the upgrade notes for GridFS.', E_USER_DEPRECATED);
                 }
 
                 if (isset($mapping['id']) && $mapping['id'] === true) {
-                    @trigger_error(sprintf('Using the "id" attribute to denote identifiers in the XML mapping for class "%s" is deprecated and will be removed in 2.0. Please map your identifiers using the "id" element.', $class->getName()), E_USER_DEPRECATED);
+                    @trigger_error(sprintf('Using the "id" attribute to denote identifiers in the XML mapping for class "%s" is deprecated and will be removed in doctrine/mongodb-odm 2.0. Please map your identifiers using the "id" element.', $class->getName()), E_USER_DEPRECATED);
 
                     if (isset($mapping['strategy'])) {
                         $mapping['options'] = array();
@@ -219,7 +219,7 @@ class XmlDriver extends FileDriver
                 } elseif (isset($attributes['fieldName'])) {
                     @trigger_error(
                         sprintf(
-                            'Field "%s" in class "%s" is mapped using a "fieldName" attribute which is deprecated. Use the "field-name" attribute instead.',
+                            'Field "%s" in class "%s" is mapped using a "fieldName" attribute which is deprecated and will be removed in doctrine/mongodb-odm 2.0. Use the "field-name" attribute instead.',
                             isset($mapping['name']) ? $mapping['name'] : $mapping['fieldName'],
                             $class->getName()
                         ),
@@ -331,7 +331,7 @@ class XmlDriver extends FileDriver
             $mapping['fieldName'] = (string) $attributes['fieldName'];
 
             @trigger_error(
-                sprintf('Field "%s" in class "%s" is mapped using a "fieldName" attribute which is deprecated. Use the "field-name" attribute instead.', $mapping['name'], $class->getName()),
+                sprintf('Field "%s" in class "%s" is mapped using a "fieldName" attribute which is deprecated and will be removed in doctrine/mongodb-odm 2.0. Use the "field-name" attribute instead.', $mapping['name'], $class->getName()),
                 E_USER_DEPRECATED
             );
         }
@@ -391,7 +391,7 @@ class XmlDriver extends FileDriver
             $mapping['fieldName'] = (string) $attributes['fieldName'];
 
             @trigger_error(
-                sprintf('Field "%s" in class "%s" is mapped using a "fieldName" attribute which is deprecated. Use the "field-name" attribute instead.', $mapping['name'], $class->getName()),
+                sprintf('Field "%s" in class "%s" is mapped using a "fieldName" attribute which is deprecated and will be removed in doctrine/mongodb-odm 2.0. Use the "field-name" attribute instead.', $mapping['name'], $class->getName()),
                 E_USER_DEPRECATED
             );
         }
@@ -641,6 +641,6 @@ class XmlDriver extends FileDriver
             libxml_use_internal_errors($previousUseErrors);
         }
 
-        @trigger_error(sprintf('The mapping file "%s" does not follow the mapping schema. Loading invalid files is deprecated and will no longer work in 2.0', $filename), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The mapping file "%s" does not follow the mapping schema. Loading invalid files is deprecated and will no longer work in doctrine/mongodb-odm 2.0', $filename), E_USER_DEPRECATED);
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/YamlDriver.php
@@ -43,7 +43,7 @@ class YamlDriver extends FileDriver
      */
     public function __construct($locator, $fileExtension = self::DEFAULT_FILE_EXTENSION)
     {
-        @trigger_error(sprintf('The "%s" class is deprecated and will be removed in 2.0. Please switch to XML or annotation mapping.', self::class), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" class is deprecated and will be removed in doctrine/mongodb-odm 2.0. Please switch to XML or annotation mapping.', self::class), E_USER_DEPRECATED);
 
         parent::__construct($locator, $fileExtension);
     }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -33,7 +33,7 @@ class MappingException extends BaseMappingException
     public function __construct($message = "", $code = 0, Throwable $previous = null)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         parent::__construct($message, $code, $previous);
     }

--- a/lib/Doctrine/ODM/MongoDB/MongoDBException.php
+++ b/lib/Doctrine/ODM/MongoDB/MongoDBException.php
@@ -41,7 +41,7 @@ class MongoDBException extends \Exception
     public static function invalidFindByCall($documentName, $fieldName, $method)
     {
         @trigger_error(
-            sprintf('The "%s" method is deprecated in MongoDB ODM 1.3 and will be removed in 2.0. Magic findBy methods will no longer be supported.', __METHOD__),
+            sprintf('The "%s" method is deprecated in doctrine/mongodb-odm 1.3 and will be removed in 2.0. Magic findBy methods will no longer be supported.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -91,7 +91,7 @@ class MongoDBException extends \Exception
     public static function findByRequiresParameter($methodName)
     {
         @trigger_error(
-            sprintf('The "%s" method is deprecated in MongoDB ODM 1.3 and will be removed in 2.0. Magic findBy methods will no longer be supported.', __METHOD__),
+            sprintf('The "%s" method is deprecated in doctrine/mongodb-odm 1.3 and will be removed in 2.0. Magic findBy methods will no longer be supported.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -126,7 +126,7 @@ class MongoDBException extends \Exception
     public static function queryNotIndexed($className, $unindexedFields)
     {
         @trigger_error(
-            sprintf('The "%s" method is deprecated in MongoDB ODM 1.2 and will be removed in 2.0. The requireIndexes functionality will no longer be supported.', __METHOD__),
+            sprintf('The "%s" method is deprecated in doctrine/mongodb-odm 1.2 and will be removed in 2.0. The requireIndexes functionality will no longer be supported.', __METHOD__),
             E_USER_DEPRECATED
         );
 

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -43,7 +43,7 @@ class PersistentCollection implements PersistentCollectionInterface
     public function __construct(BaseCollection $coll, DocumentManager $dm, UnitOfWork $uow)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         $this->coll = $coll;
         $this->dm = $dm;

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionException.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionException.php
@@ -33,7 +33,7 @@ class PersistentCollectionException extends MongoDBException
     public function __construct($message = "", $code = 0, Throwable $previous = null)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         parent::__construct($message, $code, $previous);
     }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -80,7 +80,7 @@ class CollectionPersister
     public function __construct(DocumentManager $dm, PersistenceBuilder $pb, UnitOfWork $uow)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         $this->dm = $dm;
         $this->pb = $pb;
@@ -129,7 +129,7 @@ class CollectionPersister
      */
     public function delete(PersistentCollectionInterface $coll, array $options)
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be changed to the signature of deleteAll in 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be changed to the signature of deleteAll in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         $mapping = $coll->getMapping();
         if ($mapping['isInverseSide']) {
@@ -154,7 +154,7 @@ class CollectionPersister
      */
     public function update(PersistentCollectionInterface $coll, array $options)
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be changed to the signature of updateAll in 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be changed to the signature of updateAll in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         $mapping = $coll->getMapping();
 

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -139,7 +139,7 @@ class DocumentPersister
         CriteriaMerger $cm = null
     ) {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         $this->pb = $pb;
         $this->dm = $dm;
@@ -928,7 +928,7 @@ class DocumentPersister
     public function prepareSortOrProjection(array $fields)
     {
         @trigger_error(
-            sprintf('The "%s" method was deprecated in MongoDB ODM 1.3 and will be dropped in 2.0. Use "prepareSort" or "prepareProjection" accordingly.', __METHOD__),
+            sprintf('The "%s" method was deprecated in doctrine/mongodb-odm 1.3 and will be dropped in 2.0. Use "prepareSort" or "prepareProjection" accordingly.', __METHOD__),
             E_USER_DEPRECATED
         );
 

--- a/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
@@ -58,7 +58,7 @@ class PersistenceBuilder
     public function __construct(DocumentManager $dm, UnitOfWork $uow)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         $this->dm = $dm;
         $this->uow = $uow;

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -136,7 +136,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function requireIndexes($requireIndexes = true)
     {
         @trigger_error(
-            'requireIndexes was deprecated in version 1.2 and will be removed altogether in 2.0.',
+            'requireIndexes was deprecated in doctrine/mongodb-odm 1.2 and will be removed altogether in 2.0.',
             E_USER_DEPRECATED
         );
         $this->requireIndexes = $requireIndexes;
@@ -200,7 +200,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
      */
     public function eagerCursor($bool = true)
     {
-        @trigger_error(sprintf('Ths "%s" method is deprecated and will be removed in 2.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('Ths "%s" method is deprecated and will be removed in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         if ( ! $bool && ! empty($this->primers)) {
             throw new \BadMethodCallException("Can't set eagerCursor to false when using reference primers");
@@ -299,7 +299,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function update($documentName = null)
     {
         @trigger_error(
-            sprintf('%s was deprecated in version 1.2 - use updateOne or updateMany instead.', __METHOD__),
+            sprintf('%s was deprecated in doctrine/mongodb-odm 1.2 - use updateOne or updateMany instead.', __METHOD__),
             E_USER_DEPRECATED
         );
         $this->setDocumentName($documentName);
@@ -383,7 +383,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function group($keys, array $initial, $reduce = null, array $options = [])
     {
         @trigger_error(
-            sprintf('%s was deprecated in version 1.2 - use Aggregation Builder\'s group stage instead.', __METHOD__),
+            sprintf('%s was deprecated in doctrine/mongodb-odm 1.2 and will be removed in 2.0. Use Aggregation Builder\'s group stage instead.', __METHOD__),
             E_USER_DEPRECATED
         );
         return parent::group($keys, $initial, $reduce, $options);
@@ -398,7 +398,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     {
         if ($bool) {
             @trigger_error(
-                sprintf('%s was deprecated in version 1.2 - use setReadPreference instead.', __METHOD__),
+                sprintf('%s was deprecated in doctrine/mongodb-odm 1.2 and will be removed in 2.0. Use setReadPreference instead.', __METHOD__),
                 E_USER_DEPRECATED
             );
         }
@@ -549,7 +549,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function mapReduce($map, $reduce, $out = ['inline' => true], array $options = [])
     {
         @trigger_error(
-            'Support for mapReduce queries was deprecated in MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.',
+            'Support for mapReduce queries was deprecated in doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.',
             E_USER_DEPRECATED
         );
 
@@ -563,7 +563,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function map($map)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -577,7 +577,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function reduce($reduce)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -591,7 +591,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function finalize($finalize)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -605,7 +605,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function out($out)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -619,7 +619,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function mapReduceOptions(array $options)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -633,7 +633,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function distanceMultiplier($distanceMultiplier)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -647,7 +647,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function geoNear($x, $y = null)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -661,7 +661,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     {
         if (func_num_args() < 3) {
             @trigger_error(
-                sprintf('Calling "%s" with fewer than 3 arguments was deprecated in MongoDB ODM 1.3 and will require at least 3 arguments in 2.0.', __METHOD__),
+                sprintf('Calling "%s" with fewer than 3 arguments was deprecated in doctrine/mongodb-odm 1.3 and will require at least 3 arguments in 2.0.', __METHOD__),
                 E_USER_DEPRECATED
             );
         }
@@ -676,7 +676,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function spherical($spherical = true)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -690,7 +690,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function maxDistance($maxDistance)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -704,7 +704,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function minDistance($minDistance)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -718,7 +718,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function withinBox($x1, $y1, $x2, $y2)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -732,7 +732,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function withinCenter($x, $y, $radius)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -746,7 +746,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function withinCenterSphere($x, $y, $radius)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -760,7 +760,7 @@ class Builder extends \Doctrine\MongoDB\Query\Builder
     public function withinPolygon()
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 

--- a/lib/Doctrine/ODM/MongoDB/Query/CriteriaMerger.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/CriteriaMerger.php
@@ -33,7 +33,7 @@ class CriteriaMerger
     public function __construct()
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Expr.php
@@ -128,7 +128,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
                 $this->query[$mapping['name'] . '.' . $key] = $reference[$key];
             }
         } else {
-            @trigger_error('Calling ' . __METHOD__ . ' without a current field set will no longer be possible in ODM 2.0.', E_USER_DEPRECATED);
+            @trigger_error('Calling ' . __METHOD__ . ' without a current field set will no longer be possible in doctrine/mongodb-odm 2.0.', E_USER_DEPRECATED);
 
             $this->query = $this->dm->createDBRef($document);
         }
@@ -180,7 +180,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
                 $this->query[$mapping['name']]['$elemMatch'][$key] = $reference[$key];
             }
         } else {
-            @trigger_error('Calling ' . __METHOD__ . ' without a current field set will no longer be possible in ODM 2.0.', E_USER_DEPRECATED);
+            @trigger_error('Calling ' . __METHOD__ . ' without a current field set will no longer be possible in doctrine/mongodb-odm 2.0.', E_USER_DEPRECATED);
 
             $this->query['$elemMatch'] = $this->dm->createDBRef($document);
         }
@@ -252,7 +252,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
     {
         if (func_num_args() < 3) {
             @trigger_error(
-                sprintf('Calling "%s" with fewer than 3 arguments was deprecated in MongoDB ODM 1.3 and will require at least 3 arguments in 2.0.', __METHOD__),
+                sprintf('Calling "%s" with fewer than 3 arguments was deprecated in doctrine/mongodb-odm 1.3 and will require at least 3 arguments in 2.0.', __METHOD__),
                 E_USER_DEPRECATED
             );
         }
@@ -267,7 +267,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
     public function maxDistance($maxDistance)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -281,7 +281,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
     public function minDistance($minDistance)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -295,7 +295,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
     public function withinBox($x1, $y1, $x2, $y2)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -309,7 +309,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
     public function withinCenter($x, $y, $radius)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -323,7 +323,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
     public function withinCenterSphere($x, $y, $radius)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -337,7 +337,7 @@ class Expr extends \Doctrine\MongoDB\Query\Expr
     public function withinPolygon()
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use the aggregation pipeline instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 

--- a/lib/Doctrine/ODM/MongoDB/Query/FieldExtractor.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/FieldExtractor.php
@@ -35,7 +35,7 @@ class FieldExtractor
     public function __construct(array $query, array $sort = array())
     {
         @trigger_error(
-            sprintf('%s was deprecated in version 1.2 and will be removed altogether in 2.0.', __CLASS__),
+            sprintf('The "%s" class was deprecated in doctrine/mongodb-odm 1.2 and will be removed altogether in 2.0.', __CLASS__),
             E_USER_DEPRECATED
         );
         $this->query = $query;

--- a/lib/Doctrine/ODM/MongoDB/Query/FilterCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/FilterCollection.php
@@ -59,7 +59,7 @@ class FilterCollection
     public function __construct(DocumentManager $dm, CriteriaMerger $cm = null)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         $this->dm = $dm;
         $this->cm = $cm ?: new CriteriaMerger();

--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -112,13 +112,13 @@ class Query extends \Doctrine\MongoDB\Query\Query
     public function __construct(DocumentManager $dm, ClassMetadata $class, Collection $collection, array $query = array(), array $options = array(), $hydrate = true, $refresh = false, array $primers = array(), $requireIndexes = null, $readOnly = false)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
 
         $primers = array_filter($primers);
 
         if (isset($query['eagerCursor'])) {
-            @trigger_error(sprintf('The "eagerCursor" option for "%s" is deprecated and will be removed in 2.0.', self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The "eagerCursor" option for "%s" is deprecated and will be removed in doctrine/mongodb-odm 2.0.', self::class), E_USER_DEPRECATED);
         }
 
         if ( ! empty($primers)) {
@@ -148,7 +148,7 @@ class Query extends \Doctrine\MongoDB\Query\Query
                     break;
             }
 
-            @trigger_error(sprintf('The "%s" query type is deprecated and will be removed in ODM 2.0.', $queryName), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The "%s" query type is deprecated and will be removed in ODM doctrine/mongodb-odm 2.0.', $queryName), E_USER_DEPRECATED);
         }
 
         parent::__construct($collection, $query, $options);
@@ -237,7 +237,7 @@ class Query extends \Doctrine\MongoDB\Query\Query
     public function getFieldsInQuery()
     {
         @trigger_error(
-            sprintf('%s was deprecated in version 1.2 and will be removed altogether in 2.0.', __METHOD__),
+            sprintf('The "%s" method was deprecated in doctrine/mongodb-odm 1.2 and will be removed altogether in 2.0.', __METHOD__),
             E_USER_DEPRECATED
         );
         $query = isset($this->query['query']) ? $this->query['query'] : array();
@@ -257,7 +257,7 @@ class Query extends \Doctrine\MongoDB\Query\Query
     public function isIndexed()
     {
         @trigger_error(
-            sprintf('%s was deprecated in version 1.2 and will be removed altogether in 2.0.', __METHOD__),
+            sprintf('The "%s" method was deprecated in doctrine/mongodb-odm 1.2 and will be removed altogether in 2.0.', __METHOD__),
             E_USER_DEPRECATED
         );
         $fields = $this->getFieldsInQuery();
@@ -279,7 +279,7 @@ class Query extends \Doctrine\MongoDB\Query\Query
     public function getUnindexedFields()
     {
         @trigger_error(
-            sprintf('%s was deprecated in version 1.2 and will be removed altogether in 2.0.', __METHOD__),
+            sprintf('The "%s" method was deprecated in doctrine/mongodb-odm 1.2 and will be removed altogether in 2.0.', __METHOD__),
             E_USER_DEPRECATED
         );
         $unindexedFields = array();
@@ -401,7 +401,7 @@ class Query extends \Doctrine\MongoDB\Query\Query
     public function count($foundOnly = false)
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please run separate count queries instead.', __METHOD__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please run separate count queries instead.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -415,7 +415,7 @@ class Query extends \Doctrine\MongoDB\Query\Query
     public function iterate()
     {
         @trigger_error(
-            sprintf('The %s method is deprecated since MongoDB ODM 1.3 and will be removed in 2.0. Please use "%s::getIterator()" instead.', __METHOD__, __CLASS__),
+            sprintf('The %s method is deprecated since doctrine/mongodb-odm 1.3 and will be removed in 2.0. Please use "%s::getIterator()" instead.', __METHOD__, __CLASS__),
             E_USER_DEPRECATED
         );
 

--- a/lib/Doctrine/ODM/MongoDB/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/QueryExpressionVisitor.php
@@ -73,7 +73,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
     public function __construct(Builder $builder)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         $this->builder = $builder;
     }

--- a/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
@@ -71,7 +71,7 @@ class ReferencePrimer
     public function __construct(DocumentManager $dm, UnitOfWork $uow)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
 
         $this->dm = $dm;

--- a/lib/Doctrine/ODM/MongoDB/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Repository/DefaultRepositoryFactory.php
@@ -34,7 +34,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
     {
         if (get_class($this) !== DefaultRepositoryFactory::class) {
             @trigger_error(
-                sprintf('The %s class extends %s which will be final in ODM 2.0. You should extend %s instead.', __CLASS__,  DefaultRepositoryFactory::class, AbstractRepositoryFactory::class),
+                sprintf('The "%s" class extends "%s" which will be final in doctrine/mongodb-odm 2.0. You should extend "%s" instead.', __CLASS__,  DefaultRepositoryFactory::class, AbstractRepositoryFactory::class),
                 E_USER_DEPRECATED
             );
         }

--- a/lib/Doctrine/ODM/MongoDB/Repository/DocumentRepository.php
+++ b/lib/Doctrine/ODM/MongoDB/Repository/DocumentRepository.php
@@ -221,7 +221,7 @@ class DocumentRepository implements ObjectRepository, Selectable
     public function __call($method, $arguments)
     {
         @trigger_error(
-            'Using magic findBy and findOneBy calls was deprecated in version 1.2 and will be removed altogether in 2.0.',
+            'Using magic "findBy" and "findOneBy" calls was deprecated in doctrine/mongodb-odm 1.2 and will be removed altogether in 2.0.',
             E_USER_DEPRECATED
         );
         if (strpos($method, 'findBy') === 0) {

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -59,7 +59,7 @@ class SchemaManager
     public function __construct(DocumentManager $dm, ClassMetadataFactory $cmf)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         $this->dm = $dm;
         $this->metadataFactory = $cmf;
@@ -436,7 +436,7 @@ class SchemaManager
     public function createDatabases()
     {
         @trigger_error(
-            sprintf('%s was deprecated in version 1.2 - databases are created automatically by MongoDB (>= 3.0).', __METHOD__),
+            sprintf('The method "%s" was deprecated in doctrine/mongodb-odm 1.2 and will be removed in 2.0. Databases are created automatically by MongoDB (>= 3.0).', __METHOD__),
             E_USER_DEPRECATED
         );
         foreach ($this->metadataFactory->getAllMetadata() as $class) {
@@ -458,7 +458,7 @@ class SchemaManager
     public function createDocumentDatabase($documentName)
     {
         @trigger_error(
-            sprintf('%s was deprecated in version 1.2 - databases are created automatically by MongoDB (>= 3.0).', __METHOD__),
+            sprintf('The "%s" method was deprecated in doctrine/mongodb-odm 1.2 and will be removed in 2.0. Databases are created automatically by MongoDB (>= 3.0).', __METHOD__),
             E_USER_DEPRECATED
         );
         $class = $this->dm->getClassMetadata($documentName);
@@ -622,7 +622,7 @@ class SchemaManager
     public function ensureSharding(array $indexOptions = array())
     {
         if (! empty($indexOptions)) {
-            @trigger_error(sprintf('The "indexOptions" argument in "%s" is deprecated and will be removed in 2.0.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The "indexOptions" argument in "%s" is deprecated and will be removed in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
         }
 
         foreach ($this->metadataFactory->getAllMetadata() as $class) {
@@ -645,7 +645,7 @@ class SchemaManager
     public function ensureDocumentSharding($documentName, array $indexOptions = array())
     {
         if (! empty($indexOptions)) {
-            @trigger_error(sprintf('The "indexOptions" argument in "%s" is deprecated and will be removed in 2.0.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The "indexOptions" argument in "%s" is deprecated and will be removed in doctrine/mongodb-odm 2.0.', __METHOD__), E_USER_DEPRECATED);
         }
 
         $class = $this->dm->getClassMetadata($documentName);

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/AbstractCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/AbstractCommand.php
@@ -91,7 +91,7 @@ abstract class AbstractCommand extends Command
             return null;
         }
 
-        @trigger_error(sprintf('The "timeout" option for command "%s" is deprecated and will be removed in 2.0. Use the maxTimeMs option instead.', static::class), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "timeout" option for command "%s" is deprecated and will be removed in doctrine/mongodb-odm 2.0. Use the maxTimeMs option instead.', static::class), E_USER_DEPRECATED);
 
         return (int) $timeout;
     }

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
@@ -47,7 +47,7 @@ class CreateCommand extends AbstractCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if ($input->getOption(self::DB)) {
-            @trigger_error('The ' . self::DB . ' option is deprecated and will be removed in ODM 2.0', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The "%s"" option is deprecated and will be removed in doctrine/mongodb-odm 2.0', self::DB), E_USER_DEPRECATED);
         }
 
         foreach ($this->createOrder as $option) {

--- a/lib/Doctrine/ODM/MongoDB/Types/IncrementType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/IncrementType.php
@@ -30,7 +30,7 @@ class IncrementType extends Type
     public function convertToDatabaseValue($value)
     {
         @trigger_error(
-            'Increment type was deprecated in version 1.1 - use int or float with increment storage strategy instead.',
+            'Increment type was deprecated in version doctrine/mongodb-odm 1.1 - use int or float with increment storage strategy instead.',
             E_USER_DEPRECATED
         );
         return $value !== null ? (is_float($value) ? (float) $value : (int) $value) : null;
@@ -39,7 +39,7 @@ class IncrementType extends Type
     public function convertToPHPValue($value)
     {
         @trigger_error(
-            'Increment type was deprecated in version 1.1 - use int or float with increment storage strategy instead.',
+            'Increment type was deprecated in version doctrine/mongodb-odm 1.1 - use int or float with increment storage strategy instead.',
             E_USER_DEPRECATED
         );
         return $value !== null ? (is_float($value) ? (float) $value : (int) $value) : null;

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -278,7 +278,7 @@ class UnitOfWork implements PropertyChangedListener
     public function __construct(DocumentManager $dm, EventManager $evm, HydratorFactory $hydratorFactory)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         $this->dm = $dm;
         $this->evm = $evm;
@@ -420,7 +420,7 @@ class UnitOfWork implements PropertyChangedListener
 
         $this->commitsInProgress++;
         if ($this->commitsInProgress > 1) {
-            @trigger_error('There is already a commit operation in progress. Calling flush in an event subscriber is deprecated and will be forbidden in 2.0.', E_USER_DEPRECATED);
+            @trigger_error('There is already a commit operation in progress. Calling flush in an event subscriber is deprecated and will be forbidden in doctrine/mongodb-odm 2.0.', E_USER_DEPRECATED);
         }
         try {
             if ($this->orphanRemovals) {
@@ -1375,7 +1375,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function isScheduledForDirtyCheck($document)
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in 2.0. Use isScheduledForSynchronization instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in doctrine/mongodb-odm 2.0. Use isScheduledForSynchronization instead.', __METHOD__), E_USER_DEPRECATED);
 
         return $this->isScheduledForSynchronization($document);
     }
@@ -1629,7 +1629,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function scheduleForDirtyCheck($document)
     {
-        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in 2.0. Use "scheduleForSynchronization" instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s" method is deprecated and will be removed in doctrine/mongodb-odm 2.0. Use "scheduleForSynchronization" instead.', __METHOD__), E_USER_DEPRECATED);
 
         $this->scheduleForSynchronization($document);
     }

--- a/lib/Doctrine/ODM/MongoDB/Utility/CollectionHelper.php
+++ b/lib/Doctrine/ODM/MongoDB/Utility/CollectionHelper.php
@@ -34,7 +34,7 @@ class CollectionHelper
     public function __construct()
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
+++ b/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
@@ -60,7 +60,7 @@ class LifecycleEventManager
     public function __construct(DocumentManager $dm, UnitOfWork $uow, EventManager $evm)
     {
         if (self::class !== static::class) {
-            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in MongoDB ODM 2.0.', static::class, self::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The class "%s" extends "%s" which will be final in doctrine/mongodb-odm 2.0.', static::class, self::class), E_USER_DEPRECATED);
         }
         $this->dm = $dm;
         $this->evm = $evm;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes/no
| Fixed issues | Fixes #2010 

#### Summary

This adds the packagist package name to all deprecation notices currently thrown. It also encapsulates most identifiers in double quotes to help users figure out what is part of the deprecation message and what is part of a deprecated identifier.