### PR TITLE
Deprecate using doctrine/cache for metadata caching

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -22,3 +22,11 @@ Using `@Index` annotation(s) on a class level is a preferred way for defining
 indexes for documents. Using `@Index` in the `@Indexes` annotation or an `indexes`
 property of other annotations was deprecated and will be removed in ODM 3.0.
 
+## DocumentManager configuration
+
+Using doctrine/cache to cache metadata is deprecated in favor of using PSR-6.
+The `getMetadataCacheImpl` and `setMetadataCacheImpl` methods in
+`Doctrine\ODM\MongoDB\Configuration` have been deprecated. Please use
+`getMetadataCache`and `setMetadataCache` with a PSR-6 implementation instead.
+Note that even after switching to PSR-6, `getMetadataCacheImpl` will return a
+cache instance that wraps the PSR-6 cache.

--- a/benchmark/BaseBench.php
+++ b/benchmark/BaseBench.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Benchmark;
 
-use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use MongoDB\Client;
 use MongoDB\Model\DatabaseInfo;
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 use function array_map;
 use function getenv;
@@ -48,7 +48,7 @@ abstract class BaseBench
         $config->setPersistentCollectionNamespace('PersistentCollections');
         $config->setDefaultDB(self::DATABASE_NAME);
         $config->setMetadataDriverImpl(self::createMetadataDriverImpl());
