### PR TITLE
Provide rewindable option to Aggregation and Query builders/queries

### DIFF
--- a/docs/en/reference/aggregation-builder.rst
+++ b/docs/en/reference/aggregation-builder.rst
@@ -191,6 +191,26 @@ specified document.
     can map embedded documents, define references, and even use discriminators
     to get different result documents according to the aggregation result.
 
+Disabling Result Caching
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Due to MongoDB cursors not being rewindable, ODM uses a caching iterator when
+returning results from aggregation pipelines. This cache allows you to iterate a
+result cursor multiple times without re-executing the original aggregation
+pipeline. However, in long-running processes or when handling a large number of
+results, this can lead to high memory usage. To disable this result cache, you
+can tell the query builder to not return a caching iterator:
+
+.. code-block:: php
+
+    <?php
+
+    $builder = $dm->createAggregationBuilder(\Documents\Orders::class);
+    $builder->setRewindable(false);
+
+When setting this option to ``false``, attempting a second iteration will result
+in an exception.
+
 Aggregation pipeline stages
 ---------------------------
 

--- a/docs/en/reference/query-builder-api.rst
+++ b/docs/en/reference/query-builder-api.rst
@@ -287,6 +287,28 @@ get the raw results directly back from mongo by using the
 
     print_r($users);
 
