### PR TITLE
Optimise build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,20 @@ env:
     - ADAPTER_VERSION="^1.0.0"
     - SERVER_DISTRO=ubuntu1604
     - SERVER_VERSION=4.2.0
+  matrix:
+    - SERVER_VERSION="3.0.15"
+    - SERVER_VERSION="3.2.22"
+    - SERVER_VERSION="3.4.23"
+    - SERVER_VERSION="3.6.14"
+    - SERVER_VERSION="4.0.12"
+    - SERVER_VERSION="4.2.0"
 
 jobs:
   include:
     # Test against lowest dependencies, including driver and server versions
     - stage: Test
       php: 5.6
-      env: DRIVER_VERSION="1.6.7" COMPOSER_FLAGS="--prefer-lowest" SERVER_VERSION="3.6.14"
-
-    # Test against MongoDB 4.0
-    - stage: Test
-      php: 7.3
-      env: SERVER_VERSION="4.0.12"
+      env: DRIVER_VERSION="1.6.7" COMPOSER_FLAGS="--prefer-lowest" SERVER_VERSION="3.0.15"
 
     # Test sharded cluster functionality
     - stage: Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
     # Test against MongoDB 4.0
     - stage: Test
       php: 7.3
-      env: SERVER_VERSION="4.0."
+      env: SERVER_VERSION="4.0.12"
 
     # Test sharded cluster functionality
     - stage: Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,6 @@ install:
   - .travis/setup_mongodb.sh
   - sudo pip install mongo-orchestration
   - sudo mongo-orchestration start
-
-before_script:
   - .travis/setup_mo.sh
   - composer self-update
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then yes '' | pecl -q install -f mongo-${DRIVER_VERSION}; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,14 +34,28 @@ jobs:
       php: 7.3
       env: DEPLOYMENT=SHARDED_CLUSTER_RS
       script:
-        - ./vendor/bin/phpunit --group=sharding --coverage-clover=coverage.clover
+        - ./vendor/bin/phpunit --group=sharding
 
     # Test on replica sets
     - stage: Test
       php: 7.3
       env: DEPLOYMENT=REPLICASET
+
+    # Run tests with coverage
+    - stage: Code Quality
+      php: 7.2
+      env: DEPLOYMENT=SHARDED_CLUSTER_RS
+      before_script:
+        - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}
+        - if [[ ! $(php -m | grep -si xdebug) ]]; then echo "xdebug required for coverage"; exit 1; fi
+        - vendor/bin/phpunit --dump-xdebug-filter xdebug-filter.php
       script:
-        - ./vendor/bin/phpunit --coverage-clover=coverage.clover
+        - export DOCTRINE_MONGODB_SERVER=`cat /tmp/uri.txt`
+        - echo $DOCTRINE_MONGODB_SERVER
+        - vendor/bin/phpunit --prepend xdebug-filter.php --coverage-clover=coverage.clover
+      after_script:
+        - wget https://scrutinizer-ci.com/ocular.phar
+        - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
 
     # Performance tests
     - stage: Performance
@@ -51,6 +65,9 @@ jobs:
     - stage: Performance
       php: 7.3
       script: vendor/bin/phpbench run --report=default --revs=100 --iterations=5 --report=aggregate
+
+before_install:
+  - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
 
 install:
   - .travis/setup_mongodb.sh
@@ -66,8 +83,4 @@ install:
   - echo $DOCTRINE_MONGODB_SERVER
 
 script:
-  - ./vendor/bin/phpunit --coverage-clover=coverage.clover
-
-after_script:
-    - wget https://scrutinizer-ci.com/ocular.phar
-    - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - ./vendor/bin/phpunit


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

* Simplify usage of build steps to make this more consistent with the master branch
* Fix wrong version number in 4.0 build stage. This resulted in the default MongoDB version (currently 4.0.7) to be used on travis-ci
* Extract coverage to a separate build to speed up build times
* Add builds against all MongoDB versions supported by the PHP driver

This makes the build files for 1.3.x and master more consistent, with master then using this version of the build file and just adding the new code quality stages.