### PR TITLE
Fix wrong handling for nullable fields in upsert and update

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
@@ -418,6 +418,7 @@ class EmbeddedTest extends BaseTest
 
         $check = $this->dm->getDocumentCollection(User::class)->findOne();
         $this->assertEmpty($check['phonenumbers']);
+        $this->assertNull($check['addressNullable']);
         $this->assertArrayNotHasKey('address', $check);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2310Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2310Test.php
@@ -8,7 +8,6 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents74\GH2310Container;
 use Documents74\GH2310Embedded;
 use MongoDB\BSON\ObjectId;
-use ReflectionProperty;
 
 use function phpversion;
 use function version_compare;
@@ -36,8 +35,7 @@ class GH2310Test extends BaseTest
 
         self::assertInstanceOf(GH2310Container::class, $result);
         self::assertSame($document->id, $result->id);
-        $reflectionProperty = new ReflectionProperty($result, 'embedded');
-        self::assertFalse($reflectionProperty->isInitialized($result));
+        self::assertNull($result->embedded);
     }
 
     public function testAggregatorBuilderWithNullableEmbeddedAfterUpsert(): void
@@ -53,8 +51,7 @@ class GH2310Test extends BaseTest
 
         self::assertInstanceOf(GH2310Container::class, $result);
         self::assertSame($document->id, $result->id);
