### PR TITLE
Merge release 1.3.4 into 2.0.x

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1783,6 +1783,11 @@ final class UnitOfWork implements PropertyChangedListener
                                 $targetClass = $this->dm->getClassMetadata($targetDocument);
                                 $relatedId   = $targetClass->getIdentifierObject($other);
 
+                                $current = $prop->getValue($managedCopy);
+                                if ($current !== null) {
+                                    $this->removeFromIdentityMap($current);
+                                }
+
                                 if ($targetClass->subClasses) {
                                     $other = $this->dm->find($targetClass->name, $relatedId);
                                 } else {


### PR DESCRIPTION
Release [1.3.4](https://github.com/doctrine/mongodb-odm/milestone/52)



1.3.4
=====

- Total issues resolved: **1**
- Total pull requests resolved: **1**
- Total contributors: **2**

Bug
---

 - [2108: Fix merging of documents when not cascading references](https://github.com/doctrine/mongodb-odm/pull/2108) thanks to @alcaeus and @TheHett


