### PR TITLE
Use expectException(Message) instead of annotations

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/ExprTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation;
 use BadMethodCallException;
 use Doctrine\ODM\MongoDB\Aggregation\Expr;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use LogicException;
 
 class ExprTest extends BaseTest
 {
@@ -68,9 +69,6 @@ class ExprTest extends BaseTest
         );
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testExpressionWithoutField()
     {
         $nestedExpr = $this->createExpr();
@@ -82,6 +80,7 @@ class ExprTest extends BaseTest
 
         $expr = $this->createExpr();
 
+        $this->expectException(LogicException::class);
         $expr->expression($nestedExpr);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OutTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OutTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
+use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Sharded\ShardedUser;
 use Documents\SimpleReferenceUser;
@@ -37,17 +38,12 @@ class OutTest extends BaseTest
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
-     * @expectedExceptionMessage Cannot use class 'Documents\Sharded\ShardedUser' as collection for out stage.
-     */
     public function testOutStageWithShardedClassName()
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
-        $builder
-            ->out(ShardedUser::class);
-
-        $builder->getPipeline();
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Cannot use class \'Documents\Sharded\ShardedUser\' as collection for out stage.');
+        $builder->out(ShardedUser::class);
     }
 
     public function testSubsequentOutStagesAreOverwritten()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\PersistentCollection;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Repository\GridFSRepository;
@@ -31,14 +32,15 @@ class CustomCollectionsTest extends BaseTest
         $this->assertSame(MyDocumentsCollection::class, $cm->fieldMappings['inverseRefMany']['collectionClass']);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
