### PR TITLE
Added missing check for order of compound keys

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -617,6 +617,16 @@ class SchemaManagerTest extends BaseTest
                 'mongoIndex' => ['key' => ['foo' => 1]],
                 'documentIndex' => ['keys' => ['foo' => -1]],
             ],
+            'compoundIndexKeysSame' => [
+                'expected' => true,
+                'mongoIndex' => ['key' => ['foo' => 1, 'baz' => 1]],
+                'documentIndex' => ['keys' => ['foo' => 1, 'baz' => 1]],
+            ],
+            'compoundIndexKeysSameDifferentOrder' => [
+                'expected' => false,
+                'mongoIndex' => ['key' => ['foo' => 1, 'baz' => 1]],
+                'documentIndex' => ['keys' => ['baz' => 1, 'foo' => 1]],
+            ],
             // Sparse option
             'sparseOnlyInMongoIndex' => [
                 'expected' => false,
@@ -824,33 +834,44 @@ class SchemaManagerTest extends BaseTest
             'compoundIndexKeysSameAndWeightsSame' => [
                 'expected' => true,
                 'mongoIndex' => [
+                    'key' => ['a' => -1, '_fts' => 'text', '_ftsx' => 1, 'd' => 1],
+                    'weights' => ['b' => 1, 'c' => 2],
+                ],
+                'documentIndex' => [
+                    'keys' => ['a' => -1, 'b' => 'text', 'c' => 'text',  'd' => 1],
+                    'options' => ['weights' => ['b' => 1, 'c' => 2]],
+                ],
+            ],
+            'compoundIndexKeysDifferentOrder' => [
+                'expected' => false,
+                'mongoIndex' => [
                     'key' => ['_fts' => 'text', '_ftsx' => 1, 'a' => -1, 'd' => 1],
                     'weights' => ['b' => 1, 'c' => 2],
                 ],
                 'documentIndex' => [
-                    'keys' => ['a' => -1,  'b' => 'text', 'c' => 'text', 'd' => 1],
+                    'keys' => ['a' => -1, 'b' => 'text', 'c' => 'text', 'd' => 1],
                     'options' => ['weights' => ['b' => 1, 'c' => 2]],
                 ],
             ],
             'compoundIndexKeysSameAndWeightsDiffer' => [
                 'expected' => false,
                 'mongoIndex' => [
-                    'key' => ['_fts' => 'text', '_ftsx' => 1, 'a' => -1, 'd' => 1],
+                    'key' => ['a' => -1, '_fts' => 'text', '_ftsx' => 1, 'd' => 1],
                     'weights' => ['b' => 1, 'c' => 2],
                 ],
                 'documentIndex' => [
-                    'keys' => ['a' => -1,  'b' => 'text', 'c' => 'text', 'd' => 1],
+                    'keys' => ['a' => -1, 'b' => 'text', 'c' => 'text', 'd' => 1],
                     'options' => ['weights' => ['b' => 3, 'c' => 2]],
                 ],
             ],
             'compoundIndexKeysDifferAndWeightsSame' => [
                 'expected' => false,
                 'mongoIndex' => [
-                    'key' => ['_fts' => 'text', '_ftsx' => 1, 'a' => 1, 'd' => 1],
+                    'key' => ['a' => 1, '_fts' => 'text', '_ftsx' => 1, 'd' => 1],
                     'weights' => ['b' => 1, 'c' => 2],
                 ],
                 'documentIndex' => [
-                    'keys' => ['a' => -1,  'b' => 'text', 'c' => 'text', 'd' => 1],
+                    'keys' => ['a' => -1, 'b' => 'text', 'c' => 'text', 'd' => 1],
                     'options' => ['weights' => ['b' => 1, 'c' => 2]],
                 ],
             ],


### PR DESCRIPTION
Signed-off-by: Christoph Grabenstein <christoph.grabenstein@sensiolabs.de>

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2257

#### Summary

The fix consist of two main changes:
* added a strict check of the `array_key`s of the index-key-arrays.
* added a method that checks if the text indexes are at the same position.
