### PR TITLE
JSON Schema Validation

### DIFF
--- a/docs/en/cookbook/validation-of-documents.rst
+++ b/docs/en/cookbook/validation-of-documents.rst
@@ -1,6 +1,9 @@
 Validation of Documents
 =======================
 
+Validation of Documents - Application Side
+------------------------------------------
+
 .. sectionauthor:: Benjamin Eberlei <kontakt@beberlei.de>
 
 Doctrine does not ship with any internal validators, the reason
@@ -128,3 +131,123 @@ the Versionable extension, which requires another type of event
 called "onFlush".
 
 Further readings: :doc:`Lifecycle Events <../reference/events>`
+
+Validation of Documents - Database Side
+---------------------------------------
+
+.. sectionauthor:: Alexandre Abrioux <alexandre-abrioux@users.noreply.github.com>
+
+.. note::
+
+    This feature has been introduced in version 2.3.0
+
+MongoDB ≥ 3.6 offers the capability to validate documents during
+insertions and updates through a schema associated to the collection
+(cf. `MongoDB documentation <https://docs.mongodb.com/manual/core/schema-validation/>`_).
+
+Doctrine MongoDB ODM now provides a way to take advantage of this functionality
+thanks to the new :doc:`@Validation <../reference/annotations-reference#validation>`
+annotation and its properties (also available with XML mapping):
+
+-
+  ``validator`` - The schema that will be used to validate documents.
+  It is a string representing a BSON document under the
+  `Extended JSON specification <https://github.com/mongodb/specifications/blob/master/source/extended-json.rst>`_.
+-
+  ``action`` - The behavior followed by MongoDB to handle documents that
+  violate the validation rules.
+-
+  ``level`` - The threshold used by MongoDB to filter operations that
+  will get validated.
+
+Once defined, those options will be added to the collection after running
+the ``odm:schema:create`` or ``odm:schema:update`` command.
+
+.. configuration-block::
+
+    .. code-block:: php
+
+        <?php
+
+        namespace Documents;
+
+        use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+        use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+
+        /**
+         * @ODM\Document
+         * @ODM\Validation(
+         *     validator=SchemaValidated::VALIDATOR,
+         *     action=ClassMetadata::SCHEMA_VALIDATION_ACTION_WARN,
+         *     level=ClassMetadata::SCHEMA_VALIDATION_LEVEL_MODERATE,
+         * )
+         */
+        class SchemaValidated
+        {
+            public const VALIDATOR = <<<'EOT'
+        {
+            "$jsonSchema": {
+                "required": ["name"],
+                "properties": {
+                    "name": {
+                        "bsonType": "string",
+                        "description": "must be a string and is required"
+                    }
+                }
+            },
+            "$or": [
+                { "phone": { "$type": "string" } },
+                { "email": { "$regex": { "$regularExpression" : { "pattern": "@mongodb\\.com$", "options": "" } } } },
+                { "status": { "$in": [ "Unknown", "Incomplete" ] } }
+            ]
+        }
+        EOT;
+
+            /** @ODM\Id */
+            private $id;
+
+            /** @ODM\Field(type="string") */
+            private $name;
+
+            /** @ODM\Field(type="string") */
+            private $phone;
+
+            /** @ODM\Field(type="string") */
+            private $email;
+
+            /** @ODM\Field(type="string") */
+            private $status;
+        }
+
+    .. code-block:: xml
+
+        <?xml version="1.0" encoding="UTF-8"?>
+        <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                          xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                          http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+            <document name="SchemaValidated">
+                <schema-validation action="warn" level="moderate">
+                    {
+                        "$jsonSchema": {
+                            "required": ["name"],
+                            "properties": {
+                                "name": {
+                                    "bsonType": "string",
+                                    "description": "must be a string and is required"
+                                }
+                            }
+                        },
+                        "$or": [
+                            { "phone": { "$type": "string" } },
+                            { "email": { "$regex": { "$regularExpression" : { "pattern": "@mongodb\\.com$", "options": "" } } } },
+                            { "status": { "$in": [ "Unknown", "Incomplete" ] } }
+                        ]
+                    }
+                </schema-validation>
+            </document>
+        </doctrine-mongo-mapping>
+
+Please refer to the :doc:`@Validation <../reference/annotations-reference#document>` annotation reference
+for more details on how to use this feature.

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -102,6 +102,7 @@
       <xs:element name="indexes" type="odm:indexes" minOccurs="0" />
       <xs:element name="shard-key" type="odm:shard-key" minOccurs="0" />
       <xs:element name="read-preference" type="odm:read-preference" minOccurs="0" />
