### PR TITLE
[2.2] Fix builds

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -50,6 +50,11 @@ jobs:
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
 
+      - name: "Upload composer.lock as build artifact"
+        uses: actions/upload-artifact@v2
+        with:
+          name: composer.lock
+          path: composer.lock
 
       # https://github.com/doctrine/.github/issues/3
       - name: "Run PHP_CodeSniffer"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,12 +12,10 @@ env:
 jobs:
   phpunit:
     name: "PHPUnit"
-    runs-on: "${{ matrix.os }}"
+    runs-on: "ubuntu-18.04"
 
     strategy:
       matrix:
-        os:
-          - "ubuntu-18.04"
         php-version:
           - "7.2"
           - "7.3"
@@ -35,13 +33,11 @@ jobs:
           - "highest"
         include:
           - deps: "lowest"
-            os: "ubuntu-16.04"
             php-version: "7.2"
             mongodb-version: "3.6"
             driver-version: "1.5.0"
             topology: "server"
           - topology: "sharded_cluster"
-            os: "ubuntu-18.04"
             php-version: "8.0"
             mongodb-version: "4.4"
             driver-version: "stable"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -86,6 +86,12 @@ jobs:
           dependency-versions: "${{ matrix.dependencies }}"
           composer-options: "--prefer-dist"
 
+      - name: "Upload composer.lock as build artifact"
+        uses: actions/upload-artifact@v2
+        with:
+          name: composer.lock
+          path: composer.lock
+
       - id: setup-mongodb
         uses: mongodb-labs/drivers-evergreen-tools@master
         with:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -54,6 +54,12 @@ jobs:
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
 
+      - name: "Upload composer.lock as build artifact"
+        uses: actions/upload-artifact@v2
+        with:
+          name: composer.lock
+          path: composer.lock
+
       # https://github.com/doctrine/.github/issues/3
       - name: "Run PHP_CodeSniffer"
         run: "vendor/bin/phpbench run --report=default --revs=100 --iterations=5 --report=aggregate"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -49,6 +49,12 @@ jobs:
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
 
+      - name: "Upload composer.lock as build artifact"
+        uses: actions/upload-artifact@v2
+        with:
+          name: composer.lock
+          path: composer.lock
+
       - name: "Run a static analysis with phpstan/phpstan"
         run: "vendor/bin/phpstan analyse --error-format=github"
 
@@ -74,6 +80,12 @@ jobs:
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
+
+      - name: "Upload composer.lock as build artifact"
+        uses: actions/upload-artifact@v2
+        with:
+          name: composer.lock
+          path: composer.lock
 
       - name: "Run a static analysis with vimeo/psalm"
         run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc) --php-version=${{ matrix.php-version }}"

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "ext-bcmath": "*",
         "doctrine/coding-standard": "^8.2",
         "jmikola/geojson": "^1.0",
-        "phpbench/phpbench": "^1.0.0-alpha3",
+        "phpbench/phpbench": "^1.0.0",
         "phpstan/phpstan": "^0.12.32",
         "phpunit/phpunit": "^8.5 || ^9",
         "squizlabs/php_codesniffer": "^3.5",

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,4 +1,4 @@
 {
-    "bootstrap": "tests/bootstrap.php",
-    "path": "benchmark"
+    "runner.bootstrap": "tests/bootstrap.php",
+    "runner.path": "benchmark"
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,27 +1,44 @@
 parameters:
-    ignoreErrors:
-        # Adding a parameter would be BC-break
-        -
-            message: "#^PHPDoc tag @param references unknown parameter\\: \\$applyFilters$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+	ignoreErrors:
+		# Adding a parameter would be BC-break
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$applyFilters$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
 
-        # Making classes final as suggested would be a BC-break
-        -
-            message: "#^Unsafe usage of new static\\(\\)\\.$#"
-            paths:
-                 - lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
-                 - lib/Doctrine/ODM/MongoDB/DocumentManager.php
+		# Making classes final as suggested would be a BC-break
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
 
-        # The limit option in GeoNear has been removed in MongoDB 4.2 in favor of $limit stage
-        -
-            message: "#^Return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\GeoNear\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\GeoNear\\:\\:limit\\(\\) should be compatible with return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Limit\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\:\\:limit\\(\\)$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GeoNear.php
+		# The limit option in GeoNear has been removed in MongoDB 4.2 in favor of $limit stage
+		-
+			message: "#^Return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\GeoNear\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\GeoNear\\:\\:limit\\(\\) should be compatible with return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Limit\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\:\\:limit\\(\\)$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GeoNear.php
 
-        # Union types cannot be added yet
-        -
-            message: "#^Result of && is always false\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/Query/Builder.php
+		# Fixed in 2.3
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:find\\(\\) should return T of object\\|null but returns object\\|null\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/DocumentManager.php
+
+		# Fixed in 2.3
+		-
+			message: "#^Return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadataFactory\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getMetadataFactory\\(\\) should be compatible with return type \\(Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadataFactory\\<Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\>\\) of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getMetadataFactory\\(\\)$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/DocumentManager.php
+
+		# Making classes final as suggested would be a BC-break
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/DocumentManager.php
+
+		# Union types cannot be added yet
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Query/Builder.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.7.3@38c452ae584467e939d55377aaf83b5a26f19dd1">
+  <file src="lib/Doctrine/ODM/MongoDB/DocumentManager.php">
+    <ParamNameMismatch occurrences="8">
+      <code>$document</code>
+      <code>$document</code>
+      <code>$document</code>
+      <code>$document</code>
+      <code>$document</code>
+      <code>$document</code>
+      <code>$documentName</code>
+      <code>$documentName</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php">
+    <ParamNameMismatch occurrences="2">
+      <code>$fieldName</code>
+      <code>$fieldName</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$value</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ODM/MongoDB/Query/QueryExpressionVisitor.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$compositeExpr</code>
+    </ParamNameMismatch>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="lib/Doctrine/ODM/MongoDB" />


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | task
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Backports changes from #2306 and fixes various build issues. I've also added a build step to expose the composer.lock file as build artefact to make debugging easier (e.g. if issues only appear in a specific version of psalm or phpstan).