### PR TITLE
Introduce interface for command loggers

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/APM/CommandLogger.php
+++ b/lib/Doctrine/ODM/MongoDB/APM/CommandLogger.php
@@ -7,13 +7,12 @@ namespace Doctrine\ODM\MongoDB\APM;
 use Countable;
 use MongoDB\Driver\Monitoring\CommandFailedEvent;
 use MongoDB\Driver\Monitoring\CommandStartedEvent;
-use MongoDB\Driver\Monitoring\CommandSubscriber;
 use MongoDB\Driver\Monitoring\CommandSucceededEvent;
 use function count;
 use function MongoDB\Driver\Monitoring\addSubscriber;
 use function MongoDB\Driver\Monitoring\removeSubscriber;
 
-final class CommandLogger implements Countable, CommandSubscriber
+final class CommandLogger implements Countable, CommandLoggerInterface
 {
     /** @var Command[] */
     private $commands = [];

--- a/lib/Doctrine/ODM/MongoDB/APM/CommandLoggerInterface.php
+++ b/lib/Doctrine/ODM/MongoDB/APM/CommandLoggerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\APM;
+
+use MongoDB\Driver\Monitoring\CommandSubscriber;
+
+interface CommandLoggerInterface extends CommandSubscriber
+{
+    /**
+     * Registers this command logger instance with the MongoDB library so it can receive command events
+     */
+    public function register() : void;
+
+    /**
+     * Unregisters this command logger instance with the MongoDB library so it no longer receives command events
+     */
+    public function unregister() : void;
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

This interface is necessary so the Symfony Bundle can allow registering multiple loggers for commands. This was brought up by @jmikola in https://github.com/doctrine/DoctrineMongoDBBundle/pull/569#discussion_r303586382.