### PR TITLE
Cast also-load xml attribute to string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
             "Doctrine\\ODM\\MongoDB\\Benchmark\\": "benchmark",
             "Doctrine\\ODM\\MongoDB\\Tests\\": "tests/Doctrine/ODM/MongoDB/Tests",
             "Documents\\": "tests/Documents",
-            "Stubs\\": "tests/Stubs"
+            "Stubs\\": "tests/Stubs",
+            "TestDocuments\\" :"tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures"
         }
     },
     "extra": {

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -98,7 +98,7 @@
     <xs:attribute name="lock" type="xs:boolean" />
     <xs:attribute name="not-saved" type="xs:boolean" />
     <xs:attribute name="nullable" type="xs:boolean" />
-    <xs:attribute name="also-load" type="xs:NMTOKEN" />
+    <xs:attribute name="also-load" type="xs:string" />
     <!-- index options -->
     <xs:attribute name="background" type="xs:boolean" />
     <xs:attribute name="drop-dups" type="xs:boolean" />

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -228,7 +228,7 @@ class XmlDriver extends FileDriver
                 }
 
                 if (isset($attributes['also-load'])) {
-                    $mapping['alsoLoadFields'] = explode(',', $attributes['also-load']);
+                    $mapping['alsoLoadFields'] = explode(',', (string) $attributes['also-load']);
                 } elseif (isset($attributes['version'])) {
                     $mapping['version'] = ('true' === (string) $attributes['version']);
                 } elseif (isset($attributes['lock'])) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -6,13 +6,6 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use TestDocuments\PrimedCollectionDocument;
 use PHPUnit\Framework\TestCase;
 
-require_once 'fixtures/InvalidPartialFilterDocument.php';
-require_once 'fixtures/PartialFilterDocument.php';
-require_once 'fixtures/PrimedCollectionDocument.php';
-require_once 'fixtures/User.php';
-require_once 'fixtures/EmbeddedDocument.php';
-require_once 'fixtures/QueryResultDocument.php';
-
 abstract class AbstractDriverTest extends TestCase
 {
     protected $driver;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
@@ -4,10 +4,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Mapping\Driver;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
+use TestDocuments\AlsoLoadDocument;
 use TestDocuments\UserCustomIdGenerator;
 use TestDocuments\UserCustomIdGeneratorWithIdField;
-
-require_once 'fixtures/AlsoLoadDocument.php';
 
 class XmlDriverTest extends AbstractDriverTest
 {
@@ -90,10 +89,10 @@ class XmlDriverTest extends AbstractDriverTest
         ], $classMetadata->getIndexes());
     }
 
-    public function testDriver()
+    public function testAlsoLoadFieldMapping()
     {
-        $classMetadata = new ClassMetadata('TestDocuments\AlsoLoadDocument');
-        $this->driver->loadMetadataForClass('TestDocuments\AlsoLoadDocument', $classMetadata);
+        $classMetadata = new ClassMetadata(AlsoLoadDocument::class);
+        $this->driver->loadMetadataForClass(AlsoLoadDocument::class, $classMetadata);
 
         $this->assertEquals(array(
             'fieldName' => 'createdAt',

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
@@ -7,6 +7,8 @@ use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
 use TestDocuments\UserCustomIdGenerator;
 use TestDocuments\UserCustomIdGeneratorWithIdField;
 
+require_once 'fixtures/AlsoLoadDocument.php';
+
 class XmlDriverTest extends AbstractDriverTest
 {
     public function setUp()
@@ -86,6 +88,29 @@ class XmlDriverTest extends AbstractDriverTest
                 'options' => [],
             ],
         ], $classMetadata->getIndexes());
+    }
+
+    public function testDriver()
+    {
+        $classMetadata = new ClassMetadata('TestDocuments\AlsoLoadDocument');
+        $this->driver->loadMetadataForClass('TestDocuments\AlsoLoadDocument', $classMetadata);
+
+        $this->assertEquals(array(
+            'fieldName' => 'createdAt',
+            'name' => 'createdAt',
+            'type' => 'date',
+            'isCascadeDetach' => false,
+            'isCascadeMerge' => false,
+            'isCascadePersist' => false,
+            'isCascadeRefresh' => false,
+            'isCascadeRemove' => false,
+            'isInverseSide' => false,
+            'isOwningSide' => true,
+            'nullable' => false,
+            'strategy' => ClassMetadata::STORAGE_STRATEGY_SET,
+            'also-load' => 'createdOn,creation_date',
+            'alsoLoadFields' => array('createdOn', 'creation_date'),
+        ), $classMetadata->fieldMappings['createdAt']);
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/AlsoLoadDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/AlsoLoadDocument.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace TestDocuments;
+
+class AlsoLoadDocument
+{
+    protected $id;
+
+    protected $createdAt;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTime();
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.AlsoLoadDocument.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.AlsoLoadDocument.dcm.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="TestDocuments\AlsoLoadDocument" db="documents" collection="users">
+        <field name="id" id="true" />
+        <field name="createdAt" type="date" also-load="createdOn,creation_date"/>
+    </document>
+</doctrine-mongo-mapping>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary
Need to cast also-xml to string before calling explode as it is a SimpleXmlElement object otherwise a fatal error is thrown
