### PR TITLE
FIX - info message must be lowercase

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php
@@ -97,7 +97,7 @@ EOT
             $dm->getHydratorFactory()->generateHydratorClasses($metadatas, $destPath);
 
             // Outputting information message
-            $output->write(PHP_EOL . sprintf('Hydrator classes generated to "<info>%s</INFO>"', $destPath) . PHP_EOL);
+            $output->write(PHP_EOL . sprintf('Hydrator classes generated to "<info>%s</info>"', $destPath) . PHP_EOL);
         } else {
             $output->write('No Metadata Classes to process.' . PHP_EOL);
         }

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GeneratePersistentCollectionsCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GeneratePersistentCollectionsCommand.php
@@ -107,7 +107,7 @@ EOT
             }
 
             // Outputting information message
-            $output->write(PHP_EOL . sprintf('Persistent collections classes generated to "<info>%s</INFO>"', $destPath) . PHP_EOL);
+            $output->write(PHP_EOL . sprintf('Persistent collections classes generated to "<info>%s</info>"', $destPath) . PHP_EOL);
         } else {
             $output->write('No Metadata Classes to process.' . PHP_EOL);
         }

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
@@ -100,7 +100,7 @@ EOT
             $dm->getProxyFactory()->generateProxyClasses($metadatas, $destPath);
 
             // Outputting information message
-            $output->write(PHP_EOL . sprintf('Proxy classes generated to "<info>%s</INFO>"', $destPath) . PHP_EOL);
+            $output->write(PHP_EOL . sprintf('Proxy classes generated to "<info>%s</info>"', $destPath) . PHP_EOL);
         } else {
             $output->write('No Metadata Classes to process.' . PHP_EOL);
         }

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateRepositoriesCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateRepositoriesCommand.php
@@ -96,7 +96,7 @@ EOT
 
             if ($numRepositories) {
                 // Outputting information message
-                $output->write(PHP_EOL . sprintf('Repository classes generated to "<info>%s</INFO>"', $destPath) . PHP_EOL);
+                $output->write(PHP_EOL . sprintf('Repository classes generated to "<info>%s</info>"', $destPath) . PHP_EOL);
             } else {
                 $output->write('No Repository classes were found to be processed.' . PHP_EOL);
             }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->
Some messages are rendered as `Hydrator classes generated to "path/to/my/project/var/pre-cached/Hydrators</INFO>"`.
Because the opening and closing tags are not case sensitive.
So i use `</info>` instead of `</INFO>` for these messages.
