### PR TITLE
Performance benchmark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,15 @@ jobs:
       script:
         - ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
+    # Performance tests
+    - stage: Performance
+      php: 5.6
+      script: vendor/bin/phpbench run --report=default --revs=100 --iterations=5 --report=aggregate
+
+    - stage: Performance
+      php: 7.3
+      script: vendor/bin/phpbench run --report=default --revs=100 --iterations=5 --report=aggregate
+
 install:
   - .travis/setup_mongodb.sh
   - sudo pip install mongo-orchestration

--- a/benchmark/BaseBench.php
+++ b/benchmark/BaseBench.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Benchmark;
+
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\MongoDB\Connection;
+use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+
+/**
+ * @BeforeMethods({"initDocumentManager", "clearDatabase"})
+ */
+abstract class BaseBench
+{
+    const DATABASE_NAME = 'doctrine_odm_performance';
+
+    /**
+     * @var DocumentManager
+     */
+    protected static $documentManager;
+
+    /**
+     * @return DocumentManager
+     */
+    protected function getDocumentManager()
+    {
+        return self::$documentManager;
+    }
+
+    public function initDocumentManager()
+    {
+        $config = new Configuration();
+
+        $config->setProxyDir(__DIR__ . '/../../tests/Proxies');
+        $config->setProxyNamespace('Proxies');
+        $config->setHydratorDir(__DIR__ . '/../../tests/Hydrators');
+        $config->setHydratorNamespace('Hydrators');
+        $config->setPersistentCollectionDir(__DIR__ . '/../../tests/PersistentCollections');
+        $config->setPersistentCollectionNamespace('PersistentCollections');
+        $config->setDefaultDB(self::DATABASE_NAME);
+        $config->setMetadataDriverImpl(self::createMetadataDriverImpl());
+        $config->setMetadataCacheImpl(new ArrayCache());
+
+        $connection = new Connection(
+            getenv("DOCTRINE_MONGODB_SERVER") ?: DOCTRINE_MONGODB_SERVER,
+            [],
+            $config
+        );
+
+        self::$documentManager = DocumentManager::create($connection, $config);
+    }
+
+    public function clearDatabase()
+    {
+        // Check if the database exists. Calling listCollections on a non-existing
+        // database in a sharded setup will cause an invalid command cursor to be
+        // returned
+        $databases = self::$documentManager->getConnection()->listDatabases();
+        $databaseNames = array_map(function ($database) { return $database['name']; }, $databases['databases']);
+        if (! in_array(self::DATABASE_NAME, $databaseNames)) {
+            return;
+        }
+
+        $collections = self::$documentManager->getConnection()->selectDatabase(self::DATABASE_NAME)->listCollections();
+
+        foreach ($collections as $collection) {
+            $collection->drop();
+        }
+    }
+
+    protected static function createMetadataDriverImpl()
+    {
+        return AnnotationDriver::create(__DIR__ . '/../tests/Documents');
+    }
+}

