### PR TITLE
Fix mapping of the nullable option for XML driver

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -243,7 +243,7 @@ class XmlDriver extends FileDriver
                 $attributes = $field->attributes();
                 foreach ($attributes as $key => $value) {
                     $mapping[$key]     = (string) $value;
-                    $booleanAttributes = ['reference', 'embed', 'unique', 'sparse'];
+                    $booleanAttributes = ['reference', 'embed', 'unique', 'sparse', 'nullable'];
                     if (! in_array($key, $booleanAttributes)) {
                         continue;
                     }
@@ -362,6 +362,7 @@ class XmlDriver extends FileDriver
             'collectionClass' => isset($attributes['collection-class']) ? (string) $attributes['collection-class'] : null,
             'name'            => (string) $attributes['field'],
             'strategy'        => (string) ($attributes['strategy'] ?? $defaultStrategy),
+            'nullable'        => isset($attributes['nullable']) ? ((string) $attributes['nullable'] === 'true') : false,
         ];
         if (isset($attributes['field-name'])) {
             $mapping['fieldName'] = (string) $attributes['field-name'];
@@ -419,6 +420,7 @@ class XmlDriver extends FileDriver
             'limit'            => isset($attributes['limit']) ? (int) $attributes['limit'] : null,
             'skip'             => isset($attributes['skip']) ? (int) $attributes['skip'] : null,
             'prime'            => [],
+            'nullable'         => isset($attributes['nullable']) ? ((string) $attributes['nullable'] === 'true') : false,
         ];
 
         if (isset($attributes['field-name'])) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -12,6 +12,7 @@ use Documents\Phonenumber;
 use Documents\Profile;
 use PHPUnit\Framework\TestCase;
 use TestDocuments\EmbeddedDocument;
+use TestDocuments\NullableFieldsDocument;
 use TestDocuments\PartialFilterDocument;
 use TestDocuments\PrimedCollectionDocument;
 use TestDocuments\QueryResultDocument;
@@ -391,5 +392,120 @@ abstract class AbstractDriverTest extends TestCase
             'orphanRemoval' => false,
             'prime' => ['references'],
         ], $classMetadata->fieldMappings['inverseMappedBy']);
