### PR TITLE
Fix some phpdoc

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -465,7 +465,7 @@ class Builder
      * including the _id field. You can promote an existing embedded document to
      * the top level, or create a new document for promotion.
      *
-     * @param string|array|null $expression Optional. A replacement expression that
+     * @param string|array|Expr|null $expression Optional. A replacement expression that
      * resolves to a document.
      */
     public function replaceRoot($expression = null): Stage\ReplaceRoot

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AbstractBucket.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AbstractBucket.php
@@ -33,7 +33,7 @@ abstract class AbstractBucket extends Stage
     /** @var Bucket\AbstractOutput|null */
     protected $output;
 
-    /** @var Expr|array */
+    /** @var Expr|array|string */
     protected $groupBy;
 
     public function __construct(Builder $builder, DocumentManager $documentManager, ClassMetadata $class)
@@ -48,7 +48,7 @@ abstract class AbstractBucket extends Stage
      * An expression to group documents by. To specify a field path, prefix the
      * field name with a dollar sign $ and enclose it in quotes.
      *
-     * @param array|Expr $expression
+     * @param array|Expr|string $expression
      */
     public function groupBy($expression): self
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket.php
@@ -26,7 +26,7 @@ class Bucket extends AbstractBucket
      * boundaries. The specified values must be in ascending order and all of
      * the same type. The exception is if the values are of mixed numeric types.
      *
-     * @param array ...$boundaries
+     * @param mixed $boundaries
      */
     public function boundaries(...$boundaries): self
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceRoot.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceRoot.php
@@ -24,7 +24,7 @@ class ReplaceRoot extends Operator
     /** @var ClassMetadata */
     private $class;
 
-    /** @var string|array|null */
+    /** @var string|array|Expr|null */
     private $expression;
 
     public function __construct(Builder $builder, DocumentManager $documentManager, ClassMetadata $class, $expression = null)

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -58,7 +58,7 @@ use function trigger_deprecation;
  *    the serialized representation).
  *
  * @final
- * @template T of object
+ * @template-covariant T of object
  * @template-implements BaseClassMetadata<T>
  */
 /* final */ class ClassMetadata implements BaseClassMetadata


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->

Raising psalm level locally and analyzing tests directory made some issues appear:

ReplaceRoot allowing `Expr`:

https://github.com/doctrine/mongodb-odm/blob/f225a0cfc5ba878aba3e32b7f5fd70facc2d4eee/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php#L45-L49

`Bucket::groupBy` allowing `string`:

https://github.com/doctrine/mongodb-odm/blob/f225a0cfc5ba878aba3e32b7f5fd70facc2d4eee/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketTest.php#L20-L22

With `ClassMetadata` I was getting:

```
ERROR: InvalidArgument - tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php:418:30 - Argument 2 of Doctrine\ODM\MongoDB\Query\Query::__construct expects Doctrine\ODM\MongoDB\Mapping\ClassMetadata<object>, Doctrine\ODM\MongoDB\Mapping\ClassMetadata<Documents\User> provided (see https://psalm.dev/004)
        new Query($this->dm, new ClassMetadata(User::class), $this->getMockCollection(), ['type' => -1], []);
```

Making it covariant I think it makes sense as it is in [`doctrine/persistence`](https://github.com/doctrine/persistence/blob/d138f3ab5f761055cab1054070377cfd3222e368/lib/Doctrine/Persistence/Mapping/ClassMetadata.php#L7-L12).