### PR TITLE
Change returned type references in query builder documentation

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -264,6 +264,9 @@ ocramius. If you are checking for proxies, the following changed:
 * The `getIterator` method in `Doctrine\ODM\MongoDB\Query\Query` returns an
   iterator of type `Doctrine\ODM\MongoDB\Iterator\Iterator` instead of a MongoDB
   cursor.
+* The `execute` method in `Doctrine\ODM\MongoDB\Query\Query` now returns an
+  iterator of type `Doctrine\ODM\MongoDB\Iterator\Iterator` for find queries,
+  and a plain array for distinct queries.
 * The `eagerCursor` helper in `Doctrine\ODM\MongoDB\Query\Builder` and its logic
   have been removed entirely without replacement.
 * Querying for a mapped superclass in a complex inheritance chain will now only

--- a/docs/en/reference/query-builder-api.rst
+++ b/docs/en/reference/query-builder-api.rst
@@ -98,7 +98,7 @@ You can execute a query by getting a ``Query`` through the ``getQuery()`` method
     $qb = $dm->createQueryBuilder(User::class);
     $query = $qb->getQuery();
 
-Now you can ``execute()`` that query and it will return a cursor for you to iterate over the results:
+Now you can ``execute()`` that query and it will return an ``Iterator`` for you to iterate over the results:
 
 .. code-block:: php
 
@@ -193,7 +193,7 @@ method:
         ->getQuery()
         ->execute();
 
-The above would give you an ``ArrayCollection`` of all the distinct user ages!
+The above would give you an array of all the distinct user ages!
 
 .. note::
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | n/a

#### Summary

Looks like something that was missed in the 2.x changes; `execute()` no longer returns a cursor but an `Iterator`, and `distinct()` returns a plain array.

I do wonder if there should be an additional note for `distinct()` calling out that the returned type is different, since that can be a bit jarring (I was migrating a project and it took me a minute to understand exactly what was different here).