### PR TITLE
relax naming rule for index key name

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -328,7 +328,7 @@
   </xs:complexType>
 
   <xs:complexType name="index-key">
-    <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
     <xs:attribute name="order" type="xs:NMTOKEN" default="asc" />
   </xs:complexType>
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no


#### Summary

As discussed in Slack I propose to loosen the index key name from `NMTOKEN` to `string`.

TL;DR: Sometimes field names have characters that aren't covered by NMTOKEN and setting an index on such a field becomes impossible. MongoDB has no problems with field names or indexes containing arbitrary characters (e.g. a `\`).

I have no idea how to write a test for that, though.
