### PR TITLE
Fix handling of upserts during scheduling for deletion

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1357,6 +1357,10 @@ final class UnitOfWork implements PropertyChangedListener
             unset($this->documentUpdates[$oid]);
         }
 
+        if (isset($this->documentUpserts[$oid])) {
+            unset($this->documentUpserts[$oid]);
+        }
+
         if (isset($this->documentDeletions[$oid])) {
             return;
         }

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -115,7 +115,7 @@ class UnitOfWorkTest extends BaseTest
         $this->uow->scheduleForDelete($user);
         $this->assertFalse($this->uow->isScheduledForDelete($user));
     }
-    
+
     public function testScheduleForDeleteShouldUnregisterScheduledUpserts()
     {
         $class    = $this->dm->getClassMetadata(ForumUser::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -115,6 +115,24 @@ class UnitOfWorkTest extends BaseTest
         $this->uow->scheduleForDelete($user);
         $this->assertFalse($this->uow->isScheduledForDelete($user));
     }
+    
+    public function testScheduleForDeleteShouldUnregisterScheduledUpserts()
+    {
+        $class    = $this->dm->getClassMetadata(ForumUser::class);
+        $user     = new ForumUser();
+        $user->id = new ObjectId();
+        $this->assertFalse($this->uow->isScheduledForInsert($user));
+        $this->assertFalse($this->uow->isScheduledForUpsert($user));
+        $this->assertFalse($this->uow->isScheduledForDelete($user));
+        $this->uow->scheduleForUpsert($class, $user);
+        $this->assertFalse($this->uow->isScheduledForInsert($user));
+        $this->assertTrue($this->uow->isScheduledForUpsert($user));
+        $this->assertFalse($this->uow->isScheduledForDelete($user));
+        $this->uow->scheduleForDelete($user);
+        $this->assertFalse($this->uow->isScheduledForInsert($user));
+        $this->assertFalse($this->uow->isScheduledForUpsert($user));
+        $this->assertTrue($this->uow->isScheduledForDelete($user));
+    }
 
     public function testThrowsOnPersistOfMappedSuperclass()
     {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->

Currently, when a document is scheduled for upsert and later scheduled for deletion, the flush will fail, since the document will be *both* marked for upsert and deletion.

When scheduling for deletion, scheduled insertions and updates are already reverted. This PR adds reverting of scheduled upserts.
