### PR TITLE
Use proxy class name resolvers instead of local workaround

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -1,0 +1,14 @@
+# UPGRADE FROM 2.2 to 2.3
+
+## Proxy Class Name Resolution
+
+The `Doctrine\ODM\MongoDB\Proxy\Resolver\ClassNameResolver` interface has been
+deprecated in favor of the `Doctrine\Persistence\Mapping\ProxyClassNameResolver`
+interface.
+
+The `getClassNameResolver` method in `DocumentManager` is deprecated and should
+not be used. To retrieve the mapped class name for any object or class string,
+fetch metadata for the class and read the class using `$metadata->getName()`.
+The metadata layer is aware of these proxy namespace changes and how to resolve
+them, so users should always go through the metadata layer to retrieve mapped
+class names.

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -21,3 +21,16 @@ will no longer be extendable.
 The `boolean`, `integer`, and `int_id` mapping types have been removed. Use the
 `bool`, `int`, and `int` types, respectively. These types behave exactly the
 same.
+
+## Proxy Class Name Resolution
+
+The `Doctrine\ODM\MongoDB\Proxy\Resolver\ClassNameResolver` interface has been
+dropped in favor of the `Doctrine\Persistence\Mapping\ProxyClassNameResolver`
+interface.
+
+The `getClassNameResolver` method in `DocumentManager` has been removed. To
+retrieve the mapped class name for any object or class string,  fetch metadata
+for the class and read the class using `$metadata->getName()`. The metadata
+layer is aware of these proxy namespace changes and how to resolve them, so
+users should always go through the metadata layer to retrieve mapped class
+names.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/collections": "^1.5",
         "doctrine/event-manager": "^1.0",
         "doctrine/instantiator": "^1.1",
-        "doctrine/persistence": "^1.3.5 || ^2.0",
+        "doctrine/persistence": "^2.2",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "jean85/pretty-package-versions": "^1.3.0 || ^2.0.1",
         "mongodb/mongodb": "^1.2.0",

--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB;
 
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Common\EventManager;
 use Doctrine\ODM\MongoDB\Hydrator\HydratorFactory;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
@@ -36,7 +35,6 @@ use function get_class;
 use function gettype;
 use function is_object;
 use function ltrim;