+      <xs:element name="schema-validation" type="odm:schema-validation" minOccurs="0" />
     </xs:choice>
 
     <xs:attribute name="db" type="xs:NMTOKEN" />
@@ -514,4 +515,29 @@
     <xs:attribute name="name" type="xs:string" use="required" />
     <xs:attribute name="value" type="xs:string" use="required" />
   </xs:complexType>
+
+  <xs:complexType name="schema-validation">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="action" type="odm:schema-validation-action" />
+        <xs:attribute name="level" type="odm:schema-validation-level" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:simpleType name="schema-validation-action">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="error" />
+      <xs:enumeration value="warn" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="schema-validation-level">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="off" />
+      <xs:enumeration value="strict" />
+      <xs:enumeration value="moderate" />
+    </xs:restriction>
+  </xs:simpleType>
+
 </xs:schema>

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Validation.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Validation.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
+
+/**
+ * @Annotation
+ * @Target({"CLASS"})
+ */
+class Validation
+{
+    /** @var string */
+    public $validator;
+
+    /**
+     * @var string
+     * @Enum({
+     *     \Doctrine\ODM\MongoDB\Mapping\ClassMetadata::SCHEMA_VALIDATION_ACTION_ERROR,
+     *     \Doctrine\ODM\MongoDB\Mapping\ClassMetadata::SCHEMA_VALIDATION_ACTION_WARN,
+     *     })
+     */
+    public $action;
+
+    /**
+     * @var string
+     * @Enum({
+     *     \Doctrine\ODM\MongoDB\Mapping\ClassMetadata::SCHEMA_VALIDATION_LEVEL_OFF,
+     *     \Doctrine\ODM\MongoDB\Mapping\ClassMetadata::SCHEMA_VALIDATION_LEVEL_STRICT,
+     *     \Doctrine\ODM\MongoDB\Mapping\ClassMetadata::SCHEMA_VALIDATION_LEVEL_MODERATE,
+     *     })
+     */
+    public $level;
+}

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -125,6 +125,23 @@ use function trigger_deprecation;
     public const REFERENCE_STORE_AS_DB_REF_WITH_DB = 'dbRefWithDb';
     public const REFERENCE_STORE_AS_REF            = 'ref';
 
+    /**
+     * The collection schema validationAction values
+     *
+     * @see https://docs.mongodb.com/manual/core/schema-validation/#accept-or-reject-invalid-documents
+     */
+    public const SCHEMA_VALIDATION_ACTION_ERROR = 'error';
+    public const SCHEMA_VALIDATION_ACTION_WARN  = 'warn';
+
+    /**
+     * The collection schema validationLevel values
+     *
+     * @see https://docs.mongodb.com/manual/core/schema-validation/#existing-documents
+     */
+    public const SCHEMA_VALIDATION_LEVEL_OFF      = 'off';
+    public const SCHEMA_VALIDATION_LEVEL_STRICT   = 'strict';
+    public const SCHEMA_VALIDATION_LEVEL_MODERATE = 'moderate';
+
     /* The inheritance mapping types */
     /**
      * NONE means the class does not participate in an inheritance hierarchy
@@ -270,6 +287,27 @@ use function trigger_deprecation;
      * @var array<string, array>
      */
     public $shardKey = [];
