### PR TITLE
Proposal: check entity type (instanceof) in subscriber and minor formatting of the article

### DIFF
--- a/docs/en/cookbook/blending-orm-and-mongodb-odm.rst
+++ b/docs/en/cookbook/blending-orm-and-mongodb-odm.rst
@@ -120,12 +120,7 @@ or in .yaml
         tags:
             - { name: doctrine.event_listener, connection: default, event: postLoad}
 
-
-So now we need to define a class named `MyEventSubscriber` and pass a dependency to the `DocumentManager`. 
-It will have a `postLoad()` method that sets the product document reference. 
-
-
-So now we need to define a class named `MyEventSubscriber` and pass a dependency to the `DocumentManager`. It will have a `postLoad()` method that sets the product document reference:
+So now we need to define a class named `MyEventSubscriber` and `DocumentManager` as a dependency. It will have a `postLoad()` method that sets the product document reference:
 
 .. code-block:: php
 
@@ -145,8 +140,8 @@ So now we need to define a class named `MyEventSubscriber` and pass a dependency
         {
             $order = $eventArgs->getEntity();
 
-            if (!($order instanceof Order)) {
-                // fails silently if entity other then Order is loaded
+            if (!$order instanceof Order) {
+                // early return if entity other then Order is loaded
                 return;
             }
 
@@ -163,7 +158,7 @@ So now we need to define a class named `MyEventSubscriber` and pass a dependency
 The `postLoad` method will be invoked after an ORM entity is loaded from the database. This allows us 
 to use the `DocumentManager` to set the `$product` property with a reference to the `Product` document 
 with the product id we previously stored. Please note, that the event subscriber will be called on 
-postLoad of any given entity that is loaded by doctrine. Thus, it is recommended to check for the current 
+postLoad for all entities that are loaded by doctrine. Thus, it is recommended to check for the current 
 entity.  
 
 Working with Products and Orders

--- a/docs/en/cookbook/blending-orm-and-mongodb-odm.rst
+++ b/docs/en/cookbook/blending-orm-and-mongodb-odm.rst
@@ -171,7 +171,7 @@ Now create a new `Order` and link it to a `Product` in MySQL:
 Later we can retrieve the entity and lazily load the reference to the document in MongoDB:
 
 .. code-block:: php
-
+ 
     <?php
 
     $order = $em->find('Order', $order->getId());

--- a/docs/en/cookbook/blending-orm-and-mongodb-odm.rst
+++ b/docs/en/cookbook/blending-orm-and-mongodb-odm.rst
@@ -120,7 +120,7 @@ or in .yaml
         tags:
             - { name: doctrine.event_listener, connection: default, event: postLoad}
 
-So now we need to define a class named `MyEventSubscriber` and `DocumentManager` as a dependency. It will have a `postLoad()` method that sets the product document reference:
+So now we need to define a class named `MyEventSubscriber` and pass `DocumentManager` as a dependency. It will have a `postLoad()` method that sets the product document reference:
 
 .. code-block:: php
 

--- a/docs/en/cookbook/blending-orm-and-mongodb-odm.rst
+++ b/docs/en/cookbook/blending-orm-and-mongodb-odm.rst
@@ -194,7 +194,7 @@ Now create a new `Order` and link it to a `Product` in MySQL:
 Later we can retrieve the entity and lazily load the reference to the document in MongoDB:
 
 .. code-block:: php
- 
+
     <?php
 
     $order = $em->find('Order', $order->getId());

--- a/docs/en/cookbook/blending-orm-and-mongodb-odm.rst
+++ b/docs/en/cookbook/blending-orm-and-mongodb-odm.rst
@@ -1,7 +1,7 @@
 Blending the ORM and MongoDB ODM
 ================================
 
-Since the start of the ``Doctrine MongoDB Object Document Mapper``_ project people have asked how it can be integrated with the ``ORM``_. This article will demonstrates how you can integrate the two transparently, maintaining a clean domain model.
+Since the start of the `Doctrine MongoDB Object Document Mapper`_ project people have asked how it can be integrated with the `ORM`_. This article will demonstrates how you can integrate the two transparently, maintaining a clean domain model.
 
 This example will have a ``Product`` that is stored in MongoDB and the ``Order`` stored in a MySQL database.
 

--- a/docs/en/cookbook/blending-orm-and-mongodb-odm.rst
+++ b/docs/en/cookbook/blending-orm-and-mongodb-odm.rst
@@ -1,14 +1,14 @@
 Blending the ORM and MongoDB ODM
 ================================
 
-Since the start of the `Doctrine MongoDB Object Document Mapper`_ project people have asked how it can be integrated with the `ORM`_. This article will demonstrates how you can integrate the two transparently, maintaining a clean domain model.
+Since the start of the ``Doctrine MongoDB Object Document Mapper``_ project people have asked how it can be integrated with the ``ORM``_. This article will demonstrates how you can integrate the two transparently, maintaining a clean domain model.
 
-This example will have a `Product` that is stored in MongoDB and the `Order` stored in a MySQL database.
+This example will have a ``Product`` that is stored in MongoDB and the ``Order`` stored in a MySQL database.
 
 Define Product
 --------------
 
-First lets define our `Product` document:
+First lets define our ``Product`` document:
 
 .. code-block:: php
 
@@ -44,7 +44,7 @@ First lets define our `Product` document:
 Define Entity
 -------------
 
-Next create the `Order` entity that has a `$product` and `$productId` property linking it to the `Product` that is stored with MongoDB:
+Next create the ``Order`` entity that has a ``$product`` and ``$productId`` property linking it to the ``Product`` that is stored with MongoDB:
 
 .. code-block:: php
 
@@ -101,7 +101,7 @@ Next create the `Order` entity that has a `$product` and `$productId` property l
 Event Subscriber
 ----------------
 
-Now we need to setup an event subscriber that will set the `$product` property of all `Order` instances to a reference to the document product so it can be lazily loaded when it is accessed the first time. So first register a new event subscriber:
+Now we need to setup an event subscriber that will set the ``$product`` property of all ``Order`` instances to a reference to the document product so it can be lazily loaded when it is accessed the first time. So first register a new event subscriber:
 
 .. code-block:: php
 
@@ -120,7 +120,7 @@ or in .yaml
         tags:
             - { name: doctrine.event_listener, connection: default, event: postLoad}
 
-So now we need to define a class named `MyEventSubscriber` and pass `DocumentManager` as a dependency. It will have a `postLoad()` method that sets the product document reference:
+So now we need to define a class named ``MyEventSubscriber`` and pass ``DocumentManager`` as a dependency. It will have a ``postLoad()`` method that sets the product document reference:
 
 .. code-block:: php
 
@@ -155,8 +155,8 @@ So now we need to define a class named `MyEventSubscriber` and pass `DocumentMan
         }
     }
 
-The `postLoad` method will be invoked after an ORM entity is loaded from the database. This allows us 
-to use the `DocumentManager` to set the `$product` property with a reference to the `Product` document 
+The ``postLoad`` method will be invoked after an ORM entity is loaded from the database. This allows us 
+to use the ``DocumentManager`` to set the ``$product`` property with a reference to the ``Product`` document 
 with the product id we previously stored. Please note, that the event subscriber will be called on 
 postLoad for all entities that are loaded by doctrine. Thus, it is recommended to check for the current 
 entity.  
@@ -164,7 +164,7 @@ entity.
 Working with Products and Orders
 --------------------------------
 
-First create a new `Product`:
+First create a new ``Product``:
 
 .. code-block:: php
 
@@ -175,7 +175,7 @@ First create a new `Product`:
     $dm->persist($product);
     $dm->flush();
 
-Now create a new `Order` and link it to a `Product` in MySQL:
+Now create a new ``Order`` and link it to a ``Product`` in MySQL:
 
 .. code-block:: php
 
@@ -200,7 +200,7 @@ Later we can retrieve the entity and lazily load the reference to the document i
     // Initializes proxy and queries the database
     echo "Order Title: " . $product->getTitle();
 
-If you were to print the `$order` you would see that we got back regular PHP objects:
+If you were to print the ``$order`` you would see that we got back regular PHP objects:
 
 .. code-block:: php
 


### PR DESCRIPTION
Before I work on this PR I would like to ask on your opinion. I find the way the subscriber is written misleading. Currently, the subsriber will try to link the ODM Document to *every* ORM Entity. With other words the subscriber is  called post load of *every* entity defined in the project. What we want is something like

```
public function postLoad(LifecycleEventArgs $eventArgs)
    {
        $entity = $eventArgs->getEntity();

        if ($entity instanceof Order) {
            // business here
        }
}
```

Am I correct or am I missing a piece of information?

Also, in this PR I would add an example of a .yaml configuration of the listener.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| BC Break     | yes/no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->