-use function method_exists;
 use function sprintf;
 
 /**
@@ -182,12 +180,7 @@ class DocumentManager implements ObjectManager
 
         $cacheDriver = $this->config->getMetadataCache();
         if ($cacheDriver) {
-            // Todo: check can be removed when doctrine/persistence 2.2 is required
-            if (method_exists($this->metadataFactory, 'setCache')) {
-                $this->metadataFactory->setCache($cacheDriver);
-            } else {
-                $this->metadataFactory->setCacheDriver(DoctrineProvider::wrap($cacheDriver));
-            }
+            $this->metadataFactory->setCache($cacheDriver);
         }
 
         $hydratorDir           = $this->config->getHydratorDir();
@@ -206,6 +199,8 @@ class DocumentManager implements ObjectManager
         $this->proxyFactory      = new StaticProxyFactory($this);
         $this->repositoryFactory = $this->config->getRepositoryFactory();
         $this->classNameResolver = new CachingClassNameResolver(new ProxyManagerClassNameResolver($this->config));
+
+        $this->metadataFactory->setProxyClassNameResolver($this->classNameResolver);
     }
 
     /**
@@ -288,7 +283,11 @@ class DocumentManager implements ObjectManager
         return $this->schemaManager;
     }
 
-    /** Returns the class name resolver which is used to resolve real class names for proxy objects. */
+    /**
+     * Returns the class name resolver which is used to resolve real class names for proxy objects.
+     *
+     * @deprecated
+     */
     public function getClassNameResolver(): ClassNameResolver
     {
         return $this->classNameResolver;
@@ -312,14 +311,14 @@ class DocumentManager implements ObjectManager
      */
     public function getDocumentDatabase(string $className): Database
     {
-        $className = $this->classNameResolver->getRealClass($className);
+        $metadata = $this->metadataFactory->getMetadataFor($className);
+        assert($metadata instanceof ClassMetadata);
+
+        $className = $metadata->getName();
 
         if (isset($this->documentDatabases[$className])) {
             return $this->documentDatabases[$className];
         }
-
-        $metadata = $this->metadataFactory->getMetadataFor($className);
-        assert($metadata instanceof ClassMetadata);
 
         $db                                  = $metadata->getDatabase();
         $db                                  = $db ?: $this->config->getDefaultDB();
@@ -346,8 +345,6 @@ class DocumentManager implements ObjectManager
      */
     public function getDocumentCollection(string $className): Collection
     {
-        $className = $this->classNameResolver->getRealClass($className);
-
         $metadata = $this->metadataFactory->getMetadataFor($className);
         assert($metadata instanceof ClassMetadata);
 
@@ -382,8 +379,6 @@ class DocumentManager implements ObjectManager
      */
     public function getDocumentBucket(string $className): Bucket
     {
-        $className = $this->classNameResolver->getRealClass($className);
-
         $metadata = $this->metadataFactory->getMetadataFor($className);
         assert($metadata instanceof ClassMetadata);
 

--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -286,7 +286,7 @@ class DocumentManager implements ObjectManager
     /**
      * Returns the class name resolver which is used to resolve real class names for proxy objects.
      *
-     * @deprecated
+     * @deprecated Fetch metadata for any class string (e.g. proxy object class) and read the class name from the metadata object
      */
     public function getClassNameResolver(): ClassNameResolver
     {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -63,11 +63,6 @@ final class ClassMetadataFactory extends AbstractClassMetadataFactory
         $this->config = $config;
     }
 
-    public function getMetadataFor($className)
-    {
-        return parent::getMetadataFor($this->dm->getClassNameResolver()->getRealClass($className));
-    }
-
     /**
      * Lazy initialization of this stuff, especially the metadata driver,
      * since these are not needed at all when a metadata cache is active.

--- a/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/CachingClassNameResolver.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/CachingClassNameResolver.php
@@ -33,7 +33,7 @@ final class CachingClassNameResolver implements ClassNameResolver, ProxyClassNam
     public function resolveClassName(string $className): string
     {
         if (! isset($this->resolvedNames[$className])) {
-            $this->resolvedNames[$className] = $this->resolver->getRealClass($className);
+            $this->resolvedNames[$className] = $this->resolver->resolveClassName($className);
         }
 
         return $this->resolvedNames[$className];

--- a/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/CachingClassNameResolver.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/CachingClassNameResolver.php
@@ -4,18 +4,20 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Proxy\Resolver;
 
+use Doctrine\Persistence\Mapping\ProxyClassNameResolver;
+
 /**
  * @internal
  */
-final class CachingClassNameResolver implements ClassNameResolver
+final class CachingClassNameResolver implements ClassNameResolver, ProxyClassNameResolver
 {
-    /** @var ClassNameResolver */
+    /** @var ProxyClassNameResolver */
     private $resolver;
 
     /** @var array<string, string> */
     private $resolvedNames = [];
 
-    public function __construct(ClassNameResolver $resolver)
+    public function __construct(ProxyClassNameResolver $resolver)
     {
         $this->resolver = $resolver;
     }
@@ -25,10 +27,15 @@ final class CachingClassNameResolver implements ClassNameResolver
      */
     public function getRealClass(string $class): string
     {
-        if (! isset($this->resolvedNames[$class])) {
-            $this->resolvedNames[$class] = $this->resolver->getRealClass($class);
+        return $this->resolveClassName($class);
+    }
+
+    public function resolveClassName(string $className): string
+    {
+        if (! isset($this->resolvedNames[$className])) {
+            $this->resolvedNames[$className] = $this->resolver->getRealClass($className);
         }
 
-        return $this->resolvedNames[$class];
+        return $this->resolvedNames[$className];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/ClassNameResolver.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/ClassNameResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Proxy\Resolver;
 
+/** @deprecated */
 interface ClassNameResolver
 {
     /**

--- a/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/ClassNameResolver.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/ClassNameResolver.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Proxy\Resolver;
 
-/** @deprecated */
+/** @deprecated Deprecated in favor of Doctrine\Persistence\Mapping\ProxyClassNameResolver */
 interface ClassNameResolver
 {
     /**

--- a/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/ProxyManagerClassNameResolver.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/ProxyManagerClassNameResolver.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Proxy\Resolver;
 
 use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\Persistence\Mapping\ProxyClassNameResolver;
 use ProxyManager\Inflector\ClassNameInflectorInterface;
 
 /**
  * @internal
  */
-final class ProxyManagerClassNameResolver implements ClassNameResolver
+final class ProxyManagerClassNameResolver implements ClassNameResolver, ProxyClassNameResolver
 {
     /** @var Configuration */
     private $configuration;
@@ -20,12 +21,14 @@ final class ProxyManagerClassNameResolver implements ClassNameResolver
         $this->configuration = $configuration;
     }
 
-    /**
-     * Gets the real class name of a class name that could be a proxy.
-     */
     public function getRealClass(string $class): string
     {
-        return $this->getClassNameInflector()->getUserClassName($class);
+        return $this->resolveClassName($class);
+    }
+
+    public function resolveClassName(string $className): string
+    {
+        return $this->getClassNameInflector()->getUserClassName($className);
     }
 
     private function getClassNameInflector(): ClassNameInflectorInterface

--- a/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/ProxyManagerClassNameResolver.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/ProxyManagerClassNameResolver.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Proxy\Resolver;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\Persistence\Mapping\ProxyClassNameResolver;
 use ProxyManager\Inflector\ClassNameInflectorInterface;
+use ProxyManager\Proxy\ProxyInterface;
 
 /**
  * @internal
@@ -26,6 +27,11 @@ final class ProxyManagerClassNameResolver implements ClassNameResolver, ProxyCla
         return $this->resolveClassName($class);
     }
 
+    /**
+     * @psalm-template RealClassName of object
+     * @psalm-param class-string<RealClassName>|class-string<ProxyInterface<RealClassName>> $className
+     * @psalm-return class-string<RealClassName>
+     */
     public function resolveClassName(string $className): string
     {
         return $this->getClassNameInflector()->getUserClassName($className);

--- a/tests/Doctrine/ODM/MongoDB/Tests/RepositoryFactoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/RepositoryFactoryTest.php
@@ -9,6 +9,8 @@ use Doctrine\ODM\MongoDB\Repository\DefaultRepositoryFactory;
 use Doctrine\ODM\MongoDB\Repository\RepositoryFactory;
 use Documents\User;
 
+use function get_class;
+
 class RepositoryFactoryTest extends BaseTest
 {
     public function testRepositoryFactoryCanBeReplaced()
@@ -25,9 +27,10 @@ class RepositoryFactoryTest extends BaseTest
 
     public function testRepositoriesAreSameForSameClasses()
     {
+        $proxy = $this->dm->getPartialReference(User::class, 'abc');
         $this->assertSame(
             $this->dm->getRepository(User::class),
-            $this->dm->getRepository(\Proxies\__CG__\Documents\User::class)
+            $this->dm->getRepository(get_class($proxy))
         );
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues |

#### Summary

With the release of doctrine/persistence 2.2, we can now leverage class name resolvers in the metadata factory directly and can remove our workaround wherever we fetched metadata.