### PR TITLE
Flipped key/value for SimplifiedXmlDriver example

### DIFF
--- a/docs/en/reference/xml-mapping.rst
+++ b/docs/en/reference/xml-mapping.rst
@@ -85,11 +85,11 @@ Configuration of this client works a little bit different:
 .. code-block:: php
 
     <?php
-    $namespaces = array(
-        'MyProject\Documents' => '/path/to/files1',
-        'OtherProject\Documents' => '/path/to/files2'
+    $prefixes = array(
+        '/path/to/files1' => 'MyProject\Documents',
+        '/path/to/files2' => 'OtherProject\Documents'
     );
-    $driver = new \Doctrine\ODM\MongoDB\Mapping\Driver\SimplifiedXmlDriver($namespaces);
+    $driver = new \Doctrine\ODM\MongoDB\Mapping\Driver\SimplifiedXmlDriver($prefixes);
     $driver->setGlobalBasename('global'); // global.mongodb-odm.xml
 
 Example


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

Hi,

I believe the example for `SimplifiedXmlDriver` is wrong, the keys/values are flipped. [SymfonyFileLocator](https://github.com/doctrine/persistence/blob/2ae45c1436572dbcb1036801793b8b726c6a9f53/lib/Doctrine/Common/Persistence/Mapping/Driver/SymfonyFileLocator.php#L84) uses the keys as paths, see that `array_keys($prefixes)`?

```php
    public function addNamespacePrefixes(array $prefixes)
    {
        $this->prefixes = array_merge($this->prefixes, $prefixes);
        $this->paths    = array_merge($this->paths, array_keys($prefixes));
    }
```

I would expect namespace prefix to be a key as well, but it's not the case. For instance the following code is not working:

```yaml
    prefixes:
      HelloFresh\MenuService\Domain\Menu: src/Infrastructure/Persistence/Resource/doctrine/document/Menu
      HelloFresh\MenuService\Domain\Preset: src/Infrastructure/Persistence/Resource/doctrine/document/Preset
```

But this one is:

```yaml
    prefixes:
      src/Infrastructure/Persistence/Resource/doctrine/document/Menu: HelloFresh\MenuService\Domain\Menu
      src/Infrastructure/Persistence/Resource/doctrine/document/Preset: HelloFresh\MenuService\Domain\Preset
```