### PR TITLE
Fix wrong usage of discriminator map in complex document inheritance chains

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -17,7 +17,7 @@
   use ODM 2.0 directly.
 * `doctrine/mongodb` is no longer used by ODM. If you've been relying on its
   functionality, please update accordingly. Most utility classes from 
-  `doctrine/mongodb` have been merged into their ODM counterparts. Classes 
+  `doctrine/mongodb` have been merged into their ODM counterparts. Classes
   handling connections to MongoDB servers are being replaced by the MongoDB 
   library (`mongodb/mongodb`).
 * The constructor signature of `Doctrine\ODM\MongoDB\DocumentManager` as well as
@@ -261,6 +261,9 @@ ocramius. If you are checking for proxies, the following changed:
   cursor.
 * The `eagerCursor` helper in `Doctrine\ODM\MongoDB\Query\Builder` and its logic
   have been removed entirely without replacement.
+* Querying for a mapped superclass in a complex inheritance chain will now only
+  return children of that specific class instead of all classes in the
+  inheritance tree.
 
 ## Schema manager
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -784,6 +784,10 @@ class ClassMetadata implements BaseClassMetadata
             throw MappingException::discriminatorNotAllowedForGridFS($this->name);
         }
 
+        $this->subClasses         = [];
+        $this->discriminatorMap   = [];
+        $this->discriminatorValue = null;
+
         foreach ($map as $value => $className) {
             $this->discriminatorMap[$value] = $className;
             if ($this->name === $className) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1962Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1962Test.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class GH1962Test extends BaseTest
+{
+    public function testDiscriminatorMaps()
+    {
+        $metadata = $this->dm->getClassMetadata(GH1962Superclass::class);
+        self::assertCount(3, $metadata->discriminatorMap);
+
+        $metadata = $this->dm->getClassMetadata(GH1962BarSuperclass::class);
+        self::assertCount(2, $metadata->discriminatorMap);
+    }
+
+    public function testFetchingDiscriminatedDocuments()
+    {
+        $foo = new GH1962FooDocument();
+        $bar = new GH1962BarDocument();
+        $baz = new GH1962BazDocument();
+
+        $this->dm->persist($foo);
+        $this->dm->persist($bar);
+        $this->dm->persist($baz);
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        self::assertCount(3, $this->dm->getRepository(GH1962Superclass::class)->findAll());
+        self::assertCount(2, $this->dm->getRepository(GH1962BarSuperclass::class)->findAll());
+
+        self::assertCount(1, $this->dm->getRepository(GH1962FooDocument::class)->findAll());
+        self::assertCount(1, $this->dm->getRepository(GH1962BarDocument::class)->findAll());
+        self::assertCount(1, $this->dm->getRepository(GH1962BazDocument::class)->findAll());
+    }
+
+    public function testFetchingDiscriminatedDocumentsWithoutDiscriminatorMap()
+    {
+        $foo = new GH1962FooDocumentWithoutDiscriminatorMap();
+        $bar = new GH1962BarDocumentWithoutDiscriminatorMap();
+        $baz = new GH1962BazDocumentWithoutDiscriminatorMap();
+
+        $this->dm->persist($foo);
+        $this->dm->persist($bar);
+        $this->dm->persist($baz);
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        // Since the extending superclass does not know about its child classes,
+        // it will yield the same results as querying for the parent class
+        // Without discriminator maps, only leafs in the inheritance tree will
+        // use a discriminator value in the query
+        self::assertCount(3, $this->dm->getRepository(GH1962SuperclassWithoutDiscriminatorMap::class)->findAll());
+        self::assertCount(3, $this->dm->getRepository(GH1962BarSuperclassWithoutDiscriminatorMap::class)->findAll());
+
+        self::assertCount(3, $this->dm->getRepository(GH1962FooDocumentWithoutDiscriminatorMap::class)->findAll());
+        self::assertCount(3, $this->dm->getRepository(GH1962BarDocumentWithoutDiscriminatorMap::class)->findAll());
+        self::assertCount(1, $this->dm->getRepository(GH1962BazDocumentWithoutDiscriminatorMap::class)->findAll());
+    }
+}
+
+/**
+ * @ODM\MappedSuperclass()
+ * @ODM\DiscriminatorField("type")
+ * @ODM\InheritanceType("SINGLE_COLLECTION")
+ * @ODM\DiscriminatorMap({
+ *     "foo"=GH1962FooDocument::class,
+ *     "bar"=GH1962BarDocument::class,
+ *     "baz"=GH1962BazDocument::class
+ * })
+ */
+class GH1962Superclass
+{
+    /** @ODM\Id */
+    public $id;
+}
+
+/** @ODM\Document */
+class GH1962FooDocument extends GH1962Superclass
+{
+}
+
+/**
+ * @ODM\MappedSuperclass()
+ * @ODM\DiscriminatorMap({
+ *     "bar"=GH1962BarDocument::class,
+ *     "baz"=GH1962BazDocument::class
+ * })
+ */
+class GH1962BarSuperclass extends GH1962Superclass
+{
+}
+
+/** @ODM\Document */
+class GH1962BarDocument extends GH1962BarSuperclass
+{
+}
+
+/** @ODM\Document */
+class GH1962BazDocument extends GH1962BarSuperclass
+{
+}
+/**
+ * @ODM\MappedSuperclass()
+ * @ODM\DiscriminatorField("type")
+ * @ODM\InheritanceType("SINGLE_COLLECTION")
+ */
+class GH1962SuperclassWithoutDiscriminatorMap
+{
+    /** @ODM\Id */
+    public $id;
+}
+
+/** @ODM\Document */
+class GH1962FooDocumentWithoutDiscriminatorMap extends GH1962SuperclassWithoutDiscriminatorMap
+{
+}
+
+/** @ODM\MappedSuperclass() */
+class GH1962BarSuperclassWithoutDiscriminatorMap extends GH1962SuperclassWithoutDiscriminatorMap
+{
+}
+
+/** @ODM\Document */
+class GH1962BarDocumentWithoutDiscriminatorMap extends GH1962BarSuperclassWithoutDiscriminatorMap
+{
+}
+
+/**
+ * @ODM\Document
+ * @ODM\DiscriminatorValue(GH1962BazDocumentWithoutDiscriminatorMap::class)
+ */
+class GH1962BazDocumentWithoutDiscriminatorMap extends GH1962BarSuperclassWithoutDiscriminatorMap
+{
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -39,13 +39,25 @@ class BuilderTest extends BaseTest
             ->field('featureFull')->references($f)
             ->getQuery()->debug();
 
-        $this->assertEquals([ 'featureFull.$id' => new ObjectId($f->id) ], $q1['query']);
+        $this->assertEquals(
+            [
+                'featureFull.$id' => new ObjectId($f->id),
+                'type' => ['$in' => ['ca', 'cb', 'cc']],
+            ],
+            $q1['query']
+        );
 
         $q2 = $this->dm->createQueryBuilder(ParentClass::class)
             ->field('featureSimple')->references($f)
             ->getQuery()->debug();
 
-        $this->assertEquals([ 'featureSimple' => new ObjectId($f->id) ], $q2['query']);
+        $this->assertEquals(
+            [
+                'featureSimple' => new ObjectId($f->id),
+                'type' => ['$in' => ['ca', 'cb', 'cc']],
+            ],
+            $q2['query']
+        );
 
         $q3 = $this->dm->createQueryBuilder(ParentClass::class)
             ->field('featurePartial')->references($f)
@@ -55,6 +67,7 @@ class BuilderTest extends BaseTest
             [
                 'featurePartial.$id' => new ObjectId($f->id),
                 'featurePartial.$ref' => 'Feature',
+                'type' => ['$in' => ['ca', 'cb', 'cc']],
             ],
             $q3['query']
         );
@@ -97,13 +110,27 @@ class BuilderTest extends BaseTest
             ->field('featureFullMany')->includesReferenceTo($f)
             ->getQuery()->debug();
 
-        $this->assertEquals([ 'featureFullMany' => [ '$elemMatch' => [ '$id' => new ObjectId($f->id) ] ] ], $q1['query']);
+        $this->assertEquals(
+            [
+                'featureFullMany' => [
+                    '$elemMatch' => ['$id' => new ObjectId($f->id)],
+                ],
+                'type' => ['$in' => ['ca', 'cb', 'cc']],
+            ],
+            $q1['query']
+        );
 
         $q2 = $this->dm->createQueryBuilder(ParentClass::class)
             ->field('featureSimpleMany')->includesReferenceTo($f)
             ->getQuery()->debug();
 
-        $this->assertEquals([ 'featureSimpleMany' => new ObjectId($f->id) ], $q2['query']);
+        $this->assertEquals(
+            [
+                'featureSimpleMany' => new ObjectId($f->id),
+                'type' => ['$in' => ['ca', 'cb', 'cc']],
+            ],
+            $q2['query']
+        );
 
         $q3 = $this->dm->createQueryBuilder(ParentClass::class)
             ->field('featurePartialMany')->includesReferenceTo($f)
@@ -117,6 +144,7 @@ class BuilderTest extends BaseTest
                         '$ref' => 'Feature',
                     ],
                 ],
+                'type' => ['$in' => ['ca', 'cb', 'cc']],
             ],
             $q3['query']
         );


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/improvement
| BC Break     | yes
| Fixed issues | #2024 (partially)

#### Summary

See #1962 for details. This brings the wanted functionality into 2.0 as we can't have it in 1.x due to a regression with partial discriminator maps. While #2024 wants the same behaviour for inheritance chains without discriminators, this isn't possible since the subclasses of a particular class aren't known.