### PR TITLE
Upgrade to doctrine/coding-standard 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "require-dev": {
         "ext-bcmath": "*",
-        "doctrine/coding-standard": "^8.2",
+        "doctrine/coding-standard": "^9.0",
         "jmikola/geojson": "^1.0",
         "phpbench/phpbench": "^1.0.0",
         "phpstan/phpstan": "^0.12.32",

--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -561,13 +561,12 @@ class DocumentManager implements ObjectManager
      * Gets the repository for a document class.
      *
      * @param string $documentName The name of the Document.
-     *
-     * @return ObjectRepository  The repository.
-     *
-     * @template T of object
      * @psalm-param class-string<T> $documentName
      *
+     * @return ObjectRepository  The repository.
      * @psalm-return ObjectRepository<T>
+     *
+     * @template T of object
      */
     public function getRepository($documentName)
     {
@@ -661,11 +660,11 @@ class DocumentManager implements ObjectManager
      * @param mixed  $id
      * @param int    $lockMode
      * @param int    $lockVersion
-     *
-     * @template T of object
      * @psalm-param class-string<T> $className
      *
      * @psalm-return T|null
+     *
+     * @template T of object
      */
     public function find($className, $id, $lockMode = LockMode::NONE, $lockVersion = null): ?object
     {

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -469,15 +469,14 @@ final class DocumentPersister
      * be used to match an _id value.
      *
      * @param mixed $criteria Query criteria
+     * @psalm-param T|null $document
+     *
+     * @psalm-return T|null
      *
      * @throws LockException
      *
      * @todo Check identity map? loadById method? Try to guess whether
      *     $criteria is the id?
-     *
-     * @psalm-param T|null $document
-     *
-     * @psalm-return T|null
      */
     public function load($criteria, ?object $document = null, array $hints = [], int $lockMode = 0, ?array $sort = null): ?object
     {
@@ -630,11 +629,9 @@ final class DocumentPersister
      * @param array       $result   The query result.
      * @param object|null $document The document object to fill, if any.
      * @param array       $hints    Hints for document creation.
-     *
-     * @return object The filled and managed document object.
-     *
      * @psalm-param T|null $document
      *
+     * @return object The filled and managed document object.
      * @psalm-return T
      */
     private function createDocument(array $result, ?object $document = null, array $hints = []): object

--- a/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/ProxyManagerClassNameResolver.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Resolver/ProxyManagerClassNameResolver.php
@@ -28,9 +28,11 @@ final class ProxyManagerClassNameResolver implements ClassNameResolver, ProxyCla
     }
 
     /**
-     * @psalm-template RealClassName of object
      * @psalm-param class-string<RealClassName>|class-string<ProxyInterface<RealClassName>> $className
+     *
      * @psalm-return class-string<RealClassName>
+     *
+     * @psalm-template RealClassName of object
      */
     public function resolveClassName(string $className): string
     {

--- a/lib/Doctrine/ODM/MongoDB/Repository/DocumentRepository.php
+++ b/lib/Doctrine/ODM/MongoDB/Repository/DocumentRepository.php
@@ -58,7 +58,6 @@ class DocumentRepository implements ObjectRepository, Selectable
      * @param DocumentManager $dm            The DocumentManager to use.
      * @param UnitOfWork      $uow           The UnitOfWork to use.
      * @param ClassMetadata   $classMetadata The class metadata.
-     *
      * @psalm-param ClassMetadata<T>   $classMetadata The class metadata.
      */
     public function __construct(DocumentManager $dm, UnitOfWork $uow, ClassMetadata $classMetadata)

--- a/lib/Doctrine/ODM/MongoDB/Repository/RepositoryFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Repository/RepositoryFactory.php
@@ -15,9 +15,11 @@ interface RepositoryFactory
     /**
      * Gets the repository for a document class.
      *
-     * @template T of object
      * @psalm-param class-string<T> $documentName
+     *
      * @psalm-return ObjectRepository<T>
+     *
+     * @template T of object
      */
     public function getRepository(DocumentManager $documentManager, string $documentName): ObjectRepository;
 }

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -325,9 +325,11 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Get the document persister instance for the given document name
      *
-     * @template T of object
      * @psalm-param class-string<T> $documentName
+     *
      * @psalm-return Persisters\DocumentPersister<T>
+     *
+     * @template T of object
      */
     public function getDocumentPersister(string $documentName): Persisters\DocumentPersister
     {
@@ -2621,10 +2623,12 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Creates a document. Used for reconstitution of documents during hydration.
      *
-     * @template T of object
      * @psalm-param class-string<T> $className
      * @psalm-param T|null $document
+     *
      * @psalm-return T
+     *
+     * @template T of object
      */
     public function getOrCreateDocument(string $className, array $data, array &$hints = [], ?object $document = null): object
     {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -59,22 +59,6 @@
         <exclude-pattern>lib/Doctrine/ODM/MongoDB/Events.php</exclude-pattern>
     </rule>
 
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements">
-        <properties>
-            <property name="alwaysUsedPropertiesAnnotations" type="array" value="
-                @ODM\Id,
-                @ODM\Field,
-                @ODM\EmbedOne,
-                @ODM\EmbedMany,
-                @ODM\ReferenceOne,
-                @ODM\ReferenceMany
-            "/>
-        </properties>
-        <exclude-pattern>tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php</exclude-pattern>
-        <exclude-pattern>tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataFactoryTest.php</exclude-pattern>
-        <exclude-pattern>tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php</exclude-pattern>
-    </rule>
-
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->

`SlevomatCodingStandard.Classes.UnusedPrivateElements` [was deprecated](https://github.com/slevomat/coding-standard/blob/6.4.1/SlevomatCodingStandard/Sniffs/Classes/UnusedPrivateElementsSniff.php#L61).
