### PR TITLE
Class name resolver performance optimisation

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -231,8 +231,13 @@ ocramius. If you are checking for proxies, the following changed:
   resolver from the document manager:
   ```php
   $dm->getClassNameResolver()->getRealClass($className);
-  $dm->getClassNameResolver()->getClass($object);
   ```
+* The return value of the `getClassNameResolver` method was updated in
+  2.0.0. The previously returned
+  `Doctrine\ODM\MongoDB\Proxy\ClassNameResolver` class was dropped in favour of
+  the `Doctrine\ODM\MongoDB\Proxy\Resolver\ClassNameResolver` interface. This
+  BC break was necessary to mitigate a performance regression. The `getClass`
+  method was dropped from the interface as it wasn't being used.
 
 ## Repository
 

--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -13,6 +13,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Proxy\Factory\ProxyFactory;
 use Doctrine\ODM\MongoDB\Proxy\Factory\StaticProxyFactory;
+use Doctrine\ODM\MongoDB\Proxy\Resolver\CachingClassNameResolver;
 use Doctrine\ODM\MongoDB\Proxy\Resolver\ClassNameResolver;
 use Doctrine\ODM\MongoDB\Proxy\Resolver\ProxyManagerClassNameResolver;
 use Doctrine\ODM\MongoDB\Query\FilterCollection;
@@ -184,7 +185,7 @@ class DocumentManager implements ObjectManager
         $this->schemaManager     = new SchemaManager($this, $this->metadataFactory);
         $this->proxyFactory      = new StaticProxyFactory($this);
         $this->repositoryFactory = $this->config->getRepositoryFactory();
-        $this->classNameResolver = new ProxyManagerClassNameResolver($this->config);
+        $this->classNameResolver = new CachingClassNameResolver(new ProxyManagerClassNameResolver($this->config));
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -11,9 +11,10 @@ use Doctrine\ODM\MongoDB\Hydrator\HydratorFactory;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
-use Doctrine\ODM\MongoDB\Proxy\ClassNameResolver;
 use Doctrine\ODM\MongoDB\Proxy\Factory\ProxyFactory;
 use Doctrine\ODM\MongoDB\Proxy\Factory\StaticProxyFactory;
+use Doctrine\ODM\MongoDB\Proxy\Resolver\ClassNameResolver;
+use Doctrine\ODM\MongoDB\Proxy\Resolver\ProxyManagerClassNameResolver;
 use Doctrine\ODM\MongoDB\Query\FilterCollection;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\ODM\MongoDB\Repository\RepositoryFactory;
@@ -183,7 +184,7 @@ class DocumentManager implements ObjectManager
         $this->schemaManager     = new SchemaManager($this, $this->metadataFactory);
         $this->proxyFactory      = new StaticProxyFactory($this);
         $this->repositoryFactory = $this->config->getRepositoryFactory();
-        $this->classNameResolver = new ClassNameResolver($this->config);
+        $this->classNameResolver = new ProxyManagerClassNameResolver($this->config);
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/CachingClassNameResolver.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/CachingClassNameResolver.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Proxy\Resolver;
+
+/**
+ * @internal
+ */
+final class CachingClassNameResolver implements ClassNameResolver
+{
+    /** @var ClassNameResolver */
+    private $resolver;
+
+    /** @var array<string, string> */
+    private $resolvedNames = [];
+
+    public function __construct(ClassNameResolver $resolver)
+    {
+        $this->resolver = $resolver;
+    }
+
+    /**
+     * Gets the real class name of a class name that could be a proxy.
+     */
+    public function getRealClass(string $class) : string
+    {
+        if (! isset($this->resolvedNames[$class])) {
+            $this->resolvedNames[$class] = $this->resolver->getRealClass($class);
+        }
+
+        return $this->resolvedNames[$class];
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/ClassNameResolver.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/ClassNameResolver.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Proxy\Resolver;
+
+interface ClassNameResolver
+{
+    /**
+     * Gets the real class name of a class name that could be a proxy.
+     */
+    public function getRealClass(string $class) : string;
+}

--- a/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/ProxyManagerClassNameResolver.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/ProxyManagerClassNameResolver.php
@@ -2,13 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\ODM\MongoDB\Proxy;
+namespace Doctrine\ODM\MongoDB\Proxy\Resolver;
 
 use Doctrine\ODM\MongoDB\Configuration;
 use ProxyManager\Inflector\ClassNameInflectorInterface;
-use function get_class;
 
-final class ClassNameResolver
+/**
+ * @internal
+ */
+final class ProxyManagerClassNameResolver implements ClassNameResolver
 {
     /** @var Configuration */
     private $configuration;
@@ -24,14 +26,6 @@ final class ClassNameResolver
     public function getRealClass(string $class) : string
     {
         return $this->getClassNameInflector()->getUserClassName($class);
-    }
-
-    /**
-     * Gets the real class name of an object (even if its a proxy).
-     */
-    public function getClass(object $object) : string
-    {
-        return $this->getRealClass(get_class($object));
     }
 
     private function getClassNameInflector() : ClassNameInflectorInterface


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | 

#### Summary

cc @watari

#1908 suggests a number of changes to improve document performance. I was especially curious about the changes to the document manager, where an additional cache for `ClassMetadata` is added. Looking at that change in isolation, it turns out that most of the improvements to the performance test suite come from that single change.

Upon further investigation, I was able to pinpoint the performance regression to the class name resolution for proxy objects, which now was added to MongoDB ODM until the doctrine/persistence layer supports multiple proxy implementations.

This PR removes this issue by adding a caching version of a class name resolver which removes the need for repeatedly resolving the same class names. Since the original resolver was not marked as `@internal`, it is only deprecated and not removed entirely. The new implementations are marked as `@internal` as users shouldn't need to instantiate those directly. The associated interface is not marked as `@internal` and is covered by the BC promise.

I'll take a look at the other changes in #1908 in separate PRs or merge it directly with the DocumentManager change removed.

For reference, the following times are from before and after the change:
```
⅀T: 9,645.960μs μSD/r 0.000μs μRSD/r: 0.000%
⅀T: 8,144.470μs μSD/r 0.000μs μRSD/r: 0.000%
```

This is an improvement of ~15.5% just for this change alone!