### PR TITLE
Fix sandbox using old Doctrine\MongoDB\Connection class

### DIFF
--- a/tools/sandbox/config.php
+++ b/tools/sandbox/config.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
-use Doctrine\MongoDB\Connection;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
@@ -18,8 +17,6 @@ $loader = require_once $file;
 $loader->add('Documents', __DIR__);
 AnnotationRegistry::registerLoader([$loader, 'loadClass']);
 
-$connection = new Connection();
-
 $config = new Configuration();
 $config->setProxyDir(__DIR__ . '/Proxies');
 $config->setProxyNamespace('Proxies');
@@ -30,4 +27,4 @@ $config->setDefaultDB('doctrine_odm_sandbox');
 // $config->setMetadataCacheImpl(new Doctrine\Common\Cache\ApcCache());
 $config->setMetadataDriverImpl(AnnotationDriver::create(__DIR__ . '/Documents'));
 
-$dm = DocumentManager::create($connection, $config);
+$dm = DocumentManager::create(null, $config);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2245

#### Summary

Removes the reference to the `Doctrine\MongoDB\Connection` class from the archived https://github.com/doctrine/mongodb driver repository.
