### PR TITLE
Cast also-load xml attribute to string

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -112,7 +112,7 @@
     <xs:attribute name="lock" type="xs:boolean" />
     <xs:attribute name="not-saved" type="xs:boolean" />
     <xs:attribute name="nullable" type="xs:boolean" />
-    <xs:attribute name="also-load" type="xs:NMTOKEN" />
+    <xs:attribute name="also-load" type="xs:string" />
 
     <!-- index options -->
     <xs:attribute name="background" type="xs:boolean" />

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -216,7 +216,7 @@ class XmlDriver extends FileDriver
                 }
 
                 if (isset($attributes['also-load'])) {
-                    $mapping['alsoLoadFields'] = explode(',', $attributes['also-load']);
+                    $mapping['alsoLoadFields'] = explode(',', (string) $attributes['also-load']);
                 } elseif (isset($attributes['version'])) {
                     $mapping['version'] = ((string) $attributes['version'] === 'true');
                 } elseif (isset($attributes['lock'])) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -95,6 +95,8 @@ abstract class AbstractDriverTest extends TestCase
             'isOwningSide' => true,
             'nullable' => false,
             'strategy' => ClassMetadata::STORAGE_STRATEGY_SET,
+            'also-load' => 'createdOn,creation_date',
+            'alsoLoadFields' => ['createdOn', 'creation_date']
         ], $classMetadata->fieldMappings['createdAt']);
 
         $this->assertEquals([

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.User.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.User.dcm.xml
@@ -8,7 +8,7 @@
     <document name="TestDocuments\User" db="documents" collection="users">
         <id />
         <field name="username" type="string" unique="true" sparse="true"/>
-        <field name="createdAt" type="date" />
+        <field name="createdAt" type="date" also-load="createdOn,creation_date"/>
         <field name="tags" type="collection" />
         <embed-one target-document="Documents\Address" field="address" />
         <!--<field name="profile" targetDocument="Documents\Profile" reference="true" type="one" cascade="all" />-->


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary
Need to cast also-xml to string before calling explode as it is a SimpleXmlElement object otherwise a fatal error is thrown
