### PR TITLE
Fix invalid strict comparison when validating mappings

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ValidateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ValidateCommand.php
@@ -44,7 +44,9 @@ EOT
 
         $errors = 0;
         foreach ($metadataFactory->getAllMetadata() as $meta) {
-            if ($meta === unserialize(serialize($meta))) {
+            // Don't use === to compare as that will always evaluate to false since we receive a different object
+            // phpcs:ignore SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedEqualOperator
+            if ($meta == unserialize(serialize($meta))) {
                 continue;
             }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fixes #2289

#### Summary

Automated checkstyle fixes strike again. Strict comparisons will always fail when comparing original metadata to the unserialised variant.

cc @dominikzogg