+
+    /**
+     * Allows users to specify a validation schema for the collection.
+     *
+     * @var array|object|null
+     */
+    private $validator;
+
+    /**
+     * Determines whether to error on invalid documents or just warn about the violations but allow invalid documents to be inserted.
+     *
+     * @var string
+     */
+    private $validationAction = self::SCHEMA_VALIDATION_ACTION_ERROR;
+
+    /**
+     * Determines how strictly MongoDB applies the validation rules to existing documents during an update.
+     *
+     * @var string
+     */
+    private $validationLevel = self::SCHEMA_VALIDATION_LEVEL_STRICT;
 
     /**
      * READ-ONLY: The name of the document class.
@@ -991,6 +1029,42 @@ use function trigger_deprecation;
     public function isSharded(): bool
     {
         return $this->shardKey !== [];
+    }
+
+    /**
+     * @return array|object|null
+     */
+    public function getValidator()
+    {
+        return $this->validator;
+    }
+
+    /**
+     * @param array|object|null $validator
+     */
+    public function setValidator($validator): void
+    {
+        $this->validator = $validator;
+    }
+
+    public function getValidationAction(): string
+    {
+        return $this->validationAction;
+    }
+
+    public function setValidationAction(string $validationAction): void
+    {
+        $this->validationAction = $validationAction;
+    }
+
+    public function getValidationLevel(): string
+    {
+        return $this->validationLevel;
+    }
+
+    public function setValidationLevel(string $validationLevel): void
+    {
+        $this->validationLevel = $validationLevel;
     }
 
     /**
@@ -2159,6 +2233,12 @@ use function trigger_deprecation;
 
         if ($this->isReadOnly) {
             $serialized[] = 'isReadOnly';
+        }
+
+        if ($this->validator !== null) {
+            $serialized[] = 'validator';
+            $serialized[] = 'validationAction';
+            $serialized[] = 'validationLevel';
         }
 
         return $serialized;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -271,4 +271,9 @@ final class MappingException extends BaseMappingException
     {
         return new self(sprintf('Root class "%s" for view "%s" could not be found.', $rootClass, $className));
     }
+
+    public static function schemaValidationError(int $errorCode, string $errorMessage, string $className, string $property): self
+    {
+        return new self(sprintf('The following schema validation error occurred while parsing the "%s" property of the "%s" class: "%s" (code %s).', $property, $className, $errorMessage, $errorCode));
+    }
 }

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
@@ -41,9 +41,13 @@ class UpdateCommand extends AbstractCommand
             if (is_string($class)) {
                 $this->processDocumentIndex($sm, $class, $this->getMaxTimeMsFromInput($input), $this->getWriteConcernFromInput($input));
                 $output->writeln(sprintf('Updated <comment>index(es)</comment> for <info>%s</info>', $class));
+                $this->processDocumentValidator($sm, $class, $this->getMaxTimeMsFromInput($input), $this->getWriteConcernFromInput($input));
+                $output->writeln(sprintf('Updated <comment>validation</comment> for <info>%s</info>', $class));
             } else {
                 $this->processIndex($sm, $this->getMaxTimeMsFromInput($input), $this->getWriteConcernFromInput($input));
                 $output->writeln('Updated <comment>indexes</comment> for <info>all classes</info>');
+                $this->processValidators($sm, $this->getMaxTimeMsFromInput($input), $this->getWriteConcernFromInput($input));
+                $output->writeln('Updated <comment>validation</comment> for <info>all classes</info>');
             }
         } catch (Throwable $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
@@ -61,6 +65,16 @@ class UpdateCommand extends AbstractCommand
     protected function processIndex(SchemaManager $sm, ?int $maxTimeMs, ?WriteConcern $writeConcern)
     {
         $sm->updateIndexes($maxTimeMs, $writeConcern);
+    }
+
+    protected function processDocumentValidator(SchemaManager $sm, string $document, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    {
+        $sm->updateDocumentValidator($document, $maxTimeMs, $writeConcern);
+    }
+
+    protected function processValidators(SchemaManager $sm, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    {
+        $sm->updateValidators($maxTimeMs, $writeConcern);
     }
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ValidationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ValidationTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\SchemaValidated;
+
+use function MongoDB\BSON\fromJSON;
+use function MongoDB\BSON\fromPHP;
+use function MongoDB\BSON\toCanonicalExtendedJSON;
+use function MongoDB\BSON\toPHP;
+
+class ValidationTest extends BaseTest
+{
+    public function testCreateUpdateValidatedDocument()
+    {
+        $this->requireVersion($this->getServerVersion(), '3.6.0', '<', 'MongoDB cannot perform JSON schema validation before version 3.6');
+
+        // Test creation of SchemaValidated collection
+        $cm = $this->dm->getClassMetadata(SchemaValidated::class);
+        $this->dm->getSchemaManager()->createDocumentCollection($cm->name);
+        $expectedValidatorJson = <<<'EOT'
+{
+    "$jsonSchema": {
+        "required": ["name"],
+        "properties": {
+            "name": {
+                "bsonType": "string",
+                "description": "must be a string and is required"
+            }
+        }
+    },
+    "$or": [
+        { "phone": { "$type": "string" } },
+        { "email": { "$regex": { "$regularExpression" : { "pattern": "@mongodb\\.com$", "options": "" } } } },
+        { "status": { "$in": [ "Unknown", "Incomplete" ] } }
+    ]
+}
+EOT;
+        $expectedValidatorBson = fromJSON($expectedValidatorJson);
+        $expectedValidator     = toPHP($expectedValidatorBson, []);
+        $expectedOptions       = [
+            'validator' => $expectedValidator,
+            'validationLevel' => ClassMetadata::SCHEMA_VALIDATION_LEVEL_MODERATE,
+            'validationAction' => ClassMetadata::SCHEMA_VALIDATION_ACTION_WARN,
+        ];
+        $expectedOptionsBson   = fromPHP($expectedOptions);
+        $expectedOptionsJson   = toCanonicalExtendedJSON($expectedOptionsBson);
+        $collections           = $this->dm->getDocumentDatabase($cm->name)->listCollections();
+        $assertNb              = 0;
+        foreach ($collections as $collection) {
+            if ($collection->getName() !== $cm->getCollection()) {
+                continue;
+            }
+
+            $assertNb++;
+            $collectionOptionsBson = fromPHP($collection->getOptions());
+            $collectionOptionsJson = toCanonicalExtendedJSON($collectionOptionsBson);
+            $this->assertJsonStringEqualsJsonString($expectedOptionsJson, $collectionOptionsJson);
+        }
+
+        $this->assertEquals(1, $assertNb);
+
+        // Test updating the same collection, this time removing the validators and resetting to default options
+        $cmUpdated = $this->dm->getClassMetadata(SchemaValidatedUpdate::class);
+        $this->dm->getSchemaManager()->updateDocumentValidator($cmUpdated->name);
+        // We expect the default values set by MongoDB
+        // See: https://docs.mongodb.com/manual/reference/command/collMod/#document-validation
+        $expectedOptions = [
+            'validationLevel' => ClassMetadata::SCHEMA_VALIDATION_LEVEL_STRICT,
+            'validationAction' => ClassMetadata::SCHEMA_VALIDATION_ACTION_ERROR,
+        ];
+        $collections     = $this->dm->getDocumentDatabase($cmUpdated->name)->listCollections();
+        $assertNb        = 0;
+        foreach ($collections as $collection) {
+            if ($collection->getName() !== $cm->getCollection()) {
+                continue;
+            }
+
+            $assertNb++;
+            $this->assertEquals($expectedOptions, $collection->getOptions());
+        }
+
+        $this->assertEquals(1, $assertNb);
+    }
+}
+
+/**
+ * @ODM\Document(collection="SchemaValidated")
+ */
+class SchemaValidatedUpdate extends SchemaValidated
+{
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
@@ -242,6 +242,15 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         ];
     }
 
