### PR TITLE
Throw hydrator exceptions when encountering invalid types

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorException.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Hydrator;
 
 use Doctrine\ODM\MongoDB\MongoDBException;
+use function sprintf;
 
 /**
  * MongoDB ODM Hydrator Exception
@@ -24,5 +25,28 @@ final class HydratorException extends MongoDBException
     public static function hydratorNamespaceRequired() : self
     {
         return new self('You must configure a hydrator namespace. See docs for details');
+    }
+
+    public static function associationTypeMismatch(string $className, string $fieldName, string $expectedType, string $actualType)
+    {
+        return new self(sprintf(
+            'Expected association for field "%s" in document of type "%s" to be of type "%s", "%s" received.',
+            $fieldName,
+            $className,
+            $expectedType,
+            $actualType
+        ));
+    }
+
+    public static function associationItemTypeMismatch(string $className, string $fieldName, $key, string $expectedType, string $actualType)
+    {
+        return new self(sprintf(
+            'Expected association item with key "%s" for field "%s" in document of type "%s" to be of type "%s", "%s" received.',
+            $key,
+            $fieldName,
+            $className,
+            $expectedType,
+            $actualType
+        ));
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -245,6 +245,11 @@ EOF
         /** @ReferenceOne */
         if (isset(\$data['%1\$s'])) {
             \$reference = \$data['%1\$s'];
+
+            if (\$this->class->fieldMappings['%2\$s']['storeAs'] !== ClassMetadata::REFERENCE_STORE_AS_ID && ! is_array(\$reference)) {
+                throw HydratorException::associationTypeMismatch('%3\$s', '%1\$s', 'array', gettype(\$reference));
+            }
+
             \$className = \$this->unitOfWork->getClassNameForAssociation(\$this->class->fieldMappings['%2\$s'], \$reference);
             \$identifier = ClassMetadata::getReferenceId(\$reference, \$this->class->fieldMappings['%2\$s']['storeAs']);
             \$targetMetadata = \$this->dm->getClassMetadata(\$className);
@@ -257,7 +262,8 @@ EOF
 EOF
                     ,
                     $mapping['name'],
-                    $mapping['fieldName']
+                    $mapping['fieldName'],
+                    $class->getName()
                 );
             } elseif ($mapping['association'] === ClassMetadata::REFERENCE_ONE && $mapping['isInverseSide']) {
                 if (isset($mapping['repositoryMethod']) && $mapping['repositoryMethod']) {
@@ -305,6 +311,11 @@ EOF
 
         /** @Many */
         \$mongoData = isset(\$data['%1\$s']) ? \$data['%1\$s'] : null;
+
+        if (\$mongoData !== null && ! is_array(\$mongoData)) {
+            throw HydratorException::associationTypeMismatch('%3\$s', '%1\$s', 'array', gettype(\$mongoData));
+        }
+
         \$return = \$this->dm->getConfiguration()->getPersistentCollectionFactory()->create(\$this->dm, \$this->class->fieldMappings['%2\$s']);
         \$return->setHints(\$hints);
         \$return->setOwner(\$document, \$this->class->fieldMappings['%2\$s']);
@@ -318,7 +329,8 @@ EOF
 EOF
                     ,
                     $mapping['name'],
-                    $mapping['fieldName']
+                    $mapping['fieldName'],
+                    $class->getName()
                 );
             } elseif ($mapping['association'] === ClassMetadata::EMBED_ONE) {
                 $code .= sprintf(
@@ -327,6 +339,11 @@ EOF
         /** @EmbedOne */
         if (isset(\$data['%1\$s'])) {
             \$embeddedDocument = \$data['%1\$s'];
+
+            if (! is_array(\$embeddedDocument)) {
+                throw HydratorException::associationTypeMismatch('%3\$s', '%1\$s', 'array', gettype(\$embeddedDocument));
+            }
+        
             \$className = \$this->unitOfWork->getClassNameForAssociation(\$this->class->fieldMappings['%2\$s'], \$embeddedDocument);
             \$embeddedMetadata = \$this->dm->getClassMetadata(\$className);
             \$return = \$embeddedMetadata->newInstance();
@@ -347,7 +364,8 @@ EOF
 EOF
                     ,
                     $mapping['name'],
-                    $mapping['fieldName']
+                    $mapping['fieldName'],
+                    $class->getName()
                 );
             }
         }
@@ -360,6 +378,7 @@ EOF
 namespace $namespace;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Hydrator\HydratorException;
 use Doctrine\ODM\MongoDB\Hydrator\HydratorInterface;
 use Doctrine\ODM\MongoDB\Query\Query;
 use Doctrine\ODM\MongoDB\UnitOfWork;

