### PR TITLE
Remove safe index option from documentation

### DIFF
--- a/docs/en/reference/indexes.rst
+++ b/docs/en/reference/indexes.rst
@@ -46,10 +46,6 @@ You can customize the index with some additional options:
    synchronously. If you specify TRUE with this option, index creation
    will be asynchronous.
 -
-   **safe** - You can specify a boolean value for checking if the
-   index creation succeeded. The driver will throw a
-   ``MongoDB\Driver\Exception\CommandException`` if index creation failed.
--
    **expireAfterSeconds** - If you specify this option then the associated
    document will be automatically removed when the provided time (in seconds)
    has passed. This option is bound to a number of limitations, which


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

The `safe` option is no longer supported by MongoDB and was dropped without replacement in 2.0 (see UPGRADE-2.0 document). This removes a left-over instance of that option in the documentation.