+Disabling Result Caching
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Due to MongoDB cursors not being rewindable, ODM uses a caching iterator when
+returning results from queries. This cache allows you to iterate a result cursor
+multiple times without re-executing the original query. However, in long-running
+processes or when handling a large number of results, this can lead to high
+memory usage. To disable this result cache, you can tell the query builder to
+not return a caching iterator:
+
+.. code-block:: php
+
+    <?php
+
+    $blogPosts = $dm->createQueryBuilder(BlogPost::class)
+        ->setRewindable(false)
+        ->getQuery()
+        ->execute();
+
+When setting this option to ``false``, attempting a second iteration will result
+in an exception.
+
 Limiting Results
 ~~~~~~~~~~~~~~~~
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -265,6 +265,16 @@ abstract class Stage
     }
 
     /**
+     * Controls if resulting iterator should be wrapped with CachingIterator.
+     */
+    public function rewindable(bool $rewindable = true) : self
+    {
+        $this->builder->rewindable($rewindable);
+
+        return $this;
+    }
+
+    /**
      * Randomly selects the specified number of documents from its input.
      *
      * @see https://docs.mongodb.org/manual/reference/operator/aggregation/sample/

--- a/lib/Doctrine/ODM/MongoDB/Iterator/UnrewindableIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/UnrewindableIterator.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Iterator;
+
+use Generator;
+use LogicException;
+use RuntimeException;
+use Traversable;
+use function iterator_to_array;
+use function sprintf;
+
+/**
+ * Iterator for wrapping a Traversable/Cursor.
+ *
+ * @internal
+ */
+final class UnrewindableIterator implements Iterator
+{
+    /** @var Generator|null */
+    private $iterator;
+
+    /** @var bool */
+    private $iteratorAdvanced = false;
+
+    /**
+     * Initialize the iterator. This effectively rewinds the Traversable and
+     * the wrapping Generator, which will execute up to its first yield statement.
+     * Additionally, this mimics behavior of the SPL iterators and allows users
+     * to omit an explicit call to rewind() before using the other methods.
+     */
+    public function __construct(Traversable $iterator)
+    {
+        $this->iterator = $this->wrapTraversable($iterator);
+        $this->iterator->key();
+    }
+
+    public function toArray() : array
+    {
+        $this->preventRewinding(__METHOD__);
+
+        $toArray = function () {
+            if (! $this->valid()) {
+                return;
+            }
+            yield $this->key() => $this->current();
+            yield from $this->getIterator();
+        };
+
+        return iterator_to_array($toArray());
+    }
+
+    /**
+     * @see http://php.net/iterator.current
+     *
+     * @return mixed
+     */
+    public function current()
+    {
+        return $this->getIterator()->current();
+    }
+
+    /**
+     * @see http://php.net/iterator.mixed
+     *
+     * @return mixed
+     */
+    public function key()
+    {
+        if ($this->iterator) {
+            return $this->iterator->key();
+        }
+
+        return null;
+    }
+
+    /**
+     * @see http://php.net/iterator.next
+     */
+    public function next() : void
+    {
+        if (! $this->iterator) {
+            return;
+        }
+
+        $this->iterator->next();
+    }
+
+    /**
+     * @see http://php.net/iterator.rewind
+     */
+    public function rewind() : void
+    {
+        $this->preventRewinding(__METHOD__);
+    }
+
+    /**
+     * @see http://php.net/iterator.valid
+     */
+    public function valid() : bool
+    {
+        return $this->key() !== null;
+    }
+
+    private function preventRewinding(string $method) : void
+    {
+        if ($this->iteratorAdvanced) {
+            throw new LogicException(sprintf(
+                'Cannot call %s for iterator that already yielded results',
+                $method
+            ));
+        }
+    }
+
+    private function getIterator() : Generator
+    {
+        if ($this->iterator === null) {
+            throw new RuntimeException('Iterator has already been destroyed');
+        }
+
+        return $this->iterator;
+    }
+
+    private function wrapTraversable(Traversable $traversable) : Generator
+    {
+        foreach ($traversable as $key => $value) {
+            yield $key => $value;
+            $this->iteratorAdvanced = true;
+        }
+
+        $this->iterator = null;
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -80,6 +80,9 @@ class Builder
      */
     private $readOnly = false;
 
+    /** @var bool */
+    private $rewindable = true;
+
     /**
      * The Collection instance.
      *
@@ -713,7 +716,8 @@ class Builder
             $this->hydrate,
             $this->refresh,
             $this->primers,
-            $this->readOnly
+            $this->readOnly,
+            $this->rewindable
         );
     }
 
@@ -1375,6 +1379,13 @@ class Builder
     public function setReadPreference(ReadPreference $readPreference) : self
     {
         $this->query['readPreference'] = $readPreference;
+
+        return $this;
+    }
+
+    public function setRewindable(bool $rewindable = true) : self
+    {
+        $this->rewindable = $rewindable;
 
         return $this;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
@@ -7,13 +7,13 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation;
 use DateTimeImmutable;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
+use Doctrine\ODM\MongoDB\Iterator\UnrewindableIterator;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Article;
 use Documents\BlogPost;
 use Documents\BlogTagAggregation;
 use Documents\CmsComment;
 use Documents\GuestServer;
-use Documents\Project;
 use Documents\Tag;
 use MongoDB\BSON\UTCDateTime;
 use function array_keys;
@@ -352,10 +352,21 @@ class BuilderTest extends BaseTest
     public function testBuilderWithIndexStatsStageDoesNotApplyFilters()
     {
         $builder = $this->dm
-            ->createAggregationBuilder(Project::class)
+            ->createAggregationBuilder(BlogPost::class)
             ->indexStats();
 
         $this->assertSame('$indexStats', array_keys($builder->getPipeline()[0])[0]);
+    }
+
+    public function testNonRewindableBuilder()
+    {
+        $builder = $this->dm
+            ->createAggregationBuilder(BlogPost::class)
+            ->match()
+            ->rewindable(false);
+
+        $iterator = $builder->execute();
+        $this->assertInstanceOf(UnrewindableIterator::class, $iterator);
     }
 
     private function insertTestData()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/UnrewindableIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/UnrewindableIteratorTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Iterator;
+
+use Doctrine\ODM\MongoDB\Iterator\UnrewindableIterator;
+use Exception;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+use function iterator_to_array;
+
+class UnrewindableIteratorTest extends TestCase
+{
+    /**
+     * Sanity check for all following tests.
+     */
+    public function testTraversingGeneratorConsumesIt()
+    {
+        $iterator = $this->getTraversable([1, 2, 3]);
+        $this->assertSame([1, 2, 3], iterator_to_array($iterator));
+        $this->expectException(Throwable::class);
+        $this->expectExceptionMessage('Cannot traverse an already closed generator');
+        $this->assertSame([1, 2, 3], iterator_to_array($iterator));
+    }
+
+    public function testConstructorRewinds()
+    {
+        $iterator = new UnrewindableIterator($this->getTraversable([1, 2, 3]));
+
+        $this->assertTrue($iterator->valid());
+        $this->assertSame(0, $iterator->key());
+        $this->assertSame(1, $iterator->current());
+    }
+
+    public function testIteration()
+    {
+        $iterator = new UnrewindableIterator($this->getTraversable([1, 2, 3]));
+
+        $expectedKey  = 0;
+        $expectedItem = 1;
+
+        foreach ($iterator as $key => $item) {
+            $this->assertSame($expectedKey++, $key);
+            $this->assertSame($expectedItem++, $item);
+        }
+
+        $this->assertFalse($iterator->valid());
+    }
+
+    public function testIterationWithEmptySet()
+    {
+        $iterator = new UnrewindableIterator($this->getTraversable([]));
+
+        $iterator->rewind();
+        $this->assertFalse($iterator->valid());
+    }
+
+    public function testToArrayWithEmptySet()
+    {
+        $iterator = new UnrewindableIterator($this->getTraversable([]));
+
+        $this->assertEquals([], $iterator->toArray());
+    }
+
+    public function testPartialIterationDoesNotExhaust()
+    {
+        $traversable = $this->getTraversableThatThrows([1, 2, new Exception()]);
+        $iterator    = new UnrewindableIterator($traversable);
+
+        $expectedKey  = 0;
+        $expectedItem = 1;
+
+        foreach ($iterator as $key => $item) {
+            $this->assertSame($expectedKey++, $key);
+            $this->assertSame($expectedItem++, $item);
+
+            if ($key === 1) {
+                break;
+            }
+        }
+
+        $this->assertTrue($iterator->valid());
+    }
+
+    public function testRewindAfterPartialIteration()
+    {
+        $iterator = new UnrewindableIterator($this->getTraversable([1, 2, 3]));
+
+        $iterator->rewind();
+        $this->assertTrue($iterator->valid());
+        $this->assertSame(0, $iterator->key());
+        $this->assertSame(1, $iterator->current());
+
+        $iterator->next();
+        $this->expectException(LogicException::class);
+        iterator_to_array($iterator);
+    }
+
+    public function testToArray()
+    {
+        $iterator = new UnrewindableIterator($this->getTraversable([1, 2, 3]));
+        $this->assertSame([1, 2, 3], $iterator->toArray());
+    }
+
+    public function testToArrayAfterPartialIteration()
+    {
+        $iterator = new UnrewindableIterator($this->getTraversable([1, 2, 3]));
+
+        $iterator->rewind();
+        $this->assertTrue($iterator->valid());
+        $this->assertSame(0, $iterator->key());
+        $this->assertSame(1, $iterator->current());
+
+        $iterator->next();
+        $this->expectException(LogicException::class);
+        $iterator->toArray();
+    }
+
+    private function getTraversable($items)
+    {
+        foreach ($items as $item) {
+            yield $item;
+        }
+    }
+
+    private function getTraversableThatThrows($items)
+    {
+        foreach ($items as $item) {
+            if ($item instanceof Exception) {
+                throw $item;
+            }
+
+            yield $item;
+        }
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Query;
 
 use DateTime;
+use Doctrine\ODM\MongoDB\Iterator\UnrewindableIterator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Query\Builder;
@@ -806,6 +807,15 @@ class BuilderTest extends BaseTest
             ],
         ];
         $this->assertEquals($expected, $qb->getNewObj());
+    }
+
+    public function testNonRewindable()
+    {
+        $query = $this->getTestQueryBuilder()
+            ->setRewindable(false)
+            ->getQuery();
+
+        $this->assertInstanceOf(UnrewindableIterator::class, $query->execute());
     }
 
     private function getTestQueryBuilder()


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #2113 

#### Summary

Proof of concept for allowing user control over wrapping resulting `Traversable`/`Iterator` with `CachingIterator` - to prevent memory issues when iterating over large result sets.

Note: This PR is incomplete - still needs ~tests, relevant comment blocks and~ documentation adjustments.

- [x] Add tests
- [x] Add comments to code
- [x] Adjust documentation
