### PR TITLE
Fix preparation of $elemMatch operators in queries

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1321,7 +1321,12 @@ final class DocumentPersister
                 continue;
             }
 
-            // Recursively process expressions within a $not operator
+            // Recursively process expressions within a $not or $elemMatch operator
+            if ($k === '$elemMatch' && is_array($v)) {
+                $expression[$k] = $this->prepareQueryOrNewObj($v, false);
+                continue;
+            }
+
             if ($k === '$not' && is_array($v)) {
                 $expression[$k] = $this->prepareQueryExpression($v, $class);
                 continue;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -198,7 +198,7 @@ class DocumentPersisterTest extends BaseTest
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
         $value    = ['_id' => ['$elemMatch' => $hashId]];
-        $expected = ['_id' => ['$elemMatch' => (object) $hashId]];
+        $expected = ['_id' => ['$elemMatch' => $hashId]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
@@ -208,7 +208,7 @@ class DocumentPersisterTest extends BaseTest
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
         $value    = ['_id' => ['$not' => ['$elemMatch' => $hashId]]];
-        $expected = ['_id' => ['$not' => ['$elemMatch' => (object) $hashId]]];
+        $expected = ['_id' => ['$not' => ['$elemMatch' => $hashId]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
@@ -396,7 +396,7 @@ class DocumentPersisterTest extends BaseTest
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
         $value    = ['simpleRef' => ['$elemMatch' => $hashId]];
-        $expected = ['simpleRef' => ['$elemMatch' => (object) $hashId]];
+        $expected = ['simpleRef' => ['$elemMatch' => $hashId]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
@@ -406,7 +406,7 @@ class DocumentPersisterTest extends BaseTest
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
         $value    = ['simpleRef' => ['$not' => ['$elemMatch' => $hashId]]];
-        $expected = ['simpleRef' => ['$not' => ['$elemMatch' => (object) $hashId]]];
+        $expected = ['simpleRef' => ['$not' => ['$elemMatch' => $hashId]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
@@ -473,7 +473,7 @@ class DocumentPersisterTest extends BaseTest
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
         $value    = ['complexRef.id' => ['$elemMatch' => $hashId]];
-        $expected = ['complexRef.$id' => ['$elemMatch' => (object) $hashId]];
+        $expected = ['complexRef.$id' => ['$elemMatch' => $hashId]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
@@ -483,7 +483,7 @@ class DocumentPersisterTest extends BaseTest
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
         $value    = ['complexRef.id' => ['$not' => ['$elemMatch' => $hashId]]];
-        $expected = ['complexRef.$id' => ['$not' => ['$elemMatch' => (object) $hashId]]];
+        $expected = ['complexRef.$id' => ['$not' => ['$elemMatch' => $hashId]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
@@ -587,7 +587,7 @@ class DocumentPersisterTest extends BaseTest
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
         $value    = ['embeddedRef.id' => ['$elemMatch' => $hashId]];
-        $expected = ['embeddedRef.id' => ['$elemMatch' => (object) $hashId]];
+        $expected = ['embeddedRef.id' => ['$elemMatch' => $hashId]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
@@ -597,7 +597,7 @@ class DocumentPersisterTest extends BaseTest
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 
         $value    = ['embeddedRef.id' => ['$not' => ['$elemMatch' => $hashId]]];
-        $expected = ['embeddedRef.id' => ['$not' => ['$elemMatch' => (object) $hashId]]];
+        $expected = ['embeddedRef.id' => ['$not' => ['$elemMatch' => $hashId]]];
 
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2251Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2251Test.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\User;
+use MongoDB\BSON\ObjectId;
+
+class GH2251Test extends BaseTest
+{
+    /**
+     * @testWith ["groups"]
+     *           ["groupsSimple"]
+     */
+    public function testElemMatchQuery(string $fieldName)
+    {
+        $builder = $this->dm->createQueryBuilder(User::class);
+
+        $objectIds = [
+            new ObjectId('5fae9a775ef4492e3c72b3f3'),
+            new ObjectId('5fae9a775ef4492e3c72b3f4'),
+        ];
+
+        $notIn     = $builder->expr()->notIn($objectIds);
+        $elemMatch = $builder->expr()
+            ->field($fieldName)
+            ->elemMatch($notIn);
+
+        $builder->addNor(
+            $elemMatch
+        );
+
+        $this->assertSame(
+            [
+                '$nor' => [
+                    [
+                        $fieldName => [
+                            '$elemMatch' => ['$nin' => $objectIds],
+                        ],
+                    ],
+                ],
+            ],
+            $builder->getQueryArray()
+        );
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fixes #2251

#### Summary

Contrary to the suggestion in https://github.com/doctrine/mongodb-odm/issues/2251#issuecomment-734850221, the solution is to give `$elemMatch` the same treatment as `$not` and recurse the query preparation.