### PR TITLE
Chaged the Text Search docs on language

### DIFF
--- a/docs/en/reference/query-builder-api.rst
+++ b/docs/en/reference/query-builder-api.rst
@@ -677,8 +677,8 @@ method:
 
     // Run a text search against the index
     $qb = $dm->createQueryBuilder('Document')
-        ->language('it')
-        ->text('parole che stai cercando');
+        ->text('parole che stai cercando')
+        ->language('it');
 
 
 Update Queries


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement?
| BC Break     | no?
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary
When trying to do
```
        ->language('it')
        ->text('parole che stai cercando');
```
I get:
`This method requires a $text operator (call text() first)`

I assumed the docs was wrong. If I am somehow not understanding this, please feel free to close the PR.
<!-- Provide a summary your change. -->
