### PR TITLE
Run psalm with php 8

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -97,4 +97,4 @@ jobs:
         run: "composer install --no-interaction --no-progress"
 
       - name: "Run a static analysis with vimeo/psalm"
-        run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc)"
+        run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc) --php-version=${{ matrix.php-version }}"

--- a/psalm.xml
+++ b/psalm.xml
@@ -9,6 +9,8 @@
     <projectFiles>
         <directory name="lib/Doctrine/ODM/MongoDB" />
         <ignoreFiles>
+            <file name="lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup/Match.php" />
+            <file name="lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Match.php" />
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->

Psalm is failing because if there is no php version specified, it uses the lower bound of composer, so if a library uses PHP 7.4+ syntax, it fails.

Ref: https://github.com/laminas/laminas-code/issues/67