### PR TITLE
[1.3.x] Fix locking when ClassMetadata is unserialized

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -2357,6 +2357,11 @@ class ClassMetadata implements BaseClassMetadata
             $serialized[] = 'versionField';
         }
 
+        if ($this->isLockable) {
+            $serialized[] = 'isLockable';
+            $serialized[] = 'lockField';
+        }
+
         if ($this->lifecycleCallbacks) {
             $serialized[] = 'lifecycleCallbacks';
         }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2278

#### Summary

Caching / unserializing ClassMetadata broke locking functionality