### PR TITLE
[1.3] Adds support for Symfony 5.0 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "symfony/console": "~2.3|~3.0|^4.0",
+        "symfony/console": "~2.3|~3.0|^4.0|^5.0",
         "doctrine/annotations": "~1.2",
         "doctrine/collections": "~1.1",
         "doctrine/common": "^2.5.0",
@@ -27,7 +27,7 @@
     "require-dev": {
         "phpbench/phpbench": "^0.13.0",
         "phpunit/phpunit": "^5.7.21|^7.5",
-        "symfony/yaml": "~2.3|~3.0|^4.0"
+        "symfony/yaml": "~2.3|~3.0|^4.0|^5.0"
     },
     "suggest": {
         "symfony/yaml": "Enables the YAML metadata mapping driver",

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -72,5 +72,7 @@ EOT
         } else {
             $output->write('No entries to be deleted.' . PHP_EOL);
         }
+
+        return 0;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ConvertMappingToXmlCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ConvertMappingToXmlCommand.php
@@ -41,7 +41,7 @@ class ConvertMappingToXmlCommand extends Command
 
         if (! count($metadatas)) {
             $output->writeln('No Metadata Classes to process.');
-            return;
+            return 0;
         }
 
         /** @var ClassMetadataInfo $metadata */
@@ -59,6 +59,8 @@ class ConvertMappingToXmlCommand extends Command
         }
 
         $output->writeln(PHP_EOL . sprintf('XML mapping files generated to "<info>%s</info>"', $destPath));
+
+        return 0;
     }
 
     private function inspectDeprecations(ClassMetadataInfo $metadata, OutputInterface $output)

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateDocumentsCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateDocumentsCommand.php
@@ -159,5 +159,7 @@ EOT
         } else {
             $output->writeln('No Metadata Classes to process.');
         }
+
+        return 0;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php
@@ -101,5 +101,7 @@ EOT
         } else {
             $output->write('No Metadata Classes to process.' . PHP_EOL);
         }
+
+        return 0;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GeneratePersistentCollectionsCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GeneratePersistentCollectionsCommand.php
@@ -111,5 +111,7 @@ EOT
         } else {
             $output->write('No Metadata Classes to process.' . PHP_EOL);
         }
+
+        return 0;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
@@ -104,5 +104,7 @@ EOT
         } else {
             $output->write('No Metadata Classes to process.' . PHP_EOL);
         }
+
+        return 0;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateRepositoriesCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateRepositoriesCommand.php
@@ -103,5 +103,7 @@ EOT
         } else {
             $output->write('No Metadata Classes to process.' . PHP_EOL);
         }
+
+        return 0;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
@@ -106,5 +106,7 @@ EOT
         foreach ($qb->getQuery() as $result) {
             Debug::dump($result, $depth);
         }
+
+        return 0;
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

We must return `int` in execute of symfony console command. `null` is no longer allowed.

Related to #2115 
