### PR TITLE
Remove unneceesary internal designations

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -283,7 +283,6 @@ class DocumentManager implements ObjectManager
      *
      * @param string $className The class name.
      * @return \Doctrine\ODM\MongoDB\Mapping\ClassMetadata
-     * @internal Performance-sensitive method.
      */
     public function getClassMetadata($className)
     {

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -578,9 +578,6 @@ trait PersistentCollectionTrait
     /**
      * Called by PHP when this collection is serialized. Ensures that the
      * internal state of the collection can be reproduced after serialization
-     *
-     * @internal Tried to implement Serializable first but that did not work well
-     *           with circular references. This solution seems simpler and works well.
      */
     public function __sleep()
     {

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2047,7 +2047,6 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param object $document
      * @param array $visited
-     * @internal This method always considers documents with an assigned identifier as DETACHED.
      */
     private function doDetach($document, array &$visited)
     {
@@ -2697,7 +2696,6 @@ class UnitOfWork implements PropertyChangedListener
      * @param array $hints Any hints to account for during reconstitution/lookup of the document.
      * @param object $document The document to be hydrated into in case of creation
      * @return object The document instance.
-     * @internal Highly performance-sensitive method.
      */
     public function getOrCreateDocument($className, $data, &$hints = array(), $document = null)
     {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | (partly) fixes #2122

#### Summary

This removes a few `@internal` designations for methods that aren't really internal, but where the comment was used to leave notes that shouldn't be exposed in an API documentation.
