### PR TITLE
Move phpcs to Github actions

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,0 +1,47 @@
+
+name: "Coding Standards"
+
+on:
+  pull_request:
+    branches:
+      - "*.x"
+      - "master"
+  push:
+    branches:
+      - "*.x"
+      - "master"
+
+jobs:
+  coding-standards:
+    name: "Coding Standards"
+    runs-on: "ubuntu-20.04"
+
+    strategy:
+      matrix:
+        php-version:
+          - "7.4"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          tools: "cs2pr"
+
+      - name: "Cache dependencies installed with Composer"
+        uses: "actions/cache@v2"
+        with:
+          path: "~/.composer/cache"
+          key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"
+          restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
+
+      - name: "Install dependencies with Composer"
+        run: "composer install --no-interaction --no-progress --no-suggest"
+
+      # https://github.com/doctrine/.github/issues/3
+      - name: "Run PHP_CodeSniffer"
+        run: "vendor/bin/phpcs -q --no-colors --report=checkstyle | cs2pr"

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,11 +63,6 @@ jobs:
       script:
         - vendor/bin/phpstan analyse
 
-    - stage: Code Quality
-      php: 7.2
-      script:
-        - vendor/bin/phpcs
-
     # Performance tests
     - stage: Performance
       php: 7.3


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

<!-- Provide a summary your change. -->
This PR moves phpcs check from travis to Github action using https://github.com/doctrine/.github/blob/a30adfd2efc185595e43d9338e5617048f5e99a9/workflow-templates/coding-standards.yml as a template.

The GA does not execute because it's a remote branch, I've created a PR to my own showing how it works: https://github.com/franmomu/mongodb-odm/pull/3