### PR TITLE
Follow-up tasks for build modernisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
 
 env:
   global:
-    - DEPLOYMENT=SHARDED_CLUSTER_RS
+    - DEPLOYMENT=STANDALONE
     - KEY_SERVER="hkp://keyserver.ubuntu.com:80"
     - MONGO_REPO_URI="https://repo.mongodb.org/apt/ubuntu"
     - MONGO_REPO_TYPE="xenial/mongodb-org/"
@@ -33,6 +33,13 @@ jobs:
       php: 7.3
       env: SERVER_VERSION="4.0" KEY_ID="9DA31620334BD75D9DCB49F368818C72E52529D4"
 
+    # Test sharded cluster functionality
+    - stage: Test
+      php: 7.3
+      env: DEPLOYMENT=SHARDED_CLUSTER_RS
+      script:
+        - ./vendor/bin/phpunit --group=sharding --coverage-clover=coverage.clover
+
 before_install:
   - sudo apt-key adv --keyserver ${KEY_SERVER} --recv ${KEY_ID}
   - echo "deb ${MONGO_REPO_URI} ${MONGO_REPO_TYPE}${SERVER_VERSION} multiverse" | sudo tee ${SOURCES_LOC}
@@ -51,10 +58,10 @@ before_script:
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then pecl install -f mongodb-${DRIVER_VERSION}; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then composer config "platform.ext-mongo" "1.6.16" && composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}"; fi
   - composer update ${COMPOSER_FLAGS}
-
-script:
   - export DOCTRINE_MONGODB_SERVER=`cat /tmp/uri.txt`
   - echo $DOCTRINE_MONGODB_SERVER
+
+script:
   - ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,26 +12,22 @@ php:
 env:
   global:
     - DEPLOYMENT=STANDALONE
-    - KEY_SERVER="hkp://keyserver.ubuntu.com:80"
-    - MONGO_REPO_URI="https://repo.mongodb.org/apt/ubuntu"
-    - MONGO_REPO_TYPE="xenial/mongodb-org/"
-    - SOURCES_LOC="/etc/apt/sources.list.d/mongodb.list"
     - DRIVER_VERSION="stable"
     - ADAPTER_VERSION="^1.0.0"
-    - SERVER_VERSION="4.2"
-    - KEY_ID="E162F504A20CDF15827F718D4B7C549A058F8B6B"
+    - SERVER_DISTRO=ubuntu1604
+    - SERVER_VERSION=4.2.0
 
 jobs:
   include:
     # Test against lowest dependencies, including driver and server versions
     - stage: Test
       php: 5.6
-      env: DRIVER_VERSION="1.6.7" COMPOSER_FLAGS="--prefer-lowest" SERVER_VERSION="3.6" KEY_ID="2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
+      env: DRIVER_VERSION="1.6.7" COMPOSER_FLAGS="--prefer-lowest" SERVER_VERSION="3.6.14"
 
     # Test against MongoDB 4.0
     - stage: Test
       php: 7.3
-      env: SERVER_VERSION="4.0" KEY_ID="9DA31620334BD75D9DCB49F368818C72E52529D4"
+      env: SERVER_VERSION="4.0."
 
     # Test sharded cluster functionality
     - stage: Test
@@ -47,14 +43,8 @@ jobs:
       script:
         - ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
-before_install:
-  - sudo apt-key adv --keyserver ${KEY_SERVER} --recv ${KEY_ID}
-  - echo "deb ${MONGO_REPO_URI} ${MONGO_REPO_TYPE}${SERVER_VERSION} multiverse" | sudo tee ${SOURCES_LOC}
-  - sudo apt-get update -qq
-
 install:
-  - sudo apt-get --allow-unauthenticated install mongodb-org
-  - if nc -z localhost 27017; then sudo service mongod stop; fi
+  - .travis/setup_mongodb.sh
   - sudo pip install mongo-orchestration
   - sudo mongo-orchestration start
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,13 @@ jobs:
       script:
         - ./vendor/bin/phpunit --group=sharding --coverage-clover=coverage.clover
 
+    # Test on replica sets
+    - stage: Test
+      php: 7.3
+      env: DEPLOYMENT=REPLICASET
+      script:
+        - ./vendor/bin/phpunit --coverage-clover=coverage.clover
+
 before_install:
   - sudo apt-key adv --keyserver ${KEY_SERVER} --recv ${KEY_ID}
   - echo "deb ${MONGO_REPO_URI} ${MONGO_REPO_TYPE}${SERVER_VERSION} multiverse" | sudo tee ${SOURCES_LOC}

--- a/.travis/setup_mo.sh
+++ b/.travis/setup_mo.sh
@@ -2,6 +2,8 @@
 
 echo Loading MO for $DEPLOYMENT
 
+mongo-orchestration --version
+
 if [[ -z $TRAVIS_BUILD_DIR ]]; then
     export TRAVIS_BUILD_DIR=`pwd`;
 fi

--- a/.travis/setup_mongodb.sh
+++ b/.travis/setup_mongodb.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if nc -z localhost 27017
+then
+  sudo service mongod stop
+fi
+
+export SERVER_FILENAME=mongodb-linux-x86_64-${SERVER_DISTRO}-${SERVER_VERSION}
+wget -qO- http://fastdl.mongodb.org/linux/${SERVER_FILENAME}.tgz | tar xz
+export PATH=${PWD}/${SERVER_FILENAME}/bin:${PATH}
+mongod --version

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,6 +31,8 @@
         <const name="DOCTRINE_MONGODB_SERVER" value="mongodb://localhost:27017" />
         <const name="DOCTRINE_MONGODB_DATABASE" value="doctrine_odm_tests" />
 
+        <!-- These two ini settings prevent errors with command cursors due to
+             the cursor ID being in an unsupported format on newer servers. -->
         <ini name="mongo.native_long" value="false" />
         <ini name="mongo.long_as_object" value="true" />
     </php>


### PR DESCRIPTION
This PR covers improvements suggested by @jmikola in https://github.com/doctrine/mongodb-odm/pull/2056#pullrequestreview-286835097:
* Run tests on standalone servers, adding a build stage for sharded tests (which only runs sharing-specific tests for build speed) and replica sets (as it covers what we think is the most popular use-case
* Add note about ini settings required to get the legacy extension working on newer MongoDB server version.