### PR TITLE
Remove conflict markers

### DIFF
--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -17,13 +17,9 @@
 
        reference/introduction
        reference/architecture
-<<<<<<< HEAD
-       reference/basic-mapping
-       reference/custom-mapping-types
-=======
        reference/console-commands
        reference/basic-mapping
->>>>>>> 2.0.x
+       reference/custom-mapping-types
        reference/reference-mapping
        reference/bidirectional-references
        reference/complex-references


### PR DESCRIPTION
This removes conflict markers from the sidebar and adds a missing docs section back.

Thanks @TimoBakx for pointing this out to me!