### PR TITLE
Fix ReplaceRoot aggregation stage tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/cache": "~1.0",
         "doctrine/inflector": "~1.0",
         "doctrine/instantiator": "^1.0.1",
-        "doctrine/mongodb": "^1.6.3"
+        "doctrine/mongodb": "^1.6.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.21|^6.4",

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
@@ -70,7 +70,11 @@ class BuilderTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ],
             [
                 '$replaceRoot' => [
-                    'isToday' => ['$eq' => ['$createdAt', new \MongoDate($dateTime->format('U'), $dateTime->format('u'))]],
+                    'newRoot' => (object) [
+                        'isToday' => [
+                            '$eq' => ['$createdAt', new \MongoDate($dateTime->format('U'), $dateTime->format('u'))]
+                        ],
+                    ],
                 ]
             ]
         ];
@@ -105,7 +109,7 @@ class BuilderTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
                 '$sort' => ['ip' => 1],
             ],
             [
-                '$replaceRoot' => '$ip',
+                '$replaceRoot' => ['newRoot' => '$ip'],
             ]
         ];
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
@@ -20,7 +20,9 @@ class ReplaceRootTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->assertEquals(
             ['$replaceRoot' => [
-                'isToday' => ['$eq' => ['$createdAt', $mongoDate]],
+                'newRoot' => (object) [
+                    'isToday' => ['$eq' => ['$createdAt', $mongoDate]],
+                ],
             ]],
             $stage->getExpression()
         );
@@ -41,7 +43,9 @@ class ReplaceRootTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->assertEquals(
             ['$replaceRoot' => [
-                'isToday' => ['$eq' => ['$createdAt', $mongoDate]],
+                'newRoot' => (object) [
+                    'isToday' => ['$eq' => ['$createdAt', $mongoDate]],
+                ],
             ]],
             $stage->getExpression()
         );
@@ -58,7 +62,9 @@ class ReplaceRootTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
 
         $this->assertEquals(
             ['$replaceRoot' => [
-                'someField' => ['$concat' => ['$ip', 'foo']],
+                'newRoot' => (object) [
+                    'someField' => ['$concat' => ['$ip', 'foo']],
+                ],
             ]],
             $stage->getExpression()
         );
@@ -72,7 +78,9 @@ class ReplaceRootTest extends \Doctrine\ODM\MongoDB\Tests\BaseTest
             ->replaceRoot('$authorIp');
 
         $this->assertEquals(
-            ['$replaceRoot' => '$ip'],
+            [
+                '$replaceRoot' => ['newRoot' => '$ip'],
+            ],
             $stage->getExpression()
         );
     }


### PR DESCRIPTION
Since the upstream library was fixed, we need to adapt the tests to ensure they won't randomly fail.
