### PR TITLE
Introduce aggregation API to replicate query API

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -1,10 +1,16 @@
 # UPGRADE FROM 2.0 to 2.1
 
-The `Doctrine\ODM\MongoDB\Id\AbstractIdGenerator` class has been deprecated. Custom ID generators must implement
-the `Doctrine\ODM\MongoDB\Id\IdGenerator` interface.
+## ID generators
 
-The `Doctrine\ODM\MongoDB\Mapping\ClassMetadata` class has been marked final. The class will no longer be extendable 
-in ODM 3.0.
+The `Doctrine\ODM\MongoDB\Id\AbstractIdGenerator` class has been deprecated.
+Custom ID generators must implement the `Doctrine\ODM\MongoDB\Id\IdGenerator`
+interface.
 
-The `boolean`, `integer`, and `int_id` mapping types have been deprecated. Use their shorthand counterparts: `bool` and 
-`int` respectively. The `int_id` and `int` types are working exactly the same.
+## Metadata
+
+The `Doctrine\ODM\MongoDB\Mapping\ClassMetadata` class has been marked final and
+will no longer be extendable in 3.0.
+
+The `boolean`, `integer`, and `int_id` mapping types have been deprecated. Use
+the `bool`, `int`, and `int` types, respectively. These types behave exactly the
+same.

--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -1,0 +1,10 @@
+# UPGRADE FROM 2.1 to 2.2
+
+## Aggregation
+
+The new `Doctrine\ODM\MongoDB\Aggregation\Builder::getAggregation()` method
+returns an `Doctrine\ODM\MongoDB\Aggregation\Aggregation` instance, comparable
+to the `Query` class.
+
+The `Doctrine\ODM\MongoDB\Aggregation\Builder::execute()` method was deprecated
+and will be removed in ODM 3.0.

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -1,0 +1,23 @@
+# UPGRADE FROM 2.x to 3.0
+
+## Aggregation
+
+The new `Doctrine\ODM\MongoDB\Aggregation\Builder::getAggregation()` method
+returns an `Doctrine\ODM\MongoDB\Aggregation\Aggregation` instance, comparable
+to the `Query` class.
+
+The `Doctrine\ODM\MongoDB\Aggregation\Builder::execute()` method was removed.
+
+## ID generators
+
+The `Doctrine\ODM\MongoDB\Id\AbstractIdGenerator` class has been removed. Custom
+ID generators must implement the `Doctrine\ODM\MongoDB\Id\IdGenerator`
+interface.
+
+## Metadata
+The `Doctrine\ODM\MongoDB\Mapping\ClassMetadata` class has been marked final and
+will no longer be extendable.
+
+The `boolean`, `integer`, and `int_id` mapping types have been removed. Use the
+`bool`, `int`, and `int` types, respectively. These types behave exactly the
+same.

--- a/docs/en/reference/aggregation-builder.rst
+++ b/docs/en/reference/aggregation-builder.rst
@@ -101,15 +101,16 @@ those values into an embedded object for the ``id`` field. For example:
 Executing an aggregation pipeline
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can execute a pipeline using the ``execute()`` method. This will run the
-aggregation pipeline and return a cursor for you to iterate over the results:
+When you are done building your pipeline, you can build an ``Aggregation``
+object using the ``getAggregation()`` method. The returning instance can yield a
+single result or return an iterator containing all results.
 
 .. code-block:: php
 
     <?php
 
     $builder = $dm->createAggregationBuilder(\Documents\User::class);
-    $result = $builder->execute();
+    $result = $builder->getAggregation();
 
 If you instead want to look at the built aggregation pipeline, call the
 ``Builder::getPipeline()`` method.
@@ -209,7 +210,8 @@ can tell the query builder to not return a caching iterator:
     $builder->setRewindable(false);
 
 When setting this option to ``false``, attempting a second iteration will result
