### PR TITLE
Disable retryable writes on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
 
 env:
   global:
-    - DOCTRINE_MONGODB_SERVER="mongodb://localhost:27017"
+    - DOCTRINE_MONGODB_SERVER="mongodb://localhost:27017/?retryWrites=false"
     - KEY_SERVER="hkp://keyserver.ubuntu.com:80"
     - MONGO_REPO_URI="https://repo.mongodb.org/apt/ubuntu"
     - MONGO_REPO_TYPE="trusty/mongodb-org/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
@@ -23,7 +22,7 @@ env:
 matrix:
   include:
     - php: 5.6
-      env: DRIVER_VERSION="1.6.7" COMPOSER_FLAGS="--prefer-lowest" SERVER_VERSION="3.2" KEY_ID="EA312927"
+      env: DRIVER_VERSION="1.6.7" COMPOSER_FLAGS="--prefer-lowest" SERVER_VERSION="3.2" KEY_ID="EA312927" DOCTRINE_MONGODB_SERVER="mongodb://localhost:27017"
     - php: 7.2
       env: SERVER_VERSION="3.6" KEY_ID="2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
     - php: 7.3


### PR DESCRIPTION
This fixes the build after updating to `ext-mongodb` 1.6.0 since retryable writes don't play nice with sharded clusters backed by standalone servers (which you shouldn't run in production anyways).