+    }
+
+    public function testNullableFieldsMapping()
+    {
+        $classMetadata = new ClassMetadata(NullableFieldsDocument::class);
+        $this->driver->loadMetadataForClass(NullableFieldsDocument::class, $classMetadata);
+
+        $this->assertEquals([
+            'fieldName' => 'username',
+            'name' => 'username',
+            'type' => 'string',
+            'isCascadeDetach' => false,
+            'isCascadeMerge' => false,
+            'isCascadePersist' => false,
+            'isCascadeRefresh' => false,
+            'isCascadeRemove' => false,
+            'isInverseSide' => false,
+            'isOwningSide' => true,
+            'nullable' => true,
+            'strategy' => ClassMetadata::STORAGE_STRATEGY_SET,
+        ], $classMetadata->fieldMappings['username']);
+
+        $this->assertEquals([
+            'association' => ClassMetadata::EMBED_ONE,
+            'fieldName' => 'address',
+            'name' => 'address',
+            'type' => ClassMetadata::ONE,
+            'embedded' => true,
+            'targetDocument' => Address::class,
+            'collectionClass' => null,
+            'isCascadeDetach' => true,
+            'isCascadeMerge' => true,
+            'isCascadePersist' => true,
+            'isCascadeRefresh' => true,
+            'isCascadeRemove' => true,
+            'isInverseSide' => false,
+            'isOwningSide' => true,
+            'nullable' => true,
+            'strategy' => ClassMetadata::STORAGE_STRATEGY_SET,
+        ], $classMetadata->fieldMappings['address']);
+
+        $this->assertEquals([
+            'association' => ClassMetadata::EMBED_MANY,
+            'fieldName' => 'phonenumbers',
+            'name' => 'phonenumbers',
+            'type' => ClassMetadata::MANY,
+            'embedded' => true,
+            'targetDocument' => Phonenumber::class,
+            'collectionClass' => null,
+            'isCascadeDetach' => true,
+            'isCascadeMerge' => true,
+            'isCascadePersist' => true,
+            'isCascadeRefresh' => true,
+            'isCascadeRemove' => true,
+            'isInverseSide' => false,
+            'isOwningSide' => true,
+            'nullable' => true,
+            'strategy' => ClassMetadata::STORAGE_STRATEGY_PUSH_ALL,
+        ], $classMetadata->fieldMappings['phonenumbers']);
+
+        $this->assertEquals([
+            'association' => ClassMetadata::REFERENCE_ONE,
+            'fieldName' => 'profile',
+            'name' => 'profile',
+            'type' => ClassMetadata::ONE,
+            'reference' => true,
+            'storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF,
+            'targetDocument' => Profile::class,
+            'collectionClass' => null,
+            'cascade' => [],
+            'isCascadeDetach' => false,
+            'isCascadeMerge' => false,
+            'isCascadePersist' => false,
+            'isCascadeRefresh' => false,
+            'isCascadeRemove' => false,
+            'isInverseSide' => false,
+            'isOwningSide' => true,
+            'nullable' => true,
+            'strategy' => ClassMetadata::STORAGE_STRATEGY_SET,
+            'inversedBy' => null,
+            'mappedBy' => null,
+            'repositoryMethod' => null,
+            'limit' => null,
+            'skip' => null,
+            'orphanRemoval' => false,
+            'prime' => [],
+        ], $classMetadata->fieldMappings['profile']);
+
+        $this->assertEquals([
+            'association' => ClassMetadata::REFERENCE_MANY,
+            'fieldName' => 'groups',
+            'name' => 'groups',
+            'type' => ClassMetadata::MANY,
+            'reference' => true,
+            'storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF,
+            'targetDocument' => Group::class,
+            'collectionClass' => null,
+            'cascade' => [],
+            'isCascadeDetach' => false,
+            'isCascadeMerge' => false,
+            'isCascadePersist' => false,
+            'isCascadeRefresh' => false,
+            'isCascadeRemove' => false,
+            'isInverseSide' => false,
+            'isOwningSide' => true,
+            'nullable' => true,
+            'strategy' => ClassMetadata::STORAGE_STRATEGY_PUSH_ALL,
+            'inversedBy' => null,
+            'mappedBy' => null,
+            'repositoryMethod' => null,
+            'limit' => null,
+            'skip' => null,
+            'orphanRemoval' => false,
+            'prime' => [],
+        ], $classMetadata->fieldMappings['groups']);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/NullableFieldsDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/NullableFieldsDocument.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestDocuments;
+
+class NullableFieldsDocument
+{
+    protected $id;
+
+    protected $username;
+
+    protected $address;
+
+    protected $profile;
+
+    protected $phonenumbers;
+
+    protected $groups;
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.NullableFieldsDocument.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.NullableFieldsDocument.dcm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                        http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="TestDocuments\NullableFieldsDocument">
+        <id/>
+        <field name="username" type="string" nullable="true"/>
+        <embed-one target-document="Documents\Address" field="address" nullable="true"/>
+        <embed-many target-document="Documents\Phonenumber" field="phonenumbers" nullable="true"/>
+        <reference-one target-document="Documents\Profile" field="profile" nullable="true"/>
+        <reference-many target-document="Documents\Group" field="groups" nullable="true"/>
+    </document>
+</doctrine-mongo-mapping>


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | https://github.com/doctrine/mongodb-odm/issues/2295

#### Summary

- [x] Fix XML driver to map the attribute `nullable` for basic fields.
- [x] Fix for embed documents.
- [x] Fix for reference documents.
- [x] Add tests.
