### PR TITLE
Allow version ^5.0 of Symfony components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
         "doctrine/persistence": "^1.1",
         "mongodb/mongodb": "^1.2.0",
         "ocramius/proxy-manager": "^2.2",
-        "symfony/console": "^3.4|^4.1",
-        "symfony/var-dumper": "^3.4|^4.1"
+        "symfony/console": "^3.4|^4.1|^5.0",
+        "symfony/var-dumper": "^3.4|^4.1|^5.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^6.0",


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | https://github.com/doctrine/mongodb-odm/issues/2120

#### Summary

This PR allows version `^5.0` of Symfony components, and thus unblocks updating to new major version of Symfony framework for ODM users.