+    public function testWrongValueForValidationValidatorShouldThrowException()
+    {
+        $annotationDriver = $this->loadDriver();
+        $classMetadata    = new ClassMetadata(WrongValueForValidationValidator::class);
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('The following schema validation error occurred while parsing the "validator" property of the "Doctrine\ODM\MongoDB\Tests\Mapping\WrongValueForValidationValidator" class: "Got parse error at "w", position 0: "SPECIAL_EXPECTED"" (code 0).');
+        $annotationDriver->loadMetadataForClass($classMetadata->name, $classMetadata);
+    }
+
     protected function loadDriverForCMSDocuments()
     {
         $annotationDriver = $this->loadDriver();
@@ -315,6 +324,13 @@ class AnnotationDriverTestWriteConcernMajority
  * @ODM\Document(writeConcern=0)
  */
 class AnnotationDriverTestWriteConcernUnacknowledged
+{
+    /** @ODM\Id */
+    public $id;
+}
+
+/** @ODM\Validation(validator="wrong") */
+class WrongValueForValidationValidator
 {
     /** @ODM\Id */
     public $id;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Annotations/ValidationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Annotations/ValidationTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Mapping\Annotations;
+
+use Doctrine\Common\Annotations\AnnotationException;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class ValidationTest extends BaseTest
+{
+    public function testWrongTypeForValidationValidatorShouldThrowException()
+    {
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessage('[Type Error] Attribute "validator" of @ODM\Validation declared on class Doctrine\ODM\MongoDB\Tests\Mapping\Annotations\WrongTypeForValidationValidator expects a(n) string, but got array.');
+        $this->dm->getClassMetadata(WrongTypeForValidationValidator::class);
+    }
+
+    public function testWrongTypeForValidationActionShouldThrowException()
+    {
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessage('[Type Error] Attribute "action" of @ODM\Validation declared on class Doctrine\ODM\MongoDB\Tests\Mapping\Annotations\WrongTypeForValidationAction expects a(n) string, but got boolean.');
+        $this->dm->getClassMetadata(WrongTypeForValidationAction::class);
+    }
+
+    public function testWrongValueForValidationActionShouldThrowException()
+    {
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessageMatches('#^\[Enum Error\] Attribute "action" of @Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\Annotations\\\\Validation declared on class Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\Annotations\\\\WrongValueForValidationAction accepts? only \[error, warn\], but got wrong\.$#');
+        $this->dm->getClassMetadata(WrongValueForValidationAction::class);
+    }
+
+    public function testWrongTypeForValidationLevelShouldThrowException()
+    {
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessage('[Type Error] Attribute "level" of @ODM\Validation declared on class Doctrine\ODM\MongoDB\Tests\Mapping\Annotations\WrongTypeForValidationLevel expects a(n) string, but got boolean.');
+        $this->dm->getClassMetadata(WrongTypeForValidationLevel::class);
+    }
+
+    public function testWrongValueForValidationLevelShouldThrowException()
+    {
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessageMatches('#^\[Enum Error\] Attribute "level" of @Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\Annotations\\\\Validation declared on class Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\Annotations\\\\WrongValueForValidationLevel accepts? only \[off, strict, moderate\], but got wrong\.$#');
+        $this->dm->getClassMetadata(WrongValueForValidationLevel::class);
+    }
+}
+
+/** @ODM\Validation(validator={"wrong"}) */
+class WrongTypeForValidationValidator
+{
+}
+
+/** @ODM\Validation(action=true) */
+class WrongTypeForValidationAction
+{
+}
+
+/** @ODM\Validation(action="wrong") */
+class WrongValueForValidationAction
+{
+}
+
+/** @ODM\Validation(level=true) */
+class WrongTypeForValidationLevel
+{
+}
+
+/** @ODM\Validation(level="wrong") */
+class WrongValueForValidationLevel
+{
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
@@ -10,8 +10,13 @@ use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use TestDocuments\AlsoLoadDocument;
 use TestDocuments\CustomIdGenerator;
 use TestDocuments\InvalidPartialFilterDocument;
+use TestDocuments\SchemaInvalidDocument;
+use TestDocuments\SchemaValidatedDocument;
 use TestDocuments\UserCustomIdGenerator;
 use TestDocuments\UserNonStringOptions;
+
+use function MongoDB\BSON\fromJSON;
+use function MongoDB\BSON\toPHP;
 
 class XmlDriverTest extends AbstractDriverTest
 {
@@ -92,6 +97,43 @@ class XmlDriverTest extends AbstractDriverTest
             'also-load' => 'createdOn,creation_date',
             'alsoLoadFields' => ['createdOn', 'creation_date'],
         ], $classMetadata->fieldMappings['createdAt']);
+    }
+
+    public function testValidationMapping()
+    {
+        $classMetadata = new ClassMetadata(SchemaValidatedDocument::class);
+        $this->driver->loadMetadataForClass($classMetadata->name, $classMetadata);
+        $this->assertEquals(ClassMetadata::SCHEMA_VALIDATION_ACTION_WARN, $classMetadata->getValidationAction());
+        $this->assertEquals(ClassMetadata::SCHEMA_VALIDATION_LEVEL_MODERATE, $classMetadata->getValidationLevel());
+        $expectedValidatorJson = <<<'EOT'
+{
+    "$jsonSchema": {
+        "required": ["name"],
+        "properties": {
+            "name": {
+                "bsonType": "string",
+                "description": "must be a string and is required"
+            }
+        }
+    },
+    "$or": [
+        { "phone": { "$type": "string" } },
+        { "email": { "$regex": { "$regularExpression" : { "pattern": "@mongodb\\.com$", "options": "" } } } },
+        { "status": { "$in": [ "Unknown", "Incomplete" ] } }
+    ]
+}
+EOT;
+        $expectedValidatorBson = fromJSON($expectedValidatorJson);
+        $expectedValidator     = toPHP($expectedValidatorBson, []);
+        $this->assertEquals($expectedValidator, $classMetadata->getValidator());
+    }
+
+    public function testWrongValueForValidationSchemaShouldThrowException()
+    {
+        $classMetadata = new ClassMetadata(SchemaInvalidDocument::class);
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('The following schema validation error occurred while parsing the "schema-validation" property of the "TestDocuments\SchemaInvalidDocument" class: "Got parse error at "w", position 13: "SPECIAL_EXPECTED"" (code 0).');
+        $this->driver->loadMetadataForClass($classMetadata->name, $classMetadata);
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/SchemaInvalidDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/SchemaInvalidDocument.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestDocuments;
+
+class SchemaInvalidDocument
+{
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/SchemaValidatedDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/SchemaValidatedDocument.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestDocuments;
+
+class SchemaValidatedDocument
+{
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.SchemaInvalidDocument.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.SchemaInvalidDocument.dcm.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="TestDocuments\SchemaInvalidDocument">
+        <schema-validation>
+            wrong
+        </schema-validation>
+    </document>
+</doctrine-mongo-mapping>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.SchemaValidatedDocument.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.SchemaValidatedDocument.dcm.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+    <document name="TestDocuments\SchemaValidatedDocument">
+        <schema-validation action="warn" level="moderate">
+            {
+                "$jsonSchema": {
+                    "required": ["name"],
+                    "properties": {
+                        "name": {
+                            "bsonType": "string",
+                            "description": "must be a string and is required"
+                        }
+                    }
+                },
+                "$or": [
+                    { "phone": { "$type": "string" } },
+                    { "email": { "$regex": { "$regularExpression" : { "pattern": "@mongodb\\.com$", "options": "" } } } },
+                    { "status": { "$in": [ "Unknown", "Incomplete" ] } }
+                ]
+            }
+        </schema-validation>
+    </document>
+</doctrine-mongo-mapping>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/Console/Command/AbstractCommandTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/Console/Command/AbstractCommandTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Tools\Console\Command;
+
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tools\Console\Helper\DocumentManagerHelper;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+
+abstract class AbstractCommandTest extends BaseTest
+{
+    /** @var Application */
+    protected $application;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $helperSet   = new HelperSet(
+            [
+                'dm' => new DocumentManagerHelper($this->dm),
+            ]
+        );
+        $application = new Application('Doctrine MongoDB ODM');
+        $application->setHelperSet($helperSet);
+        $this->application = $application;
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->application);
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/Console/Command/Schema/UpdateCommandTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/Console/Command/Schema/UpdateCommandTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Tools\Console\Command\Schema;
+
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Doctrine\ODM\MongoDB\Tests\Tools\Console\Command\AbstractCommandTest;
+use Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\UpdateCommand;
+use Documents\SchemaValidated;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class UpdateCommandTest extends AbstractCommandTest
+{
+    /** @var Command */
+    protected $command;
+
+    /** @var CommandTester */
+    protected $commandTester;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->application->addCommands(
+            [
+                new UpdateCommand(),
+            ]
+        );
+        $command       = $this->application->find('odm:schema:update');
+        $commandTester = new CommandTester($command);
+
+        $this->command       = $command;
+        $this->commandTester = $commandTester;
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->command);
+        unset($this->commandTester);
+    }
+
+    public function testProcessValidator()
+    {
+        $this->commandTester->execute(
+            [
+                '--class' => SchemaValidated::class,
+            ]
+        );
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Updated validation for Documents\SchemaValidated', $output);
+    }
+
+    public function testProcessValidators()
+    {
+        // Only load a subset of documents with legit annotations
+        $annotationDriver = AnnotationDriver::create(__DIR__ . '/../../../../../../../../Documents/Ecommerce');
+        $this->dm->getConfiguration()->setMetadataDriverImpl($annotationDriver);
+        $this->commandTester->execute([]);
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Updated validation for all classes', $output);
+    }
+}

--- a/tests/Documents/SchemaValidated.php
+++ b/tests/Documents/SchemaValidated.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+
+/**
+ * @ODM\Document
+ * @ODM\Validation(
+ *     validator=SchemaValidated::VALIDATOR,
+ *     action=ClassMetadata::SCHEMA_VALIDATION_ACTION_WARN,
+ *     level=ClassMetadata::SCHEMA_VALIDATION_LEVEL_MODERATE,
+ * )
+ */
+class SchemaValidated
+{
+    public const VALIDATOR = <<<'EOT'
+{
+    "$jsonSchema": {
+        "required": ["name"],
+        "properties": {
+            "name": {
+                "bsonType": "string",
+                "description": "must be a string and is required"
+            }
+        }
+    },
+    "$or": [
+        { "phone": { "$type": "string" } },
+        { "email": { "$regex": { "$regularExpression" : { "pattern": "@mongodb\\.com$", "options": "" } } } },
+        { "status": { "$in": [ "Unknown", "Incomplete" ] } }
+    ]
+}
+EOT;
+
+    /** @ODM\Id */
+    private $id;
+
+    /** @ODM\Field(type="string") */
+    private $name;
+
+    /** @ODM\Field(type="string") */
+    private $phone;
+
+    /** @ODM\Field(type="string") */
+    private $email;
+
+    /** @ODM\Field(type="string") */
+    private $status;
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | #2233 

# Summary

This pull request introduces a new `@Validation` class annotation containing three options:
- `jsonSchema`
- `action`
- `level`

; corresponding to the three options of MongoDB collections:
- [`validator.$jsonSchema`](https://docs.mongodb.com/manual/core/schema-validation/#json-schema)
- [`validationAction`](https://docs.mongodb.com/manual/core/schema-validation/#accept-or-reject-invalid-documents)
- [`validationLevel`](https://docs.mongodb.com/manual/core/schema-validation/#existing-documents)

# The JSON Extension

The MongoDB Driver requires an array for the `validator` option of the `createCollection` method and `collMod` command.

We therefore have to decode the user-defined JSON schema, thus the need to add the `ext-json` to the `require-dev` section of the `composer.json`.

The `ext-json` is still not required for users to install the package, it is only added to the suggestion list.

# Adding a new Validation annotation vs. adding new options to the Document annotation

When I started working on this feature I chose to add three new properties to the `@Document` annotation:
- `validationJsonSchema`
- `validationAction`
- `validationLevel`

But I found that it would be convenient for the `validationAction` and `validationLevel` options to be enumerations as it would help the user to realize directly during the mapping process that they made a mistake in filling those.

A wrong value would trigger `doctrine/annotations`'s inner logic and raise an `AnnotationException`.

When used with Symfony for instance users wouldn't have to wait until execution of `odm:schema:update` command to realize they made a mistake, they would know right away on cache clear which happens on every request by default on dev environment.

Using enumerations was only possible by creating a whole new annotation class as the `@Document` annotation has a constructor and therefore its properties' annotations are not parsed, see https://github.com/doctrine/annotations/blob/e2623fd97c136cc7a18b467da8d8331c01de051c/lib/Doctrine/Common/Annotations/DocParser.php#L548

To sum up adding `@Enum` on the annotation properties was only possible by creating a new class, thus the choice of a new `@Validation` annotation. It makes the annotation-driven configuration similar to the XML-driven configuration which also contains enumerations.

# The validationAction / validationLevel default values issue

MongoDB version ≥ 4.4.0 allows to reset the `validationAction` and `validationLevel` options of the collections to their default values by passing empty strings to the respective arguments of the `collMod` command.

However I found that versions 4.2.0 and bellow do not care about empty strings in the `validationAction` /  `validationLevel` arguments of the `collMod` command. The command options will just get ignored and the collection options will not be modified.

In order to reset those options during `odm:schema:update`, in case for instance the user removed the `action` / `level` options of the `@Validation` annotation, we need to have default values defined for those options in Doctrine.

Those default values are documented and are equal the default values defined by MongoDB.

However if the MongoDB team decides to change those default values in the future it could cause confusion for our users, but it's the only solution I found to be able to support MongoDB versions < 4.4.0.

# Documentation

I updated the `annotations-reference` and added a new section on the `validation-of-documents` cookbook, I hope that's OK. Feel free to proofread it and recommend some adjustments as English is not my mother tong.

# TODO
- [x] Annotation
- [x] AnnotationDriver
- [x] XmlDriver
- [x] ClassMetadata
- [x] SchemaManager
- [x] UpdateCommand
- [x] Tests: Annotation
- [x] Tests: AnnotationDriver
- [x] Tests: XmlDriver
- [x] Tests: ClassMetadata
- [x] Tests: SchemaManager
- [x] Tests : Functionnal
- [x] Tests : UpdateCommand
- [x] Documentation
- [x] Clean Commit History 

<!-- Provide a summary your change. -->