-in an exception.
+in an exception. Note that calling ``getAggregation()`` will always yield a
+fresh aggregation instance that can be re-executed.
 
 Aggregation pipeline stages
 ---------------------------

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Iterator\CachingIterator;
+use Doctrine\ODM\MongoDB\Iterator\HydratingIterator;
+use Doctrine\ODM\MongoDB\Iterator\Iterator;
+use Doctrine\ODM\MongoDB\Iterator\UnrewindableIterator;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use IteratorAggregate;
+use MongoDB\Collection;
+use MongoDB\Driver\Cursor;
+use function array_merge;
+use function assert;
+
+final class Aggregation implements IteratorAggregate
+{
+    /** @var DocumentManager */
+    private $dm;
+
+    /** @var ClassMetadata|null */
+    private $classMetadata;
+
+    /** @var Collection */
+    private $collection;
+
+    /** @var array */
+    private $pipeline;
+
+    /** @var array */
+    private $options;
+
+    /** @var bool */
+    private $rewindable;
+
+    public function __construct(DocumentManager $dm, ?ClassMetadata $classMetadata, Collection $collection, array $pipeline, array $options = [], bool $rewindable = true)
+    {
+        $this->dm            = $dm;
+        $this->classMetadata = $classMetadata;
+        $this->collection    = $collection;
+        $this->pipeline      = $pipeline;
+        $this->options       = $options;
+        $this->rewindable    = $rewindable;
+    }
+
+    public function getIterator() : Iterator
+    {
+        // Force cursor to be used
+        $options = array_merge($this->options, ['cursor' => true]);
+
+        $cursor = $this->collection->aggregate($this->pipeline, $options);
+        assert($cursor instanceof Cursor);
+
+        return $this->prepareIterator($cursor);
+    }
+
+    private function prepareIterator(Cursor $cursor) : Iterator
+    {
+        if ($this->classMetadata) {
+            $cursor = new HydratingIterator($cursor, $this->dm->getUnitOfWork(), $this->classMetadata);
+        }
+
+        return $this->rewindable ? new CachingIterator($cursor) : new UnrewindableIterator($cursor);
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -13,6 +13,7 @@ use GeoJson\Geometry\Point;
 use MongoDB\Collection;
 use OutOfRangeException;
 use TypeError;
+use const E_USER_DEPRECATED;
 use function array_map;
 use function array_unshift;
 use function func_get_arg;
@@ -21,6 +22,7 @@ use function gettype;
 use function is_array;
 use function is_bool;
 use function sprintf;
+use function trigger_error;
 
 /**
  * Fluent interface for building aggregation pipelines.
@@ -162,9 +164,16 @@ class Builder
 
     /**
      * Executes the aggregation pipeline
+     *
+     * @deprecated This method was deprecated in doctrine/mongodb-odm 2.2. Please use getAggregation() instead.
      */
     public function execute(array $options = []) : Iterator
     {
+        @trigger_error(
+            sprintf('The "%s" method was deprecated in doctrine/mongodb-odm 2.2. Please use getAggregation() instead.', __METHOD__),
+            E_USER_DEPRECATED
+        );
+
         return $this->getAggregation($options)->getIterator();
     }
 
@@ -211,6 +220,9 @@ class Builder
         return $stage;
     }
 
+    /**
+     * Returns an aggregation object for the current pipeline
+     */
     public function getAggregation(array $options = []) : Aggregation
     {
         $class = $this->hydrationClass ? $this->dm->getClassMetadata($this->hydrationClass) : null;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -6,6 +6,9 @@ namespace Doctrine\ODM\MongoDB\Aggregation;
 
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use GeoJson\Geometry\Point;
+use const E_USER_DEPRECATED;
+use function sprintf;
+use function trigger_error;
 
 /**
  * Fluent interface for building aggregation pipelines.
@@ -29,9 +32,16 @@ abstract class Stage
 
     /**
      * Executes the aggregation pipeline
+     *
+     * @deprecated This method was deprecated in doctrine/mongodb-odm 2.2. Please use getAggregation() instead.
      */
     public function execute(array $options = []) : Iterator
     {
+        @trigger_error(
+            sprintf('The "%s" method was deprecated in doctrine/mongodb-odm 2.2. Please use getAggregation() instead.', __METHOD__),
+            E_USER_DEPRECATED
+        );
+
         return $this->builder->execute($options);
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -36,6 +36,14 @@ abstract class Stage
     }
 
     /**
+     * Returns an aggregation object for the current pipeline
+     */
+    public function getAggregation(array $options = []) : Aggregation
+    {
+        return $this->builder->getAggregation($options);
+    }
+
+    /**
      * Adds new fields to documents. $addFields outputs documents that contain
      * all existing fields from the input documents and newly added fields.
      *


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

This introduces a new `Aggregation` class, that can be created from an aggregation builder using the `getAggregation` method. The `execute` method on the aggregation builder has been deprecated in favour of the new API.

#### Rationale

The query builder returns a query instance that can be passed around without executing the query, but also disallowing changes to the query. The aggregation builder on the other hand only returns an iterator that may or may not have already executed something on the database. Passing the aggregation builder around opens it up to modification that may not be intended.