### PR TITLE
[2.0] Fix wrong syntax for replaceRoot stage

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceRoot.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceRoot.php
@@ -40,8 +40,12 @@ class ReplaceRoot extends Operator
      */
     public function getExpression() : array
     {
+        $expression = $this->expression !== null ? $this->convertExpression($this->expression) : $this->expr->getExpression();
+
         return [
-            '$replaceRoot' => $this->expression !== null ? $this->convertExpression($this->expression) : $this->expr->getExpression(),
+            '$replaceRoot' => [
+                'newRoot' => is_array($expression) ? (object) $expression : $expression,
+            ],
         ];
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
@@ -233,7 +233,11 @@ class BuilderTest extends BaseTest
             ],
             [
                 '$replaceRoot' => [
-                    'isToday' => ['$eq' => ['$createdAt', new UTCDateTime((int) $dateTime->format('Uv'))]],
+                    'newRoot' => (object) [
+                        'isToday' => [
+                            '$eq' => ['$createdAt', new UTCDateTime((int) $dateTime->format('Uv'))],
+                        ],
+                    ],
                 ],
             ],
         ];
@@ -265,7 +269,7 @@ class BuilderTest extends BaseTest
             [
                 '$sort' => ['ip' => 1],
             ],
-            ['$replaceRoot' => '$ip'],
+            ['$replaceRoot' => ['newRoot' => '$ip']],
         ];
 
         $this->assertEquals($expectedPipeline, $builder->getPipeline());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
@@ -26,7 +26,9 @@ class ReplaceRootTest extends BaseTest
         $this->assertEquals(
             [
                 '$replaceRoot' => [
-                    'isToday' => ['$eq' => ['$createdAt', $mongoDate]],
+                    'newRoot' => (object) [
+                        'isToday' => ['$eq' => ['$createdAt', $mongoDate]],
+                    ],
                 ],
             ],
             $stage->getExpression()
@@ -49,7 +51,9 @@ class ReplaceRootTest extends BaseTest
         $this->assertEquals(
             [
                 '$replaceRoot' => [
-                    'isToday' => ['$eq' => ['$createdAt', $mongoDate]],
+                    'newRoot' => (object) [
+                        'isToday' => ['$eq' => ['$createdAt', $mongoDate]],
+                    ],
                 ],
             ],
             $stage->getExpression()
@@ -68,7 +72,9 @@ class ReplaceRootTest extends BaseTest
         $this->assertEquals(
             [
                 '$replaceRoot' => [
-                    'someField' => ['$concat' => ['$ip', 'foo']],
+                    'newRoot' => (object) [
+                        'someField' => ['$concat' => ['$ip', 'foo']],
+                    ],
                 ],
             ],
             $stage->getExpression()
@@ -83,7 +89,9 @@ class ReplaceRootTest extends BaseTest
             ->replaceRoot('$authorIp');
 
         $this->assertEquals(
-            ['$replaceRoot' => '$ip'],
+            [
+                '$replaceRoot' => ['newRoot' => '$ip'],
+            ],
             $stage->getExpression()
         );
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | https://github.com/doctrine/DoctrineMongoDBBundle/issues/565

#### Summary

This ports the changes from https://github.com/doctrine/mongodb/pull/333 to the master branch which now includes the main logic. For 1.x, the fix is done in doctrine/mongodb, we just need to update the tests once a fix is released.