### PR TITLE
Fix `order` syntax for YAML index examples

### DIFF
--- a/docs/en/reference/indexes.rst
+++ b/docs/en/reference/indexes.rst
@@ -136,7 +136,7 @@ For your convenience you can quickly specify a unique index with
         fields:
           username:
             unique: true
-            order: true
+            order: asc
 
 If you want to specify an index that consists of multiple fields
 you can specify them on the class doc block:
@@ -191,10 +191,8 @@ you can specify them on the class doc block:
               options:
                 unique: true
               keys:
-                accountId:
-                  order: asc
-                username:
-                  order: asc
+                accountId: asc
+                username: asc
 
 To specify multiple indexes you must use the ``@Indexes``
 annotation:
@@ -249,12 +247,10 @@ annotation:
           indexes:
             accountId:
               keys:
-                accountId:
-                  order: asc
+                accountId: asc
             username:
               keys:
-                username:
-                  order: asc
+                username: asc
 
 Embedded Indexes
 ----------------


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

The order syntax is only relevant for single-field indexes, where the index is specified within a field mapping. Multi-field indexes should simply specify the ordering (e.g. "asc") as a value for the corresponding key.

This came up in https://github.com/mongodb/mongo-php-library/issues/627.

This isn't relevant for `master`, since YamlDriver was removed in 2.0; however, this change should likely be merged up to the `1.3.x` branch. I'll defer to @malarzm and @alcaeus if it's worth back-porting to `1.0.x` and `1.1.x`, since the drop-down in the documentation does allow one to view content for those branches.