### PR TITLE
Allow mixed value in $not operator

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -1028,11 +1028,11 @@ class Builder
      * @see Expr::not()
      * @see https://docs.mongodb.com/manual/reference/operator/not/
      *
-     * @param array|Expr $expression
+     * @param array|Expr|mixed $valueOrExpression
      */
-    public function not($expression): self
+    public function not($valueOrExpression): self
     {
-        $this->expr->not($expression);
+        $this->expr->not($valueOrExpression);
 
         return $this;
     }

--- a/lib/Doctrine/ODM/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Expr.php
@@ -861,11 +861,11 @@ class Expr
      * @see Builder::not()
      * @see https://docs.mongodb.com/manual/reference/operator/not/
      *
-     * @param array|Expr $expression
+     * @param array|Expr|mixed $valueOrExpression
      */
-    public function not($expression): self
+    public function not($valueOrExpression): self
     {
-        return $this->operator('$not', $expression);
+        return $this->operator('$not', $valueOrExpression);
     }
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
@@ -15,6 +15,7 @@ use Documents\User;
 use InvalidArgumentException;
 use IteratorAggregate;
 use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;
 
 use function array_values;
@@ -92,6 +93,27 @@ class QueryTest extends BaseTest
         $this->assertNull($user);
 
         $qb->field('username')->not($qb->expr()->in(['1boo']));
+        $query = $qb->getQuery();
+        $user  = $query->getSingleResult();
+        $this->assertNotNull($user);
+    }
+
+    public function testNotAllowsRegex()
+    {
+        $user = new User();
+        $user->setUsername('boo');
+
+        $this->dm->persist($user);
+        $this->dm->flush();
+
+        $qb = $this->dm->createQueryBuilder(User::class);
+        $qb->field('username')->not(new Regex('Boo', 'i'));
+        $query = $qb->getQuery();
+        $user  = $query->getSingleResult();
+        $this->assertNull($user);
+
+        $qb = $this->dm->createQueryBuilder(User::class);
+        $qb->field('username')->not(new Regex('Boo'));
         $query = $qb->getQuery();
         $user  = $query->getSingleResult();
         $this->assertNotNull($user);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -19,6 +19,7 @@ use GeoJson\Geometry\Point;
 use InvalidArgumentException;
 use IteratorAggregate;
 use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\Regex;
 use MongoDB\Driver\ReadPreference;
 use ReflectionProperty;
 
@@ -294,6 +295,19 @@ class BuilderTest extends BaseTest
                 '$not' => [
                     '$in' => ['boo'],
                 ],
+            ],
+        ];
+        $this->assertEquals($expected, $qb->getQueryArray());
+    }
+
+    public function testNotAllowsRegex()
+    {
+        $qb = $this->getTestQueryBuilder();
+        $qb->field('username')->not(new Regex('Boo', 'i'));
+
+        $expected = [
+            'username' => [
+                '$not' => new Regex('Boo', 'i'),
             ],
         ];
         $this->assertEquals($expected, $qb->getQueryArray());


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->

[When working with regex and `$not`](https://docs.mongodb.com/v4.0/reference/operator/query/not/#not-and-regular-expressions), `$not` operator allows to pass a `MongoDB\BSON\Regex` instance.

Right now it's limited in phpdoc and when using static analysis tools you get a:

`Parameter #1 $expression of method Doctrine\ODM\MongoDB\Query\Builder::not() expects array|Doctrine\ODM\MongoDB\Query\Expr, MongoDB\BSON\Regex given.`

**Update**: should I target `2.3.x`? 🤔 