### PR TITLE
Run tests on sharded clusters

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,14 +11,14 @@ env:
   fail-fast: true
 
 jobs:
-  phpunit-standalone:
-    name: "PHPUnit on standalone servers"
+  phpunit:
+    name: "PHPUnit"
     runs-on: "${{ matrix.os }}"
 
     strategy:
       matrix:
         os:
-          - "ubuntu-20.04"
+          - "ubuntu-18.04"
         php-version:
           - "7.2"
           - "7.3"
@@ -28,23 +28,25 @@ jobs:
           - "4.4"
           - "4.2"
           - "4.0"
-          - "3.6"
         driver-version:
           - "stable"
+        topology:
+          - "server"
         deps:
           - "normal"
         include:
           - deps: "low"
-            os: "ubuntu-20.04"
+            os: "ubuntu-16.04"
             php-version: "7.2"
             mongodb-version: "3.6"
             driver-version: "1.5.0"
-
-    services:
-      mongodb:
-        image: "mongo:${{ matrix.mongodb-version }}"
-        ports:
-          - "27017:27017"
+            topology: "server"
+          - topology: "sharded_cluster"
+            os: "ubuntu-18.04"
+            php-version: "8.0"
+            mongodb-version: "4.4"
+            driver-version: "stable"
+            deps: "normal"
 
     steps:
       - name: "Checkout"
@@ -94,5 +96,13 @@ jobs:
         run: "composer update --no-interaction --no-progress --prefer-dist --prefer-lowest"
         if: "${{ matrix.deps == 'low' }}"
 
+      - id: setup-mongodb
+        uses: mongodb-labs/drivers-evergreen-tools@master
+        with:
+          version: ${{ matrix.mongodb-version }}
+          topology: ${{ matrix.topology }}
+
       - name: "Run PHPUnit"
         run: "vendor/bin/phpunit"
+        env:
+          DOCTRINE_MONGODB_SERVER: ${{ steps.setup-mongodb.outputs.cluster-uri }}

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -144,6 +144,20 @@ abstract class BaseTest extends TestCase
         $this->markTestSkipped('Test skipped because server does not support sharding');
     }
 
+    protected function skipTestIfSharded($className)
+    {
+        $result = $this->dm->getDocumentDatabase($className)->command(['listCommands' => true])->toArray()[0];
+        if (! $result['ok']) {
+            $this->markTestSkipped('Could not check whether server supports sharding');
+        }
+
+        if (! array_key_exists('shardCollection', $result['commands'])) {
+            return;
+        }
+
+        $this->markTestSkipped('Test does not apply on sharded clusters');
+    }
+
     protected function requireVersion($installedVersion, $requiredVersion, $operator, $message)
     {
         if (! version_compare($installedVersion, $requiredVersion, $operator)) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -133,9 +133,6 @@ abstract class BaseTest extends TestCase
     protected function skipTestIfNotSharded($className)
     {
         $result = $this->dm->getDocumentDatabase($className)->command(['listCommands' => true])->toArray()[0];
-        if (! $result['ok']) {
-            $this->markTestSkipped('Could not check whether server supports sharding');
-        }
 
         if (array_key_exists('shardCollection', $result['commands'])) {
             return;
@@ -147,9 +144,6 @@ abstract class BaseTest extends TestCase
     protected function skipTestIfSharded($className)
     {
         $result = $this->dm->getDocumentDatabase($className)->command(['listCommands' => true])->toArray()[0];
-        if (! $result['ok']) {
-            $this->markTestSkipped('Could not check whether server supports sharding');
-        }
 
         if (! array_key_exists('shardCollection', $result['commands'])) {
             return;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
@@ -46,6 +46,8 @@ class ReadPreferenceTest extends BaseTest
      */
     public function testHintIsSetOnQuery($readPreference, array $tags = [])
     {
+        $this->skipTestIfSharded(User::class);
+
         $query = $this->dm->getRepository(User::class)
             ->createQueryBuilder()
             ->setReadPreference(new ReadPreference($readPreference, $tags))


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

This part of the pipeline was dropped when we moved from travis-ci to GH actions. This now uses the (definitely unsupported) mongodb-labs/drivers-evergreen-tools repository to launch MongoDB clusters of any version/topology.