### PR TITLE
Link on "Reference Mapping" not exists in sidebar

### DIFF
--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -25,6 +25,7 @@
        reference/indexes
        reference/inheritance-mapping
        reference/embedded-mapping
+       reference/reference-mapping
        reference/trees
        reference/storing-files-with-gridfs
        reference/xml-mapping


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | no

#### Summary

Link on "Reference Mapping" not exists in sidebar


![Снимок экрана от 2020-03-23 13-59-44](https://user-images.githubusercontent.com/2323142/77310375-4a7f1180-6d0f-11ea-9b78-3ef37edd30e8.png)
