### PR TITLE
[2.0] Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ jobs:
         - if [[ ! $(php -m | grep -si xdebug) ]]; then echo "xdebug required for coverage"; exit 1; fi
         - vendor/bin/phpunit --dump-xdebug-filter xdebug-filter.php
       script:
+        - export DOCTRINE_MONGODB_SERVER=`cat /tmp/uri.txt`
+        - echo $DOCTRINE_MONGODB_SERVER
         - vendor/bin/phpunit --prepend xdebug-filter.php --coverage-clover=coverage.clover
       after_script:
         - wget https://scrutinizer-ci.com/ocular.phar

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
@@ -24,12 +24,6 @@ class GraphLookupTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function setUp() : void
-    {
-        parent::setUp();
-        $this->requireMongoDB34('$graphLookup tests require at least MongoDB 3.4.0');
-    }
-
     public function testGraphLookupStage()
     {
         $graphLookupStage = new GraphLookup($this->getTestAggregationBuilder(), 'employees', $this->dm, new ClassMetadata(User::class));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LookupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LookupTest.php
@@ -17,7 +17,6 @@ class LookupTest extends BaseTest
     public function setUp() : void
     {
         parent::setUp();
-        $this->requireMongoDB32('$lookup tests require at least MongoDB 3.2.0');
         $this->insertTestData();
     }
 
@@ -190,38 +189,8 @@ class LookupTest extends BaseTest
         $this->assertSame('malarzm', $result[1]['users'][0]['username']);
     }
 
-    public function testLookupStageReferenceManyWithoutUnwindMongoDB32()
-    {
-        $this->skipOnMongoDB34('$lookup tests without unwind will not work on MongoDB 3.4.0+');
-
-        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
-        $builder
-            ->lookup('users')
-                ->alias('users');
-
-        $expectedPipeline = [
-            [
-                '$lookup' => [
-                    'from' => 'users',
-                    'localField' => 'users',
-                    'foreignField' => '_id',
-                    'as' => 'users',
-                ],
-            ],
-        ];
-
-        $this->assertEquals($expectedPipeline, $builder->getPipeline());
-
-        $result = $builder->execute()->toArray();
-
-        $this->assertCount(1, $result);
-        $this->assertCount(0, $result[0]['users']);
-    }
-
     public function testLookupStageReferenceManyWithoutUnwindMongoDB34()
     {
-        $this->requireMongoDB34('$lookup tests with unwind require at least MongoDB 3.4.0');
-
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
             ->lookup('users')

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -126,21 +126,6 @@ abstract class BaseTest extends TestCase
         $this->markTestSkipped($message);
     }
 
-    protected function requireMongoDB32($message)
-    {
-        $this->requireVersion($this->getServerVersion(), '3.2.0', '<', $message);
-    }
-
-    protected function skipOnMongoDB34($message)
-    {
-        $this->requireVersion($this->getServerVersion(), '3.4.0', '>=', $message);
-    }
-
-    protected function requireMongoDB34($message)
-    {
-        $this->requireVersion($this->getServerVersion(), '3.4.0', '<', $message);
-    }
-
     protected function skipOnMongoDB42($message)
     {
         $this->requireVersion($this->getServerVersion(), '4.2.0', '>=', $message);

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -140,4 +140,14 @@ abstract class BaseTest extends TestCase
     {
         $this->requireVersion($this->getServerVersion(), '3.4.0', '<', $message);
     }
+
+    protected function skipOnMongoDB42($message)
+    {
+        $this->requireVersion($this->getServerVersion(), '4.2.0', '>=', $message);
+    }
+
+    protected function requireMongoDB42($message)
+    {
+        $this->requireVersion($this->getServerVersion(), '4.2.0', '<', $message);
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
@@ -216,8 +216,6 @@ class IndexesTest extends BaseTest
 
     public function testPartialIndexCreation()
     {
-        $this->requireMongoDB32('This test is not applicable to server versions < 3.2.0');
-
         $className = PartialIndexOnDocumentTest::class;
         $this->dm->getSchemaManager()->ensureDocumentIndexes($className);
 


### PR DESCRIPTION
* Tests regarding index name length restrictions are updated for MongoDB 4.2, which drops these restrictions
* Removed code to require/skip tests on MongoDB < 3.6
* Fix code coverage build stage (this was broken when merging in 1.3.x)