### PR TITLE
Fix query preparation when in elemMatch

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1674Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1674Test.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use MongoDB\BSON\ObjectId;
+
+class GH1674Test extends BaseTest
+{
+    public function testElemMatchUsesCorrectMapping()
+    {
+        $builder = $this->dm->createQueryBuilder(GH1674Document::class);
+        $builder
+            ->field('embedded')
+            ->elemMatch(
+                $builder->expr()
+                    ->field('id')
+                    ->equals(1)
+            );
+
+        $this->assertSame(
+            [
+                'embedded' => [
+                    '$elemMatch' => ['id' => '1'],
+                ],
+            ],
+            $builder->getQueryArray()
+        );
+    }
+}
+
+/** @ODM\Document */
+class GH1674Document
+{
+    /** @ODM\Id */
+    protected $id;
+
+    /** @ODM\EmbedMany(targetDocument=GH1674Embedded::class) */
+    protected $embedded;
+
+    public function __construct()
+    {
+        $this->id       = new ObjectId();
+        $this->embedded = new ArrayCollection();
+    }
+}
+
+/** @ODM\EmbeddedDocument */
+class GH1674Embedded
+{
+    /** @ODM\Field */
+    public $id = [];
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fixes #1674

#### Summary

As [outlined previously](https://github.com/doctrine/mongodb-odm/issues/1674#issuecomment-482079760), fixing the issue requires a little bit of work in the `Expr` class. This PR changes the logic to no longer evaluate `Expr` instances right away, but defer until they are built themselves. This allows us to look at the field mapping and update the `ClassMetadata` instance of `Expr` objects with the necessary information. Despite my previous suggestion to refactor the persister, I decided against it due to the complexity involved.

Note that this logic only applies to associations with a `targetDocument`. If no association of that kind exists, the behaviour is as before and the "parent" `ClassMetadata` instance is used.

There is a separate issue where you can't use `references` or `includesReferenceTo` on an `Expr` instance that will later be used. I'll fix that in a separate PR as that may have to wait until the next minor release due to API changes.