### PR TITLE
Add storage strategy in xsd

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -80,7 +80,7 @@
     <xs:attribute name="id" type="xs:boolean" default="false" />
     <xs:attribute name="name" type="xs:NMTOKEN" />
     <xs:attribute name="type" type="xs:NMTOKEN" />
-    <xs:attribute name="strategy" type="xs:NMTOKEN" default="set" />
+    <xs:attribute name="strategy" type="odm:storage-strategy" default="set" />
     <xs:attribute name="fieldName" type="xs:NMTOKEN" />
     <xs:attribute name="embed" type="xs:boolean" />
     <xs:attribute name="file" type="xs:boolean" />
@@ -131,11 +131,23 @@
     <xs:attribute name="collection-class" type="xs:string" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="fieldName" type="xs:NMTOKEN" />
-    <xs:attribute name="strategy" type="xs:NMTOKEN" default="pushAll" />
+    <xs:attribute name="strategy" type="odm:storage-strategy" default="pushAll" />
     <xs:attribute name="not-saved" type="xs:boolean" />
     <xs:attribute name="nullable" type="xs:boolean" />
     <xs:attribute name="also-load" type="xs:NMTOKEN" />
   </xs:complexType>
+
+  <xs:simpleType name="storage-strategy">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="addToSet"/>
+      <xs:enumeration value="pushAll"/>
+      <xs:enumeration value="increment"/>
+      <xs:enumeration value="set"/>
+      <xs:enumeration value="setArray"/>
+      <xs:enumeration value="atomicSet"/>
+      <xs:enumeration value="atomicSetArray"/>
+    </xs:restriction>
+  </xs:simpleType>
 
   <xs:simpleType name="reference-store-as">
     <xs:restriction base="xs:token">
@@ -187,7 +199,7 @@
     <!-- deprecated -->
     <xs:attribute name="simple" type="xs:boolean" />
     <xs:attribute name="store-as" type="odm:reference-store-as" default="dbRefWithDb" />
-    <xs:attribute name="strategy" type="xs:NMTOKEN" default="pushAll" />
+    <xs:attribute name="strategy" type="odm:storage-strategy" default="pushAll" />
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />
     <xs:attribute name="mapped-by" type="xs:NMTOKEN" />
     <xs:attribute name="repository-method" type="xs:NMTOKEN" />


### PR DESCRIPTION
For ease to code xml mapping (on PHPStorm, at least), I just added the storage strategies in xsd file
https://www.doctrine-project.org/projects/doctrine-mongodb-odm/en/1.2/reference/storage-strategies.html#storage-strategies

I don't know if this should be added into 1.1.x too.
Let me know what to do if it should.

Edit : Also, I'm not sure what doeas the `xs:restriction` element yet,so I just based my changed on the existing `reference-store-as` `simpleType`