--- a/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use DateTime;
+use Doctrine\ODM\MongoDB\Hydrator\HydratorException;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection;
+use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Query\Query;
 use ProxyManager\Proxy\GhostObjectInterface;
 
@@ -64,6 +66,92 @@ class HydratorTest extends BaseTest
         $this->assertFalse($this->uow->isInIdentityMap($user));
         $this->assertFalse($this->uow->isInIdentityMap($user->embedOne));
         $this->assertFalse($this->uow->isInIdentityMap($user->embedMany[0]));
+    }
+
+    public function testEmbedOneWithWrongType()
+    {
+        $user = new HydrationClosureUser();
+
+        $this->expectException(HydratorException::class);
+        $this->expectExceptionMessage('Expected association for field "embedOne" in document of type "' . HydrationClosureUser::class . '" to be of type "array", "string" received.');
+
+        $this->dm->getHydratorFactory()->hydrate($user, [
+            '_id' => 1,
+            'embedOne' => 'jon',
+        ]);
+    }
+
+    public function testEmbedManyWithWrongType()
+    {
+        $user = new HydrationClosureUser();
+
+        $this->expectException(HydratorException::class);
+        $this->expectExceptionMessage('Expected association for field "embedMany" in document of type "' . HydrationClosureUser::class . '" to be of type "array", "string" received.');
+
+        $this->dm->getHydratorFactory()->hydrate($user, [
+            '_id' => 1,
+            'embedMany' => 'jon',
+        ]);
+    }
+
+    public function testEmbedManyWithWrongElementType()
+    {
+        $user = new HydrationClosureUser();
+
+        $this->dm->getHydratorFactory()->hydrate($user, [
+            '_id' => 1,
+            'embedMany' => ['jon'],
+        ]);
+
+        $this->assertInstanceOf(PersistentCollectionInterface::class, $user->embedMany);
+
+        $this->expectException(HydratorException::class);
+        $this->expectExceptionMessage('Expected association item with key "0" for field "embedMany" in document of type "' . HydrationClosureUser::class . '" to be of type "array", "string" received.');
+
+        $user->embedMany->initialize();
+    }
+
+    public function testReferenceOneWithWrongType()
+    {
+        $user = new HydrationClosureUser();
+
+        $this->expectException(HydratorException::class);
+        $this->expectExceptionMessage('Expected association for field "referenceOne" in document of type "' . HydrationClosureUser::class . '" to be of type "array", "string" received.');
+
+        $this->dm->getHydratorFactory()->hydrate($user, [
+            '_id' => 1,
+            'referenceOne' => 'jon',
+        ]);
+    }
+
+    public function testReferenceManyWithWrongType()
+    {
+        $user = new HydrationClosureUser();
+
+        $this->expectException(HydratorException::class);
+        $this->expectExceptionMessage('Expected association for field "referenceMany" in document of type "' . HydrationClosureUser::class . '" to be of type "array", "string" received.');
+
+        $this->dm->getHydratorFactory()->hydrate($user, [
+            '_id' => 1,
+            'referenceMany' => 'jon',
+        ]);
+    }
+
+    public function testReferenceManyWithWrongElementType()
+    {
+        $user = new HydrationClosureUser();
+
+        $this->dm->getHydratorFactory()->hydrate($user, [
+            '_id' => 1,
+            'referenceMany' => ['jon'],
+        ]);
+
+        $this->assertInstanceOf(PersistentCollectionInterface::class, $user->referenceMany);
+
+        $this->expectException(HydratorException::class);
+        $this->expectExceptionMessage('Expected association item with key "0" for field "referenceMany" in document of type "' . HydrationClosureUser::class . '" to be of type "array", "string" received.');
+
+        $user->referenceMany->initialize();
     }
 }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2044 

#### Summary

This adds type checks for associations to the hydrator, to prevent errors when receiving invalid data from the database. For most associations, this resulted in a `TypeError` being thrown, but for references this could result in invalid offsets when accessing the reference "array".

To fix this problem, there are new `HydratorException` methods to account for these errors. We print the class name, field name of the offending data, as well as the expected and actual types. Since we are in the middle of hydration, we can't reliably print a full field path (we don't know if this is a root hydration or already within an embedded document), which also means that we can't print an identifier for the document being hydrated. However, the exception message better explains the problem than a PHP error does. More importantly, this makes it look less like a bug in ODM and more like an issue with the data (which it actually is).