-        $config->setMetadataCacheImpl(new ArrayCache());
+        $config->setMetadataCache(new ArrayAdapter());
 
         $client = new Client(
             getenv('DOCTRINE_MONGODB_SERVER') ?: self::DEFAULT_MONGODB_SERVER,

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^7.2 || ^8.0",
         "ext-mongodb": "^1.5",
         "doctrine/annotations": "^1.6",
-        "doctrine/cache": "^1.7",
+        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.5",
         "doctrine/event-manager": "^1.0",
         "doctrine/instantiator": "^1.1",
@@ -33,6 +33,7 @@
         "friendsofphp/proxy-manager-lts": "^1.0",
         "jean85/pretty-package-versions": "^1.3.0 || ^2.0.1",
         "mongodb/mongodb": "^1.2.0",
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "symfony/console": "^3.4|^4.1|^5.0",
         "symfony/deprecation-contracts": "^2.2",
         "symfony/var-dumper": "^3.4|^4.1|^5.0"
@@ -45,6 +46,7 @@
         "phpstan/phpstan": "^0.12.32",
         "phpunit/phpunit": "^8.5 || ^9",
         "squizlabs/php_codesniffer": "^3.5",
+        "symfony/cache": "^4.4|^5.0",
         "vimeo/psalm": "^4.2.1"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -29,14 +29,14 @@
         "doctrine/collections": "^1.5",
         "doctrine/event-manager": "^1.0",
         "doctrine/instantiator": "^1.1",
-        "doctrine/persistence": "^1.3.5|^2.0",
+        "doctrine/persistence": "^1.3.5 || ^2.0",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "jean85/pretty-package-versions": "^1.3.0 || ^2.0.1",
         "mongodb/mongodb": "^1.2.0",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
-        "symfony/console": "^3.4|^4.1|^5.0",
+        "symfony/console": "^3.4 || ^4.1 || ^5.0",
         "symfony/deprecation-contracts": "^2.2",
-        "symfony/var-dumper": "^3.4|^4.1|^5.0"
+        "symfony/var-dumper": "^3.4 || ^4.1 || ^5.0"
     },
     "require-dev": {
         "ext-bcmath": "*",
@@ -46,7 +46,7 @@
         "phpstan/phpstan": "^0.12.32",
         "phpunit/phpunit": "^8.5 || ^9",
         "squizlabs/php_codesniffer": "^3.5",
-        "symfony/cache": "^4.4|^5.0",
+        "symfony/cache": "^4.4 || ^5.0",
         "vimeo/psalm": "^4.2.1"
     },
     "suggest": {

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -6,6 +6,8 @@ namespace Doctrine\ODM\MongoDB;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\MongoDB\PersistentCollection\DefaultPersistentCollectionFactory;
@@ -25,9 +27,11 @@ use ProxyManager\Configuration as ProxyManagerConfiguration;
 use ProxyManager\Factory\LazyLoadingGhostFactory;
 use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
 use ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy;
+use Psr\Cache\CacheItemPoolInterface;
 use ReflectionClass;
 
 use function interface_exists;
+use function trigger_deprecation;
 use function trim;
 
 /**
@@ -79,6 +83,9 @@ class Configuration
      * @var array
      */
     private $attributes = [];
+
+    /** @var CacheItemPoolInterface|null */
+    private $metadataCache;
 
     /** @var ProxyManagerConfiguration */
     private $proxyManagerConfiguration;
@@ -161,12 +168,40 @@ class Configuration
 
     public function getMetadataCacheImpl(): ?Cache
     {
+        trigger_deprecation(
+            'doctrine/mongodb-odm',
+            '2.2',
+            'Using "%s" is deprecated. Please use "%s::getMetadataCache" instead.',
+            __METHOD__,
+            self::class
+        );
+
         return $this->attributes['metadataCacheImpl'] ?? null;
     }
 
     public function setMetadataCacheImpl(Cache $cacheImpl): void
     {
+        trigger_deprecation(
+            'doctrine/mongodb-odm',
+            '2.2',
+            'Using "%s" is deprecated. Please use "%s::setMetadataCache" instead.',
+            __METHOD__,
+            self::class
+        );
+
         $this->attributes['metadataCacheImpl'] = $cacheImpl;
+        $this->metadataCache                   = CacheAdapter::wrap($cacheImpl);
+    }
+
+    public function getMetadataCache(): ?CacheItemPoolInterface
+    {
+        return $this->metadataCache;
+    }
+
+    public function setMetadataCache(CacheItemPoolInterface $cache): void
+    {
+        $this->metadataCache                   = $cache;
+        $this->attributes['metadataCacheImpl'] = DoctrineProvider::wrap($cache);
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB;
 
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Common\EventManager;
 use Doctrine\ODM\MongoDB\Hydrator\HydratorFactory;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
@@ -35,6 +36,7 @@ use function get_class;
 use function gettype;
 use function is_object;
 use function ltrim;
+use function method_exists;
 use function sprintf;
 
 /**
@@ -178,9 +180,13 @@ class DocumentManager implements ObjectManager
         $this->metadataFactory->setDocumentManager($this);
         $this->metadataFactory->setConfiguration($this->config);
 
-        $cacheDriver = $this->config->getMetadataCacheImpl();
+        $cacheDriver = $this->config->getMetadataCache();
         if ($cacheDriver) {
-            $this->metadataFactory->setCacheDriver($cacheDriver);
+            if (method_exists($this->metadataFactory, 'setCache')) {
+                $this->metadataFactory->setCache($cacheDriver);
+            } else {
+                $this->metadataFactory->setCacheDriver(DoctrineProvider::wrap($cacheDriver));
+            }
         }
 
         $hydratorDir           = $this->config->getHydratorDir();

--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -182,6 +182,7 @@ class DocumentManager implements ObjectManager
 
         $cacheDriver = $this->config->getMetadataCache();
         if ($cacheDriver) {
+            // Todo: check can be removed when doctrine/persistence 2.2 is required
             if (method_exists($this->metadataFactory, 'setCache')) {
                 $this->metadataFactory->setCache($cacheDriver);
             } else {

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command\ClearCache;
 
-use Doctrine\Common\Cache\ApcCache;
+use Doctrine\ODM\MongoDB\DocumentManager;
 use InvalidArgumentException;
-use LogicException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+
+use function assert;
 
 use const PHP_EOL;
 
@@ -38,20 +39,18 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $dm          = $this->getHelper('documentManager')->getDocumentManager();
-        $cacheDriver = $dm->getConfiguration()->getMetadataCacheImpl();
+        $dm = $this->getHelper('documentManager')->getDocumentManager();
+        assert($dm instanceof DocumentManager);
+
+        $cacheDriver = $dm->getConfiguration()->getMetadataCache();
 
         if (! $cacheDriver) {
             throw new InvalidArgumentException('No Metadata cache driver is configured on given DocumentManager.');
         }
 
-        if ($cacheDriver instanceof ApcCache) {
-            throw new LogicException('Cannot clear APC Cache from Console, its shared in the Webserver memory and not accessible from the CLI.');
-        }
-
         $output->write('Clearing ALL Metadata cache entries' . PHP_EOL);
 
-        $success = $cacheDriver->deleteAll();
+        $success = $cacheDriver->clear();
 
         if ($success) {
             $output->write('The cache entries were successfully deleted.' . PHP_EOL);

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ValidateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ValidateCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command\Schema;
 
-use Doctrine\Common\Cache\VoidCache;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -40,7 +39,6 @@ EOT
         $dm = $this->getHelper('documentManager')->getDocumentManager();
         assert($dm instanceof DocumentManager);
         $metadataFactory = $dm->getMetadataFactory();
-        $metadataFactory->setCacheDriver(new VoidCache());
 
         $errors = 0;
         foreach ($metadataFactory->getAllMetadata() as $meta) {

--- a/tools/sandbox/config.php
+++ b/tools/sandbox/config.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
 
 $file = __DIR__ . '/../../vendor/autoload.php';
 
@@ -23,8 +24,7 @@ $config->setProxyNamespace('Proxies');
 $config->setHydratorDir(__DIR__ . '/Hydrators');
 $config->setHydratorNamespace('Hydrators');
 $config->setDefaultDB('doctrine_odm_sandbox');
-// $config->setLoggerCallable(function(array $log) { print_r($log); });
-// $config->setMetadataCacheImpl(new Doctrine\Common\Cache\ApcCache());
+$config->setMetadataCache(new ApcuAdapter());
 $config->setMetadataDriverImpl(AnnotationDriver::create(__DIR__ . '/Documents'));
 
 $dm = DocumentManager::create(null, $config);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

This PR deprecates using doctrine/cache for metadata caching in favour of PSR-6. To provide a full compatibility layer, the symfony/cache package is used to provide both implementations regardless of what has been set.
This PR anticipates changes in doctrine/persistence, where doctrine/cache will also be deprecated: if a new enough version of doctrine/persistence is installed, it will revert to always using a PSR-6 cache in favour of doctrine/cache. This requires https://github.com/doctrine/persistence/pull/144 to be merged first. If that PR is rejected, I'll remove the compatibility layer before merging this change.