### PR TITLE
Add more specific phpdoc to `DocumentRepository`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,12 +43,12 @@
         "doctrine/coding-standard": "^9.0",
         "jmikola/geojson": "^1.0",
         "phpbench/phpbench": "^1.0.0",
-        "phpstan/phpstan": "^0.12.32",
+        "phpstan/phpstan": "^0.12.89",
         "phpstan/phpstan-phpunit": "^0.12.19",
         "phpunit/phpunit": "^8.5 || ^9",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/cache": "^4.4 || ^5.0",
-        "vimeo/psalm": "^4.2.1"
+        "vimeo/psalm": "^4.8.1"
     },
     "suggest": {
         "ext-bcmath": "Decimal128 type support"

--- a/lib/Doctrine/ODM/MongoDB/Repository/DocumentRepository.php
+++ b/lib/Doctrine/ODM/MongoDB/Repository/DocumentRepository.php
@@ -101,6 +101,8 @@ class DocumentRepository implements ObjectRepository, Selectable
      *
      * @param mixed $id Identifier.
      *
+     * @psalm-return T|null
+     *
      * @throws MappingException
      * @throws LockException
      */
@@ -155,6 +157,8 @@ class DocumentRepository implements ObjectRepository, Selectable
 
     /**
      * Finds all documents in the repository.
+     *
+     * {@inheritDoc}
      */
     public function findAll(): array
     {
@@ -164,8 +168,7 @@ class DocumentRepository implements ObjectRepository, Selectable
     /**
      * Finds documents by a set of criteria.
      *
-     * @param int|null $limit
-     * @param int|null $offset
+     * {@inheritDoc}
      */
     public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null): array
     {
@@ -175,14 +178,20 @@ class DocumentRepository implements ObjectRepository, Selectable
     /**
      * Finds a single document by a set of criteria.
      *
-     * @param array      $criteria
-     * @param array|null $sort
+     * @param array<string, mixed>|null $sort
+     * @param array<string, mixed>      $criteria
+     *
+     * @return object|null The object.
+     * @psalm-return T|null
      */
     public function findOneBy(array $criteria, ?array $sort = null): ?object
     {
         return $this->getDocumentPersister()->load($criteria, null, [], 0, $sort);
     }
 
+    /**
+     * @psalm-return class-string<T>
+     */
     public function getDocumentName(): string
     {
         return $this->documentName;
@@ -193,11 +202,17 @@ class DocumentRepository implements ObjectRepository, Selectable
         return $this->dm;
     }
 
+    /**
+     * @psalm-return ClassMetadata<T>
+     */
     public function getClassMetadata(): ClassMetadata
     {
         return $this->class;
     }
 
+    /**
+     * @psalm-return class-string<T>
+     */
     public function getClassName(): string
     {
         return $this->getDocumentName();
@@ -207,7 +222,7 @@ class DocumentRepository implements ObjectRepository, Selectable
      * Selects all elements from a selectable that match the expression and
      * returns a new collection containing these elements.
      *
-     * @see Selectable::matching()
+     * {@inheritDoc}
      */
     public function matching(Criteria $criteria): ArrayCollection
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -230,11 +230,6 @@ parameters:
             path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
 
         -
-            message: "#^Function mongodb\\\\bson\\\\tophp invoked with 1 parameter, 2 required\\.$#"
-            count: 2
-            path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
-
-        -
             message: "#^Access to an undefined property Documents\\\\CmsArticle\\:\\:\\$title\\.$#"
             count: 4
             path: tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -67,7 +67,6 @@ class ClassMetadataTest extends BaseTest
         $cm->setVersioned(true);
         $cm->setVersionField('version');
         $validatorJson = '{ "$and": [ { "email": { "$regex": { "$regularExpression" : { "pattern": "@mongodb\\\\.com$", "options": "" } } } } ] }';
-        /** @psalm-suppress TooFewArguments */
         $cm->setValidator(toPHP(fromJSON($validatorJson)));
         $cm->setValidationAction(ClassMetadata::SCHEMA_VALIDATION_ACTION_WARN);
         $cm->setValidationLevel(ClassMetadata::SCHEMA_VALIDATION_LEVEL_OFF);
@@ -100,7 +99,6 @@ class ClassMetadataTest extends BaseTest
         $this->assertEquals('lock', $cm->lockField);
         $this->assertEquals(true, $cm->isVersioned);
         $this->assertEquals('version', $cm->versionField);
-        /** @psalm-suppress TooFewArguments */
         $this->assertEquals(toPHP(fromJSON($validatorJson)), $cm->getValidator());
         $this->assertEquals(ClassMetadata::SCHEMA_VALIDATION_ACTION_WARN, $cm->getValidationAction());
         $this->assertEquals(ClassMetadata::SCHEMA_VALIDATION_LEVEL_OFF, $cm->getValidationLevel());


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->

There have been releases of phpstan and psalm fixing the `toPHP` signature.

The phpdoc added to the `DocumentRepository` methods is because Psalm does not work well inheriting phpdoc templates in methods.