### PR TITLE
Add command example to create a capped collection

### DIFF
--- a/docs/en/reference/capped-collections.rst
+++ b/docs/en/reference/capped-collections.rst
@@ -90,3 +90,13 @@ You can drop the collection too if it already exists:
     <?php
 
     $documentManager->getSchemaManager()->dropDocumentCollection('Category');
+
+Use the ``odm:schema:create`` command to create the database schema:
+
+.. code-block:: console
+
+    $ php mongodb.php odm:schema:create
+
+It must not exist when the command is invoked. It is not possible to convert an existing collection to a capped one using Doctrine. It is, however, possible to convert it by calling a `direct Mongo command`_.
+
+.. _`direct Mongo command`: https://docs.mongodb.com/manual/core/capped-collections/#convert-a-collection-to-capped


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->

This PR adds the command to use when using Doctrine with Symfony to create a _capped collection_. 

I spent some time on debugging what exactly needs to be done to have Doctrine listen to the capped collection configuration and it was missing from the documentation.