-     * @expectedExceptionMessage stdClass used as custom collection class for stdClass::assoc has to implement Doctrine\Common\Collections\Collection interface.
-     */
     public function testCollectionClassHasToImplementCommonInterface()
     {
         $cm = new ClassMetadata('stdClass');
 
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(
+            'stdClass used as custom collection class for stdClass::assoc has to implement ' .
+            'Doctrine\Common\Collections\Collection interface.'
+        );
         $cm->mapField([
             'fieldName' => 'assoc',
             'reference' => true,

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
@@ -36,15 +36,13 @@ class CustomTypeTest extends BaseTest
         $this->assertContainsOnly('DateTime', $country->nationalHolidays);
     }
 
-    /**
-     * @expectedException Doctrine\ODM\MongoDB\Tests\Functional\CustomTypeException
-     */
     public function testConvertToDatabaseValueExpectsArray()
     {
         $country                   = new Country();
         $country->nationalHolidays = new DateTime();
 
         $this->dm->persist($country);
+        $this->expectException(CustomTypeException::class);
         $this->dm->flush();
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedIdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedIdTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use InvalidArgumentException;
 use MongoDB\BSON\ObjectId;
 
 class EmbeddedIdTest extends BaseTest
@@ -30,27 +31,29 @@ class EmbeddedIdTest extends BaseTest
         $this->assertEquals($id, $test->id);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Doctrine\ODM\MongoDB\Tests\Functional\DefaultIdStrategyNoneEmbeddedDocument uses NONE identifier generation strategy but no identifier was provided when persisting.
-     */
     public function testEmbedOneDocumentWithMissingIdentifier()
     {
         $user           = new EmbeddedStrategyNoneIdTestUser();
         $user->embedOne = new DefaultIdStrategyNoneEmbeddedDocument();
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Doctrine\ODM\MongoDB\Tests\Functional\DefaultIdStrategyNoneEmbeddedDocument uses NONE identifier ' .
+            'generation strategy but no identifier was provided when persisting.'
+        );
         $this->dm->persist($user);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Doctrine\ODM\MongoDB\Tests\Functional\DefaultIdStrategyNoneEmbeddedDocument uses NONE identifier generation strategy but no identifier was provided when persisting.
-     */
     public function testEmbedManyDocumentWithMissingIdentifier()
     {
         $user              = new EmbeddedStrategyNoneIdTestUser();
         $user->embedMany[] = new DefaultIdStrategyNoneEmbeddedDocument();
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Doctrine\ODM\MongoDB\Tests\Functional\DefaultIdStrategyNoneEmbeddedDocument uses NONE identifier ' .
+            'generation strategy but no identifier was provided when persisting.'
+        );
         $this->dm->persist($user);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use DateTime;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\PersistentCollection;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Account;
@@ -44,6 +45,7 @@ use Documents\User;
 use Documents\UserUpsert;
 use Documents\UserUpsertChild;
 use Documents\UserUpsertIdStrategyNone;
+use InvalidArgumentException;
 use MongoDB\BSON\ObjectId;
 
 class FunctionalTest extends BaseTest
@@ -516,9 +518,6 @@ class FunctionalTest extends BaseTest
         $this->assertFalse(isset($notSaved['notSaved']));
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\MongoDBException
-     */
     public function testTypeClassMissing()
     {
         $project = new Project('Test Project');
@@ -542,6 +541,7 @@ class FunctionalTest extends BaseTest
 
         /** @var PersistentCollection $collection */
         $collection = $test->getFavorites();
+        $this->expectException(MongoDBException::class);
         $collection->getTypeClass();
     }
 
@@ -710,12 +710,10 @@ class FunctionalTest extends BaseTest
         $this->assertCount(2, $test);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testNotSameCollectionThrowsException()
     {
-        $test = $this->dm->createQueryBuilder([
+        $this->expectException(InvalidArgumentException::class);
+        $this->dm->createQueryBuilder([
             User::class,
             Profile::class,
         ])->getQuery()->execute();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
@@ -9,6 +9,7 @@ use Doctrine\ODM\MongoDB\Id\UuidGenerator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use InvalidArgumentException;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
@@ -332,24 +333,26 @@ class IdTest extends BaseTest
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Doctrine\ODM\MongoDB\Tests\Functional\CustomIdUser uses NONE identifier generation strategy but no identifier was provided when persisting.
-     */
     public function testStrategyNoneAndNoIdThrowsException()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Doctrine\ODM\MongoDB\Tests\Functional\CustomIdUser uses NONE identifier generation strategy but ' .
+            'no identifier was provided when persisting.'
+        );
         $this->dm->persist(new CustomIdUser('Maciej'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Doctrine\ODM\MongoDB\Tests\Functional\TestIdTypesIdAutoUser uses AUTO identifier generation strategy but provided identifier is not a valid ObjectId.
-     */
     public function testStrategyAutoWithNotValidIdThrowsException()
     {
         $this->createIdTestClass('id', 'auto');
         $user     = new TestIdTypesIdAutoUser();
         $user->id = 1;
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Doctrine\ODM\MongoDB\Tests\Functional\TestIdTypesIdAutoUser uses AUTO identifier generation strategy ' .
+            'but provided identifier is not a valid ObjectId.'
+        );
         $this->dm->persist($user);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\Driver\Exception\BulkWriteException;
 
 class IndexesTest extends BaseTest
 {
@@ -169,48 +170,38 @@ class IndexesTest extends BaseTest
         $this->assertEquals('test', $indexes[0]['options']['name']);
     }
 
-    /**
-     * @expectedException \MongoDB\Driver\Exception\BulkWriteException
-     * @expectedExceptionMessage duplicate key error
-     */
     public function testUniqueIndexOnField()
     {
+        $this->expectException(BulkWriteException::class);
+        $this->expectExceptionMessage('duplicate key error');
         $this->uniqueTest(UniqueOnFieldTest::class);
     }
 
-    /**
-     * @expectedException \MongoDB\Driver\Exception\BulkWriteException
-     * @expectedExceptionMessage duplicate key error
-     */
     public function testUniqueIndexOnDocument()
     {
+        $this->expectException(BulkWriteException::class);
+        $this->expectExceptionMessage('duplicate key error');
         $this->uniqueTest(UniqueOnDocumentTest::class);
     }
 
-    /**
-     * @expectedException \MongoDB\Driver\Exception\BulkWriteException
-     * @expectedExceptionMessage duplicate key error
-     */
     public function testIndexesOnDocument()
     {
+        $this->expectException(BulkWriteException::class);
+        $this->expectExceptionMessage('duplicate key error');
         $this->uniqueTest(IndexesOnDocumentTest::class);
     }
 
-    /**
-     * @expectedException \MongoDB\Driver\Exception\BulkWriteException
-     * @expectedExceptionMessage duplicate key error
-     */
     public function testMultipleFieldsUniqueIndexOnDocument()
     {
+        $this->expectException(BulkWriteException::class);
+        $this->expectExceptionMessage('duplicate key error');
         $this->uniqueTest(MultipleFieldsUniqueIndexTest::class);
     }
 
-    /**
-     * @expectedException \MongoDB\Driver\Exception\BulkWriteException
-     * @expectedExceptionMessage duplicate key error
-     */
     public function testMultipleFieldIndexes()
     {
+        $this->expectException(BulkWriteException::class);
+        $this->expectExceptionMessage('duplicate key error');
         $this->uniqueTest(MultipleFieldIndexes::class);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/CachingIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/CachingIteratorTest.php
@@ -7,20 +7,20 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Iterator;
 use Doctrine\ODM\MongoDB\Iterator\CachingIterator;
 use Exception;
 use PHPUnit\Framework\TestCase;
+use Throwable;
 use function iterator_to_array;
 
 class CachingIteratorTest extends TestCase
 {
     /**
      * Sanity check for all following tests.
-     *
-     * @expectedException \Exception
-     * @expectedExceptionMessage Cannot traverse an already closed generator
      */
     public function testTraversingGeneratorConsumesIt()
     {
         $iterator = $this->getTraversable([1, 2, 3]);
         $this->assertSame([1, 2, 3], iterator_to_array($iterator));
+        $this->expectException(Throwable::class);
+        $this->expectExceptionMessage('Cannot traverse an already closed generator');
         $this->assertSame([1, 2, 3], iterator_to_array($iterator));
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
@@ -386,9 +386,6 @@ class LockTest extends BaseTest
         $this->dm->getClassMetadata(InvalidVersionDocument::class);
     }
 
-    /**
-     * @expectedException Doctrine\ODM\MongoDB\LockException
-     */
     public function testUpdatingCollectionRespectsVersionNumber()
     {
         $d = new LockInt('test');
@@ -404,12 +401,10 @@ class LockTest extends BaseTest
 
         $d->issues->add(new Issue('oops', 'version mismatch'));
         $this->uow->scheduleCollectionUpdate($d->issues);
+        $this->expectException(LockException::class);
         $this->uow->getCollectionPersister()->update($d, [$d->issues], []);
     }
 
-    /**
-     * @expectedException Doctrine\ODM\MongoDB\LockException
-     */
     public function testDeletingCollectionRespectsVersionNumber()
     {
         $d = new LockInt('test');
@@ -423,6 +418,7 @@ class LockTest extends BaseTest
             ['$set' => ['version' => 2]]
         );
 
+        $this->expectException(LockException::class);
         $this->uow->getCollectionPersister()->delete($d, [$d->issues], []);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
@@ -235,13 +235,11 @@ class QueryTest extends BaseTest
         $this->assertCount(4, $users);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRemoveQuery()
     {
         $this->dm->remove($this->user);
 
+        $this->expectException(InvalidArgumentException::class);
         // should invoke exception because $this->user doesn't exist anymore
         $this->dm->refresh($this->user);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
@@ -29,15 +29,13 @@ use Documents\Project;
 use Documents\ReferenceUser;
 use Documents\SimpleReferenceUser;
 use Documents\User;
+use InvalidArgumentException;
 use MongoDB\Driver\ReadPreference;
 use ProxyManager\Proxy\GhostObjectInterface;
 use function func_get_args;
 
 class ReferencePrimerTest extends BaseTest
 {
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testPrimeReferencesShouldRequireReferenceMapping()
     {
         $user = new User();
@@ -46,15 +44,13 @@ class ReferencePrimerTest extends BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
+        $this->expectException(InvalidArgumentException::class);
         $this->dm->createQueryBuilder(User::class)
             ->field('username')->prime(true)
             ->getQuery()
             ->toArray();
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testPrimeReferencesShouldRequireOwningSideReferenceMapping()
     {
         $user = new User();
@@ -63,6 +59,7 @@ class ReferencePrimerTest extends BaseTest
         $this->dm->flush();
         $this->dm->clear();
 
+        $this->expectException(InvalidArgumentException::class);
         $this->dm->createQueryBuilder(User::class)
             ->field('simpleReferenceOneInverse')->prime(true)
             ->getQuery()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Closure;
+use Doctrine\ODM\MongoDB\DocumentNotFoundException;
 use Doctrine\ODM\MongoDB\Event\DocumentNotFoundEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -351,10 +352,6 @@ class ReferencesTest extends BaseTest
         $this->assertEquals('Group 1', $groups[1]->getName());
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\DocumentNotFoundException
-     * @expectedExceptionMessage The "Doctrine\ODM\MongoDB\Tests\Functional\DocumentWithArrayId" document with identifier {"identifier":2} could not be found.
-     */
     public function testDocumentNotFoundExceptionWithArrayId()
     {
         $test                   = new DocumentWithArrayReference();
@@ -378,13 +375,14 @@ class ReferencesTest extends BaseTest
         );
 
         $test = $this->dm->find(get_class($test), $test->id);
+        $this->expectException(DocumentNotFoundException::class);
+        $this->expectExceptionMessage(
+            'The "Doctrine\ODM\MongoDB\Tests\Functional\DocumentWithArrayId" document with identifier ' .
+            '{"identifier":2} could not be found.'
+        );
         $test->referenceOne->initializeProxy();
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\DocumentNotFoundException
-     * @expectedExceptionMessage The "Documents\Profile" document with identifier "abcdefabcdefabcdefabcdef" could not be found.
-     */
     public function testDocumentNotFoundExceptionWithObjectId()
     {
         $profile = new Profile();
@@ -409,13 +407,13 @@ class ReferencesTest extends BaseTest
 
         $user    = $this->dm->find(get_class($user), $user->getId());
         $profile = $user->getProfile();
+        $this->expectException(DocumentNotFoundException::class);
+        $this->expectExceptionMessage(
+            'The "Documents\Profile" document with identifier "abcdefabcdefabcdefabcdef" could not be found.'
+        );
         $profile->initializeProxy();
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\DocumentNotFoundException
-     * @expectedExceptionMessage The "Doctrine\ODM\MongoDB\Tests\Functional\DocumentWithMongoBinDataId" document with identifier "testbindata" could not be found.
-     */
     public function testDocumentNotFoundExceptionWithMongoBinDataId()
     {
         $test                   = new DocumentWithMongoBinDataReference();
@@ -439,6 +437,11 @@ class ReferencesTest extends BaseTest
         );
 
         $test = $this->dm->find(get_class($test), $test->id);
+        $this->expectException(DocumentNotFoundException::class);
+        $this->expectExceptionMessage(
+            'The "Doctrine\ODM\MongoDB\Tests\Functional\DocumentWithMongoBinDataId" document with identifier ' .
+            '"testbindata" could not be found.'
+        );
         $test->referenceOne->initializeProxy();
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\APM\CommandLogger;
+use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Sharded\ShardedOne;
 use MongoDB\BSON\ObjectId;
@@ -109,9 +110,6 @@ class ShardKeyTest extends BaseTest
         $this->assertEquals($o->key, $command->filter->k);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\MongoDBException
-     */
     public function testUpdateWithShardKeyChangeException()
     {
         $o = new ShardedOne();
@@ -119,12 +117,10 @@ class ShardKeyTest extends BaseTest
         $this->dm->flush();
 
         $o->key = 'testing2';
+        $this->expectException(MongoDBException::class);
         $this->dm->flush();
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\MongoDBException
-     */
     public function testUpdateWithUpsertTrue()
     {
         $o = new ShardedOne();
@@ -132,6 +128,7 @@ class ShardKeyTest extends BaseTest
         $this->dm->flush();
 
         $o->key = 'testing2';
+        $this->expectException(MongoDBException::class);
         $this->dm->flush(['upsert' => true]);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH850Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH850Test.php
@@ -6,17 +6,18 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use InvalidArgumentException;
 
 class GH850Test extends BaseTest
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Expected object, found "" in Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH850Document::refs
-     */
     public function testPersistWrongReference()
     {
         $d = new GH850Document();
         $this->dm->persist($d);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Expected object, found "" in Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH850Document::refs'
+        );
         $this->dm->flush();
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use InvalidArgumentException;
 
 class GH971Test extends BaseTest
 {
@@ -39,12 +40,13 @@ class GH971Test extends BaseTest
         $this->assertCount(1, $results);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Upsert query that is to be performed on discriminated document does not have single discriminator. Either not use base class or set 'type' field manually.
-     */
     public function testUpsertThrowsExceptionWithIndecisiveDiscriminator()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Upsert query that is to be performed on discriminated document does not have single discriminator. ' .
+            'Either not use base class or set \'type\' field manually.'
+        );
         $this->dm->createQueryBuilder(Bicycle::class)
             ->findAndUpdate()
             ->upsert(true)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -7,7 +7,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use InvalidArgumentException;
 use function key;
 use function strcmp;
 use function usort;
@@ -131,10 +133,10 @@ abstract class AbstractMappingDriverTest extends BaseTest
      * @param ClassMetadata $class
      *
      * @depends testDocumentCollectionNameAndInheritance
-     * @expectedException \InvalidArgumentException
      */
     public function testGetAssociationTargetClassThrowsExceptionWhenEmpty($class)
     {
+        $this->expectException(InvalidArgumentException::class);
         $class->getAssociationTargetClass('invalid_association');
     }
 
@@ -442,12 +444,13 @@ abstract class AbstractMappingDriverTest extends BaseTest
         ], $class->getFieldMapping('metadata'), true);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
-     * @expectedExceptionMessage Field "bar" in class "Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverDuplicateDatabaseName" is mapped to field "baz" in the database, but that name is already in use by field "foo".
-     */
     public function testDuplicateDatabaseNameInMappingCauseErrors()
     {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(
+            'Field "bar" in class "Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverDuplicateDatabaseName" ' .
+            'is mapped to field "baz" in the database, but that name is already in use by field "foo".'
+        );
         $this->loadMetadata(AbstractMappingDriverDuplicateDatabaseName::class);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
@@ -144,12 +144,10 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $this->assertNotContains($extraneousClassName, $classes);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
-     * @expectedExceptionMessage Embedded document can't have shard key
-     */
     public function testEmbeddedClassCantHaveShardKey()
     {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Embedded document can\'t have shard key');
         $this->dm->getClassMetadata(AnnotationDriverEmbeddedWithShardKey::class);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
+use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Tests\Functional\MappedSuperclassRelated1;
 use function serialize;
@@ -23,11 +24,9 @@ class BasicInheritanceMappingTest extends BaseTest
         $this->factory->setConfiguration($this->dm->getConfiguration());
     }
 
-    /**
-     * @expectedException Doctrine\ODM\MongoDB\Mapping\MappingException
-     */
     public function testGetMetadataForTransientClassThrowsException()
     {
+        $this->expectException(MappingException::class);
         $this->factory->getMetadataFor(TransientBaseClass::class);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
+use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class ShardKeyInheritanceMappingTest extends BaseTest
@@ -37,11 +38,9 @@ class ShardKeyInheritanceMappingTest extends BaseTest
         $this->assertEquals(['keys' => ['_id' => 1], 'options' => []], $class->getShardKey());
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
-     */
     public function testShardKeySingleCollectionInheritanceOverriding()
     {
+        $this->expectException(MappingException::class);
         $this->factory->getMetadataFor(ShardedSingleCollInheritance3::class);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
@@ -8,6 +8,7 @@ use Closure;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\PersistentCollection;
 use Documents\User;
 use MongoDB\BSON\ObjectId;
@@ -29,10 +30,6 @@ class PersistentCollectionTest extends BaseTest
         $pCollection->slice($start, $limit);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\MongoDBException
-     * @expectedExceptionMessage No DocumentManager is associated with this PersistentCollection, please set one using setDocumentManager method.
-     */
     public function testExceptionForGetTypeClassWithoutDocumentManager()
     {
         $collection = new PersistentCollection(new ArrayCollection(), $this->dm, $this->uow);
@@ -43,13 +40,14 @@ class PersistentCollectionTest extends BaseTest
         $unserialized = unserialize($serialized);
 
         $unserialized->setOwner($owner, ['targetDocument' => '\stdClass']);
+        $this->expectException(MongoDBException::class);
+        $this->expectExceptionMessage(
+            'No DocumentManager is associated with this PersistentCollection, ' .
+            'please set one using setDocumentManager method.'
+        );
         $unserialized->getTypeClass();
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\MongoDBException
-     * @expectedExceptionMessage No mapping is associated with this PersistentCollection, please set one using setOwner method.
-     */
     public function testExceptionForGetTypeClassWithoutMapping()
     {
         $collection = new PersistentCollection(new ArrayCollection(), $this->dm, $this->uow);
@@ -59,6 +57,11 @@ class PersistentCollectionTest extends BaseTest
         $unserialized = unserialize($serialized);
 
         $unserialized->setDocumentManager($this->dm);
+        $this->expectException(MongoDBException::class);
+        $this->expectExceptionMessage(
+            'No mapping is associated with this PersistentCollection, ' .
+            'please set one using setOwner method.'
+        );
         $unserialized->getTypeClass();
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Query;
 
 use DateTime;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use Doctrine\ODM\MongoDB\Query\Expr;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
@@ -14,6 +15,7 @@ use Documents\Feature;
 use Documents\User;
 use GeoJson\Geometry\Geometry;
 use GeoJson\Geometry\Point;
+use InvalidArgumentException;
 use IteratorAggregate;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Driver\ReadPreference;
@@ -21,11 +23,9 @@ use ReflectionProperty;
 
 class BuilderTest extends BaseTest
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testPrimeRequiresBooleanOrCallable()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->dm->createQueryBuilder(User::class)
             ->field('groups')->prime(1);
     }
@@ -73,29 +73,31 @@ class BuilderTest extends BaseTest
         );
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
-     * @expectedExceptionMessage No mapping found for field 'nope' in class 'Doctrine\ODM\MongoDB\Tests\Query\ParentClass' nor its descendants.
-     */
     public function testReferencesThrowsSpecializedExceptionForDiscriminatedDocuments()
     {
         $f = new Feature('Smarter references');
         $this->dm->persist($f);
 
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(
+            'No mapping found for field \'nope\' in class \'Doctrine\ODM\MongoDB\Tests\Query\ParentClass\' nor ' .
+            'its descendants.'
+        );
         $this->dm->createQueryBuilder(ParentClass::class)
             ->field('nope')->references($f)
             ->getQuery();
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
-     * @expectedExceptionMessage Reference mapping for field 'conflict' in class 'Doctrine\ODM\MongoDB\Tests\Query\ChildA' conflicts with one mapped in class 'Doctrine\ODM\MongoDB\Tests\Query\ChildB'.
-     */
     public function testReferencesThrowsSpecializedExceptionForConflictingMappings()
     {
         $f = new Feature('Smarter references');
         $this->dm->persist($f);
 
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(
+            'Reference mapping for field \'conflict\' in class \'Doctrine\ODM\MongoDB\Tests\Query\ChildA\' ' .
+            'conflicts with one mapped in class \'Doctrine\ODM\MongoDB\Tests\Query\ChildB\'.'
+        );
         $this->dm->createQueryBuilder(ParentClass::class)
             ->field('conflict')->references($f)
             ->getQuery();
@@ -150,29 +152,31 @@ class BuilderTest extends BaseTest
         );
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
-     * @expectedExceptionMessage No mapping found for field 'nope' in class 'Doctrine\ODM\MongoDB\Tests\Query\ParentClass' nor its descendants.
-     */
     public function testIncludesReferenceToThrowsSpecializedExceptionForDiscriminatedDocuments()
     {
         $f = new Feature('Smarter references');
         $this->dm->persist($f);
 
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(
+            'No mapping found for field \'nope\' in class \'Doctrine\ODM\MongoDB\Tests\Query\ParentClass\' nor ' .
+            'its descendants.'
+        );
         $this->dm->createQueryBuilder(ParentClass::class)
             ->field('nope')->includesReferenceTo($f)
             ->getQuery();
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\Mapping\MappingException
-     * @expectedExceptionMessage Reference mapping for field 'conflictMany' in class 'Doctrine\ODM\MongoDB\Tests\Query\ChildA' conflicts with one mapped in class 'Doctrine\ODM\MongoDB\Tests\Query\ChildB'.
-     */
     public function testIncludesReferenceToThrowsSpecializedExceptionForConflictingMappings()
     {
         $f = new Feature('Smarter references');
         $this->dm->persist($f);
 
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(
+            'Reference mapping for field \'conflictMany\' in class \'Doctrine\ODM\MongoDB\Tests\Query\ChildA\' ' .
+            'conflicts with one mapped in class \'Doctrine\ODM\MongoDB\Tests\Query\ChildB\'.'
+        );
         $this->dm->createQueryBuilder(ParentClass::class)
             ->field('conflictMany')->includesReferenceTo($f)
             ->getQuery();
@@ -742,11 +746,9 @@ class BuilderTest extends BaseTest
         ];
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCurrentDateInvalidType()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->getTestQueryBuilder()
             ->updateOne()
             ->field('lastUpdated')->currentDate('notADate');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Query;
 
+use BadMethodCallException;
 use Doctrine\ODM\MongoDB\Query\Expr;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Profile;
@@ -271,12 +272,10 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$text' => ['$search' => 'foo', '$language' => 'en']], $expr->getQuery());
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testLanguageRequiresTextOperator()
     {
         $expr = $this->createExpr();
+        $this->expectException(BadMethodCallException::class);
         $expr->language('en');
     }
 
@@ -299,12 +298,10 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$text' => ['$search' => 'foo']], $expr->getQuery());
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testCaseSensitiveRequiresTextOperator()
     {
         $expr = $this->createExpr();
+        $this->expectException(BadMethodCallException::class);
         $expr->caseSensitive(false);
     }
 
@@ -327,12 +324,10 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$text' => ['$search' => 'foo']], $expr->getQuery());
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testDiacriticSensitiveRequiresTextOperator()
     {
         $expr = $this->createExpr();
+        $this->expectException(BadMethodCallException::class);
         $expr->diacriticSensitive(false);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/BsonFilterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/BsonFilterTest.php
@@ -5,15 +5,14 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Query\Filter;
 
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use InvalidArgumentException;
 
 class BsonFilterTest extends BaseTest
 {
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testGetParameterInvalidArgument()
     {
         $filter = new Filter($this->dm);
+        $this->expectException(InvalidArgumentException::class);
         $filter->getParameter('doesnotexist');
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/FilterCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/FilterCollectionTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Query;
 use Doctrine\ODM\MongoDB\Query\Filter\BsonFilter;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\User;
+use InvalidArgumentException;
 
 class FilterCollectionTest extends BaseTest
 {
@@ -48,12 +49,10 @@ class FilterCollectionTest extends BaseTest
         $this->assertTrue($filterCollection->isEnabled('testFilter'));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testGetFilterInvalidArgument()
     {
         $filterCollection = $this->dm->getFilterCollection();
+        $this->expectException(InvalidArgumentException::class);
         $filterCollection->getFilter('testFilter');
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/QueryExpressionVisitorTest.php
@@ -13,6 +13,7 @@ use Doctrine\ODM\MongoDB\Query\QueryExpressionVisitor;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Bars\Bar;
 use MongoDB\BSON\Regex;
+use RuntimeException;
 
 class QueryExpressionVisitorTest extends BaseTest
 {
@@ -55,12 +56,10 @@ class QueryExpressionVisitorTest extends BaseTest
         ];
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testWalkComparisonShouldThrowExceptionForUnsupportedOperator()
     {
         $comparison = new Comparison('field', 'invalidOp', new Value('value'));
+        $this->expectException(RuntimeException::class);
         $this->visitor->dispatch($comparison);
     }
 
@@ -88,13 +87,11 @@ class QueryExpressionVisitorTest extends BaseTest
         $this->assertEquals($expectedQuery, $expr->getQuery());
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testWalkCompositeExpressionShouldThrowExceptionForUnsupportedComposite()
     {
         $compositeExpr = new CompositeExpression('invalidComposite', []);
-        $expr          = $this->visitor->dispatch($compositeExpr);
+        $this->expectException(RuntimeException::class);
+        $this->visitor->dispatch($compositeExpr);
     }
 
     public function testWalkValue()

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests;
 
+use BadMethodCallException;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
@@ -12,6 +13,7 @@ use Documents\Phonenumber;
 use Documents\Project;
 use Documents\SubProject;
 use Documents\User;
+use InvalidArgumentException;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
 use MongoDB\Driver\ReadPreference;
@@ -404,17 +406,14 @@ class QueryTest extends BaseTest
         $this->assertFalse($this->uow->isInIdentityMap($readOnly->pet));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testConstructorShouldThrowExceptionForInvalidType()
     {
+        $this->expectException(InvalidArgumentException::class);
         new Query($this->dm, new ClassMetadata(User::class), $this->getMockCollection(), ['type' => -1], []);
     }
 
     /**
      * @dataProvider provideQueryTypesThatDoNotReturnAnIterator
-     * @expectedException BadMethodCallException
      */
     public function testGetIteratorShouldThrowExceptionWithoutExecutingForTypesThatDoNotReturnAnIterator($type, $method)
     {
@@ -423,6 +422,7 @@ class QueryTest extends BaseTest
 
         $query = new Query($this->dm, new ClassMetadata(User::class), $collection, ['type' => $type], []);
 
+        $this->expectException(BadMethodCallException::class);
         $query->getIterator();
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
@@ -8,6 +8,7 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
 use Doctrine\ODM\MongoDB\Types\Type;
+use InvalidArgumentException;
 use MongoDB\BSON\UTCDateTime;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -71,11 +72,11 @@ class DateTypeTest extends TestCase
 
     /**
      * @dataProvider provideInvalidDateValues
-     * @expectedException InvalidArgumentException
      */
     public function testConvertToDatabaseValueWithInvalidValues($value)
     {
         $type = Type::getType(Type::DATE);
+        $this->expectException(InvalidArgumentException::class);
         $type->convertToDatabaseValue($value);
     }
 
@@ -142,9 +143,6 @@ class DateTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function test32bit1900Date()
     {
         if (PHP_INT_SIZE !== 4) {
@@ -152,6 +150,7 @@ class DateTypeTest extends TestCase
         }
 
         $type = Type::getType(Type::DATE);
+        $this->expectException(InvalidArgumentException::class);
         $type->convertToDatabaseValue('1900-01-01');
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/InvalidValueExceptionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/InvalidValueExceptionTest.php
@@ -5,48 +5,45 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Types;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\Types\Type;
 use PHPUnit\Framework\TestCase;
 
 class InvalidValueExceptionTest extends TestCase
 {
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\MongoDBException
-     * @expectedExceptionMessage Collection type requires value of type array or null, Doctrine\Common\Collections\ArrayCollection given
-     */
     public function testCollectionDoesntAcceptObject()
     {
         $t = Type::getType('collection');
+        $this->expectException(MongoDBException::class);
+        $this->expectExceptionMessage(
+            'Collection type requires value of type array or null, Doctrine\Common\Collections\ArrayCollection given'
+        );
         $t->convertToDatabaseValue(new ArrayCollection());
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\MongoDBException
-     * @expectedExceptionMessage Collection type requires value of type array or null, scalar given
-     */
     public function testCollectionDoesntAcceptScalar()
     {
         $t = Type::getType('collection');
+        $this->expectException(MongoDBException::class);
+        $this->expectExceptionMessage('Collection type requires value of type array or null, scalar given');
         $t->convertToDatabaseValue(true);
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\MongoDBException
-     * @expectedExceptionMessage Hash type requires value of type array or null, Doctrine\Common\Collections\ArrayCollection given
-     */
     public function testHashDoesntAcceptObject()
     {
         $t = Type::getType('hash');
+        $this->expectException(MongoDBException::class);
+        $this->expectExceptionMessage(
+            'Hash type requires value of type array or null, Doctrine\Common\Collections\ArrayCollection given'
+        );
         $t->convertToDatabaseValue(new ArrayCollection());
     }
 
-    /**
-     * @expectedException \Doctrine\ODM\MongoDB\MongoDBException
-     * @expectedExceptionMessage Hash type requires value of type array or null, scalar given
-     */
     public function testHashDoesntAcceptScalar()
     {
         $t = Type::getType('hash');
+        $this->expectException(MongoDBException::class);
+        $this->expectExceptionMessage('Hash type requires value of type array or null, scalar given');
         $t->convertToDatabaseValue(true);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -115,11 +115,9 @@ class UnitOfWorkTest extends BaseTest
         $this->assertFalse($this->uow->isScheduledForDelete($user));
     }
 
-    /**
-     * @expectedException Doctrine\ODM\MongoDB\MongoDBException
-     */
     public function testThrowsOnPersistOfMappedSuperclass()
     {
+        $this->expectException(MongoDBException::class);
         $this->uow->persist(new MappedSuperclass());
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

The `@expectedException` and `@expectedExceptionMessage` annotations are deprecated. They will be removed in PHPUnit 9. This PR replaces `@expectedException` and `@expectedExceptionMessage` annotations with `expectedException()` and `expectedExceptionMessage()`.

My only concern is with [OutTest](https://github.com/doctrine/mongodb-odm/blob/a007696489d09435c332bec34140ca7310287785/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OutTest.php#L44) because `builder->out()` is throwing the exception, not `builder->getPipeline()`.