### PR TITLE
Improve phpdoc specification

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -16,7 +16,9 @@ use Doctrine\ODM\MongoDB\Proxy\Resolver\ClassNameResolver;
 use Doctrine\ODM\MongoDB\Proxy\Resolver\ProxyManagerClassNameResolver;
 use Doctrine\ODM\MongoDB\Query\FilterCollection;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
+use Doctrine\ODM\MongoDB\Repository\GridFSRepository;
 use Doctrine\ODM\MongoDB\Repository\RepositoryFactory;
+use Doctrine\ODM\MongoDB\Repository\ViewRepository;
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
 use InvalidArgumentException;
@@ -563,8 +565,8 @@ class DocumentManager implements ObjectManager
      * @param string $documentName The name of the Document.
      * @psalm-param class-string<T> $documentName
      *
-     * @return ObjectRepository  The repository.
-     * @psalm-return ObjectRepository<T>
+     * @return ObjectRepository|DocumentRepository|GridFSRepository|ViewRepository  The repository.
+     * @psalm-return DocumentRepository<T>|GridFSRepository<T>|ViewRepository<T>
      *
      * @template T of object
      */

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -35,6 +35,10 @@ use function ucfirst;
  * to a document database.
  *
  * @internal
+ *
+ * @method ClassMetadata[] getAllMetadata()
+ * @method ClassMetadata[] getLoadedMetadata()
+ * @method ClassMetadata getMetadataFor($className)
  */
 final class ClassMetadataFactory extends AbstractClassMetadataFactory
 {

--- a/lib/Doctrine/ODM/MongoDB/Repository/AbstractRepositoryFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Repository/AbstractRepositoryFactory.php
@@ -26,6 +26,13 @@ abstract class AbstractRepositoryFactory implements RepositoryFactory
      */
     private $repositoryList = [];
 
+    /**
+     * @psalm-param class-string<T> $documentName
+     *
+     * @psalm-return DocumentRepository<T>|GridFSRepository<T>|ViewRepository<T>
+     *
+     * @template T of object
+     */
     public function getRepository(DocumentManager $documentManager, string $documentName): ObjectRepository
     {
         $metadata = $documentManager->getClassMetadata($documentName);
@@ -45,7 +52,12 @@ abstract class AbstractRepositoryFactory implements RepositoryFactory
     /**
      * Create a new repository instance for a document class.
      *
-     * @return ObjectRepository|GridFSRepository|ViewRepository
+     * @psalm-param class-string<T> $documentName
+     *
+     * @return ObjectRepository|DocumentRepository|GridFSRepository|ViewRepository
+     * @psalm-return DocumentRepository<T>|GridFSRepository<T>|ViewRepository<T>
+     *
+     * @template T of object
      */
     protected function createRepository(DocumentManager $documentManager, string $documentName): ObjectRepository
     {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

These changes add more specific return type declaration as the ORM:

https://github.com/doctrine/orm/blob/a6577b89a2b028b79550ef58d9f272debdd75da4/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php#L58-L60
https://github.com/doctrine/orm/blob/a6577b89a2b028b79550ef58d9f272debdd75da4/lib/Doctrine/ORM/EntityManager.php#L758-L759

These changes fixes some issues on tests directory like:

https://github.com/doctrine/mongodb-odm/blob/f225a0cfc5ba878aba3e32b7f5fd70facc2d4eee/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php#L27-L29

`isSharded` is only available in `ClassMetadata` from this package or

https://github.com/doctrine/mongodb-odm/blob/f225a0cfc5ba878aba3e32b7f5fd70facc2d4eee/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php#L31-L33

`createQueryBuilder` not available in `ObjectRepository` but `DocumentRepository`.