### PR TITLE
fix an error in the XML schema

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -447,7 +447,7 @@
 
   <xs:complexType name="read-preference-tag-set">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="tag" type="read-preference-tag" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="tag" type="odm:read-preference-tag" minOccurs="0" maxOccurs="unbounded" />
     </xs:choice>
   </xs:complexType>
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

A small bubu in the XML mapping schema file caused `\DOMDocument::schemaValidate` to fail and `\Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver::validateSchema` therefore triggers a deprecation warning.

This is already fixed in the `2.0.0-RC2` branch.
