### PR TITLE
[Doc] Remove dropped commands

### DIFF
--- a/docs/en/reference/console-commands.rst
+++ b/docs/en/reference/console-commands.rst
@@ -6,10 +6,8 @@ Console component, to ease your development process:
 
 - ``odm:clear-cache:metadata`` - Clear all metadata cache of the various cache drivers.
 - ``odm:query`` - Query mongodb and inspect the outputted results from your document classes.
-- ``odm:generate:documents`` - Generate document classes and method stubs from your mapping information.
 - ``odm:generate:hydrators`` - Generates hydrator classes for document classes.
 - ``odm:generate:proxies`` - Generates proxy classes for document classes.
-- ``odm:generate:repositories`` -  Generate repository classes from your mapping information.
 - ``odm:schema:create`` - Allows you to create databases, collections and indexes for your documents
 - ``odm:schema:drop`` - Allows you to drop databases, collections and indexes for your documents
 - ``odm:schema:update`` - Allows you to update indexes for your documents
@@ -36,10 +34,8 @@ console command easily with the following code:
     $app->setHelperSet($helperSet);
     $app->addCommands(
         [
-            new \Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateDocumentsCommand(),
             new \Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateHydratorsCommand(),
             new \Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateProxiesCommand(),
-            new \Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateRepositoriesCommand(),
             new \Doctrine\ODM\MongoDB\Tools\Console\Command\QueryCommand(),
             new \Doctrine\ODM\MongoDB\Tools\Console\Command\ClearCache\MetadataCommand(),
             new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\CreateCommand(),


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | Documentation update

#### Summary

Remove the documentation for odm:generate:documents and odm:generate:repositories commands which have been dropped since 2.0.