--- a/benchmark/Document/HydrateDocumentBench.php
+++ b/benchmark/Document/HydrateDocumentBench.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Benchmark\Document;
+
+use Doctrine\ODM\MongoDB\Benchmark\BaseBench;
+use Doctrine\ODM\MongoDB\Hydrator\HydratorInterface;
+use Documents\User;
+use MongoDate;
+use MongoId;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+
+/**
+ * @BeforeMethods({"init"}, extend=true)
+ */
+final class HydrateDocumentBench extends BaseBench
+{
+    /**
+     * @var array
+     */
+    private static $data;
+
+    /**
+     * @var array
+     */
+    private static $embedOneData;
+
+    /**
+     * @var array
+     */
+    private static $embedManyData;
+
+    /**
+     * @var array
+     */
+    private static $referenceOneData;
+
+    /**
+     * @var array
+     */
+    private static $referenceManyData;
+
+    /**
+     * @var HydratorInterface
+     */
+    private static $hydrator;
+
+    public function init()
+    {
+        self::$data = [
+            '_id' => new MongoId(),
+            'username' => 'alcaeus',
+            'createdAt' => new MongoDate(),
+        ];
+
+        self::$embedOneData = [
+            'address' => [
+                'city' => 'Munich',
+            ],
+        ];
+
+        self::$embedManyData = [
+            'phonenumbers' => [
+                ['phonenumber' => '12345678'],
+                ['phonenumber' => '12345678'],
+            ],
+        ];
+
+        self::$referenceOneData = [
+            'account' => [
+                '$ref' => 'Account',
+                '$id' => new MongoId(),
+            ],
+        ];
+
+        self::$referenceManyData = [
+            'groups' => [
+                [
+                    '$ref' => 'Group',
+                    '$id' => new MongoId(),
+                ],
+                [
+                    '$ref' => 'Group',
+                    '$id' => new MongoId(),
+                ],
+            ],
+        ];
+
+        self::$hydrator = $this
+            ->getDocumentManager()
+            ->getHydratorFactory()
+            ->getHydratorFor(User::class);
+    }
+
+    /**
+     * @Warmup(2)
+     */
+    public function benchHydrateDocument()
+    {
+        self::$hydrator->hydrate(new User(), self::$data);
+    }
+
+    /**
+     * @Warmup(2)
+     */
+    public function benchHydrateDocumentWithEmbedOne()
+    {
+        self::$hydrator->hydrate(new User(), self::$data + self::$embedOneData);
+    }
+
+    /**
+     * @Warmup(2)
+     */
+    public function benchHydrateDocumentWithEmbedMany()
+    {
+        self::$hydrator->hydrate(new User(), self::$data + self::$embedManyData);
+    }
+
+    /**
+     * @Warmup(2)
+     */
+    public function benchHydrateDocumentWithReferenceOne()
+    {
+        self::$hydrator->hydrate(new User(), self::$data + self::$referenceOneData);
+    }
+
+    /**
+     * @Warmup(2)
+     */
+    public function benchHydrateDocumentWithReferenceMany()
+    {
+        self::$hydrator->hydrate(new User(), self::$data + self::$referenceManyData);
+    }
+}

--- a/benchmark/Document/LoadDocumentBench.php
+++ b/benchmark/Document/LoadDocumentBench.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Benchmark\Document;
+
+use DateTimeImmutable;
+use Doctrine\ODM\MongoDB\Benchmark\BaseBench;
+use Documents\Account;
+use Documents\Address;
+use Documents\Group;
+use Documents\Phonenumber;
+use Documents\User;
+use MongoId;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+
+/**
+ * @BeforeMethods({"init"}, extend=true)
+ */
+final class LoadDocumentBench extends BaseBench
+{
+    private static $userId;
+
+    public function init()
+    {
+        self::$userId = new MongoId();
+
+        $account = new Account();
+        $account->setName('alcaeus');
+
+        $address = new Address();
+        $address->setAddress('Redacted');
+        $address->setCity('Munich');
+
+        $group1 = new Group('One');
+        $group2 = new Group('Two');
+
+        $user = new User();
+        $user->setId(self::$userId);
+        $user->setUsername('alcaeus');
+        $user->setCreatedAt(new DateTimeImmutable());
+        $user->setAddress($address);
+        $user->setAccount($account);
+        $user->addPhonenumber(new Phonenumber('12345678'));
+        $user->addGroup($group1);
+        $user->addGroup($group2);
+
+        $this->getDocumentManager()->persist($user);
+        $this->getDocumentManager()->flush();
+
+        $this->getDocumentManager()->clear();
+    }
+
+    /**
+     * @Warmup(2)
+     */
+    public function benchLoadDocument()
+    {
+        $this->loadDocument();
+    }
+
+    /**
+     * @Warmup(2)
+     */
+    public function benchLoadEmbedOne()
+    {
+        $this->loadDocument()->getAddress()->getCity();
+    }
+
+    /**
+     * @Warmup(2)
+     */
+    public function benchLoadEmbedMany()
+    {
+        $this->loadDocument()->getPhonenumbers()->forAll(function ($key, Phonenumber $element) {
+            return $element->getPhoneNumber();
+        });
+    }
+
+    /**
+     * @Warmup(2)
+     */
+    public function benchLoadReferenceOne()
+    {
+        $this->loadDocument()->getAccount()->getName();
+    }
+
+    /**
+     * @Warmup(2)
+     */
+    public function benchLoadReferenceMany()
+    {
+        $this->loadDocument()->getGroups()->forAll(function ($key, Group $group) {
+            return $group->getName();
+        });
+    }
+
+    /**
+     * @return User
+     */
+    private function loadDocument()
+    {
+        return $this->getDocumentManager()->find(User::class, self::$userId);
+    }
+}

