### PR TITLE
Fix hanging upload when not specifying chunk size

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Repository/DefaultGridFSRepository.php
+++ b/lib/Doctrine/ODM/MongoDB/Repository/DefaultGridFSRepository.php
@@ -92,9 +92,12 @@ class DefaultGridFSRepository extends DocumentRepository implements GridFSReposi
             $uploadOptions = new UploadOptions();
         }
 
-        $options = [
-            'chunkSizeBytes' => $uploadOptions->chunkSizeBytes ?: $this->class->getChunkSizeBytes(),
-        ];
+        $chunkSizeBytes = $uploadOptions->chunkSizeBytes ?: $this->class->getChunkSizeBytes();
+        $options        = [];
+
+        if ($chunkSizeBytes !== null) {
+            $options['chunkSizeBytes'] = $chunkSizeBytes;
+        }
 
         if (! is_object($uploadOptions->metadata)) {
             return $options;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Repository/DefaultGridFSRepositoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Repository/DefaultGridFSRepositoryTest.php
@@ -11,6 +11,7 @@ use Doctrine\ODM\MongoDB\Repository\UploadOptions;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\File;
 use Documents\FileMetadata;
+use Documents\FileWithoutChunkSize;
 use Documents\FileWithoutMetadata;
 use Documents\User;
 use function fclose;
@@ -238,6 +239,18 @@ class DefaultGridFSRepositoryTest extends BaseTest
         } finally {
             fclose($fileResource);
         }
+    }
+
+    public function testUploadFileWithoutChunkSize()
+    {
+        /** @var FileWithoutChunkSize $file */
+        $file = $this->getRepository(FileWithoutChunkSize::class)->uploadFromFile(__FILE__);
+
+        $expectedSize = filesize(__FILE__);
+
+        self::assertSame('DefaultGridFSRepositoryTest.php', $file->getFilename());
+        self::assertSame($expectedSize, $file->getLength());
+        self::assertSame(261120, $file->getChunkSize());
     }
 
     private function getRepository($className = File::class) : GridFSRepository

--- a/tests/Documents/FileWithoutChunkSize.php
+++ b/tests/Documents/FileWithoutChunkSize.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents;
+
+use DateTimeInterface;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/** @ODM\File */
+class FileWithoutChunkSize
+{
+    /** @ODM\Id */
+    private $id;
+
+    /** @ODM\File\Filename */
+    private $filename;
+
+    /** @ODM\File\ChunkSize */
+    private $chunkSize;
+
+    /** @ODM\File\Length */
+    private $length;
+
+    /** @ODM\File\UploadDate */
+    private $uploadDate;
+
+    /** @ODM\File\Metadata(targetDocument=FileMetadata::class) */
+    private $metadata;
+
+    public function getId() : ?string
+    {
+        return $this->id;
+    }
+
+    public function getFilename() : ?string
+    {
+        return $this->filename;
+    }
+
+    public function getChunkSize() : ?int
+    {
+        return $this->chunkSize;
+    }
+
+    public function getLength() : ?int
+    {
+        return $this->length;
+    }
+
+    public function getUploadDate() : DateTimeInterface
+    {
+        return $this->uploadDate;
+    }
+
+    public function getMetadata() : ?FileMetadata
+    {
+        return $this->metadata;
+    }
+
+    public function getOrCreateMetadata() : FileMetadata
+    {
+        if (! $this->metadata) {
+            $this->metadata = new FileMetadata();
+        }
+
+        return $this->getMetadata();
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fixes #2087 

@jmikola The issue is caused by `mongodb/mongodb` using `isset` checks for options. When passing a `null` option, it will not be validated (as `isset` returns `false`) but still assigned. The `null` value is then interpreted as `0` in various places, leading to an endless loop of reading 0 bytes and not inserting an empty chunk. This is something we may want to address, so I've created [PHPLIB-494](https://jira.mongodb.org/browse/PHPLIB-494) to track this.