### PR TITLE
Use symfony/deprecation-contracts to announce deprecations in code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "mongodb/mongodb": "^1.2.0",
         "ocramius/proxy-manager": "^2.2",
         "symfony/console": "^3.4|^4.1|^5.0",
+        "symfony/deprecation-contracts": "^2.2",
         "symfony/var-dumper": "^3.4|^4.1|^5.0"
     },
     "require-dev": {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -13,7 +13,6 @@ use GeoJson\Geometry\Point;
 use MongoDB\Collection;
 use OutOfRangeException;
 use TypeError;
-use const E_USER_DEPRECATED;
 use function array_map;
 use function array_unshift;
 use function func_get_arg;
@@ -22,7 +21,7 @@ use function gettype;
 use function is_array;
 use function is_bool;
 use function sprintf;
-use function trigger_error;
+use function trigger_deprecation;
 
 /**
  * Fluent interface for building aggregation pipelines.
@@ -169,9 +168,12 @@ class Builder
      */
     public function execute(array $options = []) : Iterator
     {
-        @trigger_error(
-            sprintf('The "%s" method was deprecated in doctrine/mongodb-odm 2.2. Please use getAggregation() instead.', __METHOD__),
-            E_USER_DEPRECATED
+        trigger_deprecation(
+            'doctrine/mongodb-odm',
+            '2.2',
+            'Using "%s" is deprecated. Please use "%s::getAggregation()" instead.',
+            __METHOD__,
+            self::class
         );
 
         return $this->getAggregation($options)->getIterator();

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -6,9 +6,7 @@ namespace Doctrine\ODM\MongoDB\Aggregation;
 
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use GeoJson\Geometry\Point;
-use const E_USER_DEPRECATED;
-use function sprintf;
-use function trigger_error;
+use function trigger_deprecation;
 
 /**
  * Fluent interface for building aggregation pipelines.
@@ -37,9 +35,12 @@ abstract class Stage
      */
     public function execute(array $options = []) : Iterator
     {
-        @trigger_error(
-            sprintf('The "%s" method was deprecated in doctrine/mongodb-odm 2.2. Please use getAggregation() instead.', __METHOD__),
-            E_USER_DEPRECATED
+        trigger_deprecation(
+            'doctrine/mongodb-odm',
+            '2.2',
+            'Using "%s" is deprecated, use "%s::getAggregation()" instead.',
+            __METHOD__,
+            self::class
         );
 
         return $this->builder->execute($options);

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractField.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractField.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
-use function sprintf;
 
 abstract class AbstractField extends Annotation
 {
@@ -26,24 +25,4 @@ abstract class AbstractField extends Annotation
 
     /** @var bool */
     public $notSaved = false;
-
-    /**
-     * Gets deprecation message. The method *WILL* be removed in 2.0.
-     *
-     * @internal
-     */
-    public function getDeprecationMessage() : string
-    {
-        return sprintf('%s will be removed in ODM 2.0. Use `@ODM\Field(type="%s")` instead.', static::class, $this->type);
-    }
-
-    /**
-     * Gets whether the annotation is deprecated. The method *WILL* be removed in 2.0.
-     *
-     * @internal
-     */
-    public function isDeprecated() : bool
-    {
-        return false;
-    }
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -21,7 +21,6 @@ use LogicException;
 use ProxyManager\Proxy\GhostObjectInterface;
 use ReflectionClass;
 use ReflectionProperty;
-use const E_USER_DEPRECATED;
 use function array_filter;
 use function array_key_exists;
 use function array_keys;
@@ -41,7 +40,7 @@ use function ltrim;
 use function sprintf;
 use function strtolower;
 use function strtoupper;
-use function trigger_error;
+use function trigger_deprecation;
 
 /**
  * A <tt>ClassMetadata</tt> instance holds all the object-document mapping metadata
@@ -1999,11 +1998,13 @@ use function trigger_error;
             Type::INTID => Type::INT,
         ];
         if (isset($deprecatedTypes[$mapping['type']])) {
-            @trigger_error(sprintf(
-                '"%s" type was deprecated in doctrine/mongodb-odm 2.1 and will be removed in 3.0. Use "%s" instead.',
+            trigger_deprecation(
+                'doctrine/mongodb-odm',
+                '2.1',
+                'The "%s" mapping type is deprecated. Use "%s" instead.',
                 $mapping['type'],
                 $deprecatedTypes[$mapping['type']]
-            ), E_USER_DEPRECATED);
+            );
         }
 
         $this->fieldMappings[$mapping['fieldName']] = $mapping;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -149,7 +149,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
         if (isset($documentAnnot->indexes) && count($documentAnnot->indexes)) {
             trigger_deprecation(
                 'doctrine/mongodb-odm',
-                '2.1',
+                '2.2',
                 'The "indexes" parameter in the "%s" annotation for class "%s" is deprecated. Specify all "@Index" and "@UniqueIndex" annotations on the class.',
                 $className,
                 get_class($documentAnnot)

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -15,7 +15,6 @@ use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\Driver\AnnotationDriver as AbstractAnnotationDriver;
 use ReflectionClass;
 use ReflectionMethod;
-use const E_USER_DEPRECATED;
 use function array_merge;
 use function array_replace;
 use function assert;
@@ -25,8 +24,7 @@ use function count;
 use function get_class;
 use function interface_exists;
 use function is_array;
-use function sprintf;
-use function trigger_error;
+use function trigger_deprecation;
 
 /**
  * The AnnotationDriver reads the mapping metadata from docblock annotations.
@@ -72,12 +70,11 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 $this->addIndex($class, $annot);
             }
             if ($annot instanceof ODM\Indexes) {
-                @trigger_error(
-                    sprintf(
-                        'Indexes annotation used in %s was deprecated in doctrine/mongodb-odm 2.2 and will be removed in 3.0. Specify all Index and UniqueIndex annotations on a class level.',
-                        $className
-                    ),
-                    E_USER_DEPRECATED
+                trigger_deprecation(
+                    'doctrine/mongodb-odm',
+                    '2.1',
+                    'The "@Indexes" annotation used in class "%s" is deprecated. Specify all "@Index" and "@UniqueIndex" annotations on the class.',
+                    $className
                 );
                 $value = $annot->value;
                 foreach (is_array($value) ? $value : [$value] as $index) {
@@ -150,14 +147,14 @@ class AnnotationDriver extends AbstractAnnotationDriver
             $class->setWriteConcern($documentAnnot->writeConcern);
         }
         if (isset($documentAnnot->indexes) && count($documentAnnot->indexes)) {
-            @trigger_error(
-                sprintf(
-                    'Indexes parameter used in %s\'s %s was deprecated in doctrine/mongodb-odm 2.2 and will be removed in 3.0. Specify all Index and UniqueIndex annotations on a class level.',
-                    $className,
-                    get_class($documentAnnot)
-                ),
-                E_USER_DEPRECATED
+            trigger_deprecation(
+                'doctrine/mongodb-odm',
+                '2.1',
+                'The "indexes" parameter in the "%s" annotation for class "%s" is deprecated. Specify all "@Index" and "@UniqueIndex" annotations on the class.',
+                $className,
+                get_class($documentAnnot)
             );
+
             foreach ($documentAnnot->indexes as $index) {
                 $this->addIndex($class, $index);
             }
@@ -180,9 +177,6 @@ class AnnotationDriver extends AbstractAnnotationDriver
             foreach ($this->reader->getPropertyAnnotations($property) as $annot) {
                 if ($annot instanceof ODM\AbstractField) {
                     $fieldAnnot = $annot;
-                    if ($annot->isDeprecated()) {
-                        @trigger_error($annot->getDeprecationMessage(), E_USER_DEPRECATED);
-                    }
                 }
                 if ($annot instanceof ODM\AbstractIndex) {
                     $indexes[] = $annot;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -72,7 +72,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
             if ($annot instanceof ODM\Indexes) {
                 trigger_deprecation(
                     'doctrine/mongodb-odm',
-                    '2.1',
+                    '2.2',
                     'The "@Indexes" annotation used in class "%s" is deprecated. Specify all "@Index" and "@UniqueIndex" annotations on the class.',
                     $className
                 );


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

This replaces manual calls to `@trigger_error` with `trigger_deprecation` from the `symfony/deprecation-contracts` package. This allows users to override the `trigger_deprecation` function to implement their custom logic.

Note that this PR drops deprecation functionality for field mapping annotations that were supposed to be dropped in 2.0. Since these methods are marked `@internal`, I have no problem dropping them in a minor release.