### PR TITLE
Ignore missing background option when comparing indexes

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -30,6 +30,7 @@ final class SchemaManager
     private const CODE_SHARDING_ALREADY_INITIALIZED = 23;
 
     private const ALLOWED_MISSING_INDEX_OPTIONS = [
+        'background',
         'partialFilterExpression',
         'sparse',
         'unique',

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -679,6 +679,27 @@ class SchemaManagerTest extends BaseTest
                 'mongoIndex' => ['name' => 'foo_1_bar_1'],
                 'documentIndex' => [],
             ],
+            // background option
+            'backgroundOptionOnlyInMongoIndex' => [
+                'expected' => true,
+                'mongoIndex' => ['background' => false],
+                'documentIndex' => [],
+            ],
+            'backgroundOptionOnlyInDocumentIndex' => [
+                'expected' => true,
+                'mongoIndex' => [],
+                'documentIndex' => ['options' => ['background' => false]],
+            ],
+            'backgroundOptionOnlyInBothIndexesMismatch' => [
+                'expected' => true,
+                'mongoIndex' => ['background' => false],
+                'documentIndex' => ['options' => ['background' => true]],
+            ],
+            'backgroundOptionOnlyInBothIndexesSame' => [
+                'expected' => true,
+                'mongoIndex' => ['background' => true],
+                'documentIndex' => ['options' => ['background' => true]],
+            ],
         ];
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fixes #2147

#### Summary

When the `background` index option is missing from either the MongoDB or document index, the index is no longer considered the same. Since this option only refers to index creation, it should always be ignored entirely and not be a cause to recreate an index.