### PR TITLE
[2.3.x] Fix locking when ClassMetadata is unserialized

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -2129,6 +2129,11 @@ use function trigger_deprecation;
             $serialized[] = 'versionField';
         }
 
+        if ($this->isLockable) {
+            $serialized[] = 'isLockable';
+            $serialized[] = 'lockField';
+        }
+
         if ($this->lifecycleCallbacks) {
             $serialized[] = 'lifecycleCallbacks';
         }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2278

#### Summary

Caching / unserializing ClassMetadata broke locking functionality
