### PR TITLE
Deprecate mapping relations with targetDocument and discriminatorMap

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -1946,6 +1946,16 @@ use function trigger_deprecation;
             throw MappingException::repositoryMethodCanNotBeCombinedWithSkipLimitAndSort($this->name, $mapping['fieldName']);
         }
 
+        if (isset($mapping['targetDocument']) && isset($mapping['discriminatorMap'])) {
+            trigger_deprecation(
+                'doctrine/mongodb-odm',
+                '2.2',
+                'Mapping both "targetDocument" and "discriminatorMap" on field "%s" in class "%s" is deprecated.',
+                $mapping['fieldName'],
+                $this->name
+            );
+        }
+
         if (isset($mapping['reference']) && $mapping['type'] === 'one') {
             $mapping['association'] = self::REFERENCE_ONE;
         }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -1950,7 +1950,7 @@ use function trigger_deprecation;
             trigger_deprecation(
                 'doctrine/mongodb-odm',
                 '2.2',
-                'Mapping both "targetDocument" and "discriminatorMap" on field "%s" in class "%s" is deprecated.',
+                'Mapping both "targetDocument" and "discriminatorMap" on field "%s" in class "%s" is deprecated. Only one of them can be used at a time',
                 $mapping['fieldName'],
                 $this->name
             );

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -771,10 +771,6 @@ class DocumentPersisterTestDocument
      * @ODM\EmbedOne(
      *     targetDocument=Doctrine\ODM\MongoDB\Tests\Functional\AbstractDocumentPersisterTestDocumentAssociation::class,
      *     discriminatorField="type",
-     *     discriminatorMap={
-     *         "reference"=Doctrine\ODM\MongoDB\Tests\Functional\DocumentPersisterTestDocumentReference::class,
-     *         "embed"=Doctrine\ODM\MongoDB\Tests\Functional\DocumentPersisterTestDocumentEmbed::class
-     *     },
      *     name="associationName"
      * )
      */
@@ -827,10 +823,6 @@ abstract class AbstractDocumentPersisterTestDocumentAssociation
      * @ODM\EmbedOne(
      *     targetDocument=Doctrine\ODM\MongoDB\Tests\Functional\AbstractDocumentPersisterTestDocumentAssociation::class,
      *     discriminatorField="type",
-     *     discriminatorMap={
-     *         "reference"=Doctrine\ODM\MongoDB\Tests\Functional\DocumentPersisterTestDocumentReference::class,
-     *         "embed"=Doctrine\ODM\MongoDB\Tests\Functional\DocumentPersisterTestDocumentEmbed::class
-     *     },
      *     name="associationName"
      * )
      */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
@@ -67,7 +67,7 @@ class GH267User
     /** @ODM\Field(type="string") */
     protected $name;
 
-    /** @ODM\ReferenceOne(name="company", targetDocument=GH267Company::class, discriminatorMap={"seller"=GH267SellerCompany::class, "buyer"=GH267BuyerCompany::class}, inversedBy="users") */
+    /** @ODM\ReferenceOne(name="company", targetDocument=GH267Company::class, inversedBy="users") */
     protected $company;
 
     public function __construct($name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -134,10 +134,10 @@ abstract class AbstractMappingDriverTest extends BaseTest
     {
         $this->assertEquals(Address::class, $class->getAssociationTargetClass('address'));
         $this->assertEquals(Group::class, $class->getAssociationTargetClass('groups'));
-        $this->assertEquals(Phonenumber::class, $class->getAssociationTargetClass('phonenumbers'));
+        $this->assertNull($class->getAssociationTargetClass('phonenumbers'));
         $this->assertEquals(Phonenumber::class, $class->getAssociationTargetClass('morePhoneNumbers'));
         $this->assertEquals(Phonenumber::class, $class->getAssociationTargetClass('embeddedPhonenumber'));
-        $this->assertEquals(Phonenumber::class, $class->getAssociationTargetClass('otherPhonenumbers'));
+        $this->assertNull($class->getAssociationTargetClass('otherPhonenumbers'));
     }
 
     /**
@@ -625,7 +625,7 @@ class AbstractMappingDriverUser
     /** @ODM\ReferenceOne(targetDocument=Address::class, cascade={"remove"}) */
     public $address;
 
-    /** @ODM\ReferenceMany(targetDocument=Phonenumber::class, collectionClass=PhonenumberCollection::class, cascade={"persist"}, discriminatorField="discr", discriminatorMap={"home"=HomePhonenumber::class, "work"=WorkPhonenumber::class}, defaultDiscriminatorValue="home") */
+    /** @ODM\ReferenceMany(collectionClass=PhonenumberCollection::class, cascade={"persist"}, discriminatorField="discr", discriminatorMap={"home"=HomePhonenumber::class, "work"=WorkPhonenumber::class}, defaultDiscriminatorValue="home") */
     public $phonenumbers;
 
     /** @ODM\ReferenceMany(targetDocument=Group::class, cascade={"all"}) */
@@ -637,7 +637,7 @@ class AbstractMappingDriverUser
     /** @ODM\EmbedMany(targetDocument=Phonenumber::class, name="embedded_phone_number") */
     public $embeddedPhonenumber;
 
-    /** @ODM\EmbedMany(targetDocument=Phonenumber::class, discriminatorField="discr", discriminatorMap={"home"=HomePhonenumber::class, "work"=WorkPhonenumber::class}, defaultDiscriminatorValue="home") */
+    /** @ODM\EmbedMany(discriminatorField="discr", discriminatorMap={"home"=HomePhonenumber::class, "work"=WorkPhonenumber::class}, defaultDiscriminatorValue="home") */
     public $otherPhonenumbers;
 
     /** @ODM\Field(type="date") */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
@@ -49,7 +49,7 @@
                 <remove />
             </cascade>
         </reference-one>
-        <reference-many target-document="Doctrine\ODM\MongoDB\Tests\Mapping\Phonenumber" collection-class="Doctrine\ODM\MongoDB\Tests\Mapping\PhonenumberCollection" field="phonenumbers">
+        <reference-many collection-class="Doctrine\ODM\MongoDB\Tests\Mapping\PhonenumberCollection" field="phonenumbers">
             <cascade>
                 <persist />
             </cascade>
@@ -69,7 +69,7 @@
         </reference-many>
         <embed-one target-document="Doctrine\ODM\MongoDB\Tests\Mapping\Phonenumber" field-name="embeddedPhonenumber" field="embedded_phone_number">
         </embed-one>
-        <embed-many target-document="Doctrine\ODM\MongoDB\Tests\Mapping\Phonenumber" collection-class="Doctrine\ODM\MongoDB\Tests\Mapping\PhonenumberCollection" field="otherPhonenumbers">
+        <embed-many collection-class="Doctrine\ODM\MongoDB\Tests\Mapping\PhonenumberCollection" field="otherPhonenumbers">
             <discriminator-field name="discr" />
             <discriminator-map>
                 <discriminator-mapping value="home" class="Doctrine\ODM\MongoDB\Tests\Mapping\HomePhonenumber" />


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2203

#### Summary

Based on #2213, this deprecates this invalid mapping. The discriminatorMap will be ignored entirely, but the mapping still works (but maybe not as people would expect). Despite that, I'm hesitant to make this an exception, so we're deprecating this for removal in 3.0.