### PR TITLE
Fix links to mongodb manual

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -138,7 +138,7 @@ class Builder
      * $collStats must be the first stage in an aggregation pipeline, or else
      * the pipeline returns an error.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/collStats/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/collStats/
      */
     public function collStats() : Stage\CollStats
     {
@@ -207,7 +207,7 @@ class Builder
      *
      * You can only use this as the first stage of a pipeline.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/geoNear/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/geoNear/
      *
      * @param float|array|Point $x
      * @param float             $y
@@ -308,7 +308,7 @@ class Builder
      * Performs a recursive search on a collection, with options for restricting
      * the search by recursion depth and query filter.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/graphLookup/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/graphLookup/
      *
      * @param string $from Target collection for the $graphLookup operation to
      * search, recursively matching the connectFromField to the connectToField.
@@ -325,7 +325,7 @@ class Builder
      * Groups documents by some specified expression and outputs to the next
      * stage a document for each distinct grouping.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/group/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/group/
      */
     public function group() : Stage\Group
     {
@@ -348,7 +348,7 @@ class Builder
     /**
      * Returns statistics regarding the use of each index for the collection.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/indexStats/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/indexStats/
      */
     public function indexStats() : Stage\IndexStats
     {
@@ -361,7 +361,7 @@ class Builder
     /**
      * Limits the number of documents passed to the next stage in the pipeline.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/limit/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/limit/
      */
     public function limit(int $limit) : Stage\Limit
     {
@@ -376,7 +376,7 @@ class Builder
      * database to filter in documents from the “joined” collection for
      * processing.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/lookup/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/lookup/
      */
     public function lookup(string $from) : Stage\Lookup
     {
@@ -390,7 +390,7 @@ class Builder
      * Filters the documents to pass only the documents that match the specified
      * condition(s) to the next pipeline stage.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/match/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/match/
      */
     public function match() : Stage\Match
     {
@@ -415,7 +415,7 @@ class Builder
      * Takes the documents returned by the aggregation pipeline and writes them
      * to a specified collection. This must be the last stage in the pipeline.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/out/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/out/
      */
     public function out(string $from) : Stage\Out
     {
@@ -430,7 +430,7 @@ class Builder
      * stage in the pipeline. The specified fields can be existing fields from
      * the input documents or newly computed fields.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/project/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/project/
      */
     public function project() : Stage\Project
     {
@@ -444,7 +444,7 @@ class Builder
      * Restricts the contents of the documents based on information stored in
      * the documents themselves.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/redact/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/redact/
      */
     public function redact() : Stage\Redact
     {
@@ -486,7 +486,7 @@ class Builder
     /**
      * Randomly selects the specified number of documents from its input.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/sample/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sample/
      */
     public function sample(int $size) : Stage\Sample
     {
@@ -500,7 +500,7 @@ class Builder
      * Skips over the specified number of documents that pass into the stage and
      * passes the remaining documents to the next stage in the pipeline.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/skip/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/skip/
      */
     public function skip(int $skip) : Stage\Skip
     {
@@ -517,7 +517,7 @@ class Builder
      * If sorting by multiple fields, the first argument should be an array of
      * field name (key) and order (value) pairs.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/sort/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sort/
      *
      * @param array|string $fieldName Field name or array of field/order pairs
      * @param int|string   $order     Field order (if one field is specified)
@@ -536,7 +536,7 @@ class Builder
      * Groups incoming documents based on the value of a specified expression,
      * then computes the count of documents in each distinct group.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/sortByCount/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sortByCount/
      */
     public function sortByCount(string $expression) : Stage\SortByCount
     {
@@ -551,7 +551,7 @@ class Builder
      * for each element. Each output document is the input document with the
      * value of the array field replaced by the element.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/unwind/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/unwind/
      */
     public function unwind(string $fieldName) : Stage\Unwind
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
@@ -59,7 +59,7 @@ class Expr
      * The <number> argument can be any valid expression as long as it resolves
      * to a number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/abs/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/abs/
      *
      * @param mixed|self $number
      */
@@ -76,7 +76,7 @@ class Expr
      * The arguments can be any valid expression as long as they resolve to
      * either all numbers or to numbers and a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/add/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/add/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -90,7 +90,7 @@ class Expr
     /**
      * Adds one or more $and clauses to the current expression.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/and/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/and/
      *
      * @param array|self $expression
      * @param array|self ...$expressions
@@ -109,7 +109,7 @@ class Expr
     /**
      * Adds one or more $or clause to the current expression.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/or/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/or/
      *
      * @param array|self $expression
      * @param array|self ...$expressions
@@ -132,7 +132,7 @@ class Expr
      *
      * AddToSet is an accumulator operation only available in the group stage.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/addToSet/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/addToSet/
      *
      * @param mixed|self $expression
      */
@@ -147,7 +147,7 @@ class Expr
      *
      * The expression must resolve to an array.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/allElementsTrue/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/allElementsTrue/
      *
      * @param mixed|self $expression
      */
@@ -162,7 +162,7 @@ class Expr
      *
      * The expression must resolve to an array.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/anyElementTrue/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/anyElementTrue/
      *
      * @param array|self $expression
      */
@@ -179,7 +179,7 @@ class Expr
      * The <idx> expression can be any valid expression as long as it resolves
      * to an integer.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/arrayElemAt/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/arrayElemAt/
      *
      * @param mixed|self $array
      * @param mixed|self $index
@@ -194,7 +194,7 @@ class Expr
      * a specified expression to each document in a group of documents that
      * share the same group by key. Ignores nun-numeric values.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/avg/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/avg/
      *
      * @param mixed|self $expression
      */
@@ -227,7 +227,7 @@ class Expr
      * The <number> expression can be any valid expression as long as it
      * resolves to a number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/ceil/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/ceil/
      *
      * @param mixed|self $number
      */
@@ -242,7 +242,7 @@ class Expr
      * 1 if the first value is greater than the second.
      * 0 if the two values are equivalent.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/cmp/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/cmp/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -259,7 +259,7 @@ class Expr
      * strings. If the argument resolves to a value of null or refers to a field
      * that is missing, $concat returns null.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/concat/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/concat/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -276,7 +276,7 @@ class Expr
      * The <array> expressions can be any valid expression as long as they
      * resolve to an array.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/concatArrays/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/concatArrays/
      *
      * @param mixed|self $array1
      * @param mixed|self $array2
@@ -293,7 +293,7 @@ class Expr
      *
      * The arguments can be any valid expression.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/cond/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/cond/
      *
      * @param mixed|self $if
      * @param mixed|self $then
@@ -339,7 +339,7 @@ class Expr
      * specifiers.
      * The date argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/dateToString/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dateToString/
      *
      * @param mixed|self $expression
      */
@@ -353,7 +353,7 @@ class Expr
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/dayOfMonth/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dayOfMonth/
      *
      * @param mixed|self $expression
      */
@@ -368,7 +368,7 @@ class Expr
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/dayOfWeek/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dayOfWeek/
      *
      * @param mixed|self $expression
      */
@@ -382,7 +382,7 @@ class Expr
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/dayOfYear/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dayOfYear/
      *
      * @param mixed|self $expression
      */
@@ -421,7 +421,7 @@ class Expr
      *
      * The arguments can be any valid expression as long as the resolve to numbers.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/divide/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/divide/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -434,7 +434,7 @@ class Expr
     /**
      * Compares two values and returns whether the are equivalent.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/eq/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/eq/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -450,7 +450,7 @@ class Expr
      * The <exponent> expression can be any valid expression as long as it
      * resolves to a number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/exp/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/exp/
      *
      * @param mixed|self $exponent
      */
@@ -470,7 +470,7 @@ class Expr
     /**
      * Allows any expression to be used as a field value.
      *
-     * @see http://docs.mongodb.org/manual/meta/aggregation-quick-reference/#aggregation-expressions
+     * @see https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions
      *
      * @param mixed|self $value
      */
@@ -499,7 +499,7 @@ class Expr
      * Returns an array with only those elements that match the condition. The
      * returned elements are in the original order.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/filter/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/filter/
      *
      * @param mixed|self $input
      * @param mixed|self $as
@@ -515,7 +515,7 @@ class Expr
      * document in a group of documents that share the same group by key. Only
      * meaningful when documents are in a defined order.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/first/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/first/
      *
      * @param mixed|self $expression
      */
@@ -530,7 +530,7 @@ class Expr
      * The <number> expression can be any valid expression as long as it
      * resolves to a number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/floor/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/floor/
      *
      * @param mixed|self $number
      */
@@ -550,7 +550,7 @@ class Expr
      * false when the first value is less than or equivalent to the second
      * value.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/gt/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/gt/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -566,7 +566,7 @@ class Expr
      * value.
      * false when the first value is less than the second value.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/gte/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/gte/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -581,7 +581,7 @@ class Expr
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/hour/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/hour/
      *
      * @param mixed|self $expression
      */
@@ -598,7 +598,7 @@ class Expr
      *
      * The arguments can be any valid expression.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/ifNull/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/ifNull/
      *
      * @param mixed|self $expression
      * @param mixed|self $replacementExpression
@@ -707,7 +707,7 @@ class Expr
      *
      * The <expression> can be any valid expression.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/isArray/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isArray/
      *
      * @param mixed|self $expression
      */
@@ -722,7 +722,7 @@ class Expr
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/isoDayOfWeek/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isoDayOfWeek/
      *
      * @param mixed|self $expression
      */
@@ -739,7 +739,7 @@ class Expr
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/isoWeek/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isoWeek/
      *
      * @param mixed|self $expression
      */
@@ -756,7 +756,7 @@ class Expr
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/isoWeek/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isoWeek/
      *
      * @param mixed|self $expression
      */
@@ -770,7 +770,7 @@ class Expr
      * document in a group of documents that share the same group by a field.
      * Only meaningful when documents are in a defined order.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/last/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/last/
      *
      * @param mixed|self $expression
      */
@@ -783,7 +783,7 @@ class Expr
      * Binds variables for use in the specified expression, and returns the
      * result of the expression.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/let/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/let/
      *
      * @param mixed|self $vars Assignment block for the variables accessible in the in expression. To assign a variable, specify a string for the variable name and assign a valid expression for the value.
      * @param mixed|self $in   The expression to evaluate.
@@ -797,7 +797,7 @@ class Expr
      * Returns a value without parsing. Use for values that the aggregation
      * pipeline may interpret as an expression.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/literal/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/literal/
      *
      * @param mixed|self $value
      */
@@ -813,7 +813,7 @@ class Expr
      * The <number> expression can be any valid expression as long as it
      * resolves to a non-negative number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/log/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/log/
      *
      * @param mixed|self $number
      */
@@ -831,7 +831,7 @@ class Expr
      * The <base> expression can be any valid expression as long as it resolves
      * to a positive number greater than 1.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/log/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/log/
      *
      * @param mixed|self $number
      * @param mixed|self $base
@@ -847,7 +847,7 @@ class Expr
      * The <number> expression can be any valid expression as long as it
      * resolves to a non-negative number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/log10/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/log10/
      *
      * @param mixed|self $number
      */
@@ -862,7 +862,7 @@ class Expr
      * false when the first value is greater than or equivalent to the second
      * value.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/lt/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/lt/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -877,7 +877,7 @@ class Expr
      * true when the first value is less than or equivalent to the second value.
      * false when the first value is greater than the second value.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/lte/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/lte/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -891,7 +891,7 @@ class Expr
      * Applies an expression to each item in an array and returns an array with
      * the applied results.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/map/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/map/
      *
      * @param mixed|self $input An expression that resolves to an array.
      * @param string     $as    The variable name for the items in the input array. The in expression accesses each item in the input array by this variable.
@@ -906,7 +906,7 @@ class Expr
      * Returns the highest value that results from applying an expression to
      * each document in a group of documents that share the same group by key.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/max/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/max/
      *
      * @param mixed|self $expression
      */
@@ -918,7 +918,7 @@ class Expr
     /**
      * Returns the metadata associated with a document in a pipeline operations.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/meta/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/meta/
      *
      * @param mixed|self $metaDataKeyword
      */
@@ -932,7 +932,7 @@ class Expr
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/millisecond/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/millisecond/
      *
      * @param mixed|self $expression
      */
@@ -945,7 +945,7 @@ class Expr
      * Returns the lowest value that results from applying an expression to each
      * document in a group of documents that share the same group by key.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/min/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/min/
      *
      * @param mixed|self $expression
      */
@@ -959,7 +959,7 @@ class Expr
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/minute/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/minute/
      *
      * @param mixed|self $expression
      */
@@ -974,7 +974,7 @@ class Expr
      *
      * The arguments can be any valid expression as long as they resolve to numbers.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/mod/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/mod/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -989,7 +989,7 @@ class Expr
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/month/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/month/
      *
      * @param mixed|self $expression
      */
@@ -1003,7 +1003,7 @@ class Expr
      *
      * The arguments can be any valid expression as long as they resolve to numbers.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/multiply/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/multiply/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -1019,7 +1019,7 @@ class Expr
      * true when the values are not equivalent.
      * false when the values are equivalent.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/ne/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/ne/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -1032,7 +1032,7 @@ class Expr
     /**
      * Evaluates a boolean and returns the opposite boolean value.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/not/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/not/
      *
      * @param mixed|self $expression
      */
@@ -1049,7 +1049,7 @@ class Expr
      * The <exponent> expression can be any valid expression as long as it
      * resolves to a number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/pow/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/pow/
      *
      * @param mixed|self $number
      * @param mixed|self $exponent
@@ -1063,7 +1063,7 @@ class Expr
      * Returns an array of all values that result from applying an expression to
      * each document in a group of documents that share the same group by key.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/push/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/push/
      *
      * @param mixed|self $expression
      */
@@ -1122,7 +1122,7 @@ class Expr
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/second/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/second/
      *
      * @param mixed|self $expression
      */
@@ -1137,7 +1137,7 @@ class Expr
      *
      * The arguments can be any valid expression as long as they each resolve to an array.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/setDifference/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/setDifference/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -1153,7 +1153,7 @@ class Expr
      *
      * The arguments can be any valid expression as long as they each resolve to an array.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/setEquals/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/setEquals/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -1170,7 +1170,7 @@ class Expr
      *
      * The arguments can be any valid expression as long as they each resolve to an array.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/setIntersection/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/setIntersection/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -1187,7 +1187,7 @@ class Expr
      *
      * The arguments can be any valid expression as long as they each resolve to an array.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/setIsSubset/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/setIsSubset/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -1203,7 +1203,7 @@ class Expr
      *
      * The arguments can be any valid expression as long as they each resolve to an array.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/setUnion/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/setUnion/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -1219,7 +1219,7 @@ class Expr
      *
      * The argument can be any expression as long as it resolves to an array.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/size/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/size/
      *
      * @param mixed|self $expression
      */
@@ -1231,7 +1231,7 @@ class Expr
     /**
      * Returns a subset of an array.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/slice/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/slice/
      *
      * @param mixed|self      $array
      * @param mixed|self      $n
@@ -1270,7 +1270,7 @@ class Expr
      * The argument can be any valid expression as long as it resolves to a
      * non-negative number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/sqrt/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sqrt/
      *
      * @param mixed|self $expression
      */
@@ -1284,7 +1284,7 @@ class Expr
      *
      * The arguments can be any expression as long as it resolves to an array.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/stdDevPop/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevPop/
      *
      * @param mixed|self $expression1
      * @param mixed|self ...$expressions Additional samples
@@ -1301,7 +1301,7 @@ class Expr
      *
      * The arguments can be any expression as long as it resolves to an array.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/stdDevSamp/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevSamp/
      *
      * @param mixed|self $expression1
      * @param mixed|self ...$expressions Additional samples
@@ -1321,7 +1321,7 @@ class Expr
      *
      * The arguments can be any valid expression as long as they resolve to strings.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/strcasecmp/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/strcasecmp/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -1361,7 +1361,7 @@ class Expr
      *
      * The arguments can be any valid expression as long as long as the first argument resolves to a string, and the second and third arguments resolve to integers.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/substr/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/substr/
      *
      * @param mixed|self $string
      * @param mixed|self $start
@@ -1414,7 +1414,7 @@ class Expr
      *
      * The arguments can be any valid expression as long as they resolve to numbers and/or dates.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/subtract/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/subtract/
      *
      * @param mixed|self $expression1
      * @param mixed|self $expression2
@@ -1429,7 +1429,7 @@ class Expr
      * applying a specified expression to each document in a group of documents
      * that share the same group by key. Ignores nun-numeric values.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/sum/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sum/
      *
      * @param mixed|self $expression
      */
@@ -1443,7 +1443,7 @@ class Expr
      *
      * The argument can be any expression as long as it resolves to a string.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/toLower/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/toLower/
      *
      * @param mixed|self $expression
      */
@@ -1457,7 +1457,7 @@ class Expr
      *
      * The argument can be any expression as long as it resolves to a string.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/toUpper/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/toUpper/
      *
      * @param mixed|self $expression
      */
@@ -1472,7 +1472,7 @@ class Expr
      * The <number> expression can be any valid expression as long as it
      * resolves to a number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/trunc/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/trunc/
      *
      * @param mixed|self $number
      */
@@ -1486,7 +1486,7 @@ class Expr
      *
      * The argument can be any valid expression.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/type/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/type/
      *
      * @param mixed|self $expression
      */
@@ -1500,7 +1500,7 @@ class Expr
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/week/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/week/
      *
      * @param mixed|self $expression
      */
@@ -1514,7 +1514,7 @@ class Expr
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/year/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/year/
      *
      * @param mixed|self $expression
      */

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -110,7 +110,7 @@ abstract class Stage
      * $collStats must be the first stage in an aggregation pipeline, or else
      * the pipeline returns an error.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/geoNear/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/geoNear/
      */
     public function collStats() : Stage\CollStats
     {
@@ -144,7 +144,7 @@ abstract class Stage
      * Outputs documents in order of nearest to farthest from a specified point.
      * You can only use this as the first stage of a pipeline.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/geoNear/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/geoNear/
      *
      * @param float|array|Point $x
      * @param float             $y
@@ -166,7 +166,7 @@ abstract class Stage
      * Performs a recursive search on a collection, with options for restricting
      * the search by recursion depth and query filter.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/graphLookup/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/graphLookup/
      *
      * @param string $from Target collection for the $graphLookup operation to
      * search, recursively matching the connectFromField to the connectToField.
@@ -180,7 +180,7 @@ abstract class Stage
      * Groups documents by some specified expression and outputs to the next
      * stage a document for each distinct grouping.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/group/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/group/
      */
     public function group() : Stage\Group
     {
@@ -190,7 +190,7 @@ abstract class Stage
     /**
      * Returns statistics regarding the use of each index for the collection.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/indexStats/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/indexStats/
      */
     public function indexStats() : Stage\IndexStats
     {
@@ -200,7 +200,7 @@ abstract class Stage
     /**
      * Limits the number of documents passed to the next stage in the pipeline.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/limit/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/limit/
      *
      * @return Stage\Limit
      */
@@ -214,7 +214,7 @@ abstract class Stage
      * database to filter in documents from the “joined” collection for
      * processing.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/lookup/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/lookup/
      */
     public function lookup(string $from) : Stage\Lookup
     {
@@ -225,7 +225,7 @@ abstract class Stage
      * Filters the documents to pass only the documents that match the specified
      * condition(s) to the next pipeline stage.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/match/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/match/
      */
     public function match() : Stage\Match
     {
@@ -236,7 +236,7 @@ abstract class Stage
      * Takes the documents returned by the aggregation pipeline and writes them
      * to a specified collection. This must be the last stage in the pipeline.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/out/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/out/
      */
     public function out(string $collection) : Stage\Out
     {
@@ -248,7 +248,7 @@ abstract class Stage
      * stage in the pipeline. The specified fields can be existing fields from
      * the input documents or newly computed fields.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/project/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/project/
      */
     public function project() : Stage\Project
     {
@@ -259,7 +259,7 @@ abstract class Stage
      * Restricts the contents of the documents based on information stored in
      * the documents themselves.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/redact/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/redact/
      */
     public function redact() : Stage\Redact
     {
@@ -295,7 +295,7 @@ abstract class Stage
     /**
      * Randomly selects the specified number of documents from its input.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/sample/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sample/
      */
     public function sample(int $size) : Stage\Sample
     {
@@ -306,7 +306,7 @@ abstract class Stage
      * Skips over the specified number of documents that pass into the stage and
      * passes the remaining documents to the next stage in the pipeline.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/skip/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/skip/
      */
     public function skip(int $skip) : Stage\Skip
     {
@@ -317,7 +317,7 @@ abstract class Stage
      * Groups incoming documents based on the value of a specified expression,
      * then computes the count of documents in each distinct group.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/sortByCount/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sortByCount/
      */
     public function sortByCount(string $expression) : Stage\SortByCount
     {
@@ -330,7 +330,7 @@ abstract class Stage
      * If sorting by multiple fields, the first argument should be an array of
      * field name (key) and order (value) pairs.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/sort/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sort/
      *
      * @param array|string $fieldName Field name or array of field/order pairs
      * @param int|string   $order     Field order (if one field is specified)
@@ -345,7 +345,7 @@ abstract class Stage
      * for each element. Each output document is the input document with the
      * value of the array field replaced by the element.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/unwind/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/unwind/
      */
     public function unwind(string $fieldName) : Stage\Unwind
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket/AbstractOutput.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket/AbstractOutput.php
@@ -44,7 +44,7 @@ abstract class AbstractOutput extends Stage
      *
      * AddToSet is an accumulator operation only available in the group stage.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/addToSet/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/addToSet/
      * @see Expr::addToSet
      *
      * @param mixed|Expr $expression
@@ -63,7 +63,7 @@ abstract class AbstractOutput extends Stage
      * a specified expression to each document in a group of documents that
      * share the same group by key. Ignores nun-numeric values.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/avg/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/avg/
      * @see Expr::avg
      *
      * @param mixed|Expr $expression
@@ -80,7 +80,7 @@ abstract class AbstractOutput extends Stage
     /**
      * Used to use an expression as field value. Can be any expression.
      *
-     * @see http://docs.mongodb.org/manual/meta/aggregation-quick-reference/#aggregation-expressions
+     * @see https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions
      * @see Expr::expression
      *
      * @param mixed|Expr $value
@@ -115,7 +115,7 @@ abstract class AbstractOutput extends Stage
      * document in a group of documents that share the same group by key. Only
      * meaningful when documents are in a defined order.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/first/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/first/
      * @see Expr::first
      *
      * @param mixed|Expr $expression
@@ -134,7 +134,7 @@ abstract class AbstractOutput extends Stage
      * document in a group of documents that share the same group by a field.
      * Only meaningful when documents are in a defined order.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/last/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/last/
      * @see Expr::last
      *
      * @param mixed|Expr $expression
@@ -152,7 +152,7 @@ abstract class AbstractOutput extends Stage
      * Returns the highest value that results from applying an expression to
      * each document in a group of documents that share the same group by key.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/max/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/max/
      * @see Expr::max
      *
      * @param mixed|Expr $expression
@@ -170,7 +170,7 @@ abstract class AbstractOutput extends Stage
      * Returns the lowest value that results from applying an expression to each
      * document in a group of documents that share the same group by key.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/min/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/min/
      * @see Expr::min
      *
      * @param mixed|Expr $expression
@@ -188,7 +188,7 @@ abstract class AbstractOutput extends Stage
      * Returns an array of all values that result from applying an expression to
      * each document in a group of documents that share the same group by key.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/push/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/push/
      * @see Expr::push
      *
      * @param mixed|Expr $expression
@@ -207,7 +207,7 @@ abstract class AbstractOutput extends Stage
      *
      * The argument can be any expression as long as it resolves to an array.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/stdDevPop/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevPop/
      * @see Expr::stdDevPop
      *
      * @param mixed|Expr $expression
@@ -226,7 +226,7 @@ abstract class AbstractOutput extends Stage
      *
      * The argument can be any expression as long as it resolves to an array.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/stdDevSamp/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevSamp/
      * @see Expr::stdDevSamp
      *
      * @param mixed|Expr $expression
@@ -245,7 +245,7 @@ abstract class AbstractOutput extends Stage
      * applying a specified expression to each document in a group of documents
      * that share the same group by key. Ignores nun-numeric values.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/sum/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sum/
      * @see Expr::sum
      *
      * @param mixed|Expr $expression

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Group.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Group.php
@@ -42,7 +42,7 @@ class Group extends Operator
      *
      * AddToSet is an accumulator operation only available in the group stage.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/addToSet/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/addToSet/
      * @see Expr::addToSet
      *
      * @param mixed|Expr $expression
@@ -61,7 +61,7 @@ class Group extends Operator
      * a specified expression to each document in a group of documents that
      * share the same group by key. Ignores nun-numeric values.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/avg/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/avg/
      * @see Expr::avg
      *
      * @param mixed|Expr $expression
@@ -76,7 +76,7 @@ class Group extends Operator
     /**
      * Used to use an expression as field value. Can be any expression
      *
-     * @see http://docs.mongodb.org/manual/meta/aggregation-quick-reference/#aggregation-expressions
+     * @see https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions
      * @see Expr::expression
      *
      * @param mixed|Expr $value
@@ -105,7 +105,7 @@ class Group extends Operator
      * document in a group of documents that share the same group by key. Only
      * meaningful when documents are in a defined order.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/first/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/first/
      * @see Expr::first
      *
      * @param mixed|Expr $expression
@@ -122,7 +122,7 @@ class Group extends Operator
      * document in a group of documents that share the same group by a field.
      * Only meaningful when documents are in a defined order.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/last/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/last/
      * @see Expr::last
      *
      * @param mixed|Expr $expression
@@ -138,7 +138,7 @@ class Group extends Operator
      * Returns the highest value that results from applying an expression to
      * each document in a group of documents that share the same group by key.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/max/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/max/
      * @see Expr::max
      *
      * @param mixed|Expr $expression
@@ -154,7 +154,7 @@ class Group extends Operator
      * Returns the lowest value that results from applying an expression to each
      * document in a group of documents that share the same group by key.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/min/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/min/
      * @see Expr::min
      *
      * @param mixed|Expr $expression
@@ -170,7 +170,7 @@ class Group extends Operator
      * Returns an array of all values that result from applying an expression to
      * each document in a group of documents that share the same group by key.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/push/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/push/
      * @see Expr::push
      *
      * @param mixed|Expr $expression
@@ -187,7 +187,7 @@ class Group extends Operator
      *
      * The argument can be any expression as long as it resolves to an array.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/stdDevPop/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevPop/
      * @see Expr::stdDevPop
      *
      * @param mixed|Expr $expression
@@ -204,7 +204,7 @@ class Group extends Operator
      *
      * The argument can be any expression as long as it resolves to an array.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/stdDevSamp/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevSamp/
      * @see Expr::stdDevSamp
      *
      * @param mixed|Expr $expression
@@ -221,7 +221,7 @@ class Group extends Operator
      * applying a specified expression to each document in a group of documents
      * that share the same group by key. Ignores nun-numeric values.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/sum/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sum/
      * @see Expr::sum
      *
      * @param mixed|Expr $expression

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Match.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Match.php
@@ -43,7 +43,7 @@ class Match extends Stage
      * method.
      *
      * @see Expr::addAnd()
-     * @see http://docs.mongodb.org/manual/reference/operator/and/
+     * @see https://docs.mongodb.com/manual/reference/operator/and/
      *
      * @param array|Expr $expression
      * @param array|Expr ...$expressions
@@ -62,7 +62,7 @@ class Match extends Stage
      * method.
      *
      * @see Expr::addNor()
-     * @see http://docs.mongodb.org/manual/reference/operator/nor/
+     * @see https://docs.mongodb.com/manual/reference/operator/nor/
      *
      * @param array|Expr $expression
      * @param array|Expr ...$expressions
@@ -81,7 +81,7 @@ class Match extends Stage
      * method.
      *
      * @see Expr::addOr()
-     * @see http://docs.mongodb.org/manual/reference/operator/or/
+     * @see https://docs.mongodb.com/manual/reference/operator/or/
      *
      * @param array|Expr $expression
      * @param array|Expr ...$expressions
@@ -97,7 +97,7 @@ class Match extends Stage
      * Specify $all criteria for the current field.
      *
      * @see Expr::all()
-     * @see http://docs.mongodb.org/manual/reference/operator/all/
+     * @see https://docs.mongodb.com/manual/reference/operator/all/
      */
     public function all(array $values) : self
     {
@@ -113,7 +113,7 @@ class Match extends Stage
      * method.
      *
      * @see Expr::elemMatch()
-     * @see http://docs.mongodb.org/manual/reference/operator/elemMatch/
+     * @see https://docs.mongodb.com/manual/reference/operator/elemMatch/
      *
      * @param array|Expr $expression
      */
@@ -142,7 +142,7 @@ class Match extends Stage
      * Specify $exists criteria for the current field.
      *
      * @see Expr::exists()
-     * @see http://docs.mongodb.org/manual/reference/operator/exists/
+     * @see https://docs.mongodb.com/manual/reference/operator/exists/
      */
     public function exists(bool $bool) : self
     {
@@ -179,7 +179,7 @@ class Match extends Stage
      * geometry's JSON representation.
      *
      * @see Expr::geoIntersects()
-     * @see http://docs.mongodb.org/manual/reference/operator/geoIntersects/
+     * @see https://docs.mongodb.com/manual/reference/operator/geoIntersects/
      *
      * @param array|Geometry $geometry
      */
@@ -197,7 +197,7 @@ class Match extends Stage
      * geometry's JSON representation.
      *
      * @see Expr::geoWithin()
-     * @see http://docs.mongodb.org/manual/reference/operator/geoWithin/
+     * @see https://docs.mongodb.com/manual/reference/operator/geoWithin/
      */
     public function geoWithin(Geometry $geometry) : self
     {
@@ -216,7 +216,7 @@ class Match extends Stage
      * indexes. This cannot be used with 2dsphere indexes and GeoJSON shapes.
      *
      * @see Expr::geoWithinBox()
-     * @see http://docs.mongodb.org/manual/reference/operator/box/
+     * @see https://docs.mongodb.com/manual/reference/operator/box/
      */
     public function geoWithinBox(float $x1, float $y1, float $x2, float $y2) : self
     {
@@ -232,7 +232,7 @@ class Match extends Stage
      * indexes. This cannot be used with 2dsphere indexes and GeoJSON shapes.
      *
      * @see Expr::geoWithinCenter()
-     * @see http://docs.mongodb.org/manual/reference/operator/center/
+     * @see https://docs.mongodb.com/manual/reference/operator/center/
      */
     public function geoWithinCenter(float $x, float $y, float $radius) : self
     {
@@ -247,7 +247,7 @@ class Match extends Stage
      * Note: the $centerSphere operator supports both 2d and 2dsphere indexes.
      *
      * @see Expr::geoWithinCenterSphere()
-     * @see http://docs.mongodb.org/manual/reference/operator/centerSphere/
+     * @see https://docs.mongodb.com/manual/reference/operator/centerSphere/
      */
     public function geoWithinCenterSphere(float $x, float $y, float $radius) : self
     {
@@ -268,7 +268,7 @@ class Match extends Stage
      * indexes. This cannot be used with 2dsphere indexes and GeoJSON shapes.
      *
      * @see Expr::geoWithinPolygon()
-     * @see http://docs.mongodb.org/manual/reference/operator/polygon/
+     * @see https://docs.mongodb.com/manual/reference/operator/polygon/
      *
      * @param array $point1    First point of the polygon
      * @param array $point2    Second point of the polygon
@@ -296,7 +296,7 @@ class Match extends Stage
      * Specify $gt criteria for the current field.
      *
      * @see Expr::gt()
-     * @see http://docs.mongodb.org/manual/reference/operator/gt/
+     * @see https://docs.mongodb.com/manual/reference/operator/gt/
      *
      * @param mixed $value
      */
@@ -311,7 +311,7 @@ class Match extends Stage
      * Specify $gte criteria for the current field.
      *
      * @see Expr::gte()
-     * @see http://docs.mongodb.org/manual/reference/operator/gte/
+     * @see https://docs.mongodb.com/manual/reference/operator/gte/
      *
      * @param mixed $value
      */
@@ -326,7 +326,7 @@ class Match extends Stage
      * Specify $in criteria for the current field.
      *
      * @see Expr::in()
-     * @see http://docs.mongodb.org/manual/reference/operator/in/
+     * @see https://docs.mongodb.com/manual/reference/operator/in/
      */
     public function in(array $values) : self
     {
@@ -348,7 +348,7 @@ class Match extends Stage
      * This method must be called after text().
      *
      * @see Expr::language()
-     * @see http://docs.mongodb.org/manual/reference/operator/text/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/text/
      */
     public function language(string $language) : self
     {
@@ -361,7 +361,7 @@ class Match extends Stage
      * Specify $lt criteria for the current field.
      *
      * @see Expr::lte()
-     * @see http://docs.mongodb.org/manual/reference/operator/lte/
+     * @see https://docs.mongodb.com/manual/reference/operator/lte/
      *
      * @param mixed $value
      */
@@ -376,7 +376,7 @@ class Match extends Stage
      * Specify $lte criteria for the current field.
      *
      * @see Expr::lte()
-     * @see http://docs.mongodb.org/manual/reference/operator/lte/
+     * @see https://docs.mongodb.com/manual/reference/operator/lte/
      *
      * @param mixed $value
      */
@@ -391,7 +391,7 @@ class Match extends Stage
      * Specify $mod criteria for the current field.
      *
      * @see Expr::mod()
-     * @see http://docs.mongodb.org/manual/reference/operator/mod/
+     * @see https://docs.mongodb.com/manual/reference/operator/mod/
      *
      * @param float|int $divisor
      * @param float|int $remainder
@@ -410,7 +410,7 @@ class Match extends Stage
      * method.
      *
      * @see Expr::not()
-     * @see http://docs.mongodb.org/manual/reference/operator/not/
+     * @see https://docs.mongodb.com/manual/reference/operator/not/
      *
      * @param array|Expr $expression
      */
@@ -425,7 +425,7 @@ class Match extends Stage
      * Specify $ne criteria for the current field.
      *
      * @see Expr::notEqual()
-     * @see http://docs.mongodb.org/manual/reference/operator/ne/
+     * @see https://docs.mongodb.com/manual/reference/operator/ne/
      *
      * @param mixed $value
      */
@@ -440,7 +440,7 @@ class Match extends Stage
      * Specify $nin criteria for the current field.
      *
      * @see Expr::notIn()
-     * @see http://docs.mongodb.org/manual/reference/operator/nin/
+     * @see https://docs.mongodb.com/manual/reference/operator/nin/
      */
     public function notIn(array $values) : self
     {
@@ -478,7 +478,7 @@ class Match extends Stage
      * Specify $size criteria for the current field.
      *
      * @see Expr::size()
-     * @see http://docs.mongodb.org/manual/reference/operator/size/
+     * @see https://docs.mongodb.com/manual/reference/operator/size/
      */
     public function size(int $size) : self
     {
@@ -495,7 +495,7 @@ class Match extends Stage
      * You can only use this in the first $match stage of a pipeline.
      *
      * @see Expr::text()
-     * @see http://docs.mongodb.org/master/reference/operator/query/text/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/text/
      */
     public function text(string $search) : self
     {
@@ -508,7 +508,7 @@ class Match extends Stage
      * Specify $type criteria for the current field.
      *
      * @see Expr::type()
-     * @see http://docs.mongodb.org/manual/reference/operator/type/
+     * @see https://docs.mongodb.com/manual/reference/operator/type/
      *
      * @param int|string $type
      */

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Operator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Operator.php
@@ -45,7 +45,7 @@ abstract class Operator extends Stage
      * The <number> argument can be any valid expression as long as it resolves
      * to a number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/abs/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/abs/
      * @see Expr::abs
      *
      * @param mixed|Expr $number
@@ -64,7 +64,7 @@ abstract class Operator extends Stage
      *
      * The arguments can be any valid expression as long as they resolve to either all numbers or to numbers and a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/add/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/add/
      * @see Expr::add
      *
      * @param mixed|Expr $expression1
@@ -81,7 +81,7 @@ abstract class Operator extends Stage
     /**
      * Add one or more $and clauses to the current expression.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/and/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/and/
      * @see Expr::addAnd
      *
      * @param array|Expr $expression
@@ -97,7 +97,7 @@ abstract class Operator extends Stage
     /**
      * Add one or more $or clauses to the current expression.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/or/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/or/
      * @see Expr::addOr
      *
      * @param array|Expr $expression
@@ -116,7 +116,7 @@ abstract class Operator extends Stage
      *
      * The expression must resolve to an array.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/allElementsTrue/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/allElementsTrue/
      * @see Expr::allElementsTrue
      *
      * @param mixed|Expr $expression
@@ -134,7 +134,7 @@ abstract class Operator extends Stage
      *
      * The expression must resolve to an array.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/anyElementTrue/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/anyElementTrue/
      * @see Expr::anyElementTrue
      *
      * @param array|Expr $expression
@@ -154,7 +154,7 @@ abstract class Operator extends Stage
      * The <idx> expression can be any valid expression as long as it resolves
      * to an integer.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/arrayElemAt/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/arrayElemAt/
      * @see Expr::arrayElemAt
      *
      * @param mixed|Expr $array
@@ -173,7 +173,7 @@ abstract class Operator extends Stage
      * The <number> expression can be any valid expression as long as it
      * resolves to a number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/ceil/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/ceil/
      * @see Expr::ceil
      *
      * @param mixed|Expr $number
@@ -191,7 +191,7 @@ abstract class Operator extends Stage
      * 1 if the first value is greater than the second.
      * 0 if the two values are equivalent.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/cmp/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/cmp/
      * @see Expr::cmp
      *
      * @param mixed|Expr $expression1
@@ -211,7 +211,7 @@ abstract class Operator extends Stage
      * strings. If the argument resolves to a value of null or refers to a field
      * that is missing, $concat returns null.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/concat/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/concat/
      * @see Expr::concat
      *
      * @param mixed|Expr $expression1
@@ -231,7 +231,7 @@ abstract class Operator extends Stage
      * The <array> expressions can be any valid expression as long as they
      * resolve to an array.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/concatArrays/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/concatArrays/
      * @see Expr::concatArrays
      *
      * @param mixed|Expr $array1
@@ -251,7 +251,7 @@ abstract class Operator extends Stage
      *
      * The arguments can be any valid expression.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/cond/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/cond/
      * @see Expr::cond
      *
      * @param mixed|Expr $if
@@ -272,7 +272,7 @@ abstract class Operator extends Stage
      * specifiers.
      * The date argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/dateToString/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dateToString/
      * @see Expr::dateToString
      *
      * @param string     $format
@@ -290,7 +290,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/dayOfMonth/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dayOfMonth/
      * @see Expr::dayOfMonth
      *
      * @param mixed|Expr $expression
@@ -308,7 +308,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/dayOfWeek/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dayOfWeek/
      * @see Expr::dayOfWeek
      *
      * @param mixed|Expr $expression
@@ -325,7 +325,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/dayOfYear/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dayOfYear/
      * @see Expr::dayOfYear
      *
      * @param mixed|Expr $expression
@@ -343,7 +343,7 @@ abstract class Operator extends Stage
      *
      * The arguments can be any valid expression as long as the resolve to numbers.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/divide/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/divide/
      * @see Expr::divide
      *
      * @param mixed|Expr $expression1
@@ -359,7 +359,7 @@ abstract class Operator extends Stage
     /**
      * Compares two values and returns whether they are equivalent.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/eq/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/eq/
      * @see Expr::eq
      *
      * @param mixed|Expr $expression1
@@ -378,7 +378,7 @@ abstract class Operator extends Stage
      * The <exponent> expression can be any valid expression as long as it
      * resolves to a number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/exp/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/exp/
      * @see Expr::exp
      *
      * @param mixed|Expr $exponent
@@ -393,7 +393,7 @@ abstract class Operator extends Stage
     /**
      * Used to use an expression as field value. Can be any expression
      *
-     * @see http://docs.mongodb.org/manual/meta/aggregation-quick-reference/#aggregation-expressions
+     * @see https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions
      * @see Expr::expression
      *
      * @param mixed|Expr $value
@@ -423,7 +423,7 @@ abstract class Operator extends Stage
      * Returns an array with only those elements that match the condition. The
      * returned elements are in the original order.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/filter/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/filter/
      * @see Expr::filter
      *
      * @param mixed|Expr $input
@@ -443,7 +443,7 @@ abstract class Operator extends Stage
      * The <number> expression can be any valid expression as long as it
      * resolves to a number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/floor/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/floor/
      * @see Expr::floor
      *
      * @param mixed|Expr $number
@@ -460,7 +460,7 @@ abstract class Operator extends Stage
      * true when the first value is greater than the second value.
      * false when the first value is less than or equivalent to the second value.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/gt/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/gt/
      * @see Expr::gt
      *
      * @param mixed|Expr $expression1
@@ -478,7 +478,7 @@ abstract class Operator extends Stage
      * true when the first value is greater than or equivalent to the second value.
      * false when the first value is less than the second value.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/gte/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/gte/
      * @see Expr::gte
      *
      * @param mixed|Expr $expression1
@@ -496,7 +496,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/hour/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/hour/
      * @see Expr::hour
      *
      * @param mixed|Expr $expression
@@ -593,7 +593,7 @@ abstract class Operator extends Stage
      *
      * The arguments can be any valid expression.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/ifNull/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/ifNull/
      * @see Expr::ifNull
      *
      * @param mixed|Expr $expression
@@ -611,7 +611,7 @@ abstract class Operator extends Stage
      *
      * The <expression> can be any valid expression.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/isArray/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isArray/
      * @see Expr::isArray
      *
      * @param mixed|Expr $expression
@@ -629,7 +629,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/isoDayOfWeek/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isoDayOfWeek/
      *
      * @param mixed|Expr $expression
      */
@@ -648,7 +648,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/isoWeek/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isoWeek/
      *
      * @param mixed|Expr $expression
      */
@@ -667,7 +667,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/isoWeek/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isoWeek/
      *
      * @param mixed|Expr $expression
      */
@@ -682,7 +682,7 @@ abstract class Operator extends Stage
      * Binds variables for use in the specified expression, and returns the
      * result of the expression.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/let/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/let/
      * @see Expr::let
      *
      * @param mixed|Expr $vars Assignment block for the variables accessible in the in expression. To assign a variable, specify a string for the variable name and assign a valid expression for the value.
@@ -699,7 +699,7 @@ abstract class Operator extends Stage
      * Returns a value without parsing. Use for values that the aggregation
      * pipeline may interpret as an expression.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/literal/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/literal/
      * @see Expr::literal
      *
      * @param mixed|Expr $value
@@ -718,7 +718,7 @@ abstract class Operator extends Stage
      * The <number> expression can be any valid expression as long as it
      * resolves to a non-negative number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/log/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/log/
      * @see Expr::ln
      *
      * @param mixed|Expr $number
@@ -739,7 +739,7 @@ abstract class Operator extends Stage
      * The <base> expression can be any valid expression as long as it resolves
      * to a positive number greater than 1.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/log/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/log/
      * @see Expr::log
      *
      * @param mixed|Expr $number
@@ -760,7 +760,7 @@ abstract class Operator extends Stage
      * The <base> expression can be any valid expression as long as it resolves
      * to a positive number greater than 1.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/log/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/log/
      * @see Expr::log10
      *
      * @param mixed|Expr $number
@@ -777,7 +777,7 @@ abstract class Operator extends Stage
      * true when the first value is less than the second value.
      * false when the first value is greater than or equivalent to the second value.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/lt/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/lt/
      * @see Expr::lt
      *
      * @param mixed|Expr $expression1
@@ -795,7 +795,7 @@ abstract class Operator extends Stage
      * true when the first value is less than or equivalent to the second value.
      * false when the first value is greater than the second value.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/lte/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/lte/
      * @see Expr::lte
      *
      * @param mixed|Expr $expression1
@@ -812,7 +812,7 @@ abstract class Operator extends Stage
      * Applies an expression to each item in an array and returns an array with
      * the applied results.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/map/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/map/
      * @see Expr::map
      *
      * @param mixed|Expr $input An expression that resolves to an array.
@@ -829,7 +829,7 @@ abstract class Operator extends Stage
     /**
      * Returns the metadata associated with a document in a pipeline operations.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/meta/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/meta/
      * @see Expr::meta
      *
      * @param mixed|Expr $metaDataKeyword
@@ -846,7 +846,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/millisecond/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/millisecond/
      * @see Expr::millisecond
      *
      * @param mixed|Expr $expression
@@ -863,7 +863,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/minute/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/minute/
      * @see Expr::minute
      *
      * @param mixed|Expr $expression
@@ -881,7 +881,7 @@ abstract class Operator extends Stage
      *
      * The arguments can be any valid expression as long as they resolve to numbers.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/mod/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/mod/
      * @see Expr::mod
      *
      * @param mixed|Expr $expression1
@@ -899,7 +899,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/month/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/month/
      * @see Expr::month
      *
      * @param mixed|Expr $expression
@@ -916,7 +916,7 @@ abstract class Operator extends Stage
      *
      * The arguments can be any valid expression as long as they resolve to numbers.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/multiply/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/multiply/
      * @see Expr::multiply
      *
      * @param mixed|Expr $expression1
@@ -935,7 +935,7 @@ abstract class Operator extends Stage
      * true when the values are not equivalent.
      * false when the values are equivalent.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/ne/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/ne/
      * @see Expr::ne
      *
      * @param mixed|Expr $expression1
@@ -951,7 +951,7 @@ abstract class Operator extends Stage
     /**
      * Evaluates a boolean and returns the opposite boolean value.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/not/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/not/
      * @see Expr::not
      *
      * @param mixed|Expr $expression
@@ -971,7 +971,7 @@ abstract class Operator extends Stage
      * The <exponent> expression can be any valid expression as long as it
      * resolves to a number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/pow/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/pow/
      * @see Expr::pow
      *
      * @param mixed|Expr $number
@@ -1043,7 +1043,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/second/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/second/
      * @see Expr::second
      *
      * @param mixed|Expr $expression
@@ -1061,7 +1061,7 @@ abstract class Operator extends Stage
      *
      * The arguments can be any valid expression as long as they each resolve to an array.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/setDifference/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/setDifference/
      * @see Expr::setDifference
      *
      * @param mixed|Expr $expression1
@@ -1080,7 +1080,7 @@ abstract class Operator extends Stage
      *
      * The arguments can be any valid expression as long as they each resolve to an array.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/setEquals/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/setEquals/
      * @see Expr::setEquals
      *
      * @param mixed|Expr $expression1
@@ -1102,7 +1102,7 @@ abstract class Operator extends Stage
      *
      * The arguments can be any valid expression as long as they each resolve to an array.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/setIntersection/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/setIntersection/
      * @see Expr::setIntersection
      *
      * @param mixed|Expr $expression1
@@ -1123,7 +1123,7 @@ abstract class Operator extends Stage
      *
      * The arguments can be any valid expression as long as they each resolve to an array.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/setIsSubset/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/setIsSubset/
      * @see Expr::setIsSubset
      *
      * @param mixed|Expr $expression1
@@ -1142,7 +1142,7 @@ abstract class Operator extends Stage
      *
      * The arguments can be any valid expression as long as they each resolve to an array.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/setUnion/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/setUnion/
      * @see Expr::setUnion
      *
      * @param mixed|Expr $expression1
@@ -1161,7 +1161,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any expression as long as it resolves to an array.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/size/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/size/
      * @see Expr::size
      *
      * @param mixed|Expr $expression
@@ -1176,7 +1176,7 @@ abstract class Operator extends Stage
     /**
      * Returns a subset of an array.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/slice/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/slice/
      * @see Expr::slice
      *
      * @param mixed|Expr      $array
@@ -1216,7 +1216,7 @@ abstract class Operator extends Stage
      * The argument can be any valid expression as long as it resolves to a
      * non-negative number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/sqrt/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sqrt/
      * @see Expr::sqrt
      *
      * @param mixed|Expr $expression
@@ -1236,7 +1236,7 @@ abstract class Operator extends Stage
      *
      * The arguments can be any valid expression as long as they resolve to strings.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/strcasecmp/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/strcasecmp/
      * @see Expr::strcasecmp
      *
      * @param mixed|Expr $expression1
@@ -1283,7 +1283,7 @@ abstract class Operator extends Stage
      *
      * The arguments can be any valid expression as long as long as the first argument resolves to a string, and the second and third arguments resolve to integers.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/substr/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/substr/
      * @see Expr::substr
      *
      * @param mixed|Expr $string
@@ -1343,7 +1343,7 @@ abstract class Operator extends Stage
      *
      * The arguments can be any valid expression as long as they resolve to numbers and/or dates.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/subtract/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/subtract/
      * @see Expr::subtract
      *
      * @param mixed|Expr $expression1
@@ -1361,7 +1361,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any expression as long as it resolves to a string.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/toLower/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/toLower/
      * @see Expr::toLower
      *
      * @param mixed|Expr $expression
@@ -1378,7 +1378,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any expression as long as it resolves to a string.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/toUpper/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/toUpper/
      * @see Expr::toUpper
      *
      * @param mixed|Expr $expression
@@ -1396,7 +1396,7 @@ abstract class Operator extends Stage
      * The <number> expression can be any valid expression as long as it
      * resolves to a number.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/trunc/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/trunc/
      * @see Expr::trunc
      *
      * @param mixed|Expr $number
@@ -1413,7 +1413,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any valid expression.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/type/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/type/
      *
      * @param mixed|Expr $expression
      */
@@ -1429,7 +1429,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/week/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/week/
      * @see Expr::week
      *
      * @param mixed|Expr $expression
@@ -1446,7 +1446,7 @@ abstract class Operator extends Stage
      *
      * The argument can be any expression as long as it resolves to a date.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/year/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/year/
      * @see Expr::year
      *
      * @param mixed|Expr $expression

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Project.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Project.php
@@ -27,7 +27,7 @@ class Project extends Operator
      * a specified expression to each document in a group of documents that
      * share the same group by key. Ignores nun-numeric values.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/avg/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/avg/
      * @see Expr::avg
      *
      * @param mixed|Expr $expression1
@@ -71,7 +71,7 @@ class Project extends Operator
      * Returns the highest value that results from applying an expression to
      * each document in a group of documents that share the same group by key.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/max/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/max/
      * @see Expr::max
      *
      * @param mixed|Expr $expression1
@@ -88,7 +88,7 @@ class Project extends Operator
      * Returns the lowest value that results from applying an expression to each
      * document in a group of documents that share the same group by key.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/min/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/min/
      * @see Expr::min
      *
      * @param mixed|Expr $expression1
@@ -106,7 +106,7 @@ class Project extends Operator
      *
      * The argument can be any expression as long as it resolves to an array.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/stdDevPop/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevPop/
      * @see Expr::stdDevPop
      *
      * @param mixed|Expr $expression1
@@ -124,7 +124,7 @@ class Project extends Operator
      *
      * The argument can be any expression as long as it resolves to an array.
      *
-     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/stdDevSamp/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevSamp/
      * @see Expr::stdDevSamp
      *
      * @param mixed|Expr $expression1
@@ -142,7 +142,7 @@ class Project extends Operator
      * applying a specified expression to each document in a group of documents
      * that share the same group by key. Ignores nun-numeric values.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/sum/
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sum/
      * @see Expr::sum
      *
      * @param mixed|Expr $expression1

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -134,7 +134,7 @@ class Builder
      * You can create a new expression using the {@link Builder::expr()} method.
      *
      * @see Expr::addAnd()
-     * @see http://docs.mongodb.org/manual/reference/operator/and/
+     * @see https://docs.mongodb.com/manual/reference/operator/and/
      *
      * @param array|Expr $expression
      * @param array|Expr ...$expressions
@@ -152,7 +152,7 @@ class Builder
      * You can create a new expression using the {@link Builder::expr()} method.
      *
      * @see Expr::addNor()
-     * @see http://docs.mongodb.org/manual/reference/operator/nor/
+     * @see https://docs.mongodb.com/manual/reference/operator/nor/
      *
      * @param array|Expr $expression
      * @param array|Expr ...$expressions
@@ -170,7 +170,7 @@ class Builder
      * You can create a new expression using the {@link Builder::expr()} method.
      *
      * @see Expr::addOr()
-     * @see http://docs.mongodb.org/manual/reference/operator/or/
+     * @see https://docs.mongodb.com/manual/reference/operator/or/
      *
      * @param array|Expr $expression
      * @param array|Expr ...$expressions
@@ -194,8 +194,8 @@ class Builder
      * {@link Expr::each()}.
      *
      * @see Expr::addToSet()
-     * @see http://docs.mongodb.org/manual/reference/operator/addToSet/
-     * @see http://docs.mongodb.org/manual/reference/operator/each/
+     * @see https://docs.mongodb.com/manual/reference/operator/addToSet/
+     * @see https://docs.mongodb.com/manual/reference/operator/each/
      *
      * @param mixed|Expr $valueOrExpression
      */
@@ -210,7 +210,7 @@ class Builder
      * Specify $all criteria for the current field.
      *
      * @see Expr::all()
-     * @see http://docs.mongodb.org/manual/reference/operator/all/
+     * @see https://docs.mongodb.com/manual/reference/operator/all/
      */
     public function all(array $values) : self
     {
@@ -223,7 +223,7 @@ class Builder
      * Apply a bitwise and operation on the current field.
      *
      * @see Expr::bitAnd()
-     * @see http://docs.mongodb.org/manual/reference/operator/update/bit/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/bit/
      *
      * @return $this
      */
@@ -238,7 +238,7 @@ class Builder
      * Apply a bitwise or operation on the current field.
      *
      * @see Expr::bitOr()
-     * @see http://docs.mongodb.org/manual/reference/operator/update/bit/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/bit/
      */
     public function bitOr(int $value) : self
     {
@@ -252,7 +252,7 @@ class Builder
      * clear.
      *
      * @see Expr::bitsAllClear()
-     * @see https://docs.mongodb.org/manual/reference/operator/query/bitsAllClear/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/bitsAllClear/
      *
      * @param int|array|Binary $value
      */
@@ -268,7 +268,7 @@ class Builder
      * set.
      *
      * @see Expr::bitsAllSet()
-     * @see https://docs.mongodb.org/manual/reference/operator/query/bitsAllSet/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/bitsAllSet/
      *
      * @param int|array|Binary $value
      */
@@ -284,7 +284,7 @@ class Builder
      * clear.
      *
      * @see Expr::bitsAnyClear()
-     * @see https://docs.mongodb.org/manual/reference/operator/query/bitsAnyClear/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/bitsAnyClear/
      *
      * @param int|array|Binary $value
      */
@@ -300,7 +300,7 @@ class Builder
      * set.
      *
      * @see Expr::bitsAnySet()
-     * @see https://docs.mongodb.org/manual/reference/operator/query/bitsAnySet/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/bitsAnySet/
      *
      * @param int|array|Binary $value
      */
@@ -315,7 +315,7 @@ class Builder
      * Apply a bitwise xor operation on the current field.
      *
      * @see Expr::bitXor()
-     * @see http://docs.mongodb.org/manual/reference/operator/update/bit/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/bit/
      */
     public function bitXor(int $value) : self
     {
@@ -331,7 +331,7 @@ class Builder
      * This method must be called after text().
      *
      * @see Expr::caseSensitive()
-     * @see http://docs.mongodb.org/manual/reference/operator/text/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/text/
      *
      * @throws BadMethodCallException If the query does not already have $text criteria.
      */
@@ -346,7 +346,7 @@ class Builder
      * Associates a comment to any expression taking a query predicate.
      *
      * @see Expr::comment()
-     * @see http://docs.mongodb.org/manual/reference/operator/query/comment/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/comment/
      */
     public function comment(string $comment) : self
     {
@@ -369,7 +369,7 @@ class Builder
      * Sets the value of the current field to the current date, either as a date or a timestamp.
      *
      * @see Expr::currentDate()
-     * @see http://docs.mongodb.org/manual/reference/operator/currentDate/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/currentDate/
      */
     public function currentDate(string $type = 'date') : self
     {
@@ -399,7 +399,7 @@ class Builder
      * This method must be called after text().
      *
      * @see Builder::diacriticSensitive()
-     * @see http://docs.mongodb.org/manual/reference/operator/text/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/text/
      *
      * @throws BadMethodCallException If the query does not already have $text criteria.
      */
@@ -413,7 +413,7 @@ class Builder
     /**
      * Change the query type to a distinct command.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/distinct/
+     * @see https://docs.mongodb.com/manual/reference/command/distinct/
      */
     public function distinct(string $field) : self
     {
@@ -429,7 +429,7 @@ class Builder
      * You can create a new expression using the {@link Builder::expr()} method.
      *
      * @see Expr::elemMatch()
-     * @see http://docs.mongodb.org/manual/reference/operator/elemMatch/
+     * @see https://docs.mongodb.com/manual/reference/operator/elemMatch/
      *
      * @param array|Expr $expression
      */
@@ -481,7 +481,7 @@ class Builder
      * Specify $exists criteria for the current field.
      *
      * @see Expr::exists()
-     * @see http://docs.mongodb.org/manual/reference/operator/exists/
+     * @see https://docs.mongodb.com/manual/reference/operator/exists/
      */
     public function exists(bool $bool) : self
     {
@@ -546,7 +546,7 @@ class Builder
      * geometry's JSON representation.
      *
      * @see Expr::geoIntersects()
-     * @see http://docs.mongodb.org/manual/reference/operator/geoIntersects/
+     * @see https://docs.mongodb.com/manual/reference/operator/geoIntersects/
      *
      * @param array|Geometry $geometry
      */
@@ -564,7 +564,7 @@ class Builder
      * geometry's JSON representation.
      *
      * @see Expr::geoWithin()
-     * @see http://docs.mongodb.org/manual/reference/operator/geoWithin/
+     * @see https://docs.mongodb.com/manual/reference/operator/geoWithin/
      *
      * @param array|Geometry $geometry
      */
@@ -585,7 +585,7 @@ class Builder
      * indexes. This cannot be used with 2dsphere indexes and GeoJSON shapes.
      *
      * @see Expr::geoWithinBox()
-     * @see http://docs.mongodb.org/manual/reference/operator/box/
+     * @see https://docs.mongodb.com/manual/reference/operator/box/
      */
     public function geoWithinBox(float $x1, float $y1, float $x2, float $y2) : self
     {
@@ -601,7 +601,7 @@ class Builder
      * indexes. This cannot be used with 2dsphere indexes and GeoJSON shapes.
      *
      * @see Expr::geoWithinCenter()
-     * @see http://docs.mongodb.org/manual/reference/operator/center/
+     * @see https://docs.mongodb.com/manual/reference/operator/center/
      */
     public function geoWithinCenter(float $x, float $y, float $radius) : self
     {
@@ -616,7 +616,7 @@ class Builder
      * Note: the $centerSphere operator supports both 2d and 2dsphere indexes.
      *
      * @see Expr::geoWithinCenterSphere()
-     * @see http://docs.mongodb.org/manual/reference/operator/centerSphere/
+     * @see https://docs.mongodb.com/manual/reference/operator/centerSphere/
      */
     public function geoWithinCenterSphere(float $x, float $y, float $radius) : self
     {
@@ -637,7 +637,7 @@ class Builder
      * indexes. This cannot be used with 2dsphere indexes and GeoJSON shapes.
      *
      * @see Expr::geoWithinPolygon()
-     * @see http://docs.mongodb.org/manual/reference/operator/polygon/
+     * @see https://docs.mongodb.com/manual/reference/operator/polygon/
      *
      * @param array $point1    First point of the polygon
      * @param array $point2    Second point of the polygon
@@ -743,7 +743,7 @@ class Builder
      * Specify $gt criteria for the current field.
      *
      * @see Expr::gt()
-     * @see http://docs.mongodb.org/manual/reference/operator/gt/
+     * @see https://docs.mongodb.com/manual/reference/operator/gt/
      *
      * @param mixed $value
      */
@@ -758,7 +758,7 @@ class Builder
      * Specify $gte criteria for the current field.
      *
      * @see Expr::gte()
-     * @see http://docs.mongodb.org/manual/reference/operator/gte/
+     * @see https://docs.mongodb.com/manual/reference/operator/gte/
      *
      * @param mixed $value
      */
@@ -802,7 +802,7 @@ class Builder
      * Specify $in criteria for the current field.
      *
      * @see Expr::in()
-     * @see http://docs.mongodb.org/manual/reference/operator/in/
+     * @see https://docs.mongodb.com/manual/reference/operator/in/
      */
     public function in(array $values) : self
     {
@@ -817,7 +817,7 @@ class Builder
      * If the field does not exist, it will be set to this value.
      *
      * @see Expr::inc()
-     * @see http://docs.mongodb.org/manual/reference/operator/inc/
+     * @see https://docs.mongodb.com/manual/reference/operator/inc/
      *
      * @param float|int $value
      */
@@ -849,7 +849,7 @@ class Builder
      * This method must be called after text().
      *
      * @see Expr::language()
-     * @see http://docs.mongodb.org/manual/reference/operator/text/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/text/
      */
     public function language(string $language) : self
     {
@@ -876,7 +876,7 @@ class Builder
      * Specify $lt criteria for the current field.
      *
      * @see Expr::lte()
-     * @see http://docs.mongodb.org/manual/reference/operator/lte/
+     * @see https://docs.mongodb.com/manual/reference/operator/lte/
      *
      * @param mixed $value
      */
@@ -891,7 +891,7 @@ class Builder
      * Specify $lte criteria for the current field.
      *
      * @see Expr::lte()
-     * @see http://docs.mongodb.org/manual/reference/operator/lte/
+     * @see https://docs.mongodb.com/manual/reference/operator/lte/
      *
      * @param mixed $value
      */
@@ -906,7 +906,7 @@ class Builder
      * Updates the value of the field to a specified value if the specified value is greater than the current value of the field.
      *
      * @see Expr::max()
-     * @see http://docs.mongodb.org/manual/reference/operator/update/max/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/max/
      *
      * @param mixed $value
      */
@@ -931,7 +931,7 @@ class Builder
      * Updates the value of the field to a specified value if the specified value is less than the current value of the field.
      *
      * @see Expr::min()
-     * @see http://docs.mongodb.org/manual/reference/operator/update/min/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/min/
      *
      * @param mixed $value
      */
@@ -946,7 +946,7 @@ class Builder
      * Specify $mod criteria for the current field.
      *
      * @see Expr::mod()
-     * @see http://docs.mongodb.org/manual/reference/operator/mod/
+     * @see https://docs.mongodb.com/manual/reference/operator/mod/
      *
      * @param float|int $divisor
      * @param float|int $remainder
@@ -964,7 +964,7 @@ class Builder
      * If the field does not exist, it will be set to 0.
      *
      * @see Expr::mul()
-     * @see http://docs.mongodb.org/manual/reference/operator/mul/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/mul/
      *
      * @param float|int $value
      */
@@ -983,7 +983,7 @@ class Builder
      * an array corresponding to the point's JSON representation.
      *
      * @see Expr::near()
-     * @see http://docs.mongodb.org/manual/reference/operator/near/
+     * @see https://docs.mongodb.com/manual/reference/operator/near/
      *
      * @param float|array|Point $x
      * @param float             $y
@@ -1003,7 +1003,7 @@ class Builder
      * an array corresponding to the point's JSON representation.
      *
      * @see Expr::nearSphere()
-     * @see http://docs.mongodb.org/manual/reference/operator/nearSphere/
+     * @see https://docs.mongodb.com/manual/reference/operator/nearSphere/
      *
      * @param float|array|Point $x
      * @param float             $y
@@ -1021,7 +1021,7 @@ class Builder
      * You can create a new expression using the {@link Builder::expr()} method.
      *
      * @see Expr::not()
-     * @see http://docs.mongodb.org/manual/reference/operator/not/
+     * @see https://docs.mongodb.com/manual/reference/operator/not/
      *
      * @param array|Expr $expression
      */
@@ -1036,7 +1036,7 @@ class Builder
      * Specify $ne criteria for the current field.
      *
      * @see Expr::notEqual()
-     * @see http://docs.mongodb.org/manual/reference/operator/ne/
+     * @see https://docs.mongodb.com/manual/reference/operator/ne/
      *
      * @param mixed $value
      */
@@ -1051,7 +1051,7 @@ class Builder
      * Specify $nin criteria for the current field.
      *
      * @see Expr::notIn()
-     * @see http://docs.mongodb.org/manual/reference/operator/nin/
+     * @see https://docs.mongodb.com/manual/reference/operator/nin/
      *
      * @param array $values
      */
@@ -1066,7 +1066,7 @@ class Builder
      * Remove the first element from the current array field.
      *
      * @see Expr::popFirst()
-     * @see http://docs.mongodb.org/manual/reference/operator/pop/
+     * @see https://docs.mongodb.com/manual/reference/operator/pop/
      */
     public function popFirst() : self
     {
@@ -1079,7 +1079,7 @@ class Builder
      * Remove the last element from the current array field.
      *
      * @see Expr::popLast()
-     * @see http://docs.mongodb.org/manual/reference/operator/pop/
+     * @see https://docs.mongodb.com/manual/reference/operator/pop/
      */
     public function popLast() : self
     {
@@ -1128,7 +1128,7 @@ class Builder
      * current array field.
      *
      * @see Expr::pull()
-     * @see http://docs.mongodb.org/manual/reference/operator/pull/
+     * @see https://docs.mongodb.com/manual/reference/operator/pull/
      *
      * @param mixed|Expr $valueOrExpression
      */
@@ -1144,7 +1144,7 @@ class Builder
      * array field.
      *
      * @see Expr::pullAll()
-     * @see http://docs.mongodb.org/manual/reference/operator/pullAll/
+     * @see https://docs.mongodb.com/manual/reference/operator/pullAll/
      */
     public function pullAll(array $values) : self
     {
@@ -1165,10 +1165,10 @@ class Builder
      * also be used to limit and order array elements, respectively.
      *
      * @see Expr::push()
-     * @see http://docs.mongodb.org/manual/reference/operator/push/
-     * @see http://docs.mongodb.org/manual/reference/operator/each/
-     * @see http://docs.mongodb.org/manual/reference/operator/slice/
-     * @see http://docs.mongodb.org/manual/reference/operator/sort/
+     * @see https://docs.mongodb.com/manual/reference/operator/push/
+     * @see https://docs.mongodb.com/manual/reference/operator/each/
+     * @see https://docs.mongodb.com/manual/reference/operator/slice/
+     * @see https://docs.mongodb.com/manual/reference/operator/sort/
      *
      * @param mixed|Expr $valueOrExpression
      */
@@ -1230,7 +1230,7 @@ class Builder
      * Rename the current field.
      *
      * @see Expr::rename()
-     * @see http://docs.mongodb.org/manual/reference/operator/rename/
+     * @see https://docs.mongodb.com/manual/reference/operator/rename/
      */
     public function rename(string $name) : self
     {
@@ -1271,7 +1271,7 @@ class Builder
      * Select only matching embedded documents in an array field for the query
      * projection.
      *
-     * @see http://docs.mongodb.org/manual/reference/projection/elemMatch/
+     * @see https://docs.mongodb.com/manual/reference/projection/elemMatch/
      *
      * @param array|Expr $expression
      */
@@ -1288,7 +1288,7 @@ class Builder
     /**
      * Select a metadata field for the query projection.
      *
-     * @see http://docs.mongodb.org/master/reference/operator/projection/meta/
+     * @see https://docs.mongodb.com/manual/reference/operator/projection/meta/
      */
     public function selectMeta(string $fieldName, string $metaDataKeyword) : self
     {
@@ -1304,7 +1304,7 @@ class Builder
      * whether or not $limit is provided. See the MongoDB documentation for more
      * information.
      *
-     * @see http://docs.mongodb.org/manual/reference/projection/slice/
+     * @see https://docs.mongodb.com/manual/reference/projection/slice/
      */
     public function selectSlice(string $fieldName, int $countOrSkip, ?int $limit = null) : self
     {
@@ -1325,7 +1325,7 @@ class Builder
      * whether or not a $set operator is used.
      *
      * @see Expr::set()
-     * @see http://docs.mongodb.org/manual/reference/operator/set/
+     * @see https://docs.mongodb.com/manual/reference/operator/set/
      *
      * @param mixed $value
      */
@@ -1358,7 +1358,7 @@ class Builder
      * $setOnInsert does nothing.
      *
      * @see Expr::setOnInsert()
-     * @see https://docs.mongodb.org/manual/reference/operator/update/setOnInsert/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/setOnInsert/
      *
      * @param mixed $value
      */
@@ -1374,7 +1374,7 @@ class Builder
      *
      * This is only relevant for read-only queries and commands.
      *
-     * @see http://docs.mongodb.org/manual/core/read-preference/
+     * @see https://docs.mongodb.com/manual/core/read-preference/
      */
     public function setReadPreference(ReadPreference $readPreference) : self
     {
@@ -1406,7 +1406,7 @@ class Builder
      * Specify $size criteria for the current field.
      *
      * @see Expr::size()
-     * @see http://docs.mongodb.org/manual/reference/operator/size/
+     * @see https://docs.mongodb.com/manual/reference/operator/size/
      */
     public function size(int $size) : self
     {
@@ -1475,7 +1475,7 @@ class Builder
      * projection document. This method will call {@link Builder::selectMeta()}
      * if the field is not already set in the projection.
      *
-     * @see http://docs.mongodb.org/master/reference/operator/projection/meta/#sort
+     * @see https://docs.mongodb.com/manual/reference/operator/projection/meta/#sort
      */
     public function sortMeta(string $fieldName, string $metaDataKeyword) : self
     {
@@ -1498,7 +1498,7 @@ class Builder
      * The $language option may be set with {@link Builder::language()}.
      *
      * @see Expr::text()
-     * @see http://docs.mongodb.org/master/reference/operator/query/text/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/text/
      */
     public function text(string $search) : self
     {
@@ -1511,7 +1511,7 @@ class Builder
      * Specify $type criteria for the current field.
      *
      * @see Expr::type()
-     * @see http://docs.mongodb.org/manual/reference/operator/type/
+     * @see https://docs.mongodb.com/manual/reference/operator/type/
      *
      * @param int|string $type
      */
@@ -1528,7 +1528,7 @@ class Builder
      * The field will be removed from the document (not set to null).
      *
      * @see Expr::unsetField()
-     * @see http://docs.mongodb.org/manual/reference/operator/unset/
+     * @see https://docs.mongodb.com/manual/reference/operator/unset/
      */
     public function unsetField() : self
     {
@@ -1569,7 +1569,7 @@ class Builder
      * Specify a JavaScript expression to use for matching documents.
      *
      * @see Expr::where()
-     * @see http://docs.mongodb.org/manual/reference/operator/where/
+     * @see https://docs.mongodb.com/manual/reference/operator/where/
      *
      * @param string|Javascript $javascript
      */

--- a/lib/Doctrine/ODM/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Expr.php
@@ -81,7 +81,7 @@ class Expr
      * Add one or more $and clauses to the current query.
      *
      * @see Builder::addAnd()
-     * @see http://docs.mongodb.org/manual/reference/operator/and/
+     * @see https://docs.mongodb.com/manual/reference/operator/and/
      *
      * @param array|Expr $expression
      * @param array|Expr ...$expressions
@@ -109,7 +109,7 @@ class Expr
      * Add one or more $nor clauses to the current query.
      *
      * @see Builder::addNor()
-     * @see http://docs.mongodb.org/manual/reference/operator/nor/
+     * @see https://docs.mongodb.com/manual/reference/operator/nor/
      *
      * @param array|Expr $expression
      * @param array|Expr ...$expressions
@@ -134,7 +134,7 @@ class Expr
      * Add one or more $or clauses to the current query.
      *
      * @see Builder::addOr()
-     * @see http://docs.mongodb.org/manual/reference/operator/or/
+     * @see https://docs.mongodb.com/manual/reference/operator/or/
      *
      * @param array|Expr $expression
      * @param array|Expr ...$expressions
@@ -167,8 +167,8 @@ class Expr
      * {@link Expr::each()}.
      *
      * @see Builder::addToSet()
-     * @see http://docs.mongodb.org/manual/reference/operator/addToSet/
-     * @see http://docs.mongodb.org/manual/reference/operator/each/
+     * @see https://docs.mongodb.com/manual/reference/operator/addToSet/
+     * @see https://docs.mongodb.com/manual/reference/operator/each/
      *
      * @param mixed|Expr $valueOrExpression
      */
@@ -188,7 +188,7 @@ class Expr
      * Specify $all criteria for the current field.
      *
      * @see Builder::all()
-     * @see http://docs.mongodb.org/manual/reference/operator/all/
+     * @see https://docs.mongodb.com/manual/reference/operator/all/
      */
     public function all(array $values) : self
     {
@@ -198,7 +198,7 @@ class Expr
     /**
      * Apply a bitwise operation on the current field
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/update/bit/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/bit/
      */
     protected function bit(string $operator, int $value) : self
     {
@@ -212,7 +212,7 @@ class Expr
      * Apply a bitwise and operation on the current field.
      *
      * @see Builder::bitAnd()
-     * @see http://docs.mongodb.org/manual/reference/operator/update/bit/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/bit/
      */
     public function bitAnd(int $value) : self
     {
@@ -223,7 +223,7 @@ class Expr
      * Apply a bitwise or operation on the current field.
      *
      * @see Builder::bitOr()
-     * @see http://docs.mongodb.org/manual/reference/operator/update/bit/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/bit/
      */
     public function bitOr(int $value) : self
     {
@@ -235,7 +235,7 @@ class Expr
      * clear.
      *
      * @see Builder::bitsAllClear()
-     * @see https://docs.mongodb.org/manual/reference/operator/query/bitsAllClear/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/bitsAllClear/
      *
      * @param int|array|Binary $value
      */
@@ -251,7 +251,7 @@ class Expr
      * set.
      *
      * @see Builder::bitsAllSet()
-     * @see https://docs.mongodb.org/manual/reference/operator/query/bitsAllSet/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/bitsAllSet/
      *
      * @param int|array|Binary $value
      */
@@ -267,7 +267,7 @@ class Expr
      * clear.
      *
      * @see Builder::bitsAnyClear()
-     * @see https://docs.mongodb.org/manual/reference/operator/query/bitsAnyClear/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/bitsAnyClear/
      *
      * @param int|array|Binary $value
      */
@@ -283,7 +283,7 @@ class Expr
      * set.
      *
      * @see Builder::bitsAnySet()
-     * @see https://docs.mongodb.org/manual/reference/operator/query/bitsAnySet/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/bitsAnySet/
      *
      * @param int|array|Binary $value
      */
@@ -298,7 +298,7 @@ class Expr
      * Apply a bitwise xor operation on the current field.
      *
      * @see Builder::bitXor()
-     * @see http://docs.mongodb.org/manual/reference/operator/update/bit/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/bit/
      */
     public function bitXor(int $value) : self
     {
@@ -312,7 +312,7 @@ class Expr
      * This method must be called after text().
      *
      * @see Builder::caseSensitive()
-     * @see http://docs.mongodb.org/manual/reference/operator/text/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/text/
      *
      * @throws BadMethodCallException If the query does not already have $text criteria.
      */
@@ -336,7 +336,7 @@ class Expr
      * Associates a comment to any expression taking a query predicate.
      *
      * @see Builder::comment()
-     * @see http://docs.mongodb.org/manual/reference/operator/query/comment/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/comment/
      */
     public function comment(string $comment) : self
     {
@@ -349,7 +349,7 @@ class Expr
      * Sets the value of the current field to the current date, either as a date or a timestamp.
      *
      * @see Builder::currentDate()
-     * @see http://docs.mongodb.org/manual/reference/operator/update/currentDate/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/currentDate/
      *
      * @throws InvalidArgumentException If an invalid type is given.
      */
@@ -372,7 +372,7 @@ class Expr
      * This method must be called after text().
      *
      * @see Builder::diacriticSensitive()
-     * @see http://docs.mongodb.org/manual/reference/operator/text/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/text/
      *
      * @throws BadMethodCallException If the query does not already have $text criteria.
      */
@@ -396,7 +396,7 @@ class Expr
      * Add $each criteria to the expression for a $push operation.
      *
      * @see Expr::push()
-     * @see http://docs.mongodb.org/manual/reference/operator/each/
+     * @see https://docs.mongodb.com/manual/reference/operator/each/
      */
     public function each(array $values) : self
     {
@@ -407,7 +407,7 @@ class Expr
      * Specify $elemMatch criteria for the current field.
      *
      * @see Builder::elemMatch()
-     * @see http://docs.mongodb.org/manual/reference/operator/elemMatch/
+     * @see https://docs.mongodb.com/manual/reference/operator/elemMatch/
      *
      * @param array|Expr $expression
      */
@@ -438,7 +438,7 @@ class Expr
      * Specify $exists criteria for the current field.
      *
      * @see Builder::exists()
-     * @see http://docs.mongodb.org/manual/reference/operator/exists/
+     * @see https://docs.mongodb.com/manual/reference/operator/exists/
      */
     public function exists(bool $bool) : self
     {
@@ -464,7 +464,7 @@ class Expr
      * geometry's JSON representation.
      *
      * @see Builder::geoIntersects()
-     * @see http://docs.mongodb.org/manual/reference/operator/geoIntersects/
+     * @see https://docs.mongodb.com/manual/reference/operator/geoIntersects/
      *
      * @param array|Geometry $geometry
      */
@@ -484,7 +484,7 @@ class Expr
      * geometry's JSON representation.
      *
      * @see Builder::geoWithin()
-     * @see http://docs.mongodb.org/manual/reference/operator/geoIntersects/
+     * @see https://docs.mongodb.com/manual/reference/operator/geoIntersects/
      *
      * @param array|Geometry $geometry
      */
@@ -507,7 +507,7 @@ class Expr
      * indexes. This cannot be used with 2dsphere indexes and GeoJSON shapes.
      *
      * @see Builder::geoWithinBox()
-     * @see http://docs.mongodb.org/manual/reference/operator/box/
+     * @see https://docs.mongodb.com/manual/reference/operator/box/
      */
     public function geoWithinBox(float $x1, float $y1, float $x2, float $y2) : self
     {
@@ -523,7 +523,7 @@ class Expr
      * indexes. This cannot be used with 2dsphere indexes and GeoJSON shapes.
      *
      * @see Builider::geoWithinCenter()
-     * @see http://docs.mongodb.org/manual/reference/operator/center/
+     * @see https://docs.mongodb.com/manual/reference/operator/center/
      */
     public function geoWithinCenter(float $x, float $y, float $radius) : self
     {
@@ -538,7 +538,7 @@ class Expr
      * Note: the $centerSphere operator supports both 2d and 2dsphere indexes.
      *
      * @see Builder::geoWithinCenterSphere()
-     * @see http://docs.mongodb.org/manual/reference/operator/centerSphere/
+     * @see https://docs.mongodb.com/manual/reference/operator/centerSphere/
      */
     public function geoWithinCenterSphere(float $x, float $y, float $radius) : self
     {
@@ -559,7 +559,7 @@ class Expr
      * indexes. This cannot be used with 2dsphere indexes and GeoJSON shapes.
      *
      * @see Builder::geoWithinPolygon()
-     * @see http://docs.mongodb.org/manual/reference/operator/polygon/
+     * @see https://docs.mongodb.com/manual/reference/operator/polygon/
      *
      * @param array $point1    First point of the polygon
      * @param array $point2    Second point of the polygon
@@ -607,7 +607,7 @@ class Expr
      * Specify $gt criteria for the current field.
      *
      * @see Builder::gt()
-     * @see http://docs.mongodb.org/manual/reference/operator/gt/
+     * @see https://docs.mongodb.com/manual/reference/operator/gt/
      *
      * @param mixed $value
      */
@@ -620,7 +620,7 @@ class Expr
      * Specify $gte criteria for the current field.
      *
      * @see Builder::gte()
-     * @see http://docs.mongodb.org/manual/reference/operator/gte/
+     * @see https://docs.mongodb.com/manual/reference/operator/gte/
      *
      * @param mixed $value
      */
@@ -633,7 +633,7 @@ class Expr
      * Specify $in criteria for the current field.
      *
      * @see Builder::in()
-     * @see http://docs.mongodb.org/manual/reference/operator/in/
+     * @see https://docs.mongodb.com/manual/reference/operator/in/
      */
     public function in(array $values) : self
     {
@@ -646,7 +646,7 @@ class Expr
      * If the field does not exist, it will be set to this value.
      *
      * @see Builder::inc()
-     * @see http://docs.mongodb.org/manual/reference/operator/inc/
+     * @see https://docs.mongodb.com/manual/reference/operator/inc/
      *
      * @param float|int $value
      */
@@ -708,7 +708,7 @@ class Expr
      * This method must be called after text().
      *
      * @see Builder::language()
-     * @see http://docs.mongodb.org/manual/reference/operator/text/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/text/
      *
      * @throws BadMethodCallException If the query does not already have $text criteria.
      */
@@ -727,7 +727,7 @@ class Expr
      * Specify $lt criteria for the current field.
      *
      * @see Builder::lte()
-     * @see http://docs.mongodb.org/manual/reference/operator/lte/
+     * @see https://docs.mongodb.com/manual/reference/operator/lte/
      *
      * @param mixed $value
      */
@@ -740,7 +740,7 @@ class Expr
      * Specify $lte criteria for the current field.
      *
      * @see Builder::lte()
-     * @see http://docs.mongodb.org/manual/reference/operator/lte/
+     * @see https://docs.mongodb.com/manual/reference/operator/lte/
      *
      * @param mixed $value
      */
@@ -753,7 +753,7 @@ class Expr
      * Updates the value of the field to a specified value if the specified value is greater than the current value of the field.
      *
      * @see Builder::max()
-     * @see http://docs.mongodb.org/manual/reference/operator/update/max/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/max/
      *
      * @param mixed $value
      */
@@ -769,7 +769,7 @@ class Expr
      * Updates the value of the field to a specified value if the specified value is less than the current value of the field.
      *
      * @see Builder::min()
-     * @see http://docs.mongodb.org/manual/reference/operator/update/min/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/min/
      *
      * @param mixed $value
      */
@@ -785,7 +785,7 @@ class Expr
      * Specify $mod criteria for the current field.
      *
      * @see Builder::mod()
-     * @see http://docs.mongodb.org/manual/reference/operator/mod/
+     * @see https://docs.mongodb.com/manual/reference/operator/mod/
      *
      * @param float|int $divisor
      * @param float|int $remainder
@@ -801,7 +801,7 @@ class Expr
      * If the field does not exist, it will be set to 0.
      *
      * @see Builder::mul()
-     * @see http://docs.mongodb.org/manual/reference/operator/mul/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/mul/
      *
      * @param float|int $value
      */
@@ -821,7 +821,7 @@ class Expr
      * an array corresponding to the point's JSON representation.
      *
      * @see Builder::near()
-     * @see http://docs.mongodb.org/manual/reference/operator/near/
+     * @see https://docs.mongodb.com/manual/reference/operator/near/
      *
      * @param float|array|Point $x
      * @param float             $y
@@ -847,7 +847,7 @@ class Expr
      * an array corresponding to the point's JSON representation.
      *
      * @see Builder::nearSphere()
-     * @see http://docs.mongodb.org/manual/reference/operator/nearSphere/
+     * @see https://docs.mongodb.com/manual/reference/operator/nearSphere/
      *
      * @param float|array|Point $x
      * @param float             $y
@@ -869,7 +869,7 @@ class Expr
      * Negates an expression for the current field.
      *
      * @see Builder::not()
-     * @see http://docs.mongodb.org/manual/reference/operator/not/
+     * @see https://docs.mongodb.com/manual/reference/operator/not/
      *
      * @param array|Expr $expression
      */
@@ -882,7 +882,7 @@ class Expr
      * Specify $ne criteria for the current field.
      *
      * @see Builder::notEqual()
-     * @see http://docs.mongodb.org/manual/reference/operator/ne/
+     * @see https://docs.mongodb.com/manual/reference/operator/ne/
      *
      * @param mixed $value
      */
@@ -895,7 +895,7 @@ class Expr
      * Specify $nin criteria for the current field.
      *
      * @see Builder::notIn()
-     * @see http://docs.mongodb.org/manual/reference/operator/nin/
+     * @see https://docs.mongodb.com/manual/reference/operator/nin/
      */
     public function notIn(array $values) : self
     {
@@ -927,7 +927,7 @@ class Expr
      * Remove the first element from the current array field.
      *
      * @see Builder::popFirst()
-     * @see http://docs.mongodb.org/manual/reference/operator/pop/
+     * @see https://docs.mongodb.com/manual/reference/operator/pop/
      */
     public function popFirst() : self
     {
@@ -941,7 +941,7 @@ class Expr
      * Remove the last element from the current array field.
      *
      * @see Builder::popLast()
-     * @see http://docs.mongodb.org/manual/reference/operator/pop/
+     * @see https://docs.mongodb.com/manual/reference/operator/pop/
      */
     public function popLast() : self
     {
@@ -957,7 +957,7 @@ class Expr
      * This is useful in conjunction with {@link Expr::each()} for a
      * {@link Expr::push()} operation.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/update/position/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/position/
      */
     public function position(int $position) : self
     {
@@ -969,7 +969,7 @@ class Expr
      * current array field.
      *
      * @see Builder::pull()
-     * @see http://docs.mongodb.org/manual/reference/operator/pull/
+     * @see https://docs.mongodb.com/manual/reference/operator/pull/
      *
      * @param mixed|Expr $valueOrExpression
      */
@@ -990,7 +990,7 @@ class Expr
      * array field.
      *
      * @see Builder::pullAll()
-     * @see http://docs.mongodb.org/manual/reference/operator/pullAll/
+     * @see https://docs.mongodb.com/manual/reference/operator/pullAll/
      */
     public function pullAll(array $values) : self
     {
@@ -1012,10 +1012,10 @@ class Expr
      * also be used to limit and order array elements, respectively.
      *
      * @see Builder::push()
-     * @see http://docs.mongodb.org/manual/reference/operator/push/
-     * @see http://docs.mongodb.org/manual/reference/operator/each/
-     * @see http://docs.mongodb.org/manual/reference/operator/slice/
-     * @see http://docs.mongodb.org/manual/reference/operator/sort/
+     * @see https://docs.mongodb.com/manual/reference/operator/push/
+     * @see https://docs.mongodb.com/manual/reference/operator/each/
+     * @see https://docs.mongodb.com/manual/reference/operator/slice/
+     * @see https://docs.mongodb.com/manual/reference/operator/sort/
      *
      * @param mixed|Expr $valueOrExpression
      */
@@ -1098,7 +1098,7 @@ class Expr
      * Rename the current field.
      *
      * @see Builder::rename()
-     * @see http://docs.mongodb.org/manual/reference/operator/rename/
+     * @see https://docs.mongodb.com/manual/reference/operator/rename/
      */
     public function rename(string $name) : self
     {
@@ -1116,7 +1116,7 @@ class Expr
      * whether or not a $set operator is used.
      *
      * @see Builder::set()
-     * @see http://docs.mongodb.org/manual/reference/operator/set/
+     * @see https://docs.mongodb.com/manual/reference/operator/set/
      *
      * @param mixed $value
      */
@@ -1177,7 +1177,7 @@ class Expr
      * $setOnInsert does nothing.
      *
      * @see Builder::setOnInsert()
-     * @see https://docs.mongodb.org/manual/reference/operator/update/setOnInsert/
+     * @see https://docs.mongodb.com/manual/reference/operator/update/setOnInsert/
      *
      * @param mixed $value
      */
@@ -1205,7 +1205,7 @@ class Expr
      * Specify $size criteria for the current field.
      *
      * @see Builder::size()
-     * @see http://docs.mongodb.org/manual/reference/operator/size/
+     * @see https://docs.mongodb.com/manual/reference/operator/size/
      */
     public function size(int $size) : self
     {
@@ -1219,7 +1219,7 @@ class Expr
      * {@link Expr::push()} operation. {@link Builder::selectSlice()} should be
      * used for specifying $slice for a query projection.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/slice/
+     * @see https://docs.mongodb.com/manual/reference/operator/slice/
      */
     public function slice(int $slice) : self
     {
@@ -1236,7 +1236,7 @@ class Expr
      * {@link Expr::push()} operation. {@link Builder::sort()} should be used to
      * sort the results of a query.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/sort/
+     * @see https://docs.mongodb.com/manual/reference/operator/sort/
      *
      * @param array|string $fieldName Field name or array of field/order pairs
      * @param int|string   $order     Field order (if one field is specified)
@@ -1256,7 +1256,7 @@ class Expr
      * The $language option may be set with {@link Expr::language()}.
      *
      * @see Builder::text()
-     * @see http://docs.mongodb.org/master/reference/operator/query/text/
+     * @see https://docs.mongodb.com/manual/reference/operator/query/text/
      */
     public function text(string $search) : self
     {
@@ -1269,7 +1269,7 @@ class Expr
      * Specify $type criteria for the current field.
      *
      * @see Builder::type()
-     * @see http://docs.mongodb.org/manual/reference/operator/type/
+     * @see https://docs.mongodb.com/manual/reference/operator/type/
      *
      * @param int|string $type
      */
@@ -1284,7 +1284,7 @@ class Expr
      * The field will be removed from the document (not set to null).
      *
      * @see Builder::unsetField()
-     * @see http://docs.mongodb.org/manual/reference/operator/unset/
+     * @see https://docs.mongodb.com/manual/reference/operator/unset/
      */
     public function unsetField() : self
     {
@@ -1298,7 +1298,7 @@ class Expr
      * Specify a JavaScript expression to use for matching documents.
      *
      * @see Builder::where()
-     * @see http://docs.mongodb.org/manual/reference/operator/where/
+     * @see https://docs.mongodb.com/manual/reference/operator/where/
      *
      * @param string|Javascript $javascript
      */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
@@ -194,7 +194,7 @@ class IdTest extends BaseTest
         /* MongoDB allows comparisons between different numeric types, so we
          * cannot test integer and floating point values (e.g. 123 and 123.0).
          *
-         * See: http://docs.mongodb.org/manual/faq/developers/#what-is-the-compare-order-for-bson-types
+         * See: https://docs.mongodb.com/manual/faq/developers/#what-is-the-compare-order-for-bson-types
          */
         return [
             ['123', 123],


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->
Fixed links to mongodb manual

What does the PR do : 
- [x] Fix links that lead to "page not found"
- [x] Fix `http(s)://docs.mongodb.org` to `https://docs.mongodb.com`
- [x] Fix some links pointing to `/master/` to `/manual/` instead