### PR TITLE
Use alternatives for features deprecated in PHPUnit 8

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
@@ -615,7 +615,7 @@ class EmbeddedTest extends BaseTest
             ->getQuery()
             ->getSingleResult();
 
-        $this->assertInternalType('array', $test1Data);
+        $this->assertIsArray($test1Data);
 
         $this->assertArrayHasKey('m_id', $test1Data['embedOne']);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
@@ -79,7 +79,7 @@ class LockTest extends BaseTest
             $this->dm->persist($test);
             $this->dm->flush();
 
-            $this->assertInternalType('int', $test->getVersion());
+            $this->assertIsInt($test->getVersion());
             $this->assertEquals($i + 1, $test->getVersion());
         }
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
@@ -41,7 +41,7 @@ class NestedDocumentsTest extends BaseTest
 
         $doc = $this->dm->find(Order::class, $order->id);
         $this->assertInstanceOf(Order::class, $order);
-        $this->assertInternalType('string', $doc->product->id);
+        $this->assertIsString($doc->product->id);
         $this->assertEquals((string) $test['product']['_id'], $doc->product->id);
         $this->assertEquals('Order', $doc->title);
         $this->assertEquals('Product', $doc->product->title);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RepositoriesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RepositoriesTest.php
@@ -27,7 +27,7 @@ class RepositoriesTest extends BaseTest
     {
         $users = $this->repository->findAll();
 
-        $this->assertInternalType('array', $users);
+        $this->assertIsArray($users);
         $this->assertCount(1, $users);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH245Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH245Test.php
@@ -25,10 +25,10 @@ class GH245Test extends BaseTest
 
         $user = $this->dm->find(get_class($order), $order->id);
 
-        $this->assertInternalType('int', $order->id);
+        $this->assertIsInt($order->id);
 
         $check = $this->dm->getDocumentCollection(get_class($orderLog))->findOne();
-        $this->assertInternalType('int', $check['order']['$id']);
+        $this->assertIsInt($check['order']['$id']);
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -210,7 +210,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     public function testOwningOneToOneAssocation($class)
     {
         $this->assertTrue(isset($class->fieldMappings['address']));
-        $this->assertInternalType('array', $class->fieldMappings['address']);
+        $this->assertIsArray($class->fieldMappings['address']);
         // Check cascading
         $this->assertTrue($class->fieldMappings['address']['isCascadeRemove']);
         $this->assertFalse($class->fieldMappings['address']['isCascadePersist']);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -55,7 +55,7 @@ class ClassMetadataTest extends BaseTest
         $cm->setCollectionCapped(true);
         $cm->setCollectionMax(1000);
         $cm->setCollectionSize(500);
-        $this->assertInternalType('array', $cm->getFieldMapping('phonenumbers'));
+        $this->assertIsArray($cm->getFieldMapping('phonenumbers'));
         $this->assertCount(1, $cm->fieldMappings);
         $this->assertCount(1, $cm->associationMappings);
 
@@ -71,7 +71,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertEquals(['UserParent'], $cm->parentClasses);
         $this->assertEquals(UserRepository::class, $cm->customRepositoryClassName);
         $this->assertEquals('disc', $cm->discriminatorField);
-        $this->assertInternalType('array', $cm->getFieldMapping('phonenumbers'));
+        $this->assertIsArray($cm->getFieldMapping('phonenumbers'));
         $this->assertCount(1, $cm->fieldMappings);
         $this->assertCount(1, $cm->associationMappings);
         $this->assertEquals(['keys' => ['_id' => 1], 'options' => []], $cm->getShardKey());
@@ -137,7 +137,7 @@ class ClassMetadataTest extends BaseTest
         );
 
         $assoc = $cm->fieldMappings['groups'];
-        $this->assertInternalType('array', $assoc);
+        $this->assertIsArray($assoc);
     }
 
     public function testGetAssociationTargetClassWithoutTargetDocument()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Repository/DefaultGridFSRepositoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Repository/DefaultGridFSRepositoryTest.php
@@ -27,7 +27,7 @@ class DefaultGridFSRepositoryTest extends BaseTest
     public function testOpenUploadStreamReturnsWritableResource() : void
     {
         $uploadStream = $this->getRepository()->openUploadStream('somefile.txt');
-        self::assertInternalType('resource', $uploadStream);
+        self::assertIsResource($uploadStream);
 
         fwrite($uploadStream, 'contents');
         fclose($uploadStream);
@@ -39,7 +39,7 @@ class DefaultGridFSRepositoryTest extends BaseTest
         self::assertSame('somefile.txt', $file->getFilename());
         self::assertSame(8, $file->getLength());
         self::assertSame(12345, $file->getChunkSize());
-        self::assertEquals(new DateTime(), $file->getUploadDate(), '', 1);
+        self::assertEqualsWithDelta(new DateTime(), $file->getUploadDate(), 1);
         self::assertNull($file->getMetadata());
     }
 
@@ -49,7 +49,7 @@ class DefaultGridFSRepositoryTest extends BaseTest
         $uploadOptions->chunkSizeBytes = 1234;
 
         $uploadStream = $this->getRepository()->openUploadStream('somefile.txt', $uploadOptions);
-        self::assertInternalType('resource', $uploadStream);
+        self::assertIsResource($uploadStream);
 
         fwrite($uploadStream, 'contents');
         fclose($uploadStream);
@@ -61,7 +61,7 @@ class DefaultGridFSRepositoryTest extends BaseTest
         self::assertSame('somefile.txt', $file->getFilename());
         self::assertSame(8, $file->getLength());
         self::assertSame(1234, $file->getChunkSize());
-        self::assertEquals(new DateTime(), $file->getUploadDate(), '', 1);
+        self::assertEqualsWithDelta(new DateTime(), $file->getUploadDate(), 1);
         self::assertNull($file->getMetadata());
     }
 
@@ -96,7 +96,7 @@ class DefaultGridFSRepositoryTest extends BaseTest
         self::assertSame('somefile.txt', $file->getFilename());
         self::assertSame($expectedSize, $file->getLength());
         self::assertSame(12345, $file->getChunkSize());
-        self::assertEquals(new DateTime(), $file->getUploadDate(), '', 1);
+        self::assertEqualsWithDelta(new DateTime(), $file->getUploadDate(), 1);
         self::assertInstanceOf(FileMetadata::class, $file->getMetadata());
         self::assertInstanceOf(User::class, $file->getMetadata()->getOwner());
         self::assertSame('Foo', $file->getMetadata()->getEmbedOne()->name);
@@ -151,7 +151,7 @@ class DefaultGridFSRepositoryTest extends BaseTest
         self::assertSame('somefile.txt', $file->getFilename());
         self::assertSame($expectedSize, $file->getLength());
         self::assertSame(1234, $file->getChunkSize());
-        self::assertEquals(new DateTime(), $file->getUploadDate(), '', 1);
+        self::assertEqualsWithDelta(new DateTime(), $file->getUploadDate(), 1);
         self::assertInstanceOf(FileMetadata::class, $file->getMetadata());
 
         $stream = tmpfile();


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

- The method `assertInternalType()` is deprecated, use alternatives such as `assertIsInt()`. https://github.com/sebastianbergmann/phpunit/issues/3369
- The `$delta` parameter of `assertEquals()` is deprecated, use `assertWithDelta()` instead. https://github.com/sebastianbergmann/phpunit/issues/3341