-        $reflectionProperty = new ReflectionProperty($result, 'embedded');
-        self::assertFalse($reflectionProperty->isInitialized($result));
+        self::assertNull($result->embedded);
     }
 
     public function testFindWithNullableEmbeddedAfterInsert(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2310Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2310Test.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents74\GH2310Container;
+use Documents74\GH2310Embedded;
+use MongoDB\BSON\ObjectId;
+use ReflectionProperty;
+
+use function phpversion;
+use function version_compare;
+
+class GH2310Test extends BaseTest
+{
+    public function setUp(): void
+    {
+        if (version_compare((string) phpversion(), '7.4.0', '<')) {
+            self::markTestSkipped('PHP 7.4 is required to run this test');
+        }
+
+        parent::setUp();
+    }
+
+    public function testFindWithNullableEmbeddedAfterUpsert(): void
+    {
+        $document = new GH2310Container((string) new ObjectId(), null);
+        $this->dm->persist($document);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $repository = $this->dm->getRepository(GH2310Container::class);
+        $result     = $repository->find($document->id);
+
+        self::assertInstanceOf(GH2310Container::class, $result);
+        self::assertSame($document->id, $result->id);
+        $reflectionProperty = new ReflectionProperty($result, 'embedded');
+        self::assertFalse($reflectionProperty->isInitialized($result));
+    }
+
+    public function testAggregatorBuilderWithNullableEmbeddedAfterUpsert(): void
+    {
+        $document = new GH2310Container((string) new ObjectId(), null);
+        $this->dm->persist($document);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $aggBuilder = $this->dm->createAggregationBuilder(GH2310Container::class);
+        $aggBuilder->match()->field('id')->equals($document->id);
+        $result = $aggBuilder->hydrate(GH2310Container::class)->getAggregation()->getIterator()->current();
+
+        self::assertInstanceOf(GH2310Container::class, $result);
+        self::assertSame($document->id, $result->id);
+        $reflectionProperty = new ReflectionProperty($result, 'embedded');
+        self::assertFalse($reflectionProperty->isInitialized($result));
+    }
+
+    public function testFindWithNullableEmbeddedAfterInsert(): void
+    {
+        $document = new GH2310Container(null, null);
+        $this->dm->persist($document);
+        $this->dm->flush();
+
+        $repository = $this->dm->getRepository(GH2310Container::class);
+        $result     = $repository->find($document->id);
+
+        self::assertInstanceOf(GH2310Container::class, $result);
+        self::assertSame($document->id, $result->id);
+        self::assertNull($result->embedded);
+    }
+
+    public function testAggregatorBuilderWithNullableEmbeddedAfterInsert(): void
+    {
+        $document = new GH2310Container(null, null);
+        $this->dm->persist($document);
+        $this->dm->flush();
+
+        $aggBuilder = $this->dm->createAggregationBuilder(GH2310Container::class);
+        $aggBuilder->match()->field('id')->equals($document->id);
+        $result = $aggBuilder->hydrate(GH2310Container::class)->getAggregation()->getIterator()->current();
+
+        self::assertInstanceOf(GH2310Container::class, $result);
+        self::assertSame($document->id, $result->id);
+        self::assertNull($result->embedded);
+    }
+
+    public function testFindWithNullableEmbeddedAfterUpdate(): void
+    {
+        $document = new GH2310Container(null, new GH2310Embedded());
+        $this->dm->persist($document);
+        $this->dm->flush();
+
+        // Update embedded document to trigger nullable behaviour
+        $document->embedded = null;
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $repository = $this->dm->getRepository(GH2310Container::class);
+        $result     = $repository->find($document->id);
+
+        self::assertInstanceOf(GH2310Container::class, $result);
+        self::assertSame($document->id, $result->id);
+        self::assertNull($result->embedded);
+    }
+
+    public function testAggregatorBuilderWithNullableEmbeddedAfterUpdate(): void
+    {
+        $document = new GH2310Container(null, new GH2310Embedded());
+        $this->dm->persist($document);
+        $this->dm->flush();
+
+        // Update embedded document to trigger nullable behaviour
+        $document->embedded = null;
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $aggBuilder = $this->dm->createAggregationBuilder(GH2310Container::class);
+        $aggBuilder->match()->field('id')->equals($document->id);
+        $result = $aggBuilder->hydrate(GH2310Container::class)->getAggregation()->getIterator()->current();
+
+        self::assertInstanceOf(GH2310Container::class, $result);
+        self::assertSame($document->id, $result->id);
+        self::assertNull($result->embedded);
+    }
+}

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -28,8 +28,11 @@ class User extends BaseDocument
     /** @ODM\Field(type="date") */
     protected $createdAt;
 
-    /** @ODM\EmbedOne(targetDocument=Address::class, nullable=true) */
+    /** @ODM\EmbedOne(targetDocument=Address::class) */
     protected $address;
+
+    /** @ODM\EmbedOne(targetDocument=Address::class, nullable=true) */
+    protected $addressNullable;
 
     /** @ODM\ReferenceOne(targetDocument=Profile::class, cascade={"all"}) */
     protected $profile;
@@ -177,12 +180,14 @@ class User extends BaseDocument
 
     public function setAddress(?Address $address = null)
     {
-        $this->address = $address;
+        $this->address         = $address;
+        $this->addressNullable = $address ? clone $address : $address;
     }
 
     public function removeAddress()
     {
-        $this->address = null;
+        $this->address         = null;
+        $this->addressNullable = null;
     }
 
     public function setProfile(Profile $profile)

--- a/tests/Documents74/GH2310Container.php
+++ b/tests/Documents74/GH2310Container.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents74;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document()
+ */
+class GH2310Container
+{
+    /** @ODM\Id */
+    public ?string $id;
+
+    /** @ODM\EmbedOne(targetDocument=GH2310Embedded::class, nullable=true) */
+    public ?GH2310Embedded $embedded;
+
+    public function __construct(?string $id, ?GH2310Embedded $embedded)
+    {
+        $this->id       = $id;
+        $this->embedded = $embedded;
+    }
+}
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class GH2310Embedded
+{
+    /** @ODM\Field(type="integer") */
+    public int $value;
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fixes #2310

#### Summary

#2310 reported another instance of #2301, but on closer inspection it turns out that this was not the same bug but the same symptoms. The bug was wrong handling of `null` values during an `upsert`. I found two separate issues:

1. Nullable embedded fields are not set to `null` when the upsert results in a new document, which causes the bug described in #2310,
2. Nullable embedded fields are not set to `null` on update but rather unset, which also causes the bug described in #2310,
3. Nullable references are always set to `null` on upsert when they shouldn't.

I've kept the tests added in #2316 and expanded them to cover all insert, upsert, and update scenarios. I've also added new tests to `UpsertTest` to specifically test for the behaviour unrelated to typed properties.