### PR TITLE
Fix errors with nullable typed associations

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1830,6 +1830,11 @@ final class UnitOfWork implements PropertyChangedListener
                 $name = $nativeReflection->name;
                 $prop = $this->reflectionService->getAccessibleProperty($class->name, $name);
                 assert($prop instanceof ReflectionProperty);
+
+                if (method_exists($prop, 'isInitialized') && ! $prop->isInitialized($document)) {
+                    continue;
+                }
+
                 if (! isset($class->associationMappings[$name])) {
                     if (! $class->isIdentifier($name)) {
                         $prop->setValue($managedCopy, $prop->getValue($document));

--- a/tests/Documents74/TypedDocument.php
+++ b/tests/Documents74/TypedDocument.php
@@ -14,13 +14,28 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 class TypedDocument
 {
     /** @ODM\Id() */
-    private string $id;
+    public string $id;
 
     /** @ODM\Field(type="string") */
-    private string $name;
+    public string $name;
 
     /** @ODM\EmbedOne(targetDocument=TypedEmbeddedDocument::class) */
-    private TypedEmbeddedDocument $embedOne;
+    public TypedEmbeddedDocument $embedOne;
+
+    /** @ODM\EmbedOne(targetDocument=TypedEmbeddedDocument::class, nullable=true) */
+    public ?TypedEmbeddedDocument $nullableEmbedOne;
+
+    /** @ODM\EmbedOne(targetDocument=TypedEmbeddedDocument::class, nullable=true) */
+    public ?TypedEmbeddedDocument $initializedNullableEmbedOne = null;
+
+    /** @ODM\ReferenceOne(targetDocument=TypedDocument::class) */
+    public TypedDocument $referenceOne;
+
+    /** @ODM\ReferenceOne(targetDocument=TypedDocument::class, nullable=true) */
+    public ?TypedDocument $nullableReferenceOne;
+
+    /** @ODM\ReferenceOne(targetDocument=TypedDocument::class, nullable=true) */
+    public ?TypedDocument $initializedNullableReferenceOne = null;
 
     /** @ODM\EmbedMany(targetDocument=TypedEmbeddedDocument::class) */
     private Collection $embedMany;
@@ -28,36 +43,6 @@ class TypedDocument
     public function __construct()
     {
         $this->embedMany = new ArrayCollection();
-    }
-
-    public function getId(): string
-    {
-        return $this->id;
-    }
-
-    public function setId(string $id): void
-    {
-        $this->id = $id;
-    }
-
-    public function getName(): string
-    {
-        return $this->name;
-    }
-
-    public function setName(string $name): void
-    {
-        $this->name = $name;
-    }
-
-    public function getEmbedOne(): TypedEmbeddedDocument
-    {
-        return $this->embedOne;
-    }
-
-    public function setEmbedOne(TypedEmbeddedDocument $embedOne): void
-    {
-        $this->embedOne = $embedOne;
     }
 
     public function getEmbedMany(): Collection


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fixed #2301

#### Summary

This fixes errors when loading documents with uninitialised nullable association fields (embedOne and referenceOne were affected).

While fixing this issue, I uncovered an additional bug with public typed properties: when using `$dm->merge` with a document that has uninitialised public properties, the properties are accessed. This may be due to a bug in the reflection code, as the `TypedNoDefaultValueReflectionProperty` class is only used for non-public properties. However, I believe that our workaround is correct, as the class mentioned above returns `null` for uninitialised properties, while we actually don't want to do anything with the property if it wasn't initialised.
