### PR TITLE
Fix phpdoc for repositories

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -20,7 +20,6 @@ use Doctrine\ODM\MongoDB\Repository\GridFSRepository;
 use Doctrine\ODM\MongoDB\Repository\RepositoryFactory;
 use Doctrine\ODM\MongoDB\Repository\ViewRepository;
 use Doctrine\Persistence\ObjectManager;
-use Doctrine\Persistence\ObjectRepository;
 use InvalidArgumentException;
 use Jean85\PrettyVersions;
 use MongoDB\Client;
@@ -566,7 +565,7 @@ class DocumentManager implements ObjectManager
      * @param string $className The name of the Document.
      * @psalm-param class-string<T> $className
      *
-     * @return ObjectRepository|DocumentRepository|GridFSRepository|ViewRepository  The repository.
+     * @return DocumentRepository|GridFSRepository|ViewRepository  The repository.
      * @psalm-return DocumentRepository<T>|GridFSRepository<T>|ViewRepository<T>
      *
      * @template T of object

--- a/lib/Doctrine/ODM/MongoDB/Repository/AbstractRepositoryFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Repository/AbstractRepositoryFactory.php
@@ -11,7 +11,6 @@ use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\Persistence\ObjectRepository;
 
 use function is_a;
-use function ltrim;
 use function spl_object_hash;
 
 /**
@@ -42,7 +41,7 @@ abstract class AbstractRepositoryFactory implements RepositoryFactory
             return $this->repositoryList[$hashKey];
         }
 
-        $repository = $this->createRepository($documentManager, ltrim($documentName, '\\'));
+        $repository = $this->createRepository($documentManager, $documentName);
 
         $this->repositoryList[$hashKey] = $repository;
 
@@ -54,7 +53,7 @@ abstract class AbstractRepositoryFactory implements RepositoryFactory
      *
      * @psalm-param class-string<T> $documentName
      *
-     * @return ObjectRepository|DocumentRepository|GridFSRepository|ViewRepository
+     * @return DocumentRepository|GridFSRepository|ViewRepository
      * @psalm-return DocumentRepository<T>|GridFSRepository<T>|ViewRepository<T>
      *
      * @template T of object

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalEmbedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalEmbedTest.php
@@ -8,6 +8,8 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
+use function assert;
+
 /**
  * Test the orphan removal on embedded documents that contain references with cascade operations.
  */
@@ -138,20 +140,22 @@ class OrphanRemovalEmbedTest extends BaseTest
         $this->assertNotNull($this->getAddressRepository()->find($address3->id), 'Should have added address 3');
     }
 
-    /**
-     * @return DocumentRepository
-     */
-    private function getUserRepository()
+    private function getUserRepository(): DocumentRepository
     {
-        return $this->dm->getRepository(OrphanRemovalCascadeUser::class);
+        $repository = $this->dm->getRepository(OrphanRemovalCascadeUser::class);
+
+        assert($repository instanceof DocumentRepository);
+
+        return $repository;
     }
 
-    /**
-     * @return DocumentRepository
-     */
-    private function getAddressRepository()
+    private function getAddressRepository(): DocumentRepository
     {
-        return $this->dm->getRepository(OrphanRemovalCascadeAddress::class);
+        $repository = $this->dm->getRepository(OrphanRemovalCascadeAddress::class);
+
+        assert($repository instanceof DocumentRepository);
+
+        return $repository;
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
@@ -8,6 +8,8 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
+use function assert;
+
 class OrphanRemovalTest extends BaseTest
 {
     public function testOrphanRemoval()
@@ -279,20 +281,22 @@ class OrphanRemovalTest extends BaseTest
         $this->assertNull($this->getProfileRepository()->find($profile2->id), 'Profile 2 should have been removed');
     }
 
-    /**
-     * @return DocumentRepository
-     */
-    private function getUserRepository()
+    private function getUserRepository(): DocumentRepository
     {
-        return $this->dm->getRepository(OrphanRemovalUser::class);
+        $repository = $this->dm->getRepository(OrphanRemovalUser::class);
+
+        assert($repository instanceof DocumentRepository);
+
+        return $repository;
     }
 
-    /**
-     * @return DocumentRepository
-     */
-    private function getProfileRepository()
+    private function getProfileRepository(): DocumentRepository
     {
-        return $this->dm->getRepository(OrphanRemovalProfile::class);
+        $repository = $this->dm->getRepository(OrphanRemovalProfile::class);
+
+        assert($repository instanceof DocumentRepository);
+
+        return $repository;
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Repository/DefaultGridFSRepositoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Repository/DefaultGridFSRepositoryTest.php
@@ -257,7 +257,11 @@ class DefaultGridFSRepositoryTest extends BaseTest
 
     private function getRepository($className = File::class): GridFSRepository
     {
-        return $this->dm->getRepository($className);
+        $repository = $this->dm->getRepository($className);
+
+        assert($repository instanceof GridFSRepository);
+
+        return $repository;
     }
 
     private function uploadFile($filename, ?UploadOptions $uploadOptions = null): File


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes/no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->

Ref: https://github.com/doctrine/mongodb-odm/pull/2329

Removes ObjectRepository as return type since it will always return a more specific one (DocumentRepository, GridFSRepository or ViewRepository)