### PR TITLE
Set type maps on collection level

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -166,15 +166,12 @@ class DocumentManager implements ObjectManager
             'mongodb://127.0.0.1',
             [],
             [
-                'typeMap' => self::CLIENT_TYPEMAP,
                 'driver' => [
                     'name' => 'doctrine-odm',
                     'version' => self::getVersion(),
                 ],
             ]
         );
-
-        $this->checkTypeMap();
 
         $metadataFactoryClassName = $this->config->getClassMetadataFactoryName();
         $this->metadataFactory    = new $metadataFactoryClassName();
@@ -360,7 +357,7 @@ class DocumentManager implements ObjectManager
         if (! isset($this->documentCollections[$className])) {
             $db = $this->getDocumentDatabase($className);
 
-            $options = [];
+            $options = ['typeMap' => self::CLIENT_TYPEMAP];
             if ($metadata->readPreference !== null) {
                 $options['readPreference'] = new ReadPreference($metadata->readPreference, $metadata->readPreferenceTags);
             }
@@ -865,17 +862,6 @@ class DocumentManager implements ObjectManager
         }
 
         return $this->filterCollection;
-    }
-
-    private function checkTypeMap(): void
-    {
-        $typeMap = $this->client->getTypeMap();
-
-        foreach (self::CLIENT_TYPEMAP as $part => $expectedType) {
-            if (! isset($typeMap[$part]) || $typeMap[$part] !== $expectedType) {
-                throw MongoDBException::invalidTypeMap($part, $expectedType);
-            }
-        }
     }
 
     private static function getVersion(): string

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\ODM\MongoDB\Tests;
 use Doctrine\Common\EventManager;
 use Doctrine\ODM\MongoDB\Aggregation\Builder as AggregationBuilder;
 use Doctrine\ODM\MongoDB\Configuration;
-use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
@@ -230,29 +229,6 @@ class DocumentManagerTest extends BaseTest
         $dbRef = $this->dm->createReference($r, $class->associationMappings['ref4']);
         $this->assertCount(1, $dbRef);
         $this->assertArrayHasKey('id', $dbRef);
-    }
-
-    /**
-     * @dataProvider dataInvalidTypeMap
-     */
-    public function testThrowsExceptionOnInvalidTypeMap(string $expectedMessage, Client $client): void
-    {
-        $this->expectException(MongoDBException::class);
-        $this->expectExceptionMessage($expectedMessage);
-        DocumentManager::create($client);
-    }
-
-    public function dataInvalidTypeMap(): array
-    {
-        $noTypeMap              = new Client();
-        $invalidDocumentTypeMap = new Client('mongodb://127.0.0.1', [], ['typeMap' => ['root' => 'array', 'document' => stdClass::class]]);
-        $invalidRootTypeMap     = new Client('mongodb://127.0.0.1', [], ['typeMap' => ['root' => stdClass::class, 'document' => 'array']]);
-
-        return [
-            'No typeMap' => ['Invalid typemap provided. Type "array" is required for "root".', $noTypeMap],
-            'Invalid document' => ['Invalid typemap provided. Type "array" is required for "document".', $invalidDocumentTypeMap],
-            'Invalid root' => ['Invalid typemap provided. Type "array" is required for "root".', $invalidRootTypeMap],
-        ];
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -71,8 +71,7 @@ class SchemaManagerTest extends BaseTest
     {
         parent::setUp();
 
-        $client = $this->createMock(Client::class);
-        $client->method('getTypeMap')->willReturn(DocumentManager::CLIENT_TYPEMAP);
+        $client   = $this->createMock(Client::class);
         $this->dm = DocumentManager::create($client, $this->dm->getConfiguration(), $this->createMock(EventManager::class));
 
         foreach ($this->dm->getMetadataFactory()->getAllMetadata() as $cm) {


### PR DESCRIPTION
<!-- Fill in t1he relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

This PR improves the experience for users that create their own `MongoDB\Client` instance for the document manager. Instead of having to set the appropriate type map, ODM will now apply the type map on the collection level when calling `getDocumentCollection`. The end result is the same, as the type map gets applied to every operation (unless the operation has is own type map).
