### PR TITLE
Allow PrettyVersion 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/instantiator": "^1.1",
         "doctrine/persistence": "^1.3.5|^2.0",
         "friendsofphp/proxy-manager-lts": "^1.0",
-        "jean85/pretty-package-versions": "^1.3.0",
+        "jean85/pretty-package-versions": "^1.3.0 || ^2.0.1",
         "mongodb/mongodb": "^1.2.0",
         "symfony/console": "^3.4|^4.1|^5.0",
         "symfony/deprecation-contracts": "^2.2",


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | None

#### Summary

This simple bump allows for the 2.0 version of this lib, which leverages Composer 2 APIs and drops any sub dependency.

There are basically no BC; for more details, see the [the changelog](https://github.com/Jean85/pretty-package-versions/blob/2.x/CHANGELOG.md).

This could be easily cherry-picked in the 2.0 and 2.1 branches if needed.