### PR TITLE
Append ODM version info to driver metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "doctrine/event-manager": "^1.0",
         "doctrine/instantiator": "^1.1",
         "doctrine/persistence": "^1.3.5",
+        "jean85/pretty-package-versions": "^1.3.0",
         "mongodb/mongodb": "^1.2.0",
         "ocramius/proxy-manager": "^2.2",
         "symfony/console": "^3.4|^4.1|^5.0",


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

This uses a new option in the upcoming MongoDB driver to provide additional driver metadata. The new feature allows custom drivers (such as ODMs) to add their own metadata to the initial MongoDB handshake. This allows for a more detailed analysis of driver versions being used.

Note that this PR doesn't bump the required driver version on purpose: if the driver doesn't support this option, it doesn't throw an error but ignore the option. Furthermore, as ext-mongodb 1.8 is not released yet, I don't want to tie the ODM release schedule to that of the MongoDB driver.