### PR TITLE
Fix merging of documents when not cascading references

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1938,6 +1938,11 @@ class UnitOfWork implements PropertyChangedListener
                                 $targetClass = $this->dm->getClassMetadata($targetDocument);
                                 $relatedId = $targetClass->getIdentifierObject($other);
 
+                                $current = $prop->getValue($managedCopy);
+                                if ($current !== null) {
+                                    $this->removeFromIdentityMap($current);
+                                }
+
                                 if ($targetClass->subClasses) {
                                     $other = $this->dm->find($targetClass->name, $relatedId);
                                 } else {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fixes #2106 

#### Summary

The described issue only appears when not cascading merge operations. The problem is that the call to `registerManaged` after creating a new proxy object will return early since a document with that ID is already registered (the original proxy loaded in `$managedCopy`. This leads to the new value for the association being different from the document that is being managed by the entity manager, which again causes issues on subsequent proxy initialisations.

On a related note, I'm not sure why the merge logic includes creating a new proxy object for the managed copy and discarding the changes from the original. However, this is logic that was introduced 8 years ago to ORM, was ported to MongoDB ODM and wasn't changed in ORM since, so I don't feel comfortable changing this particular thing about it.