### PR TITLE
Added conversion from PHP values to DB values during query preparation

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1030,10 +1030,10 @@ final class DocumentPersister
                 $preparedValue = Type::convertPHPToDatabaseValue($preparedValue);
 
                 if ($this->class->hasField($key)) {
-                    $mapping = $this->class->fieldMappings[$key];
+                    $mapping  = $this->class->fieldMappings[$key];
                     $typeName = $mapping['type'];
-                    if (Type::hasType($typeName) && !in_array($typeName, ['collection', 'hash'])) {
-                        $type = Type::getType($mapping['type']);
+                    if (Type::hasType($typeName) && ! in_array($typeName, ['collection', 'hash'])) {
+                        $type          = Type::getType($mapping['type']);
                         $preparedValue = $type->convertToDatabaseValue($preparedValue);
                     }
                 }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1023,10 +1023,12 @@ final class DocumentPersister
             foreach ($preparedQueryElements as [$preparedKey, $preparedValue]) {
                 if (is_array($preparedValue)) {
                     $preparedValue = array_map('\Doctrine\ODM\MongoDB\Types\Type::convertPHPToDatabaseValue', $preparedValue);
-                } else {
+                } elseif(isset($this->class->fieldMappings[$key])) {
                     $mapping = $this->class->fieldMappings[$key];
                     $type = Type::getType($mapping['type']);
                     $preparedValue = $type->convertToDatabaseValue($preparedValue);
+                } else {
+                    $preparedValue = Type::convertPHPToDatabaseValue($preparedValue);
                 }
 
                 $preparedQuery[$preparedKey] = $preparedValue;

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1029,7 +1029,7 @@ final class DocumentPersister
 
                 $preparedValue = Type::convertPHPToDatabaseValue($preparedValue);
 
-                if ($this->class->hasField($key) && !$this->class->isIdentifier($key)) {
+                if ($this->class->hasField($key)) {
                     $mapping = $this->class->fieldMappings[$key];
                     $typeName = $mapping['type'];
                     if (Type::hasType($typeName) && !in_array($typeName, ['collection', 'hash'])) {

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1025,13 +1025,13 @@ final class DocumentPersister
                     $preparedValue = array_map('\Doctrine\ODM\MongoDB\Types\Type::convertPHPToDatabaseValue', $preparedValue);
                 } elseif ($this->class->hasField($key) && ! $this->class->isIdentifier($key)) {
                     $mapping = $this->class->fieldMappings[$key];
-                    if (empty($mapping['reference'])) {
+                    $typeName = $mapping['type'];
+                    if (!in_array($typeName, ['collection', 'hash']) && Type::hasType($typeName)) {
                         $type = Type::getType($mapping['type']);
                         $preparedValue = $type->convertToDatabaseValue($preparedValue);
                     } else {
                         $preparedValue = Type::convertPHPToDatabaseValue($preparedValue);
                     }
-
                 } else {
                     $preparedValue = Type::convertPHPToDatabaseValue($preparedValue);
                 }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1022,18 +1022,20 @@ final class DocumentPersister
             $preparedQueryElements = $this->prepareQueryElement((string) $key, $value, null, true, $isNewObj);
             foreach ($preparedQueryElements as [$preparedKey, $preparedValue]) {
                 if (is_array($preparedValue)) {
-                    $preparedValue = array_map('\Doctrine\ODM\MongoDB\Types\Type::convertPHPToDatabaseValue', $preparedValue);
-                } elseif ($this->class->hasField($key) && ! $this->class->isIdentifier($key)) {
+                    $preparedQuery[$preparedKey] = array_map('\Doctrine\ODM\MongoDB\Types\Type::convertPHPToDatabaseValue', $preparedValue);
+
+                    continue;
+                }
+
+                $preparedValue = Type::convertPHPToDatabaseValue($preparedValue);
+
+                if ($this->class->hasField($key) && !$this->class->isIdentifier($key)) {
                     $mapping = $this->class->fieldMappings[$key];
                     $typeName = $mapping['type'];
-                    if (!in_array($typeName, ['collection', 'hash']) && Type::hasType($typeName)) {
+                    if (Type::hasType($typeName) && !in_array($typeName, ['collection', 'hash'])) {
                         $type = Type::getType($mapping['type']);
                         $preparedValue = $type->convertToDatabaseValue($preparedValue);
-                    } else {
-                        $preparedValue = Type::convertPHPToDatabaseValue($preparedValue);
                     }
-                } else {
-                    $preparedValue = Type::convertPHPToDatabaseValue($preparedValue);
                 }
 
                 $preparedQuery[$preparedKey] = $preparedValue;

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1021,28 +1021,57 @@ final class DocumentPersister
 
             $preparedQueryElements = $this->prepareQueryElement((string) $key, $value, null, true, $isNewObj);
             foreach ($preparedQueryElements as [$preparedKey, $preparedValue]) {
-                if (is_array($preparedValue)) {
-                    $preparedQuery[$preparedKey] = array_map('\Doctrine\ODM\MongoDB\Types\Type::convertPHPToDatabaseValue', $preparedValue);
-
-                    continue;
-                }
-
-                $preparedValue = Type::convertPHPToDatabaseValue($preparedValue);
-
-                if ($this->class->hasField($key)) {
-                    $mapping  = $this->class->fieldMappings[$key];
-                    $typeName = $mapping['type'];
-                    if (Type::hasType($typeName) && ! in_array($typeName, ['collection', 'hash'])) {
-                        $type          = Type::getType($mapping['type']);
-                        $preparedValue = $type->convertToDatabaseValue($preparedValue);
-                    }
-                }
-
-                $preparedQuery[$preparedKey] = $preparedValue;
+                $preparedQuery[$preparedKey] = $this->convertToDatabaseValue($key, $preparedValue);
             }
         }
 
         return $preparedQuery;
+    }
+
+    /**
+     * Converts a single value to its database representation based on the mapping type
+     *
+     * @param string $fieldName
+     * @param        $value
+     *
+     * @return mixed
+     */
+    private function convertToDatabaseValue($fieldName, $value)
+    {
+        $value = Type::convertPHPToDatabaseValue($value);
+
+        if (! $this->class->hasField($fieldName)) {
+            return $value;
+        }
+
+        $mapping  = $this->class->fieldMappings[$fieldName];
+        $typeName = $mapping['type'];
+
+        if (is_array($value)) {
+            foreach ($value as $k => $v) {
+                $value[$k] = $this->convertToDatabaseValue($fieldName, $v);
+            }
+
+            return $value;
+        }
+
+        if (! empty($mapping['reference']) || ! empty($mapping['embedded'])) {
+            return $value;
+        }
+
+        if (! Type::hasType($typeName)) {
+            throw new InvalidArgumentException(
+                sprintf('Mapping type "%s" does not exist', $typeName)
+            );
+        }
+        if (in_array($typeName, ['collection', 'hash'])) {
+            return $value;
+        }
+
+        $type          = Type::getType($typeName);
+        $value = $type->convertToDatabaseValue($value);
+
+        return $value;
     }
 
     /**
@@ -1259,6 +1288,11 @@ final class DocumentPersister
             // Process query operators whose argument arrays need type conversion
             if (in_array($k, ['$in', '$nin', '$all']) && is_array($v)) {
                 foreach ($v as $k2 => $v2) {
+                    if ($v2 instanceof $class->name) {
+                        $expression[$k][$k2] = $class->getDatabaseIdentifierValue($class->getIdentifierValue($v2));
+
+                        continue;
+                    }
                     $expression[$k][$k2] = $class->getDatabaseIdentifierValue($v2);
                 }
                 continue;
@@ -1270,7 +1304,11 @@ final class DocumentPersister
                 continue;
             }
 
-            $expression[$k] = $class->getDatabaseIdentifierValue($v);
+            if ($v instanceof $class->name) {
+                $expression[$k] = $class->getDatabaseIdentifierValue($class->getIdentifierValue($v));
+            } else {
+                $expression[$k] = $class->getDatabaseIdentifierValue($v);
+            }
         }
 
         return $expression;

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1021,9 +1021,15 @@ final class DocumentPersister
 
             $preparedQueryElements = $this->prepareQueryElement((string) $key, $value, null, true, $isNewObj);
             foreach ($preparedQueryElements as [$preparedKey, $preparedValue]) {
-                $preparedQuery[$preparedKey] = is_array($preparedValue)
-                    ? array_map('\Doctrine\ODM\MongoDB\Types\Type::convertPHPToDatabaseValue', $preparedValue)
-                    : Type::convertPHPToDatabaseValue($preparedValue);
+                if (is_array($preparedValue)) {
+                    $preparedValue = array_map('\Doctrine\ODM\MongoDB\Types\Type::convertPHPToDatabaseValue', $preparedValue);
+                } else {
+                    $mapping = $this->class->fieldMappings[$key];
+                    $type = Type::getType($mapping['type']);
+                    $preparedValue = $type->convertToDatabaseValue($preparedValue);
+                }
+
+                $preparedQuery[$preparedKey] = $preparedValue;
             }
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1023,10 +1023,15 @@ final class DocumentPersister
             foreach ($preparedQueryElements as [$preparedKey, $preparedValue]) {
                 if (is_array($preparedValue)) {
                     $preparedValue = array_map('\Doctrine\ODM\MongoDB\Types\Type::convertPHPToDatabaseValue', $preparedValue);
-                } elseif(isset($this->class->fieldMappings[$key])) {
+                } elseif ($this->class->hasField($key) && ! $this->class->isIdentifier($key)) {
                     $mapping = $this->class->fieldMappings[$key];
-                    $type = Type::getType($mapping['type']);
-                    $preparedValue = $type->convertToDatabaseValue($preparedValue);
+                    if (empty($mapping['reference'])) {
+                        $type = Type::getType($mapping['type']);
+                        $preparedValue = $type->convertToDatabaseValue($preparedValue);
+                    } else {
+                        $preparedValue = Type::convertPHPToDatabaseValue($preparedValue);
+                    }
+
                 } else {
                     $preparedValue = Type::convertPHPToDatabaseValue($preparedValue);
                 }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1032,7 +1032,7 @@ final class DocumentPersister
      * Converts a single value to its database representation based on the mapping type
      *
      * @param string $fieldName
-     * @param        $value
+     * @param mixed  $value
      *
      * @return mixed
      */
@@ -1068,7 +1068,7 @@ final class DocumentPersister
             return $value;
         }
 
-        $type          = Type::getType($typeName);
+        $type  = Type::getType($typeName);
         $value = $type->convertToDatabaseValue($value);
 
         return $value;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -200,6 +200,29 @@ class DocumentPersisterTest extends BaseTest
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
     }
 
+    /**
+     * @dataProvider provideCustomIds
+     */
+    public function testPrepareQueryOrNewObjWithReferenceToDocumentWithCustomTypedId(string $objectIdString)
+    {
+        $class             = DocumentPersisterTestDocumentWithReferenceToDocumentWithCustomId::class;
+        $documentPersister = $this->uow->getDocumentPersister($class);
+
+        $customId = DocumentPersisterCustomTypedId::fromString($objectIdString);
+
+        Type::registerType('DocumentPersisterCustomId', DocumentPersisterCustomIdType::class);
+
+        $documentWithCustomId = $this->dm->getReference(
+            DocumentPersisterTestDocumentWithCustomId::class,
+            $customId
+        );
+
+        $value    = ['documentWithCustomId' => $documentWithCustomId];
+        $expected = ['documentWithCustomId' => new ObjectId($objectIdString)];
+
+        $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
+    }
+
     public function provideHashIdentifiers()
     {
         return [
@@ -815,6 +838,26 @@ class DocumentPersisterTestDocumentWithCustomId
     public function __construct(DocumentPersisterCustomTypedId $id)
     {
         $this->id = $id;
+    }
+
+    public function getId() : DocumentPersisterCustomTypedId
+    {
+        return $this->id;
+    }
+}
+
+/** @ODM\Document() */
+class DocumentPersisterTestDocumentWithReferenceToDocumentWithCustomId
+{
+    /** @ODM\Id() */
+    private $id;
+
+    /** @ODM\ReferenceOne(targetDocument=DocumentPersisterTestDocumentWithCustomId::class, storeAs="id") */
+    private $documentWithCustomId;
+
+    public function __construct(DocumentPersisterTestDocumentWithCustomId $documentWithCustomId)
+    {
+        $this->documentWithCustomId = $documentWithCustomId;
     }
 
     public function getId() : DocumentPersisterCustomTypedId

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -802,7 +802,7 @@ final class DocumentPersisterCustomIdType extends Type
 /** @ODM\Document() */
 class DocumentPersisterTestDocumentWithCustomId
 {
-    /** @ODM\Id(type="DocumentPersisterCustomId") */
+    /** @ODM\Id(strategy="NONE", type="DocumentPersisterCustomId") */
     private $id;
 
     public function __construct(DocumentPersisterCustomTypedId $id)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -185,9 +185,9 @@ class DocumentPersisterTest extends BaseTest
     }
 
     /**
-     * @dataProvider queryProviderForCustomTypeId
-     *
      * @param array $testCase
+     *
+     * @dataProvider queryProviderForCustomTypeId
      */
     public function testPrepareQueryOrNewObjWithCustomTypedId(array $testCase)
     {
@@ -206,11 +206,13 @@ class DocumentPersisterTest extends BaseTest
     {
         Type::registerType('DocumentPersisterCustomId', DocumentPersisterCustomIdType::class);
 
-        $objectIdString = (string) new ObjectId();
+        $objectIdString  = (string) new ObjectId();
         $objectIdString2 = (string) new ObjectId();
-        $customId = DocumentPersisterCustomTypedId::fromString($objectIdString);
+
+        $customId  = DocumentPersisterCustomTypedId::fromString($objectIdString);
         $customId2 = DocumentPersisterCustomTypedId::fromString($objectIdString2);
-        $documentWithCustomId = $this->dm->getReference(
+
+        $documentWithCustomId  = $this->dm->getReference(
             DocumentPersisterTestDocumentWithCustomId::class,
             $customId
         );
@@ -293,27 +295,34 @@ class DocumentPersisterTest extends BaseTest
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
     }
 
-    public static function queryProviderForCustomTypeId(): Generator
+    public static function queryProviderForCustomTypeId() : Generator
     {
-        $objectIdString = (string) new ObjectId();
+        $objectIdString  = (string) new ObjectId();
         $objectIdString2 = (string) new ObjectId();
-        $customId = DocumentPersisterCustomTypedId::fromString($objectIdString);
+
+        $customId  = DocumentPersisterCustomTypedId::fromString($objectIdString);
         $customId2 = DocumentPersisterCustomTypedId::fromString($objectIdString2);
 
-        yield 'Direct comparison' => [[
-            'query' => ['id' => $customId],
-            'expected' => ['_id' => new ObjectId($objectIdString)]
-        ]];
+        yield 'Direct comparison' => [
+            [
+                'query' => ['id' => $customId],
+                'expected' => ['_id' => new ObjectId($objectIdString)],
+            ],
+        ];
 
-        yield 'Operator with single value' => [[
-            'query' => ['id' => ['$ne' => $customId]],
-            'expected' => ['_id' => ['$ne' => new ObjectId($objectIdString)]]
-        ]];
+        yield 'Operator with single value' => [
+            [
+                'query' => ['id' => ['$ne' => $customId]],
+                'expected' => ['_id' => ['$ne' => new ObjectId($objectIdString)]],
+            ],
+        ];
 
-        yield 'Operator with multiple values' => [[
-            'query' => ['id' => ['$in' => [$customId, $customId2]]],
-            'expected' => ['_id' => ['$in' => [new ObjectId($objectIdString), new ObjectId($objectIdString2)]]]
-        ]];
+        yield 'Operator with multiple values' => [
+            [
+                'query' => ['id' => ['$in' => [$customId, $customId2]]],
+                'expected' => ['_id' => ['$in' => [new ObjectId($objectIdString), new ObjectId($objectIdString2)]]],
+            ],
+        ];
     }
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -188,7 +188,7 @@ class DocumentPersisterTest extends BaseTest
 
         $customId = DocumentPersisterCustomTypedId::fromString($objectIdString);
 
-        $value = ['_id' => $customId];
+        $value = ['id' => $customId];
         $expected = ['_id' => new ObjectId($objectIdString)];
 
         Type::registerType('DocumentPersisterCustomId', DocumentPersisterCustomIdType::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -802,7 +802,7 @@ final class DocumentPersisterCustomIdType extends Type
 /** @ODM\Document() */
 class DocumentPersisterTestDocumentWithCustomId
 {
-    /** @ODM\Field(type="DocumentPersisterCustomId") */
+    /** @ODM\Id(type="DocumentPersisterCustomId") */
     private $id;
 
     public function __construct(DocumentPersisterCustomTypedId $id)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -10,9 +10,14 @@ use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\Type;
+use InvalidArgumentException;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
 use ReflectionProperty;
+use function get_class;
+use function gettype;
+use function is_object;
+use function sprintf;
 
 class DocumentPersisterTest extends BaseTest
 {
@@ -188,7 +193,7 @@ class DocumentPersisterTest extends BaseTest
 
         $customId = DocumentPersisterCustomTypedId::fromString($objectIdString);
 
-        $value = ['id' => $customId];
+        $value    = ['id' => $customId];
         $expected = ['_id' => new ObjectId($objectIdString)];
 
         Type::registerType('DocumentPersisterCustomId', DocumentPersisterCustomIdType::class);
@@ -744,19 +749,19 @@ final class DocumentPersisterCustomTypedId
         $this->value = $value;
     }
 
-    public function toString(): string
+    public function toString() : string
     {
         return $this->value;
     }
 
-    public static function fromString(string $value): self
+    public static function fromString(string $value) : self
     {
         return new static($value);
     }
 
-    public static function generate(): self
+    public static function generate() : self
     {
-        return new static((string)(new ObjectId()));
+        return new static((string) (new ObjectId()));
     }
 }
 
@@ -768,7 +773,8 @@ final class DocumentPersisterCustomIdType extends Type
     {
         if ($value instanceof ObjectId) {
             return $value;
-        } elseif ($value instanceof DocumentPersisterCustomTypedId) {
+        }
+        if ($value instanceof DocumentPersisterCustomTypedId) {
             return new ObjectId($value->toString());
         }
 
@@ -779,16 +785,17 @@ final class DocumentPersisterCustomIdType extends Type
     {
         if ($value instanceof DocumentPersisterCustomTypedId) {
             return $value;
-        } elseif ($value instanceof ObjectId) {
-            return DocumentPersisterCustomTypedId::fromString((string)$value);
+        }
+        if ($value instanceof ObjectId) {
+            return DocumentPersisterCustomTypedId::fromString((string) $value);
         }
 
         throw self::createException($value);
     }
 
-    private static function createException($value): \InvalidArgumentException
+    private static function createException($value) : InvalidArgumentException
     {
-        return new \InvalidArgumentException(
+        return new InvalidArgumentException(
             sprintf(
                 'Expected "%s" or "%s", got "%s"',
                 DocumentPersisterCustomTypedId::class,
@@ -810,7 +817,7 @@ class DocumentPersisterTestDocumentWithCustomId
         $this->id = $id;
     }
 
-    public function getId(): DocumentPersisterCustomTypedId
+    public function getId() : DocumentPersisterCustomTypedId
     {
         return $this->id;
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature/improvement
| BC Break     | no
| Fixed issues | #2103 

#### Summary

This PR adds conversion of PHP values in queries to their DB representations using types functionality, and thus allows to query by php values rather that db values. 
