### PR TITLE
Add Document Manager Decorator like doctrine entity manager decorator fo ORM

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Decorator/DocumentManagerDecorator.php
+++ b/lib/Doctrine/ODM/MongoDB/Decorator/DocumentManagerDecorator.php
@@ -6,13 +6,13 @@ namespace Doctrine\ODM\MongoDB\Decorator;
 
 use Doctrine\Common\EventManager;
 use Doctrine\ODM\MongoDB\Aggregation\Builder as AggregationBuilder;
+use Doctrine\ODM\MongoDB\DocumentManagerInterface;
 use Doctrine\ODM\MongoDB\Hydrator\HydratorFactory;
 use Doctrine\ODM\MongoDB\Proxy\Resolver\ClassNameResolver;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use Doctrine\ODM\MongoDB\Query\FilterCollection;
 use Doctrine\ODM\MongoDB\SchemaManager;
 use Doctrine\ODM\MongoDB\UnitOfWork;
-use Doctrine\ODM\MongoDB\DocumentManagerInterface;
 use Doctrine\Persistence\ObjectManagerDecorator;
 use MongoDB\Client;
 use MongoDB\Collection;
@@ -35,7 +35,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     /**
      * {@inheritdoc}
      */
-    public function createQueryBuilder($documentName = null): Builder
+    public function createQueryBuilder($documentName = null) : Builder
     {
         return $this->wrapped->createQueryBuilder($documentName);
     }
@@ -43,7 +43,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     /**
      * {@inheritdoc}
      */
-    public function createAggregationBuilder($documentName): AggregationBuilder
+    public function createAggregationBuilder($documentName) : AggregationBuilder
     {
         return $this->wrapped->createAggregationBuilder($documentName);
     }
@@ -51,7 +51,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     /**
      * {@inheritdoc}
      */
-    public function getReference($documentName, $id): object
+    public function getReference($documentName, $id) : object
     {
         return $this->wrapped->getReference($documentName, $id);
     }
@@ -59,7 +59,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     /**
      * {@inheritdoc}
      */
-    public function getPartialReference($documentName, $identifier): object
+    public function getPartialReference($documentName, $identifier) : object
     {
         return $this->wrapped->getPartialReference($documentName, $identifier);
     }
@@ -67,7 +67,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     /**
      * {@inheritdoc}
      */
-    public function createReference(object $document, array $referenceMapping): object
+    public function createReference(object $document, array $referenceMapping) : object
     {
         return $this->wrapped->createReference($document, $referenceMapping);
     }
@@ -83,7 +83,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     /**
      * {@inheritdoc}
      */
-    public function lock(object $document, int $lockMode, ?int $lockVersion = null): void
+    public function lock(object $document, int $lockMode, ?int $lockVersion = null) : void
     {
         $this->wrapped->lock($document, $lockMode, $lockVersion);
     }
@@ -91,7 +91,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     /**
      * {@inheritdoc}
      */
-    public function unlock(object $document): void
+    public function unlock(object $document) : void
     {
         $this->wrapped->unlock($document);
     }
@@ -107,7 +107,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     /**
      * {@inheritdoc}
      */
-    public function getEventManager(): EventManager
+    public function getEventManager() : EventManager
     {
         return $this->wrapped->getEventManager();
     }
@@ -115,7 +115,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     /**
      * {@inheritdoc}
      */
-    public function getClient(): Client
+    public function getClient() : Client
     {
         return $this->wrapped->getClient();
     }
@@ -139,7 +139,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     /**
      * {@inheritdoc}
      */
-    public function getUnitOfWork(): UnitOfWork
+    public function getUnitOfWork() : UnitOfWork
     {
         return $this->wrapped->getUnitOfWork();
     }
@@ -219,7 +219,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     /**
      * {@inheritdoc}
      */
-    public function getFilterCollection(): FilterCollection
+    public function getFilterCollection() : FilterCollection
     {
         return $this->wrapped->getFilterCollection();
     }

--- a/lib/Doctrine/ODM/MongoDB/Decorator/DocumentManagerDecorator.php
+++ b/lib/Doctrine/ODM/MongoDB/Decorator/DocumentManagerDecorator.php
@@ -107,14 +107,6 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     /**
      * {@inheritdoc}
      */
