### PR TITLE
Remove phpstan error formatter

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -31,7 +31,6 @@ jobs:
           coverage: "none"
           extensions: "mongodb"
           php-version: "${{ matrix.php-version }}"
-          tools: "cs2pr"
 
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v2"
@@ -44,4 +43,4 @@ jobs:
         run: "composer install --no-interaction --no-progress --no-suggest"
 
       - name: "Run a static analysis with phpstan/phpstan"
-        run: "vendor/bin/phpstan analyse --error-format=checkstyle | cs2pr"
+        run: "vendor/bin/phpstan analyse"


### PR DESCRIPTION
The phpstan version used (0.10.x)  does not work with the error
formatter, this just removes it and it will be added in another
commit upgrading PHPStan.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

I used _improvement_ as I'm not sure about the type.

<!-- Provide a summary your change. -->
