### PR TITLE
Throw exception for targetDocument & discriminatorMap field mapping

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -1935,6 +1935,10 @@ use function trigger_error;
         if (isset($mapping['repositoryMethod']) && ! (empty($mapping['skip']) && empty($mapping['limit']) && empty($mapping['sort']))) {
             throw MappingException::repositoryMethodCanNotBeCombinedWithSkipLimitAndSort($this->name, $mapping['fieldName']);
         }
+        
+        if (isset($mapping['targetDocument']) && isset($mapping['discriminatorMap'])) {
+            throw MappingException::targetDocumentCanNotBeCombinedWithDiscriminatorMap($this->name, $mapping['fieldName']);
+        }
 
         if (isset($mapping['reference']) && $mapping['type'] === 'one') {
             $mapping['association'] = self::REFERENCE_ONE;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -1935,7 +1935,7 @@ use function trigger_error;
         if (isset($mapping['repositoryMethod']) && ! (empty($mapping['skip']) && empty($mapping['limit']) && empty($mapping['sort']))) {
             throw MappingException::repositoryMethodCanNotBeCombinedWithSkipLimitAndSort($this->name, $mapping['fieldName']);
         }
-        
+
         if (isset($mapping['targetDocument']) && isset($mapping['discriminatorMap'])) {
             throw MappingException::targetDocumentCanNotBeCombinedWithDiscriminatorMap($this->name, $mapping['fieldName']);
         }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -270,7 +270,7 @@ final class MappingException extends BaseMappingException
     {
         return new self(sprintf('Root class "%s" for view "%s" could not be found.', $rootClass, $className));
     }
-    
+
     public static function targetDocumentCanNotBeCombinedWithDiscriminatorMap(string $className, string $fieldName) : self
     {
         return new self(sprintf('Cannot combine "targetDocument" and "discriminatorMap" on field "%s" in class "%s".', $fieldName, $className));

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -270,4 +270,9 @@ final class MappingException extends BaseMappingException
     {
         return new self(sprintf('Root class "%s" for view "%s" could not be found.', $rootClass, $className));
     }
+    
+    public static function targetDocumentCanNotBeCombinedWithDiscriminatorMap(string $className, string $fieldName) : self
+    {
+        return new self(sprintf('Cannot combine "targetDocument" and "discriminatorMap" on field "%s" in class "%s".', $fieldName, $className));
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -770,10 +770,6 @@ class DocumentPersisterTestDocument
      * @ODM\EmbedOne(
      *     targetDocument=Doctrine\ODM\MongoDB\Tests\Functional\AbstractDocumentPersisterTestDocumentAssociation::class,
      *     discriminatorField="type",
-     *     discriminatorMap={
-     *         "reference"=Doctrine\ODM\MongoDB\Tests\Functional\DocumentPersisterTestDocumentReference::class,
-     *         "embed"=Doctrine\ODM\MongoDB\Tests\Functional\DocumentPersisterTestDocumentEmbed::class
-     *     },
      *     name="associationName"
      * )
      */
@@ -826,10 +822,6 @@ abstract class AbstractDocumentPersisterTestDocumentAssociation
      * @ODM\EmbedOne(
      *     targetDocument=Doctrine\ODM\MongoDB\Tests\Functional\AbstractDocumentPersisterTestDocumentAssociation::class,
      *     discriminatorField="type",
-     *     discriminatorMap={
-     *         "reference"=Doctrine\ODM\MongoDB\Tests\Functional\DocumentPersisterTestDocumentReference::class,
-     *         "embed"=Doctrine\ODM\MongoDB\Tests\Functional\DocumentPersisterTestDocumentEmbed::class
-     *     },
      *     name="associationName"
      * )
      */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
@@ -67,7 +67,7 @@ class GH267User
     /** @ODM\Field(type="string") */
     protected $name;
 
-    /** @ODM\ReferenceOne(name="company", targetDocument=GH267Company::class, discriminatorMap={"seller"=GH267SellerCompany::class, "buyer"=GH267BuyerCompany::class}, inversedBy="users") */
+    /** @ODM\ReferenceOne(name="company", targetDocument=GH267Company::class, inversedBy="users") */
     protected $company;
 
     public function __construct($name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -624,7 +624,7 @@ class AbstractMappingDriverUser
     /** @ODM\ReferenceOne(targetDocument=Address::class, cascade={"remove"}) */
     public $address;
 
-    /** @ODM\ReferenceMany(targetDocument=Phonenumber::class, collectionClass=PhonenumberCollection::class, cascade={"persist"}, discriminatorField="discr", discriminatorMap={"home"=HomePhonenumber::class, "work"=WorkPhonenumber::class}, defaultDiscriminatorValue="home") */
+    /** @ODM\ReferenceMany(collectionClass=PhonenumberCollection::class, cascade={"persist"}, discriminatorField="discr", discriminatorMap={"home"=HomePhonenumber::class, "work"=WorkPhonenumber::class}, defaultDiscriminatorValue="home") */
     public $phonenumbers;
 
     /** @ODM\ReferenceMany(targetDocument=Group::class, cascade={"all"}) */
@@ -636,7 +636,7 @@ class AbstractMappingDriverUser
     /** @ODM\EmbedMany(targetDocument=Phonenumber::class, name="embedded_phone_number") */
     public $embeddedPhonenumber;
 
-    /** @ODM\EmbedMany(targetDocument=Phonenumber::class, discriminatorField="discr", discriminatorMap={"home"=HomePhonenumber::class, "work"=WorkPhonenumber::class}, defaultDiscriminatorValue="home") */
+    /** @ODM\EmbedMany(discriminatorField="discr", discriminatorMap={"home"=HomePhonenumber::class, "work"=WorkPhonenumber::class}, defaultDiscriminatorValue="home") */
     public $otherPhonenumbers;
 
     /** @ODM\Field(type="date") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -323,6 +323,63 @@ class ClassMetadataTest extends BaseTest
         );
     }
 
+    public function testEmbedManyDocumentWithTargetDocumentAndDiscriminatorMap()
+    {
+        $cm = new ClassMetadata(CmsUser::class);
+
+        $this->expectException(MappingException::class);
+        $cm->mapManyEmbedded([
+            'field' => 'name',
+            'targetDocument' => 'CmsUser',
+            'discriminatorMap' => [
+                'default' => 'CmsUser',
+            ],
+        ]);
+    }
+
+    public function testEmbedOneDocumentWithTargetDocumentAndDiscriminatorMap()
+    {
+        $cm = new ClassMetadata(CmsUser::class);
+
+        $this->expectException(MappingException::class);
+        $cm->mapOneEmbedded([
+            'field' => 'name',
+            'targetDocument' => 'CmsUser',
+            'discriminatorMap' => [
+                'default' => 'CmsUser',
+            ],
+        ]);
+    }
+
+    public function testReferenceManyDocumentWithTargetDocumentAndDiscriminatorMap()
+    {
+        $cm = new ClassMetadata(CmsUser::class);
+
+        $this->expectException(MappingException::class);
+        $cm->mapManyReference([
+            'field' => 'name',
+            'targetDocument' => 'CmsUser',
+            'discriminatorMap' => [
+                'default' => 'CmsUser',
+            ],
+        ]);
+    }
+
+
+    public function testReferenceOneDocumentWithTargetDocumentAndDiscriminatorMap()
+    {
+        $cm = new ClassMetadata(CmsUser::class);
+
+        $this->expectException(MappingException::class);
+        $cm->mapOneReference([
+            'field' => 'name',
+            'targetDocument' => 'CmsUser',
+            'discriminatorMap' => [
+                'default' => 'CmsUser',
+            ],
+        ]);
+    }
+
     public function testGetFieldValue()
     {
         $document = new Album('ten');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -331,9 +331,7 @@ class ClassMetadataTest extends BaseTest
         $cm->mapManyEmbedded([
             'field' => 'name',
             'targetDocument' => 'CmsUser',
-            'discriminatorMap' => [
-                'default' => 'CmsUser',
-            ],
+            'discriminatorMap' => ['default' => 'CmsUser'],
         ]);
     }
 
@@ -345,9 +343,7 @@ class ClassMetadataTest extends BaseTest
         $cm->mapOneEmbedded([
             'field' => 'name',
             'targetDocument' => 'CmsUser',
-            'discriminatorMap' => [
-                'default' => 'CmsUser',
-            ],
+            'discriminatorMap' => ['default' => 'CmsUser'],
         ]);
     }
 
@@ -359,12 +355,9 @@ class ClassMetadataTest extends BaseTest
         $cm->mapManyReference([
             'field' => 'name',
             'targetDocument' => 'CmsUser',
-            'discriminatorMap' => [
-                'default' => 'CmsUser',
-            ],
+            'discriminatorMap' => ['default' => 'CmsUser'],
         ]);
     }
-
 
     public function testReferenceOneDocumentWithTargetDocumentAndDiscriminatorMap()
     {
@@ -374,9 +367,7 @@ class ClassMetadataTest extends BaseTest
         $cm->mapOneReference([
             'field' => 'name',
             'targetDocument' => 'CmsUser',
-            'discriminatorMap' => [
-                'default' => 'CmsUser',
-            ],
+            'discriminatorMap' => ['default' => 'CmsUser'],
         ]);
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #2203

#### Summary

Throws an exception when `discriminatorMap` is used alongside with `targetDocument`.

When used together their behavior was to discard object different than `targetDocument` specified, which lead to potential data loss.

I'm not sure about the tests, or placement of functions / checks, so correct me please :smiley_cat: 