--- a/benchmark/Document/StoreDocumentBench.php
+++ b/benchmark/Document/StoreDocumentBench.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Benchmark\Document;
+
+use DateTimeImmutable;
+use Doctrine\ODM\MongoDB\Benchmark\BaseBench;
+use Documents\Account;
+use Documents\Address;
+use Documents\Group;
+use Documents\Phonenumber;
+use Documents\User;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+
+final class StoreDocumentBench extends BaseBench
+{
+    /**
+     * @Warmup(2)
+     */
+    public function benchStoreDocument()
+    {
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setCreatedAt(new DateTimeImmutable());
+
+        $this->getDocumentManager()->persist($user);
+        $this->getDocumentManager()->flush();
+        $this->getDocumentManager()->clear();
+    }
+
+    /**
+     * @Warmup(2)
+     */
+    public function benchStoreDocumentWithEmbedOne()
+    {
+        $address = new Address();
+        $address->setAddress('Redacted');
+        $address->setCity('Munich');
+
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setCreatedAt(new DateTimeImmutable());
+        $user->setAddress($address);
+
+        $this->getDocumentManager()->persist($user);
+        $this->getDocumentManager()->flush();
+        $this->getDocumentManager()->clear();
+    }
+
+    /**
+     * @Warmup(2)
+     */
+    public function benchStoreDocumentWithEmbedMany()
+    {
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setCreatedAt(new DateTimeImmutable());
+        $user->addPhonenumber(new Phonenumber('12345678'));
+        $user->addPhonenumber(new Phonenumber('12345678'));
+
+        $this->getDocumentManager()->persist($user);
+        $this->getDocumentManager()->flush();
+        $this->getDocumentManager()->clear();
+    }
+
+    /**
+     * @Warmup(2)
+     */
+    public function benchStoreDocumentWithReferenceOne()
+    {
+        $account = new Account();
+        $account->setName('alcaeus');
+
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setCreatedAt(new DateTimeImmutable());
+        $user->setAccount($account);
+
+        $this->getDocumentManager()->persist($user);
+        $this->getDocumentManager()->flush();
+        $this->getDocumentManager()->clear();
+    }
+
+    /**
+     * @Warmup(2)
+     */
+    public function benchStoreDocumentWithReferenceMany()
+    {
+        $group1 = new Group('One');
+        $group2 = new Group('Two');
+
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setCreatedAt(new DateTimeImmutable());
+        $user->addGroup($group1);
+        $user->addGroup($group2);
+
+        $this->getDocumentManager()->persist($user);
+        $this->getDocumentManager()->flush();
+        $this->getDocumentManager()->clear();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "doctrine/mongodb": "^1.6.4"
     },
     "require-dev": {
+        "phpbench/phpbench": "^0.13.0",
         "phpunit/phpunit": "^5.7.21|^7.5",
         "symfony/yaml": "~2.3|~3.0|^4.0"
     },
@@ -34,6 +35,14 @@
     },
     "autoload": {
         "psr-0": { "Doctrine\\ODM\\MongoDB": "lib/" }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Doctrine\\ODM\\MongoDB\\Benchmark\\": "benchmark",
+            "Doctrine\\ODM\\MongoDB\\Tests\\": "tests/Doctrine/ODM/MongoDB/Tests",
+            "Documents\\": "tests/Documents",
+            "Stubs\\": "tests/Stubs"
+        }
     },
     "extra": {
         "branch-alias": {

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,0 +1,4 @@
+{
+    "bootstrap": "tests/bootstrap.php",
+    "path": "benchmark"
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,8 +6,4 @@ if (!file_exists($file = __DIR__.'/../vendor/autoload.php')) {
 
 $loader = require $file;
 
-$loader->add('Doctrine\ODM\MongoDB\Tests', __DIR__ . '/../tests');
-$loader->add('Documents', __DIR__);
-$loader->add('Stubs', __DIR__);
-
 \Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver::registerAnnotationClasses();


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | -

#### Summary

This PR introduces a few basic performance benchmarks to compare the performance of `ext-mongo` vs. `ext-mongodb` + `mongo-php-adapter` in 1.3, and then `ext-mongodb` natively in 2.0. For now, we have three benchmarks around storing, loading and hydrating documents. I have yet to understand the reason for the change in https://github.com/doctrine/mongodb-odm/pull/1908/files#diff-2022fc4ba746afe6891859e465c4474bR219 but will add a benchmark for that as well.

At the moment, the `BaseBench` class duplicates code from the PHPUnit bootstrap - not sure if abstracting that makes sense at this time.