### PR TITLE
Fix wrong handling of custom identifier names

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -159,6 +159,10 @@ class XmlDriver extends FileDriver
                 $mapping[$key] = (string) $value;
             }
 
+            if (isset($attributes['field-name'])) {
+                $mapping['fieldName'] = (string) $attributes['field-name'];
+            }
+
             if (isset($mapping['strategy'])) {
                 $mapping['options'] = [];
                 if (isset($field->{'generator-option'})) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -80,7 +80,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
     public function testFieldMappings($class)
     {
         $this->assertCount(14, $class->fieldMappings);
-        $this->assertTrue(isset($class->fieldMappings['id']));
+        $this->assertTrue(isset($class->fieldMappings['identifier']));
         $this->assertTrue(isset($class->fieldMappings['version']));
         $this->assertTrue(isset($class->fieldMappings['lock']));
         $this->assertTrue(isset($class->fieldMappings['name']));
@@ -146,7 +146,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\ODM\MongoDB\Tests\Bas
      */
     public function testIdentifier($class)
     {
-        $this->assertEquals('id', $class->identifier);
+        $this->assertEquals('identifier', $class->identifier);
 
         return $class;
     }
@@ -402,7 +402,7 @@ class AbstractMappingDriverUser
     /**
      * @ODM\Id
      */
-    public $id;
+    public $identifier;
 
     /**
      * @ODM\Version

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
@@ -20,7 +20,7 @@
             </tag-set>
             <tag-set />
         </read-preference>
-        <field fieldName="id" id="true" />
+        <id field-name="identifier" />
         <field fieldName="version" version="true" type="int" />
         <field fieldName="lock" lock="true" type="int" />
         <field fieldName="name" name="username" type="string" />

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.yml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/yaml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.yml
@@ -17,6 +17,7 @@ Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverUser:
   fields:
     id:
       type: id
+      fieldName: identifier
       id: true
     version:
       type: int


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fixes #2096 

#### Summary

This fixes an error where the `field-name` attribute in `id` XML mappings was not correctly mapped.