-    public function flush()
-    {
-        $this->wrapped->flush();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getEventManager(): EventManager
     {
         return $this->wrapped->getEventManager();

--- a/lib/Doctrine/ODM/MongoDB/Decorator/DocumentManagerDecorator.php
+++ b/lib/Doctrine/ODM/MongoDB/Decorator/DocumentManagerDecorator.php
@@ -12,7 +12,7 @@ use Doctrine\ODM\MongoDB\Query\Builder;
 use Doctrine\ODM\MongoDB\Query\FilterCollection;
 use Doctrine\ODM\MongoDB\SchemaManager;
 use Doctrine\ODM\MongoDB\UnitOfWork;
-use Doctrine\Persistence\ObjectManager;
+use Doctrine\ODM\MongoDB\DocumentManagerInterface;
 use Doctrine\Persistence\ObjectManagerDecorator;
 use MongoDB\Client;
 use MongoDB\Collection;
@@ -22,12 +22,12 @@ use MongoDB\GridFS\Bucket;
 /**
  * Base class for DocumentManager decorators
  */
-abstract class DocumentManagerDecorator extends ObjectManagerDecorator implements ObjectManager
+abstract class DocumentManagerDecorator extends ObjectManagerDecorator implements DocumentManagerInterface
 {
-    /** @var ObjectManager */
+    /** @var DocumentManagerInterface */
     protected $wrapped;
 
-    public function __construct(ObjectManager $wrapped)
+    public function __construct(DocumentManagerInterface $wrapped)
     {
         $this->wrapped = $wrapped;
     }

--- a/lib/Doctrine/ODM/MongoDB/Decorator/DocumentManagerDecorator.php
+++ b/lib/Doctrine/ODM/MongoDB/Decorator/DocumentManagerDecorator.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Decorator;
+
+use Doctrine\Common\EventManager;
+use Doctrine\ODM\MongoDB\Aggregation\Builder as AggregationBuilder;
+use Doctrine\ODM\MongoDB\Hydrator\HydratorFactory;
+use Doctrine\ODM\MongoDB\Proxy\Resolver\ClassNameResolver;
+use Doctrine\ODM\MongoDB\Query\Builder;
+use Doctrine\ODM\MongoDB\Query\FilterCollection;
+use Doctrine\ODM\MongoDB\SchemaManager;
+use Doctrine\ODM\MongoDB\UnitOfWork;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManagerDecorator;
+use MongoDB\Client;
+use MongoDB\Collection;
+use MongoDB\Database;
+use MongoDB\GridFS\Bucket;
+
+/**
+ * Base class for DocumentManager decorators
+ */
+abstract class DocumentManagerDecorator extends ObjectManagerDecorator implements ObjectManager
+{
+    /** @var ObjectManager */
+    protected $wrapped;
+
+    public function __construct(ObjectManager $wrapped)
+    {
+        $this->wrapped = $wrapped;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createQueryBuilder($documentName = null): Builder
+    {
+        return $this->wrapped->createQueryBuilder($documentName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createAggregationBuilder($documentName): AggregationBuilder
+    {
+        return $this->wrapped->createAggregationBuilder($documentName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReference($documentName, $id): object
+    {
+        return $this->wrapped->getReference($documentName, $id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPartialReference($documentName, $identifier): object
+    {
+        return $this->wrapped->getPartialReference($documentName, $identifier);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createReference(object $document, array $referenceMapping): object
+    {
+        return $this->wrapped->createReference($document, $referenceMapping);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function close()
+    {
+        $this->wrapped->close();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lock(object $document, int $lockMode, ?int $lockVersion = null): void
+    {
+        $this->wrapped->lock($document, $lockMode, $lockVersion);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unlock(object $document): void
+    {
+        $this->wrapped->unlock($document);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function find($documentName, $id, $lockMode = null, $lockVersion = null)
+    {
+        return $this->wrapped->find($documentName, $id, $lockMode, $lockVersion);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush()
+    {
+        $this->wrapped->flush();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEventManager(): EventManager
+    {
+        return $this->wrapped->getEventManager();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClient(): Client
+    {
+        return $this->wrapped->getClient();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration()
+    {
+        return $this->wrapped->getConfiguration();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isOpen()
+    {
+        return $this->wrapped->isOpen();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUnitOfWork(): UnitOfWork
+    {
+        return $this->wrapped->getUnitOfWork();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHydratorFactory() : HydratorFactory
+    {
+        return $this->wrapped->getHydratorFactory();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClassNameResolver() : ClassNameResolver
+    {
+        return $this->wrapped->getClassNameResolver();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSchemaManager() : SchemaManager
+    {
+        return $this->wrapped->getSchemaManager();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDocumentDatabase(string $className) : Database
+    {
+        return $this->wrapped->getDocumentDatabase($className);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDocumentDatabases() : array
+    {
+        return $this->wrapped->getDocumentDatabases();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDocumentCollections() : array
+    {
+        return $this->wrapped->getDocumentCollections();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDocumentCollection(string $className) : Collection
+    {
+        return $this->wrapped->getDocumentCollection($className);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDocumentBucket(string $className) : Bucket
+    {
+        return $this->wrapped->getDocumentBucket($className);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProxyFactory()
+    {
+        return $this->wrapped->getProxyFactory();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilterCollection(): FilterCollection
+    {
+        return $this->wrapped->getFilterCollection();
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Decorator/DocumentManagerDecorator.php
+++ b/lib/Doctrine/ODM/MongoDB/Decorator/DocumentManagerDecorator.php
@@ -6,8 +6,10 @@ namespace Doctrine\ODM\MongoDB\Decorator;
 
 use Doctrine\Common\EventManager;
 use Doctrine\ODM\MongoDB\Aggregation\Builder as AggregationBuilder;
+use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManagerInterface;
 use Doctrine\ODM\MongoDB\Hydrator\HydratorFactory;
+use Doctrine\ODM\MongoDB\Proxy\Factory\ProxyFactory;
 use Doctrine\ODM\MongoDB\Proxy\Resolver\ClassNameResolver;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use Doctrine\ODM\MongoDB\Query\FilterCollection;
@@ -123,7 +125,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     /**
      * {@inheritdoc}
      */
-    public function getConfiguration()
+    public function getConfiguration() : Configuration
     {
         return $this->wrapped->getConfiguration();
     }
@@ -131,7 +133,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     /**
      * {@inheritdoc}
      */
-    public function isOpen()
+    public function isOpen() : bool
     {
         return $this->wrapped->isOpen();
     }
@@ -211,7 +213,7 @@ abstract class DocumentManagerDecorator extends ObjectManagerDecorator implement
     /**
      * {@inheritdoc}
      */
-    public function getProxyFactory()
+    public function getProxyFactory() : ProxyFactory
     {
         return $this->wrapped->getProxyFactory();
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->
Add a decorator for the object/document manager, quite similar to the entity manager decorator
This is quite useful when using libraries like Swoole, allowing us to update/switch the object manager when existing connection has been closed.
Tests are missing and would appreciate if I can be directed on how to start
Thanks