### PR TITLE
Add missing return types

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
@@ -44,9 +44,6 @@ class Expr
     /** @var array|null */
     private $switchBranch;
 
-    /**
-     * @inheritDoc
-     */
     public function __construct(DocumentManager $dm, ClassMetadataInterface $class)
     {
         assert($class instanceof ClassMetadata);

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Group.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Group.php
@@ -80,6 +80,8 @@ class Group extends Operator
      * @see Expr::expression
      *
      * @param mixed|Expr $value
+     *
+     * @return static
      */
     public function expression($value)
     {
@@ -92,6 +94,8 @@ class Group extends Operator
      * Set the current field for building the expression.
      *
      * @see Expr::field
+     *
+     * @return static
      */
     public function field(string $fieldName)
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Group.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Group.php
@@ -74,37 +74,6 @@ class Group extends Operator
     }
 
     /**
-     * Used to use an expression as field value. Can be any expression
-     *
-     * @see https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions
-     * @see Expr::expression
-     *
-     * @param mixed|Expr $value
-     *
-     * @return static
-     */
-    public function expression($value)
-    {
-        $this->expr->expression($value);
-
-        return $this;
-    }
-
-    /**
-     * Set the current field for building the expression.
-     *
-     * @see Expr::field
-     *
-     * @return static
-     */
-    public function field(string $fieldName)
-    {
-        $this->expr->field($fieldName);
-
-        return $this;
-    }
-
-    /**
      * Returns the value that results from applying an expression to the first
      * document in a group of documents that share the same group by key. Only
      * meaningful when documents are in a defined order.

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/MatchStage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/MatchStage.php
@@ -19,9 +19,6 @@ class MatchStage extends Stage
     /** @var Expr */
     protected $query;
 
-    /**
-     * {@inheritdoc}
-     */
     public function __construct(Builder $builder)
     {
         parent::__construct($builder);

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Operator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Operator.php
@@ -23,9 +23,6 @@ abstract class Operator extends Stage
     /** @var Expr */
     protected $expr;
 
-    /**
-     * {@inheritdoc}
-     */
     public function __construct(Builder $builder)
     {
         parent::__construct($builder);

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Operator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Operator.php
@@ -47,6 +47,8 @@ abstract class Operator extends Stage
      * @see Expr::abs
      *
      * @param mixed|Expr $number
+     *
+     * @return static
      */
     public function abs($number): self
     {
@@ -68,6 +70,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
      * @param mixed|Expr ...$expressions Additional expressions
+     *
+     * @return static
      */
     public function add($expression1, $expression2, ...$expressions): self
     {
@@ -84,6 +88,8 @@ abstract class Operator extends Stage
      *
      * @param array|Expr $expression
      * @param array|Expr ...$expressions
+     *
+     * @return static
      */
     public function addAnd($expression, ...$expressions): self
     {
@@ -100,6 +106,8 @@ abstract class Operator extends Stage
      *
      * @param array|Expr $expression
      * @param array|Expr ...$expressions
+     *
+     * @return static
      */
     public function addOr($expression, ...$expressions): self
     {
@@ -118,6 +126,8 @@ abstract class Operator extends Stage
      * @see Expr::allElementsTrue
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function allElementsTrue($expression): self
     {
@@ -136,6 +146,8 @@ abstract class Operator extends Stage
      * @see Expr::anyElementTrue
      *
      * @param array|Expr $expression
+     *
+     * @return static
      */
     public function anyElementTrue($expression): self
     {
@@ -157,6 +169,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $array
      * @param mixed|Expr $index
+     *
+     * @return static
      */
     public function arrayElemAt($array, $index): self
     {
@@ -175,6 +189,8 @@ abstract class Operator extends Stage
      * @see Expr::ceil
      *
      * @param mixed|Expr $number
+     *
+     * @return static
      */
     public function ceil($number): self
     {
@@ -194,6 +210,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
+     *
+     * @return static
      */
     public function cmp($expression1, $expression2): self
     {
@@ -215,6 +233,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
      * @param mixed|Expr ...$expressions Additional expressions
+     *
+     * @return static
      */
     public function concat($expression1, $expression2, ...$expressions): self
     {
@@ -235,6 +255,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr $array1
      * @param mixed|Expr $array2
      * @param mixed|Expr ...$arrays Additional expressions
+     *
+     * @return static
      */
     public function concatArrays($array1, $array2, ...$arrays): self
     {
@@ -255,6 +277,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr $if
      * @param mixed|Expr $then
      * @param mixed|Expr $else
+     *
+     * @return static
      */
     public function cond($if, $then, $else): self
     {
@@ -275,6 +299,8 @@ abstract class Operator extends Stage
      *
      * @param string     $format
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function dateToString($format, $expression): self
     {
@@ -292,6 +318,8 @@ abstract class Operator extends Stage
      * @see Expr::dayOfMonth
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function dayOfMonth($expression): self
     {
@@ -310,6 +338,8 @@ abstract class Operator extends Stage
      * @see Expr::dayOfWeek
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function dayOfWeek($expression): self
     {
@@ -327,6 +357,8 @@ abstract class Operator extends Stage
      * @see Expr::dayOfYear
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function dayOfYear($expression): self
     {
@@ -346,6 +378,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
+     *
+     * @return static
      */
     public function divide($expression1, $expression2): self
     {
@@ -362,6 +396,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
+     *
+     * @return static
      */
     public function eq($expression1, $expression2): self
     {
@@ -380,6 +416,8 @@ abstract class Operator extends Stage
      * @see Expr::exp
      *
      * @param mixed|Expr $exponent
+     *
+     * @return static
      */
     public function exp($exponent): self
     {
@@ -395,6 +433,8 @@ abstract class Operator extends Stage
      * @see Expr::expression
      *
      * @param mixed|Expr $value
+     *
+     * @return static
      */
     public function expression($value)
     {
@@ -407,6 +447,8 @@ abstract class Operator extends Stage
      * Set the current field for building the expression.
      *
      * @see Expr::field
+     *
+     * @return static
      */
     public function field(string $fieldName)
     {
@@ -427,6 +469,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr $input
      * @param mixed|Expr $as
      * @param mixed|Expr $cond
+     *
+     * @return static
      */
     public function filter($input, $as, $cond): self
     {
@@ -445,6 +489,8 @@ abstract class Operator extends Stage
      * @see Expr::floor
      *
      * @param mixed|Expr $number
+     *
+     * @return static
      */
     public function floor($number): self
     {
@@ -463,6 +509,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
+     *
+     * @return static
      */
     public function gt($expression1, $expression2): self
     {
@@ -481,6 +529,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
+     *
+     * @return static
      */
     public function gte($expression1, $expression2): self
     {
@@ -498,6 +548,8 @@ abstract class Operator extends Stage
      * @see Expr::hour
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function hour($expression): self
     {
@@ -517,6 +569,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $expression
      * @param mixed|Expr $arrayExpression
+     *
+     * @return static
      */
     public function in($expression, $arrayExpression): self
     {
@@ -537,6 +591,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr $searchExpression Can be any valid expression.
      * @param mixed|Expr $start            Optional. An integer, or a number that can be represented as integers (such as 2.0), that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      * @param mixed|Expr $end              An integer, or a number that can be represented as integers (such as 2.0), that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
+     *
+     * @return static
      */
     public function indexOfArray($arrayExpression, $searchExpression, $start = null, $end = null): self
     {
@@ -556,6 +612,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr      $substringExpression Can be any valid expression as long as it resolves to a string.
      * @param string|int|null $start               An integral number that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      * @param string|int|null $end                 An integral number that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
+     *
+     * @return static
      */
     public function indexOfBytes($stringExpression, $substringExpression, $start = null, $end = null): self
     {
@@ -575,6 +633,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr      $substringExpression Can be any valid expression as long as it resolves to a string.
      * @param string|int|null $start               An integral number that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      * @param string|int|null $end                 An integral number that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
+     *
+     * @return static
      */
     public function indexOfCP($stringExpression, $substringExpression, $start = null, $end = null): self
     {
@@ -596,6 +656,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $expression
      * @param mixed|Expr $replacementExpression
+     *
+     * @return static
      */
     public function ifNull($expression, $replacementExpression): self
     {
@@ -613,6 +675,8 @@ abstract class Operator extends Stage
      * @see Expr::isArray
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function isArray($expression): self
     {
@@ -630,6 +694,8 @@ abstract class Operator extends Stage
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isoDayOfWeek/
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function isoDayOfWeek($expression): self
     {
@@ -649,6 +715,8 @@ abstract class Operator extends Stage
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isoWeek/
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function isoWeek($expression): self
     {
@@ -668,6 +736,8 @@ abstract class Operator extends Stage
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isoWeek/
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function isoWeekYear($expression): self
     {
@@ -685,6 +755,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $vars Assignment block for the variables accessible in the in expression. To assign a variable, specify a string for the variable name and assign a valid expression for the value.
      * @param mixed|Expr $in   The expression to evaluate.
+     *
+     * @return static
      */
     public function let($vars, $in): self
     {
@@ -701,6 +773,8 @@ abstract class Operator extends Stage
      * @see Expr::literal
      *
      * @param mixed|Expr $value
+     *
+     * @return static
      */
     public function literal($value): self
     {
@@ -720,6 +794,8 @@ abstract class Operator extends Stage
      * @see Expr::ln
      *
      * @param mixed|Expr $number
+     *
+     * @return static
      */
     public function ln($number): self
     {
@@ -742,6 +818,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $number
      * @param mixed|Expr $base
+     *
+     * @return static
      */
     public function log($number, $base): self
     {
@@ -762,6 +840,8 @@ abstract class Operator extends Stage
      * @see Expr::log10
      *
      * @param mixed|Expr $number
+     *
+     * @return static
      */
     public function log10($number): self
     {
@@ -780,6 +860,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
+     *
+     * @return static
      */
     public function lt($expression1, $expression2): self
     {
@@ -798,6 +880,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
+     *
+     * @return static
      */
     public function lte($expression1, $expression2): self
     {
@@ -816,6 +900,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr $input An expression that resolves to an array.
      * @param string     $as    The variable name for the items in the input array. The in expression accesses each item in the input array by this variable.
      * @param mixed|Expr $in    The expression to apply to each item in the input array. The expression accesses the item by its variable name.
+     *
+     * @return static
      */
     public function map($input, $as, $in): self
     {
@@ -831,6 +917,8 @@ abstract class Operator extends Stage
      * @see Expr::meta
      *
      * @param mixed|Expr $metaDataKeyword
+     *
+     * @return static
      */
     public function meta($metaDataKeyword): self
     {
@@ -848,6 +936,8 @@ abstract class Operator extends Stage
      * @see Expr::millisecond
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function millisecond($expression): self
     {
@@ -865,6 +955,8 @@ abstract class Operator extends Stage
      * @see Expr::minute
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function minute($expression): self
     {
@@ -884,6 +976,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
+     *
+     * @return static
      */
     public function mod($expression1, $expression2): self
     {
@@ -901,6 +995,8 @@ abstract class Operator extends Stage
      * @see Expr::month
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function month($expression): self
     {
@@ -920,6 +1016,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
      * @param mixed|Expr ...$expressions Additional expressions
+     *
+     * @return static
      */
     public function multiply($expression1, $expression2, ...$expressions): self
     {
@@ -938,6 +1036,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
+     *
+     * @return static
      */
     public function ne($expression1, $expression2): self
     {
@@ -953,6 +1053,8 @@ abstract class Operator extends Stage
      * @see Expr::not
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function not($expression): self
     {
@@ -974,6 +1076,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $number
      * @param mixed|Expr $exponent
+     *
+     * @return static
      */
     public function pow($number, $exponent): self
     {
@@ -993,6 +1097,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr $start An integer that specifies the start of the sequence. Can be any valid expression that resolves to an integer.
      * @param mixed|Expr $end   An integer that specifies the exclusive upper limit of the sequence. Can be any valid expression that resolves to an integer.
      * @param mixed|Expr $step  Optional. An integer that specifies the increment value. Can be any valid expression that resolves to a non-zero integer. Defaults to 1.
+     *
+     * @return static
      */
     public function range($start, $end, $step = 1): self
     {
@@ -1011,6 +1117,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr $input        Can be any valid expression that resolves to an array.
      * @param mixed|Expr $initialValue The initial cumulative value set before in is applied to the first element of the input array.
      * @param mixed|Expr $in           A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
+     *
+     * @return static
      */
     public function reduce($input, $initialValue, $in): self
     {
@@ -1027,6 +1135,8 @@ abstract class Operator extends Stage
      * @see Expr::reverseArray
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function reverseArray($expression): self
     {
@@ -1045,6 +1155,8 @@ abstract class Operator extends Stage
      * @see Expr::second
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function second($expression): self
     {
@@ -1064,6 +1176,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
+     *
+     * @return static
      */
     public function setDifference($expression1, $expression2): self
     {
@@ -1085,7 +1199,7 @@ abstract class Operator extends Stage
      * @param mixed|Expr $expression2
      * @param mixed|Expr ...$expressions Additional sets
      *
-     * @return $this
+     * @return static
      */
     public function setEquals($expression1, $expression2, ...$expressions): self
     {
@@ -1106,6 +1220,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
      * @param mixed|Expr ...$expressions Additional sets
+     *
+     * @return static
      */
     public function setIntersection($expression1, $expression2, ...$expressions): self
     {
@@ -1126,6 +1242,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
+     *
+     * @return static
      */
     public function setIsSubset($expression1, $expression2): self
     {
@@ -1146,6 +1264,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
      * @param mixed|Expr ...$expressions Additional sets
+     *
+     * @return static
      */
     public function setUnion($expression1, $expression2, ...$expressions): self
     {
@@ -1163,6 +1283,8 @@ abstract class Operator extends Stage
      * @see Expr::size
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function size($expression): self
     {
@@ -1180,6 +1302,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr      $array
      * @param mixed|Expr      $n
      * @param mixed|Expr|null $position
+     *
+     * @return static
      */
     public function slice($array, $n, $position = null): self
     {
@@ -1199,6 +1323,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $string    The string to be split. Can be any valid expression as long as it resolves to a string.
      * @param mixed|Expr $delimiter The delimiter to use when splitting the string expression. Can be any valid expression as long as it resolves to a string.
+     *
+     * @return static
      */
     public function split($string, $delimiter): self
     {
@@ -1218,6 +1344,8 @@ abstract class Operator extends Stage
      * @see Expr::sqrt
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function sqrt($expression): self
     {
@@ -1239,6 +1367,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
+     *
+     * @return static
      */
     public function strcasecmp($expression1, $expression2): self
     {
@@ -1253,6 +1383,8 @@ abstract class Operator extends Stage
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/strLenBytes/
      *
      * @param mixed|Expr $string
+     *
+     * @return static
      */
     public function strLenBytes($string): self
     {
@@ -1267,6 +1399,8 @@ abstract class Operator extends Stage
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/strLenCP/
      *
      * @param mixed|Expr $string
+     *
+     * @return static
      */
     public function strLenCP($string): self
     {
@@ -1287,6 +1421,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr $string
      * @param mixed|Expr $start
      * @param mixed|Expr $length
+     *
+     * @return static
      */
     public function substr($string, $start, $length): self
     {
@@ -1307,6 +1443,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr $string The string from which the substring will be extracted. Can be any valid expression as long as it resolves to a string.
      * @param mixed|Expr $start  Indicates the starting point of the substring. Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
      * @param mixed|Expr $count  Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
+     *
+     * @return static
      */
     public function substrBytes($string, $start, $count): self
     {
@@ -1327,6 +1465,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr $string The string from which the substring will be extracted. Can be any valid expression as long as it resolves to a string.
      * @param mixed|Expr $start  Indicates the starting point of the substring. Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
      * @param mixed|Expr $count  Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
+     *
+     * @return static
      */
     public function substrCP($string, $start, $count): self
     {
@@ -1346,6 +1486,8 @@ abstract class Operator extends Stage
      *
      * @param mixed|Expr $expression1
      * @param mixed|Expr $expression2
+     *
+     * @return static
      */
     public function subtract($expression1, $expression2): self
     {
@@ -1363,6 +1505,8 @@ abstract class Operator extends Stage
      * @see Expr::toLower
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function toLower($expression): self
     {
@@ -1380,6 +1524,8 @@ abstract class Operator extends Stage
      * @see Expr::toUpper
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function toUpper($expression): self
     {
@@ -1398,6 +1544,8 @@ abstract class Operator extends Stage
      * @see Expr::trunc
      *
      * @param mixed|Expr $number
+     *
+     * @return static
      */
     public function trunc($number): self
     {
@@ -1414,6 +1562,8 @@ abstract class Operator extends Stage
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/type/
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function type($expression): self
     {
@@ -1431,6 +1581,8 @@ abstract class Operator extends Stage
      * @see Expr::week
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function week($expression): self
     {
@@ -1448,6 +1600,8 @@ abstract class Operator extends Stage
      * @see Expr::year
      *
      * @param mixed|Expr $expression
+     *
+     * @return static
      */
     public function year($expression): self
     {
@@ -1467,6 +1621,8 @@ abstract class Operator extends Stage
      * @param mixed|Expr      $inputs           An array of expressions that resolve to arrays. The elements of these input arrays combine to form the arrays of the output array.
      * @param bool|null       $useLongestLength A boolean which specifies whether the length of the longest array determines the number of arrays in the output array.
      * @param mixed|Expr|null $defaults         An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
+     *
+     * @return static
      */
     public function zip($inputs, ?bool $useLongestLength = null, $defaults = null): self
     {

--- a/lib/Doctrine/ODM/MongoDB/Event/OnClassMetadataNotFoundEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/OnClassMetadataNotFoundEventArgs.php
@@ -21,6 +21,9 @@ final class OnClassMetadataNotFoundEventArgs extends ManagerEventArgs
     /** @var ClassMetadata|null */
     private $foundMetadata;
 
+    /**
+     * @psalm-param class-string $className
+     */
     public function __construct(string $className, DocumentManager $dm)
     {
         $this->className = $className;
@@ -28,15 +31,12 @@ final class OnClassMetadataNotFoundEventArgs extends ManagerEventArgs
         parent::__construct($dm);
     }
 
-    public function setFoundMetadata(?ClassMetadata $classMetadata = null)
+    public function setFoundMetadata(?ClassMetadata $classMetadata = null): void
     {
         $this->foundMetadata = $classMetadata;
     }
 
-    /**
-     * @return ClassMetadata|null
-     */
-    public function getFoundMetadata()
+    public function getFoundMetadata(): ?ClassMetadata
     {
         return $this->foundMetadata;
     }
@@ -44,9 +44,9 @@ final class OnClassMetadataNotFoundEventArgs extends ManagerEventArgs
     /**
      * Retrieve class name for which a failed metadata fetch attempt was executed
      *
-     * @return string
+     * @psalm-return class-string
      */
-    public function getClassName()
+    public function getClassName(): string
     {
         return $this->className;
     }

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorException.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorException.php
@@ -28,7 +28,7 @@ final class HydratorException extends MongoDBException
         return new self('You must configure a hydrator namespace. See docs for details');
     }
 
-    public static function associationTypeMismatch(string $className, string $fieldName, string $expectedType, string $actualType)
+    public static function associationTypeMismatch(string $className, string $fieldName, string $expectedType, string $actualType): self
     {
         return new self(sprintf(
             'Expected association for field "%s" in document of type "%s" to be of type "%s", "%s" received.',
@@ -39,7 +39,7 @@ final class HydratorException extends MongoDBException
         ));
     }
 
-    public static function associationItemTypeMismatch(string $className, string $fieldName, $key, string $expectedType, string $actualType)
+    public static function associationItemTypeMismatch(string $className, string $fieldName, $key, string $expectedType, string $actualType): self
     {
         return new self(sprintf(
             'Expected association item with key "%s" for field "%s" in document of type "%s" to be of type "%s", "%s" received.',

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -166,8 +166,8 @@ final class HydratorFactory
     /**
      * Generates hydrator classes for all given classes.
      *
-     * @param array  $classes The classes (ClassMetadata instances) for which to generate hydrators.
-     * @param string $toDir   The target directory of the hydrator classes. If not specified, the
+     * @param array       $classes The classes (ClassMetadata instances) for which to generate hydrators.
+     * @param string|null $toDir   The target directory of the hydrator classes. If not specified, the
      *                        directory configured on the Configuration of the DocumentManager used
      *                        by this factory is used.
      */

--- a/lib/Doctrine/ODM/MongoDB/Id/IncrementGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Id/IncrementGenerator.php
@@ -33,6 +33,8 @@ class IncrementGenerator extends AbstractIdGenerator
 
     /**
      * @param string $collection
+     *
+     * @return void
      */
     public function setCollection($collection)
     {

--- a/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
@@ -96,7 +96,7 @@ final class HydratingIterator implements Iterator
         return $this->iterator;
     }
 
-    private function hydrate($document)
+    private function hydrate($document): ?object
     {
         return $document !== null ? $this->unitOfWork->getOrCreateDocument($this->class->name, $document, $this->unitOfWorkHints) : null;
     }

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/DefaultPersistentCollectionGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/DefaultPersistentCollectionGenerator.php
@@ -114,7 +114,7 @@ final class DefaultPersistentCollectionGenerator implements PersistentCollection
     /**
      * @param string|false $fileName Filename to write collection class code or false to eval it.
      */
-    private function generateCollectionClass(string $for, string $targetFqcn, $fileName)
+    private function generateCollectionClass(string $for, string $targetFqcn, $fileName): void
     {
         $exploded  = explode('\\', $targetFqcn);
         $class     = array_pop($exploded);

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -1616,7 +1616,7 @@ class Builder
     /**
      * @param string[]|string|null $documentName an array of document names or just one.
      */
-    private function setDocumentName($documentName)
+    private function setDocumentName($documentName): void
     {
         if (is_array($documentName)) {
             $documentNames = $documentName;

--- a/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
@@ -97,7 +97,7 @@ final class ReferencePrimer
      * @param array|Traversable $documents Documents containing references to prime
      * @param string            $fieldName Field name containing references to prime
      * @param array             $hints     UnitOfWork hints for priming queries
-     * @param callable          $primer    Optional primer callable
+     * @param callable|null     $primer    Optional primer callable
      *
      * @throws InvalidArgumentException If the mapped field is not the owning
      *                                   side of a reference relationship.

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -21,6 +21,8 @@ class MetadataCommand extends Command
 {
     /**
      * @see \Symfony\Component\Console\Command\Command
+     *
+     * @return void
      */
     protected function configure()
     {

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php
@@ -29,6 +29,8 @@ class GenerateHydratorsCommand extends Console\Command\Command
 {
     /**
      * @see Console\Command\Command
+     *
+     * @return void
      */
     protected function configure()
     {

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GeneratePersistentCollectionsCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GeneratePersistentCollectionsCommand.php
@@ -29,6 +29,8 @@ class GeneratePersistentCollectionsCommand extends Console\Command\Command
 {
     /**
      * @see Console\Command\Command
+     *
+     * @return void
      */
     protected function configure()
     {

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
@@ -33,6 +33,8 @@ class GenerateProxiesCommand extends Console\Command\Command
 {
     /**
      * @see Console\Command\Command
+     *
+     * @return void
      */
     protected function configure()
     {

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
@@ -23,6 +23,8 @@ class QueryCommand extends Console\Command\Command
 {
     /**
      * @see Console\Command\Command
+     *
+     * @return void
      */
     protected function configure()
     {

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/AbstractCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/AbstractCommand.php
@@ -22,6 +22,9 @@ abstract class AbstractCommand extends Command
     public const COLLECTION = 'collection';
     public const INDEX      = 'index';
 
+    /**
+     * @return void
+     */
     protected function configure()
     {
         parent::configure();
@@ -33,16 +36,34 @@ abstract class AbstractCommand extends Command
             ->addOption('journal', null, InputOption::VALUE_REQUIRED, 'An optional journal option for the write concern that will be used for all schema operations. Using this option without a w option will cause an exception to be thrown.');
     }
 
+    /**
+     * @return void
+     */
     abstract protected function processDocumentCollection(SchemaManager $sm, string $document, ?int $maxTimeMs, ?WriteConcern $writeConcern);
 
+    /**
+     * @return void
+     */
     abstract protected function processCollection(SchemaManager $sm, ?int $maxTimeMs, ?WriteConcern $writeConcern);
 
+    /**
+     * @return void
+     */
     abstract protected function processDocumentDb(SchemaManager $sm, string $document, ?int $maxTimeMs, ?WriteConcern $writeConcern);
 
+    /**
+     * @return void
+     */
     abstract protected function processDb(SchemaManager $sm, ?int $maxTimeMs, ?WriteConcern $writeConcern);
 
+    /**
+     * @return void
+     */
     abstract protected function processDocumentIndex(SchemaManager $sm, string $document, ?int $maxTimeMs, ?WriteConcern $writeConcern);
 
+    /**
+     * @return void
+     */
     abstract protected function processIndex(SchemaManager $sm, ?int $maxTimeMs, ?WriteConcern $writeConcern);
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
@@ -24,6 +24,9 @@ class CreateCommand extends AbstractCommand
     /** @var string[] */
     private $createOrder = [self::COLLECTION, self::INDEX];
 
+    /**
+     * @return void
+     */
     protected function configure()
     {
         parent::configure();
@@ -105,6 +108,9 @@ class CreateCommand extends AbstractCommand
         $sm->ensureIndexes($maxTimeMs, $writeConcern, $background);
     }
 
+    /**
+     * @return void
+     */
     protected function processDocumentProxy(SchemaManager $sm, string $document)
     {
         $classMetadata = $this->getMetadataFactory()->getMetadataFor($document);
@@ -113,6 +119,9 @@ class CreateCommand extends AbstractCommand
         $this->getDocumentManager()->getProxyFactory()->generateProxyClasses([$classMetadata]);
     }
 
+    /**
+     * @return void
+     */
     protected function processProxy(SchemaManager $sm)
     {
         /** @var ClassMetadata[] $metadatas */

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
@@ -21,6 +21,9 @@ class DropCommand extends AbstractCommand
     /** @var string[] */
     private $dropOrder = [self::INDEX, self::COLLECTION, self::DB];
 
+    /**
+     * @return void
+     */
     protected function configure()
     {
         parent::configure();

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ShardCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ShardCommand.php
@@ -17,6 +17,9 @@ use function sprintf;
 
 class ShardCommand extends AbstractCommand
 {
+    /**
+     * @return void
+     */
     protected function configure()
     {
         parent::configure();

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
@@ -17,6 +17,9 @@ use function sprintf;
 
 class UpdateCommand extends AbstractCommand
 {
+    /**
+     * @return void
+     */
     protected function configure()
     {
         parent::configure();
@@ -67,11 +70,17 @@ class UpdateCommand extends AbstractCommand
         $sm->updateIndexes($maxTimeMs, $writeConcern);
     }
 
+    /**
+     * @return void
+     */
     protected function processDocumentValidator(SchemaManager $sm, string $document, ?int $maxTimeMs, ?WriteConcern $writeConcern)
     {
         $sm->updateDocumentValidator($document, $maxTimeMs, $writeConcern);
     }
 
+    /**
+     * @return void
+     */
     protected function processValidators(SchemaManager $sm, ?int $maxTimeMs, ?WriteConcern $writeConcern)
     {
         $sm->updateValidators($maxTimeMs, $writeConcern);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -55,11 +55,6 @@ parameters:
             path: tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
 
         -
-            message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject and null will always evaluate to false\\.$#"
-            count: 1
-            path: tests/Doctrine/ODM/MongoDB/Tests/Events/OnClassMetadataNotFoundEventArgsTest.php
-
-        -
             message: "#^Cannot access property \\$username on array\\|object\\.$#"
             count: 1
             path: tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomFieldNameTest.php

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationOperatorsProviderTrait.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationOperatorsProviderTrait.php
@@ -14,12 +14,12 @@ use function is_array;
 
 trait AggregationOperatorsProviderTrait
 {
-    public static function provideAllOperators()
+    public static function provideAllOperators(): array
     {
         return static::provideAccumulationOperators() + static::provideExpressionOperators();
     }
 
-    public static function provideAccumulationOperators()
+    public static function provideAccumulationOperators(): array
     {
         return [
             'addToSet' => [
@@ -85,7 +85,7 @@ trait AggregationOperatorsProviderTrait
         ];
     }
 
-    public static function provideExpressionOperators()
+    public static function provideExpressionOperators(): array
     {
         return [
             'abs' => [

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationTestTrait.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationTestTrait.php
@@ -12,10 +12,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 trait AggregationTestTrait
 {
-    /**
-     * @return Builder
-     */
-    protected function getTestAggregationBuilder(string $documentName = User::class)
+    protected function getTestAggregationBuilder(string $documentName = User::class): Builder
     {
         return new Builder($this->dm, $documentName);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
@@ -22,7 +22,7 @@ use function array_keys;
 
 class BuilderTest extends BaseTest
 {
-    public function testGetPipeline()
+    public function testGetPipeline(): void
     {
         $point = ['type' => 'Point', 'coordinates' => [0, 0]];
 
@@ -172,7 +172,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testAggregationBuilder()
+    public function testAggregationBuilder(): void
     {
         $this->insertTestData();
 
@@ -199,7 +199,7 @@ class BuilderTest extends BaseTest
         $this->assertSame(3, $results[0]->numPosts);
     }
 
-    public function testGetAggregation()
+    public function testGetAggregation(): void
     {
         $this->insertTestData();
 
@@ -230,7 +230,7 @@ class BuilderTest extends BaseTest
         $this->assertSame(3, $results[0]->numPosts);
     }
 
-    public function testPipelineConvertsTypes()
+    public function testPipelineConvertsTypes(): void
     {
         $builder  = $this->dm->createAggregationBuilder(Article::class);
         $dateTime = new DateTimeImmutable('2000-01-01T00:00Z');
@@ -278,7 +278,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testFieldNameConversion()
+    public function testFieldNameConversion(): void
     {
         $builder = $this->dm->createAggregationBuilder(CmsComment::class);
         $builder
@@ -308,7 +308,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testBuilderAppliesFilterAndDiscriminatorWithMatchStage()
+    public function testBuilderAppliesFilterAndDiscriminatorWithMatchStage(): void
     {
         $this->dm->getFilterCollection()->enable('testFilter');
         $filter = $this->dm->getFilterCollection()->getFilter('testFilter');
@@ -339,7 +339,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testBuilderAppliesFilterAndDiscriminatorWithGeoNearStage()
+    public function testBuilderAppliesFilterAndDiscriminatorWithGeoNearStage(): void
     {
         $this->dm->getFilterCollection()->enable('testFilter');
         $filter = $this->dm->getFilterCollection()->getFilter('testFilter');
@@ -370,7 +370,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testBuilderWithOutStageReturnsNoData()
+    public function testBuilderWithOutStageReturnsNoData(): void
     {
         $this->insertTestData();
 
@@ -382,7 +382,7 @@ class BuilderTest extends BaseTest
         $this->assertCount(0, $result);
     }
 
-    public function testBuilderWithIndexStatsStageDoesNotApplyFilters()
+    public function testBuilderWithIndexStatsStageDoesNotApplyFilters(): void
     {
         $builder = $this->dm
             ->createAggregationBuilder(BlogPost::class)
@@ -391,7 +391,7 @@ class BuilderTest extends BaseTest
         $this->assertSame('$indexStats', array_keys($builder->getPipeline()[0])[0]);
     }
 
-    public function testNonRewindableBuilder()
+    public function testNonRewindableBuilder(): void
     {
         $builder = $this->dm
             ->createAggregationBuilder(BlogPost::class)
@@ -402,7 +402,7 @@ class BuilderTest extends BaseTest
         $this->assertInstanceOf(UnrewindableIterator::class, $iterator);
     }
 
-    private function insertTestData()
+    private function insertTestData(): void
     {
         $baseballTag = new Tag('baseball');
         $footballTag = new Tag('football');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/ExprTest.php
@@ -16,7 +16,7 @@ class ExprTest extends BaseTest
     /**
      * @dataProvider provideAllOperators
      */
-    public function testGenericOperator($expected, $operator, $args)
+    public function testGenericOperator($expected, $operator, $args): void
     {
         $expr = $this->createExpr();
         $args = $this->resolveArgs($args);
@@ -28,7 +28,7 @@ class ExprTest extends BaseTest
     /**
      * @dataProvider provideAllOperators
      */
-    public function testGenericOperatorWithField($expected, $operator, $args)
+    public function testGenericOperatorWithField($expected, $operator, $args): void
     {
         $expr = $this->createExpr();
         $args = $this->resolveArgs($args);
@@ -37,7 +37,7 @@ class ExprTest extends BaseTest
         $this->assertSame(['foo' => $expected], $expr->getExpression());
     }
 
-    public function testExpr()
+    public function testExpr(): void
     {
         $expr = $this->createExpr();
 
@@ -46,7 +46,7 @@ class ExprTest extends BaseTest
         $this->assertNotSame($newExpr, $expr);
     }
 
-    public function testExpression()
+    public function testExpression(): void
     {
         $nestedExpr = $this->createExpr();
         $nestedExpr
@@ -69,7 +69,7 @@ class ExprTest extends BaseTest
         );
     }
 
-    public function testExpressionWithoutField()
+    public function testExpressionWithoutField(): void
     {
         $nestedExpr = $this->createExpr();
         $nestedExpr
@@ -84,7 +84,7 @@ class ExprTest extends BaseTest
         $expr->expression($nestedExpr);
     }
 
-    public function testSwitch()
+    public function testSwitch(): void
     {
         $expr = $this->createExpr();
 
@@ -109,7 +109,7 @@ class ExprTest extends BaseTest
         );
     }
 
-    public function testCallingCaseWithoutSwitchThrowsException()
+    public function testCallingCaseWithoutSwitchThrowsException(): void
     {
         $expr = $this->createExpr();
 
@@ -119,7 +119,7 @@ class ExprTest extends BaseTest
         $expr->case('$field');
     }
 
-    public function testCallingThenWithoutCaseThrowsException()
+    public function testCallingThenWithoutCaseThrowsException(): void
     {
         $expr = $this->createExpr();
 
@@ -129,7 +129,7 @@ class ExprTest extends BaseTest
         $expr->then('$field');
     }
 
-    public function testCallingThenWithoutCaseAfterSuccessfulCaseThrowsException()
+    public function testCallingThenWithoutCaseAfterSuccessfulCaseThrowsException(): void
     {
         $expr = $this->createExpr();
 
@@ -143,7 +143,7 @@ class ExprTest extends BaseTest
         $expr->then('$field');
     }
 
-    public function testCallingDefaultWithoutSwitchThrowsException()
+    public function testCallingDefaultWithoutSwitchThrowsException(): void
     {
         $expr = $this->createExpr();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/AddFieldsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/AddFieldsTest.php
@@ -12,7 +12,7 @@ class AddFieldsTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testAddFieldsStage()
+    public function testAddFieldsStage(): void
     {
         $addFieldsStage = new AddFields($this->getTestAggregationBuilder());
         $addFieldsStage
@@ -22,7 +22,7 @@ class AddFieldsTest extends BaseTest
         $this->assertSame(['$addFields' => ['product' => ['$multiply' => ['$field', 5]]]], $addFieldsStage->getExpression());
     }
 
-    public function testProjectFromBuilder()
+    public function testProjectFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketAutoTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketAutoTest.php
@@ -15,7 +15,7 @@ class BucketAutoTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testBucketAutoStage()
+    public function testBucketAutoStage(): void
     {
         $bucketStage = new BucketAuto($this->getTestAggregationBuilder(), $this->dm, new ClassMetadata(User::class));
         $bucketStage
@@ -36,7 +36,7 @@ class BucketAutoTest extends BaseTest
         ], $bucketStage->getExpression());
     }
 
-    public function testBucketAutoFromBuilder()
+    public function testBucketAutoFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->bucketAuto()
@@ -59,7 +59,7 @@ class BucketAutoTest extends BaseTest
         ], $builder->getPipeline());
     }
 
-    public function testBucketAutoSkipsUndefinedProperties()
+    public function testBucketAutoSkipsUndefinedProperties(): void
     {
         $bucketStage = new BucketAuto($this->getTestAggregationBuilder(), $this->dm, new ClassMetadata(User::class));
         $bucketStage
@@ -74,7 +74,7 @@ class BucketAutoTest extends BaseTest
         ], $bucketStage->getExpression());
     }
 
-    public function testFieldNameConversion()
+    public function testFieldNameConversion(): void
     {
         $builder = $this->dm->createAggregationBuilder(CmsComment::class);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketTest.php
@@ -15,7 +15,7 @@ class BucketTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testBucketStage()
+    public function testBucketStage(): void
     {
         $bucketStage = new Bucket($this->getTestAggregationBuilder(), $this->dm, new ClassMetadata(User::class));
         $bucketStage
@@ -36,7 +36,7 @@ class BucketTest extends BaseTest
         ], $bucketStage->getExpression());
     }
 
-    public function testBucketFromBuilder()
+    public function testBucketFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->bucket()
@@ -59,7 +59,7 @@ class BucketTest extends BaseTest
         ], $builder->getPipeline());
     }
 
-    public function testBucketSkipsUndefinedProperties()
+    public function testBucketSkipsUndefinedProperties(): void
     {
         $bucketStage = new Bucket($this->getTestAggregationBuilder(), $this->dm, new ClassMetadata(User::class));
         $bucketStage
@@ -74,7 +74,7 @@ class BucketTest extends BaseTest
         ], $bucketStage->getExpression());
     }
 
-    public function testFieldNameConversion()
+    public function testFieldNameConversion(): void
     {
         $builder = $this->dm->createAggregationBuilder(CmsComment::class);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/CollStatsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/CollStatsTest.php
@@ -12,14 +12,14 @@ class CollStatsTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testCollStatsStage()
+    public function testCollStatsStage(): void
     {
         $collStatsStage = new CollStats($this->getTestAggregationBuilder());
 
         $this->assertSame(['$collStats' => []], $collStatsStage->getExpression());
     }
 
-    public function testCollStatsStageWithLatencyStats()
+    public function testCollStatsStageWithLatencyStats(): void
     {
         $collStatsStage = new CollStats($this->getTestAggregationBuilder());
         $collStatsStage->showLatencyStats();
@@ -27,7 +27,7 @@ class CollStatsTest extends BaseTest
         $this->assertSame(['$collStats' => ['latencyStats' => ['histograms' => false]]], $collStatsStage->getExpression());
     }
 
-    public function testCollStatsStageWithLatencyStatsHistograms()
+    public function testCollStatsStageWithLatencyStatsHistograms(): void
     {
         $collStatsStage = new CollStats($this->getTestAggregationBuilder());
         $collStatsStage->showLatencyStats(true);
@@ -35,7 +35,7 @@ class CollStatsTest extends BaseTest
         $this->assertSame(['$collStats' => ['latencyStats' => ['histograms' => true]]], $collStatsStage->getExpression());
     }
 
-    public function testCollStatsStageWithStorageStats()
+    public function testCollStatsStageWithStorageStats(): void
     {
         $collStatsStage = new CollStats($this->getTestAggregationBuilder());
         $collStatsStage->showStorageStats();
@@ -43,7 +43,7 @@ class CollStatsTest extends BaseTest
         $this->assertSame(['$collStats' => ['storageStats' => []]], $collStatsStage->getExpression());
     }
 
-    public function testCollStatsFromBuilder()
+    public function testCollStatsFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->collStats()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/CountTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/CountTest.php
@@ -12,14 +12,14 @@ class CountTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testCountStage()
+    public function testCountStage(): void
     {
         $countStage = new Count($this->getTestAggregationBuilder(), 'document_count');
 
         $this->assertSame(['$count' => 'document_count'], $countStage->getExpression());
     }
 
-    public function testCountFromBuilder()
+    public function testCountFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->count('document_count');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FacetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FacetTest.php
@@ -15,7 +15,7 @@ class FacetTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testFacetStage()
+    public function testFacetStage(): void
     {
         $nestedBuilder = $this->getTestAggregationBuilder();
         $nestedBuilder->sortByCount('$tags');
@@ -35,7 +35,7 @@ class FacetTest extends BaseTest
         ], $facetStage->getExpression());
     }
 
-    public function testFacetFromBuilder()
+    public function testFacetFromBuilder(): void
     {
         $nestedBuilder = $this->getTestAggregationBuilder();
         $nestedBuilder->sortByCount('$tags');
@@ -57,7 +57,7 @@ class FacetTest extends BaseTest
         ], $builder->getPipeline());
     }
 
-    public function testFacetThrowsExceptionWithoutFieldName()
+    public function testFacetThrowsExceptionWithoutFieldName(): void
     {
         $facetStage = new Facet($this->getTestAggregationBuilder());
 
@@ -69,7 +69,7 @@ class FacetTest extends BaseTest
     /**
      * @psalm-suppress InvalidArgument on purpose to throw exception
      */
-    public function testFacetThrowsExceptionOnInvalidPipeline()
+    public function testFacetThrowsExceptionOnInvalidPipeline(): void
     {
         $facetStage = new Facet($this->getTestAggregationBuilder());
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GeoNearTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GeoNearTest.php
@@ -12,7 +12,7 @@ class GeoNearTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testGeoNearStage()
+    public function testGeoNearStage(): void
     {
         $geoNearStage = new GeoNear($this->getTestAggregationBuilder(), 0, 0);
         $geoNearStage
@@ -24,7 +24,7 @@ class GeoNearTest extends BaseTest
         $this->assertSame(['$geoNear' => $stage], $geoNearStage->getExpression());
     }
 
-    public function testGeoNearFromBuilder()
+    public function testGeoNearFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder
@@ -40,7 +40,7 @@ class GeoNearTest extends BaseTest
     /**
      * @dataProvider provideOptionalSettings
      */
-    public function testOptionalSettings($field, $value)
+    public function testOptionalSettings($field, $value): void
     {
         $geoNearStage = new GeoNear($this->getTestAggregationBuilder(), 0, 0);
 
@@ -53,7 +53,7 @@ class GeoNearTest extends BaseTest
         $this->assertSame($value, $pipeline['$geoNear'][$field]);
     }
 
-    public static function provideOptionalSettings()
+    public static function provideOptionalSettings(): array
     {
         return [
             'distanceMultiplier' => ['distanceMultiplier', 15.0],
@@ -65,7 +65,7 @@ class GeoNearTest extends BaseTest
         ];
     }
 
-    public function testLimitDoesNotCreateExtraStage()
+    public function testLimitDoesNotCreateExtraStage(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
@@ -25,7 +25,7 @@ class GraphLookupTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testGraphLookupStage()
+    public function testGraphLookupStage(): void
     {
         $graphLookupStage = new GraphLookup($this->getTestAggregationBuilder(), 'employees', $this->dm, new ClassMetadata(User::class));
         $graphLookupStage
@@ -49,7 +49,7 @@ class GraphLookupTest extends BaseTest
         );
     }
 
-    public function testGraphLookupFromBuilder()
+    public function testGraphLookupFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->graphLookup('employees')
@@ -75,7 +75,7 @@ class GraphLookupTest extends BaseTest
         );
     }
 
-    public function testGraphLookupWithMatch()
+    public function testGraphLookupWithMatch(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->graphLookup('employees')
@@ -108,7 +108,7 @@ class GraphLookupTest extends BaseTest
         );
     }
 
-    public function provideEmployeeAggregations()
+    public function provideEmployeeAggregations(): array
     {
         return [
             'owningSide' => [
@@ -150,7 +150,7 @@ class GraphLookupTest extends BaseTest
     /**
      * @dataProvider provideEmployeeAggregations
      */
-    public function testGraphLookupWithEmployees(Closure $addGraphLookupStage, array $expectedFields)
+    public function testGraphLookupWithEmployees(Closure $addGraphLookupStage, array $expectedFields): void
     {
         $this->insertEmployeeTestData();
 
@@ -183,7 +183,7 @@ class GraphLookupTest extends BaseTest
         }
     }
 
-    public function provideTravellerAggregations()
+    public function provideTravellerAggregations(): array
     {
         return [
             'owningSide' => [
@@ -220,7 +220,7 @@ class GraphLookupTest extends BaseTest
     /**
      * @dataProvider provideTravellerAggregations
      */
-    public function testGraphLookupWithTraveller(Closure $addGraphLookupStage, array $expectedFields)
+    public function testGraphLookupWithTraveller(Closure $addGraphLookupStage, array $expectedFields): void
     {
         $this->insertTravellerTestData();
 
@@ -246,7 +246,7 @@ class GraphLookupTest extends BaseTest
         $this->assertCount(3, $result);
     }
 
-    public function testGraphLookupToShardedCollectionThrowsException()
+    public function testGraphLookupToShardedCollectionThrowsException(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
 
@@ -255,7 +255,7 @@ class GraphLookupTest extends BaseTest
             ->graphLookup(ShardedOne::class);
     }
 
-    public function testGraphLookupWithUnmappedFields()
+    public function testGraphLookupWithUnmappedFields(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
 
@@ -282,7 +282,7 @@ class GraphLookupTest extends BaseTest
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testGraphLookupWithconnectFromFieldToDifferentTargetClass()
+    public function testGraphLookupWithconnectFromFieldToDifferentTargetClass(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
 
@@ -294,7 +294,7 @@ class GraphLookupTest extends BaseTest
                 ->alias('targets');
     }
 
-    private function insertEmployeeTestData()
+    private function insertEmployeeTestData(): void
     {
         $dev    = new Employee('Dev');
         $eliot  = new Employee('Eliot', $dev);
@@ -308,7 +308,7 @@ class GraphLookupTest extends BaseTest
         $this->dm->flush();
     }
 
-    private function insertTravellerTestData()
+    private function insertTravellerTestData(): void
     {
         $jfk = new Airport('JFK');
         $bos = new Airport('BOS');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GroupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GroupTest.php
@@ -18,7 +18,7 @@ class GroupTest extends BaseTest
     /**
      * @dataProvider provideProxiedExprMethods
      */
-    public function testProxiedExprMethods($method, $args = [])
+    public function testProxiedExprMethods($method, $args = []): void
     {
         $args = $this->resolveArgs($args);
 
@@ -29,7 +29,7 @@ class GroupTest extends BaseTest
             ->with(...$args);
 
         $stage = new class ($this->getTestAggregationBuilder()) extends Group {
-            public function setExpr(Expr $expr)
+            public function setExpr(Expr $expr): void
             {
                 $this->expr = $expr;
             }
@@ -39,7 +39,7 @@ class GroupTest extends BaseTest
         $this->assertSame($stage, $stage->$method(...$args));
     }
 
-    public function provideProxiedExprMethods()
+    public function provideProxiedExprMethods(): array
     {
         return [
             'addToSet()' => ['addToSet', ['$field']],
@@ -67,7 +67,7 @@ class GroupTest extends BaseTest
         ];
     }
 
-    public function testGroupStage()
+    public function testGroupStage(): void
     {
         $groupStage = new Group($this->getTestAggregationBuilder());
         $groupStage
@@ -79,7 +79,7 @@ class GroupTest extends BaseTest
         $this->assertSame(['$group' => ['_id' => '$field', 'count' => ['$sum' => 1]]], $groupStage->getExpression());
     }
 
-    public function testGroupFromBuilder()
+    public function testGroupFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder
@@ -92,7 +92,7 @@ class GroupTest extends BaseTest
         $this->assertSame([['$group' => ['_id' => '$field', 'count' => ['$sum' => 1]]]], $builder->getPipeline());
     }
 
-    public function testGroupWithOperatorInId()
+    public function testGroupWithOperatorInId(): void
     {
         $groupStage = new Group($this->getTestAggregationBuilder());
         $groupStage

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/IndexStatsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/IndexStatsTest.php
@@ -13,14 +13,14 @@ class IndexStatsTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testIndexStatsStage()
+    public function testIndexStatsStage(): void
     {
         $indexStatsStage = new IndexStats($this->getTestAggregationBuilder());
 
         $this->assertEquals(['$indexStats' => new stdClass()], $indexStatsStage->getExpression());
     }
 
-    public function testIndexStatsFromBuilder()
+    public function testIndexStatsFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->indexStats();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LimitTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LimitTest.php
@@ -12,14 +12,14 @@ class LimitTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testLimitStage()
+    public function testLimitStage(): void
     {
         $limitStage = new Limit($this->getTestAggregationBuilder(), 10);
 
         $this->assertSame(['$limit' => 10], $limitStage->getExpression());
     }
 
-    public function testLimitFromBuilder()
+    public function testLimitFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->limit(10);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LookupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LookupTest.php
@@ -20,7 +20,7 @@ class LookupTest extends BaseTest
         $this->insertTestData();
     }
 
-    public function testLookupStage()
+    public function testLookupStage(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -47,7 +47,7 @@ class LookupTest extends BaseTest
         $this->assertSame('alcaeus', $result[0]['user'][0]['username']);
     }
 
-    public function testLookupStageWithFieldNameTranslation()
+    public function testLookupStageWithFieldNameTranslation(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -70,7 +70,7 @@ class LookupTest extends BaseTest
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testLookupStageWithClassName()
+    public function testLookupStageWithClassName(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -99,7 +99,7 @@ class LookupTest extends BaseTest
         $this->assertSame('alcaeus', $result[0]['user'][0]['username']);
     }
 
-    public function testLookupStageWithCollectionName()
+    public function testLookupStageWithCollectionName(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -127,7 +127,7 @@ class LookupTest extends BaseTest
         $this->assertCount(0, $result[0]['user']);
     }
 
-    public function testLookupStageReferenceMany()
+    public function testLookupStageReferenceMany(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -158,7 +158,7 @@ class LookupTest extends BaseTest
         $this->assertSame('malarzm', $result[1]['users'][0]['username']);
     }
 
-    public function testLookupStageReferenceManyStoreAsRef()
+    public function testLookupStageReferenceManyStoreAsRef(): void
     {
         $builder = $this->dm->createAggregationBuilder(ReferenceUser::class);
         $builder
@@ -189,7 +189,7 @@ class LookupTest extends BaseTest
         $this->assertSame('malarzm', $result[1]['users'][0]['username']);
     }
 
-    public function testLookupStageReferenceManyWithoutUnwindMongoDB34()
+    public function testLookupStageReferenceManyWithoutUnwindMongoDB34(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -217,7 +217,7 @@ class LookupTest extends BaseTest
         $this->assertSame('malarzm', $result[0]['users'][1]['username']);
     }
 
-    public function testLookupStageReferenceOneInverse()
+    public function testLookupStageReferenceOneInverse(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
         $builder
@@ -249,7 +249,7 @@ class LookupTest extends BaseTest
         $this->assertCount(1, $result[0]['simpleReferenceOneInverse']);
     }
 
-    public function testLookupStageReferenceManyInverse()
+    public function testLookupStageReferenceManyInverse(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
         $builder
@@ -281,7 +281,7 @@ class LookupTest extends BaseTest
         $this->assertCount(1, $result[0]['simpleReferenceManyInverse']);
     }
 
-    public function testLookupStageReferenceOneInverseStoreAsRef()
+    public function testLookupStageReferenceOneInverseStoreAsRef(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
         $builder
@@ -313,7 +313,7 @@ class LookupTest extends BaseTest
         $this->assertCount(1, $result[0]['embeddedReferenceOneInverse']);
     }
 
-    public function testLookupStageReferenceManyInverseStoreAsRef()
+    public function testLookupStageReferenceManyInverseStoreAsRef(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
         $builder
@@ -345,7 +345,7 @@ class LookupTest extends BaseTest
         $this->assertCount(1, $result[0]['embeddedReferenceManyInverse']);
     }
 
-    public function testLookupToShardedCollectionThrowsException()
+    public function testLookupToShardedCollectionThrowsException(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
 
@@ -356,7 +356,7 @@ class LookupTest extends BaseTest
                 ->foreignField('id');
     }
 
-    public function testLookupToShardedReferenceThrowsException()
+    public function testLookupToShardedReferenceThrowsException(): void
     {
         $builder = $this->dm->createAggregationBuilder(ShardedOne::class);
 
@@ -365,7 +365,7 @@ class LookupTest extends BaseTest
             ->lookup('user');
     }
 
-    private function insertTestData()
+    private function insertTestData(): void
     {
         $user1 = new User();
         $user1->setUsername('alcaeus');
@@ -392,7 +392,7 @@ class LookupTest extends BaseTest
         $this->dm->flush();
     }
 
-    public function testLookupStageAndDefaultAlias()
+    public function testLookupStageAndDefaultAlias(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
         $builder
@@ -415,7 +415,7 @@ class LookupTest extends BaseTest
         $this->assertCount(1, $result[0]['simpleReferenceOneInverse']);
     }
 
-    public function testLookupStageAndDefaultAliasOverride()
+    public function testLookupStageAndDefaultAliasOverride(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
         $builder

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
@@ -12,6 +12,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\User;
 use GeoJson\Geometry\Geometry;
 use MongoDB\BSON\UTCDateTime;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class MatchStageTest extends BaseTest
 {
@@ -117,6 +118,9 @@ class MatchStageTest extends BaseTest
         );
     }
 
+    /**
+     * @return MockObject&Geometry
+     */
     private function getMockGeometry()
     {
         return $this->getMockBuilder(Geometry::class)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
@@ -17,7 +17,7 @@ class MatchStageTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testMatchStage()
+    public function testMatchStage(): void
     {
         $matchStage = new MatchStage($this->getTestAggregationBuilder());
         $matchStage
@@ -27,7 +27,7 @@ class MatchStageTest extends BaseTest
         $this->assertSame(['$match' => ['someField' => 'someValue']], $matchStage->getExpression());
     }
 
-    public function testMatchFromBuilder()
+    public function testMatchFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder
@@ -41,7 +41,7 @@ class MatchStageTest extends BaseTest
     /**
      * @dataProvider provideProxiedExprMethods
      */
-    public function testProxiedExprMethods($method, array $args = [])
+    public function testProxiedExprMethods($method, array $args = []): void
     {
         $expr = $this->getMockQueryExpr();
         $expr
@@ -50,7 +50,7 @@ class MatchStageTest extends BaseTest
             ->with(...$args);
 
         $stage = new class ($this->getTestAggregationBuilder()) extends MatchStage {
-            public function setQuery(Expr $query)
+            public function setQuery(Expr $query): void
             {
                 $this->query = $query;
             }
@@ -60,7 +60,7 @@ class MatchStageTest extends BaseTest
         $this->assertSame($stage, $stage->$method(...$args));
     }
 
-    public function provideProxiedExprMethods()
+    public function provideProxiedExprMethods(): array
     {
         return [
             'field()' => ['field', ['fieldName']],
@@ -96,7 +96,7 @@ class MatchStageTest extends BaseTest
         ];
     }
 
-    public function testTypeConversion()
+    public function testTypeConversion(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OperatorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OperatorTest.php
@@ -19,7 +19,7 @@ class OperatorTest extends BaseTest
     /**
      * @dataProvider provideExpressionOperators
      */
-    public function testProxiedExpressionOperators($expected, $operator, $args)
+    public function testProxiedExpressionOperators($expected, $operator, $args): void
     {
         $stage = $this->getStubStage();
         $args  = $this->resolveArgs($args);
@@ -28,7 +28,7 @@ class OperatorTest extends BaseTest
         $this->assertSame($expected, $stage->getExpression());
     }
 
-    public function testExpression()
+    public function testExpression(): void
     {
         $stage = $this->getStubStage();
 
@@ -51,7 +51,7 @@ class OperatorTest extends BaseTest
         );
     }
 
-    public function testSwitch()
+    public function testSwitch(): void
     {
         $stage = $this->getStubStage();
 
@@ -76,7 +76,7 @@ class OperatorTest extends BaseTest
         );
     }
 
-    public function testCallingCaseWithoutSwitchThrowsException()
+    public function testCallingCaseWithoutSwitchThrowsException(): void
     {
         $stage = $this->getStubStage();
 
@@ -86,7 +86,7 @@ class OperatorTest extends BaseTest
         $stage->case('$field');
     }
 
-    public function testCallingThenWithoutCaseThrowsException()
+    public function testCallingThenWithoutCaseThrowsException(): void
     {
         $stage = $this->getStubStage();
 
@@ -96,7 +96,7 @@ class OperatorTest extends BaseTest
         $stage->then('$field');
     }
 
-    public function testCallingThenWithoutCaseAfterSuccessfulCaseThrowsException()
+    public function testCallingThenWithoutCaseAfterSuccessfulCaseThrowsException(): void
     {
         $stage = $this->getStubStage();
 
@@ -110,7 +110,7 @@ class OperatorTest extends BaseTest
         $stage->then('$field');
     }
 
-    public function testCallingDefaultWithoutSwitchThrowsException()
+    public function testCallingDefaultWithoutSwitchThrowsException(): void
     {
         $stage = $this->getStubStage();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OutTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OutTest.php
@@ -12,7 +12,7 @@ use Documents\User;
 
 class OutTest extends BaseTest
 {
-    public function testOutStageWithClassName()
+    public function testOutStageWithClassName(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -25,7 +25,7 @@ class OutTest extends BaseTest
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testOutStageWithCollectionName()
+    public function testOutStageWithCollectionName(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -38,7 +38,7 @@ class OutTest extends BaseTest
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testOutStageWithShardedClassName()
+    public function testOutStageWithShardedClassName(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $this->expectException(MappingException::class);
@@ -46,7 +46,7 @@ class OutTest extends BaseTest
         $builder->out(ShardedUser::class);
     }
 
-    public function testSubsequentOutStagesAreOverwritten()
+    public function testSubsequentOutStagesAreOverwritten(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
@@ -54,7 +54,7 @@ class ProjectTest extends BaseTest
         $this->assertSame(['$project' => ['something' => ['$' . $operator => ['$expression1', '$expression2']]]], $projectStage->getExpression());
     }
 
-    public function provideAccumulators()
+    public function provideAccumulators(): array
     {
         $operators = ['avg', 'max', 'min', 'stdDevPop', 'stdDevSamp', 'sum'];
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
@@ -16,7 +16,7 @@ class ProjectTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testProjectStage()
+    public function testProjectStage(): void
     {
         $projectStage = new Project($this->getTestAggregationBuilder());
         $projectStage
@@ -28,7 +28,7 @@ class ProjectTest extends BaseTest
         $this->assertSame(['$project' => ['_id' => false, '$field' => true, '$otherField' => true, 'product' => ['$multiply' => ['$field', 5]]]], $projectStage->getExpression());
     }
 
-    public function testProjectFromBuilder()
+    public function testProjectFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder
@@ -44,7 +44,7 @@ class ProjectTest extends BaseTest
     /**
      * @dataProvider provideAccumulators
      */
-    public function testAccumulatorsWithMultipleArguments($operator)
+    public function testAccumulatorsWithMultipleArguments($operator): void
     {
         $projectStage = new Project($this->getTestAggregationBuilder());
         $projectStage
@@ -66,7 +66,7 @@ class ProjectTest extends BaseTest
     /**
      * @dataProvider provideProxiedExprMethods
      */
-    public function testProxiedExprMethods($method, $args = [])
+    public function testProxiedExprMethods($method, $args = []): void
     {
         $expr = $this->getMockAggregationExpr();
         $expr
@@ -75,7 +75,7 @@ class ProjectTest extends BaseTest
             ->with(...$args);
 
         $stage = new class ($this->getTestAggregationBuilder()) extends Project {
-            public function setExpr(Expr $expr)
+            public function setExpr(Expr $expr): void
             {
                 $this->expr = $expr;
             }
@@ -85,7 +85,7 @@ class ProjectTest extends BaseTest
         $this->assertSame($stage, $stage->$method(...$args));
     }
 
-    public static function provideProxiedExprMethods()
+    public static function provideProxiedExprMethods(): array
     {
         return [
             'avg()' => ['avg', ['$field']],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/RedactTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/RedactTest.php
@@ -12,7 +12,7 @@ class RedactTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testRedactStage()
+    public function testRedactStage(): void
     {
         $builder = $this->getTestAggregationBuilder();
 
@@ -27,7 +27,7 @@ class RedactTest extends BaseTest
         $this->assertSame(['$redact' => ['$cond' => ['if' => ['$lte' => ['$accessLevel', 3]], 'then' => '$$KEEP', 'else' => '$$REDACT']]], $redactStage->getExpression());
     }
 
-    public function testRedactFromBuilder()
+    public function testRedactFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
@@ -12,7 +12,7 @@ use MongoDB\BSON\UTCDateTime;
 
 class ReplaceRootTest extends BaseTest
 {
-    public function testTypeConversion()
+    public function testTypeConversion(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
 
@@ -35,7 +35,7 @@ class ReplaceRootTest extends BaseTest
         );
     }
 
-    public function testTypeConversionWithDirectExpression()
+    public function testTypeConversionWithDirectExpression(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
 
@@ -60,7 +60,7 @@ class ReplaceRootTest extends BaseTest
         );
     }
 
-    public function testFieldNameConversion()
+    public function testFieldNameConversion(): void
     {
         $builder = $this->dm->createAggregationBuilder(CmsComment::class);
 
@@ -81,7 +81,7 @@ class ReplaceRootTest extends BaseTest
         );
     }
 
-    public function testFieldNameConversionWithDirectExpression()
+    public function testFieldNameConversionWithDirectExpression(): void
     {
         $builder = $this->dm->createAggregationBuilder(CmsComment::class);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SampleTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SampleTest.php
@@ -12,14 +12,14 @@ class SampleTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testSampleStage()
+    public function testSampleStage(): void
     {
         $sampleStage = new Sample($this->getTestAggregationBuilder(), 10);
 
         $this->assertSame(['$sample' => ['size' => 10]], $sampleStage->getExpression());
     }
 
-    public function testSampleFromBuilder()
+    public function testSampleFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->sample(10);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SkipTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SkipTest.php
@@ -12,14 +12,14 @@ class SkipTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testSkipStage()
+    public function testSkipStage(): void
     {
         $skipStage = new Skip($this->getTestAggregationBuilder(), 10);
 
         $this->assertSame(['$skip' => 10], $skipStage->getExpression());
     }
 
-    public function testSkipFromBuilder()
+    public function testSkipFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->skip(10);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortByCountTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortByCountTest.php
@@ -9,7 +9,7 @@ use Documents\CmsComment;
 
 class SortByCountTest extends BaseTest
 {
-    public function testFieldNameConversion()
+    public function testFieldNameConversion(): void
     {
         $builder = $this->dm->createAggregationBuilder(CmsComment::class);
         $builder->sortByCount('$authorIp');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortTest.php
@@ -15,7 +15,7 @@ class SortTest extends BaseTest
     /**
      * @dataProvider provideSortOptions
      */
-    public function testSortStage($expectedSort, $field, $order = null)
+    public function testSortStage($expectedSort, $field, $order = null): void
     {
         $sortStage = new Sort($this->getTestAggregationBuilder(), $field, $order);
 
@@ -25,7 +25,7 @@ class SortTest extends BaseTest
     /**
      * @dataProvider provideSortOptions
      */
-    public function testSortFromBuilder($expectedSort, $field, $order = null)
+    public function testSortFromBuilder($expectedSort, $field, $order = null): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->sort($field, $order);
@@ -33,7 +33,7 @@ class SortTest extends BaseTest
         $this->assertSame([['$sort' => $expectedSort]], $builder->getPipeline());
     }
 
-    public static function provideSortOptions()
+    public static function provideSortOptions(): array
     {
         return [
             'singleFieldSeparated' => [

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnwindTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnwindTest.php
@@ -12,14 +12,14 @@ class UnwindTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testUnwindStage()
+    public function testUnwindStage(): void
     {
         $unwindStage = new Unwind($this->getTestAggregationBuilder(), 'fieldName');
 
         $this->assertSame(['$unwind' => 'fieldName'], $unwindStage->getExpression());
     }
 
-    public function testUnwindStageWithNewFields()
+    public function testUnwindStageWithNewFields(): void
     {
         $unwindStage = new Unwind($this->getTestAggregationBuilder(), 'fieldName');
         $unwindStage
@@ -29,7 +29,7 @@ class UnwindTest extends BaseTest
         $this->assertSame(['$unwind' => ['path' => 'fieldName', 'includeArrayIndex' => 'index', 'preserveNullAndEmptyArrays' => true]], $unwindStage->getExpression());
     }
 
-    public function testUnwindFromBuilder()
+    public function testUnwindFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->unwind('fieldName');
@@ -37,7 +37,7 @@ class UnwindTest extends BaseTest
         $this->assertSame([['$unwind' => 'fieldName']], $builder->getPipeline());
     }
 
-    public function testSubsequentUnwindStagesArePreserved()
+    public function testSubsequentUnwindStagesArePreserved(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -9,6 +9,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\MongoDB\Tests\Query\Filter\Filter;
 use Doctrine\ODM\MongoDB\UnitOfWork;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use MongoDB\Client;
 use MongoDB\Model\DatabaseInfo;
 use PHPUnit\Framework\TestCase;
@@ -103,6 +104,9 @@ abstract class BaseTest extends TestCase
         }
     }
 
+    /**
+     * @return MappingDriver
+     */
     protected function createMetadataDriverImpl()
     {
         return AnnotationDriver::create(__DIR__ . '/../../../../Documents');

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -67,7 +67,7 @@ abstract class BaseTest extends TestCase
         }
     }
 
-    protected function getConfiguration()
+    protected function getConfiguration(): Configuration
     {
         $config = new Configuration();
 
@@ -108,7 +108,7 @@ abstract class BaseTest extends TestCase
         return AnnotationDriver::create(__DIR__ . '/../../../../Documents');
     }
 
-    protected function createTestDocumentManager()
+    protected function createTestDocumentManager(): DocumentManager
     {
         $config = $this->getConfiguration();
         $client = new Client(getenv('DOCTRINE_MONGODB_SERVER') ?: DOCTRINE_MONGODB_SERVER, [], ['typeMap' => ['root' => 'array', 'document' => 'array']]);
@@ -123,7 +123,7 @@ abstract class BaseTest extends TestCase
         return $result['version'];
     }
 
-    protected function skipTestIfNotSharded($className)
+    protected function skipTestIfNotSharded($className): void
     {
         $result = $this->dm->getDocumentDatabase($className)->command(['listCommands' => true])->toArray()[0];
 
@@ -134,7 +134,7 @@ abstract class BaseTest extends TestCase
         $this->markTestSkipped('Test skipped because server does not support sharding');
     }
 
-    protected function skipTestIfSharded($className)
+    protected function skipTestIfSharded($className): void
     {
         $result = $this->dm->getDocumentDatabase($className)->command(['listCommands' => true])->toArray()[0];
 
@@ -145,7 +145,7 @@ abstract class BaseTest extends TestCase
         $this->markTestSkipped('Test does not apply on sharded clusters');
     }
 
-    protected function requireVersion($installedVersion, $requiredVersion, $operator, $message)
+    protected function requireVersion($installedVersion, $requiredVersion, $operator, $message): void
     {
         if (! version_compare($installedVersion, $requiredVersion, $operator)) {
             return;
@@ -154,12 +154,12 @@ abstract class BaseTest extends TestCase
         $this->markTestSkipped($message);
     }
 
-    protected function skipOnMongoDB42($message)
+    protected function skipOnMongoDB42($message): void
     {
         $this->requireVersion($this->getServerVersion(), '4.2.0', '>=', $message);
     }
 
-    protected function requireMongoDB42($message)
+    protected function requireMongoDB42($message): void
     {
         $this->requireVersion($this->getServerVersion(), '4.2.0', '<', $message);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionGenerator;
 
 class ConfigurationTest extends BaseTest
 {
-    public function testDefaultPersistentCollectionFactory()
+    public function testDefaultPersistentCollectionFactory(): void
     {
         $c       = new Configuration();
         $factory = $c->getPersistentCollectionFactory();
@@ -18,7 +18,7 @@ class ConfigurationTest extends BaseTest
         $this->assertSame($factory, $c->getPersistentCollectionFactory());
     }
 
-    public function testDefaultPersistentCollectionGenerator()
+    public function testDefaultPersistentCollectionGenerator(): void
     {
         $c = new Configuration();
         $c->setPersistentCollectionDir(__DIR__ . '/../../../../PersistentCollections');

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -130,11 +130,9 @@ class DocumentManagerTest extends BaseTest
     }
 
     /**
-     * @param string $methodName
-     *
      * @dataProvider dataMethodsAffectedByNoObjectArguments
      */
-    public function testThrowsExceptionOnNonObjectValues($methodName)
+    public function testThrowsExceptionOnNonObjectValues(string $methodName)
     {
         $this->expectException(InvalidArgumentException::class);
         $this->dm->$methodName(null);
@@ -152,11 +150,9 @@ class DocumentManagerTest extends BaseTest
     }
 
     /**
-     * @param string $methodName
-     *
      * @dataProvider dataAffectedByErrorIfClosedException
      */
-    public function testAffectedByErrorIfClosedException($methodName)
+    public function testAffectedByErrorIfClosedException(string $methodName)
     {
         $this->expectException(MongoDBException::class);
         $this->expectExceptionMessage('closed');

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -37,72 +37,72 @@ use function get_class;
 
 class DocumentManagerTest extends BaseTest
 {
-    public function testCustomRepository()
+    public function testCustomRepository(): void
     {
         $this->assertInstanceOf(Repository::class, $this->dm->getRepository(Document::class));
     }
 
-    public function testCustomRepositoryMappedsuperclass()
+    public function testCustomRepositoryMappedsuperclass(): void
     {
         $this->assertInstanceOf(BaseCategoryRepository::class, $this->dm->getRepository(BaseCategory::class));
     }
 
-    public function testCustomRepositoryMappedsuperclassChild()
+    public function testCustomRepositoryMappedsuperclassChild(): void
     {
         $this->assertInstanceOf(BaseCategoryRepository::class, $this->dm->getRepository(Category::class));
     }
 
-    public function testGetConnection()
+    public function testGetConnection(): void
     {
         $this->assertInstanceOf(Client::class, $this->dm->getClient());
     }
 
-    public function testGetMetadataFactory()
+    public function testGetMetadataFactory(): void
     {
         $this->assertInstanceOf(ClassMetadataFactory::class, $this->dm->getMetadataFactory());
     }
 
-    public function testGetConfiguration()
+    public function testGetConfiguration(): void
     {
         $this->assertInstanceOf(Configuration::class, $this->dm->getConfiguration());
     }
 
-    public function testGetUnitOfWork()
+    public function testGetUnitOfWork(): void
     {
         $this->assertInstanceOf(UnitOfWork::class, $this->dm->getUnitOfWork());
     }
 
-    public function testGetProxyFactory()
+    public function testGetProxyFactory(): void
     {
         $this->assertInstanceOf(ProxyFactory::class, $this->dm->getProxyFactory());
     }
 
-    public function testGetEventManager()
+    public function testGetEventManager(): void
     {
         $this->assertInstanceOf(EventManager::class, $this->dm->getEventManager());
     }
 
-    public function testGetSchemaManager()
+    public function testGetSchemaManager(): void
     {
         $this->assertInstanceOf(SchemaManager::class, $this->dm->getSchemaManager());
     }
 
-    public function testCreateQueryBuilder()
+    public function testCreateQueryBuilder(): void
     {
         $this->assertInstanceOf(QueryBuilder::class, $this->dm->createQueryBuilder());
     }
 
-    public function testCreateAggregationBuilder()
+    public function testCreateAggregationBuilder(): void
     {
         $this->assertInstanceOf(AggregationBuilder::class, $this->dm->createAggregationBuilder(BlogPost::class));
     }
 
-    public function testGetFilterCollection()
+    public function testGetFilterCollection(): void
     {
         $this->assertInstanceOf(FilterCollection::class, $this->dm->getFilterCollection());
     }
 
-    public function testGetPartialReference()
+    public function testGetPartialReference(): void
     {
         $id   = new ObjectId();
         $user = $this->dm->getPartialReference(CmsUser::class, $id);
@@ -111,14 +111,14 @@ class DocumentManagerTest extends BaseTest
         $this->assertNull($user->getName());
     }
 
-    public function testDocumentManagerIsClosedAccessor()
+    public function testDocumentManagerIsClosedAccessor(): void
     {
         $this->assertTrue($this->dm->isOpen());
         $this->dm->close();
         $this->assertFalse($this->dm->isOpen());
     }
 
-    public function dataMethodsAffectedByNoObjectArguments()
+    public function dataMethodsAffectedByNoObjectArguments(): array
     {
         return [
             ['persist'],
@@ -132,13 +132,13 @@ class DocumentManagerTest extends BaseTest
     /**
      * @dataProvider dataMethodsAffectedByNoObjectArguments
      */
-    public function testThrowsExceptionOnNonObjectValues(string $methodName)
+    public function testThrowsExceptionOnNonObjectValues(string $methodName): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->dm->$methodName(null);
     }
 
-    public function dataAffectedByErrorIfClosedException()
+    public function dataAffectedByErrorIfClosedException(): array
     {
         return [
             ['flush'],
@@ -152,7 +152,7 @@ class DocumentManagerTest extends BaseTest
     /**
      * @dataProvider dataAffectedByErrorIfClosedException
      */
-    public function testAffectedByErrorIfClosedException(string $methodName)
+    public function testAffectedByErrorIfClosedException(string $methodName): void
     {
         $this->expectException(MongoDBException::class);
         $this->expectExceptionMessage('closed');
@@ -165,7 +165,7 @@ class DocumentManagerTest extends BaseTest
         }
     }
 
-    public function testCannotCreateDbRefWithoutId()
+    public function testCannotCreateDbRefWithoutId(): void
     {
         $d = new User();
         $this->expectException(RuntimeException::class);
@@ -176,7 +176,7 @@ class DocumentManagerTest extends BaseTest
         $this->dm->createReference($d, ['storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF]);
     }
 
-    public function testCreateDbRefWithNonNullEmptyId()
+    public function testCreateDbRefWithNonNullEmptyId(): void
     {
         $phonenumber              = new CmsPhonenumber();
         $phonenumber->phonenumber = 0;
@@ -187,7 +187,7 @@ class DocumentManagerTest extends BaseTest
         $this->assertSame(['$ref' => 'CmsPhonenumber', '$id' => 0], $dbRef);
     }
 
-    public function testDisriminatedSimpleReferenceFails()
+    public function testDisriminatedSimpleReferenceFails(): void
     {
         $d = new WrongSimpleRefDocument();
         $r = new ParticipantSolo('Maciej');
@@ -201,7 +201,7 @@ class DocumentManagerTest extends BaseTest
         $this->dm->createReference($r, $class->associationMappings['ref']);
     }
 
-    public function testDifferentStoreAsDbReferences()
+    public function testDifferentStoreAsDbReferences(): void
     {
         $r = new User();
         $this->dm->persist($r);

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
@@ -20,7 +20,7 @@ use const DOCTRINE_MONGODB_DATABASE;
 
 class DocumentRepositoryTest extends BaseTest
 {
-    public function testMatchingAcceptsCriteriaWithNullWhereExpression()
+    public function testMatchingAcceptsCriteriaWithNullWhereExpression(): void
     {
         $repository = $this->dm->getRepository(User::class);
         $criteria   = new Criteria();
@@ -29,7 +29,7 @@ class DocumentRepositoryTest extends BaseTest
         $this->assertInstanceOf(Collection::class, $repository->matching($criteria));
     }
 
-    public function testFindByRefOneFull()
+    public function testFindByRefOneFull(): void
     {
         $user    = new User();
         $account = new Account('name');
@@ -48,7 +48,7 @@ class DocumentRepositoryTest extends BaseTest
         $this->assertSame($user, $this->dm->getRepository(User::class)->findOneBy(['account' => $account]));
     }
 
-    public function testFindByRefOneWithoutTargetDocumentFull()
+    public function testFindByRefOneWithoutTargetDocumentFull(): void
     {
         $user    = new User();
         $account = new Account('name');
@@ -71,7 +71,7 @@ class DocumentRepositoryTest extends BaseTest
         $this->assertSame($account, $this->dm->getRepository(Account::class)->findOneBy(['user' => $user]));
     }
 
-    public function testFindByRefOneWithoutTargetDocumentStoredAsDbRef()
+    public function testFindByRefOneWithoutTargetDocumentStoredAsDbRef(): void
     {
         $user    = new User();
         $account = new Account('name');
@@ -93,7 +93,7 @@ class DocumentRepositoryTest extends BaseTest
         $this->assertSame($account, $this->dm->getRepository(Account::class)->findOneBy(['userDbRef' => $user]));
     }
 
-    public function testFindDiscriminatedByRefManyFull()
+    public function testFindDiscriminatedByRefManyFull(): void
     {
         $project   = new SubProject('mongodb-odm');
         $developer = new Developer('alcaeus', new ArrayCollection([$project]));
@@ -111,7 +111,7 @@ class DocumentRepositoryTest extends BaseTest
         $this->assertSame($developer, $this->dm->getRepository(Developer::class)->findOneBy(['projects' => $project]));
     }
 
-    public function testFindByRefOneSimple()
+    public function testFindByRefOneSimple(): void
     {
         $user    = new User();
         $account = new Account('name');
@@ -122,7 +122,7 @@ class DocumentRepositoryTest extends BaseTest
         $this->assertSame($user, $this->dm->getRepository(User::class)->findOneBy(['accountSimple' => $account]));
     }
 
-    public function testFindByEmbedOne()
+    public function testFindByEmbedOne(): void
     {
         $user    = new User();
         $address = new Address();
@@ -133,7 +133,7 @@ class DocumentRepositoryTest extends BaseTest
         $this->assertSame($user, $this->dm->getRepository(User::class)->findOneBy(['address' => $address]));
     }
 
-    public function testFindByRefManyFull()
+    public function testFindByRefManyFull(): void
     {
         $user  = new User();
         $group = new Group('group');
@@ -159,7 +159,7 @@ class DocumentRepositoryTest extends BaseTest
         $this->assertSame($user, $this->dm->getRepository(User::class)->findOneBy(['groups' => $group]));
     }
 
-    public function testFindByRefManySimple()
+    public function testFindByRefManySimple(): void
     {
         $user  = new User();
         $group = new Group('group');
@@ -170,7 +170,7 @@ class DocumentRepositoryTest extends BaseTest
         $this->assertSame($user, $this->dm->getRepository(User::class)->findOneBy(['groupsSimple' => $group]));
     }
 
-    public function testFindByEmbedMany()
+    public function testFindByEmbedMany(): void
     {
         $user        = new User();
         $phonenumber = new Phonenumber('12345678');
@@ -180,7 +180,7 @@ class DocumentRepositoryTest extends BaseTest
         $this->assertSame($user, $this->dm->getRepository(User::class)->findOneBy(['phonenumbers' => $phonenumber]));
     }
 
-    public function testFindOneByWithSort()
+    public function testFindOneByWithSort(): void
     {
         $george = new User();
         $george->setUsername('George');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleCallbacksTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleCallbacksTest.php
@@ -12,7 +12,7 @@ use Doctrine\ODM\MongoDB\UnitOfWork;
 
 class LifecycleCallbacksTest extends BaseTest
 {
-    private function createUser($name = 'jon', $fullName = 'Jonathan H. Wage')
+    private function createUser($name = 'jon', $fullName = 'Jonathan H. Wage'): User
     {
         $user                = new User();
         $user->name          = $name;
@@ -24,7 +24,7 @@ class LifecycleCallbacksTest extends BaseTest
         return $user;
     }
 
-    public function testPreUpdateChangingValue()
+    public function testPreUpdateChangingValue(): void
     {
         $user = $this->createUser();
         $this->dm->clear();
@@ -43,7 +43,7 @@ class LifecycleCallbacksTest extends BaseTest
         $this->assertInstanceOf(DateTime::class, $user->profile->updatedAt);
     }
 
-    public function testPreAndPostPersist()
+    public function testPreAndPostPersist(): void
     {
         $user = $this->createUser();
         $this->assertTrue($user->prePersist);
@@ -53,7 +53,7 @@ class LifecycleCallbacksTest extends BaseTest
         $this->assertTrue($user->profile->postPersist);
     }
 
-    public function testPreUpdate()
+    public function testPreUpdate(): void
     {
         $user                = $this->createUser();
         $user->name          = 'jwage';
@@ -67,7 +67,7 @@ class LifecycleCallbacksTest extends BaseTest
         $this->assertTrue($user->profile->postUpdate);
     }
 
-    public function testPreFlush()
+    public function testPreFlush(): void
     {
         $user                = $this->createUser();
         $user->name          = 'jwage';
@@ -78,7 +78,7 @@ class LifecycleCallbacksTest extends BaseTest
         $this->assertTrue($user->profile->preFlush);
     }
 
-    public function testPreLoadAndPostLoad()
+    public function testPreLoadAndPostLoad(): void
     {
         $user = $this->createUser();
         $this->dm->clear();
@@ -91,7 +91,7 @@ class LifecycleCallbacksTest extends BaseTest
         $this->assertTrue($user->profile->postLoad);
     }
 
-    public function testPreAndPostRemove()
+    public function testPreAndPostRemove(): void
     {
         $user = $this->createUser();
 
@@ -108,7 +108,7 @@ class LifecycleCallbacksTest extends BaseTest
         $this->assertTrue($user->profile->postRemove);
     }
 
-    public function testEmbedManyEvent()
+    public function testEmbedManyEvent(): void
     {
         $user             = new User();
         $user->name       = 'jon';
@@ -154,7 +154,7 @@ class LifecycleCallbacksTest extends BaseTest
         $this->assertTrue($profile->postRemove);
     }
 
-    public function testMultipleLevelsOfEmbedded()
+    public function testMultipleLevelsOfEmbedded(): void
     {
         $user                   = $this->createUser();
         $profile                = new Profile();
@@ -212,7 +212,7 @@ class LifecycleCallbacksTest extends BaseTest
         $this->assertTrue($user->profiles[0]->postRemove);
     }
 
-    public function testReferences()
+    public function testReferences(): void
     {
         $user  = $this->createUser();
         $user2 = $this->createUser('maciej', 'Maciej Malarz');
@@ -227,7 +227,7 @@ class LifecycleCallbacksTest extends BaseTest
         $this->assertFalse($user2->postUpdate);
     }
 
-    public function testEventsNotFiredForInverseSide()
+    public function testEventsNotFiredForInverseSide(): void
     {
         $customer = new Customer();
         $cart     = new Cart();
@@ -311,57 +311,57 @@ abstract class BaseDocument
     public $preFlush    = false;
 
     /** @ODM\PrePersist */
-    public function prePersist(Event\LifecycleEventArgs $e)
+    public function prePersist(Event\LifecycleEventArgs $e): void
     {
         $this->prePersist = true;
         $this->createdAt  = new DateTime();
     }
 
     /** @ODM\PostPersist */
-    public function postPersist(Event\LifecycleEventArgs $e)
+    public function postPersist(Event\LifecycleEventArgs $e): void
     {
         $this->postPersist = true;
     }
 
     /** @ODM\PreUpdate */
-    public function preUpdate(Event\PreUpdateEventArgs $e)
+    public function preUpdate(Event\PreUpdateEventArgs $e): void
     {
         $this->preUpdate = true;
         $this->updatedAt = new DateTime();
     }
 
     /** @ODM\PostUpdate */
-    public function postUpdate(Event\LifecycleEventArgs $e)
+    public function postUpdate(Event\LifecycleEventArgs $e): void
     {
         $this->postUpdate = true;
     }
 
     /** @ODM\PreRemove */
-    public function preRemove(Event\LifecycleEventArgs $e)
+    public function preRemove(Event\LifecycleEventArgs $e): void
     {
         $this->preRemove = true;
     }
 
     /** @ODM\PostRemove */
-    public function postRemove(Event\LifecycleEventArgs $e)
+    public function postRemove(Event\LifecycleEventArgs $e): void
     {
         $this->postRemove = true;
     }
 
     /** @ODM\PreLoad */
-    public function preLoad(Event\PreLoadEventArgs $e)
+    public function preLoad(Event\PreLoadEventArgs $e): void
     {
         $this->preLoad = true;
     }
 
     /** @ODM\PostLoad */
-    public function postLoad(Event\LifecycleEventArgs $e)
+    public function postLoad(Event\LifecycleEventArgs $e): void
     {
         $this->postLoad = true;
     }
 
     /** @ODM\PreFlush */
-    public function preFlush(Event\PreFlushEventArgs $e)
+    public function preFlush(Event\PreFlushEventArgs $e): void
     {
         $this->preFlush = true;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleListenersTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleListenersTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Events;
 
 use BadMethodCallException;
+use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Event\PostCollectionLoadEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -17,7 +18,7 @@ class LifecycleListenersTest extends BaseTest
     /** @var MyEventListener */
     private $listener;
 
-    private function getDocumentManager()
+    private function getDocumentManager(): ?DocumentManager
     {
         $this->listener = new MyEventListener();
         $evm            = $this->dm->getEventManager();
@@ -36,7 +37,7 @@ class LifecycleListenersTest extends BaseTest
         return $this->dm;
     }
 
-    public function testLifecycleListeners()
+    public function testLifecycleListeners(): void
     {
         $dm = $this->getDocumentManager();
 
@@ -116,7 +117,7 @@ class LifecycleListenersTest extends BaseTest
         $this->listener->called = [];
     }
 
-    public function testMultipleLevelsOfEmbeddedDocsPrePersist()
+    public function testMultipleLevelsOfEmbeddedDocsPrePersist(): void
     {
         $dm = $this->getDocumentManager();
 
@@ -152,7 +153,7 @@ class LifecycleListenersTest extends BaseTest
         $this->listener->called = [];
     }
 
-    public function testChangeToReferenceFieldTriggersEvents()
+    public function testChangeToReferenceFieldTriggersEvents(): void
     {
         $dm             = $this->getDocumentManager();
         $document       = new TestDocument();
@@ -188,7 +189,7 @@ class LifecycleListenersTest extends BaseTest
         $this->listener->called = [];
     }
 
-    public function testPostCollectionLoad()
+    public function testPostCollectionLoad(): void
     {
         $evm = $this->dm->getEventManager();
         $evm->addEventListener([Events::postCollectionLoad], new PostCollectionLoadEventListener($this));
@@ -239,7 +240,7 @@ class PostCollectionLoadEventListener
         $this->phpunit = $phpunit;
     }
 
-    public function postCollectionLoad(PostCollectionLoadEventArgs $e)
+    public function postCollectionLoad(PostCollectionLoadEventArgs $e): void
     {
         switch ($this->at++) {
             case 0:

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/OnClassMetadataNotFoundEventArgsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/OnClassMetadataNotFoundEventArgsTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class OnClassMetadataNotFoundEventArgsTest extends TestCase
 {
-    public function testEventArgsMutability()
+    public function testEventArgsMutability(): void
     {
         $documentManager = $this->createMock(DocumentManager::class);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/OnClassMetadataNotFoundEventArgsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/OnClassMetadataNotFoundEventArgsTest.php
@@ -8,6 +8,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Event\OnClassMetadataNotFoundEventArgs;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class OnClassMetadataNotFoundEventArgsTest extends TestCase
 {
@@ -15,9 +16,9 @@ class OnClassMetadataNotFoundEventArgsTest extends TestCase
     {
         $documentManager = $this->createMock(DocumentManager::class);
 
-        $args = new OnClassMetadataNotFoundEventArgs('foo', $documentManager);
+        $args = new OnClassMetadataNotFoundEventArgs(stdClass::class, $documentManager);
 
-        $this->assertSame('foo', $args->getClassName());
+        $this->assertSame(stdClass::class, $args->getClassName());
         $this->assertSame($documentManager, $args->getObjectManager());
 
         $this->assertNull($args->getFoundMetadata());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/PreLoadEventArgsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/PreLoadEventArgsTest.php
@@ -10,7 +10,7 @@ use Documents\Group;
 
 class PreLoadEventArgsTest extends BaseTest
 {
-    public function testGetData()
+    public function testGetData(): void
     {
         $document = new Group('test');
         $dm       = $this->dm;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/PreUpdateEventArgsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/PreUpdateEventArgsTest.php
@@ -17,7 +17,7 @@ use function in_array;
 
 class PreUpdateEventArgsTest extends BaseTest
 {
-    public function testChangeSetIsUpdated()
+    public function testChangeSetIsUpdated(): void
     {
         $this->dm->getEventManager()->addEventListener(Events::preUpdate, new ChangeSetIsUpdatedListener());
 
@@ -32,7 +32,7 @@ class PreUpdateEventArgsTest extends BaseTest
         $this->assertEquals('Changed', $a->getBody());
     }
 
-    public function testCollectionsAreInChangeSet()
+    public function testCollectionsAreInChangeSet(): void
     {
         $listener = new CollectionsAreInChangeSetListener($this);
         $this->dm->getEventManager()->addEventListener(Events::preUpdate, $listener);
@@ -65,7 +65,7 @@ class PreUpdateEventArgsTest extends BaseTest
 
 class ChangeSetIsUpdatedListener
 {
-    public function preUpdate(PreUpdateEventArgs $e)
+    public function preUpdate(PreUpdateEventArgs $e): void
     {
         $e->setNewValue('body', 'Changed');
     }
@@ -83,12 +83,12 @@ class CollectionsAreInChangeSetListener
         $this->phpunit = $phpunit;
     }
 
-    public function checkOnly(array $allowed)
+    public function checkOnly(array $allowed): void
     {
         $this->allowed = $allowed;
     }
 
-    public function preUpdate(PreUpdateEventArgs $e)
+    public function preUpdate(PreUpdateEventArgs $e): void
     {
         switch (get_class($e->getDocument())) {
             case Book::class:

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AlsoLoadTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AlsoLoadTest.php
@@ -11,7 +11,7 @@ use function explode;
 
 class AlsoLoadTest extends BaseTest
 {
-    public function testPropertyAlsoLoadDoesNotInterfereWithBasicHydration()
+    public function testPropertyAlsoLoadDoesNotInterfereWithBasicHydration(): void
     {
         $document = [
             'foo' => 'foo',
@@ -29,7 +29,7 @@ class AlsoLoadTest extends BaseTest
         $this->assertNull($document->baz, '"baz" gets its own null value and ignores "zip" and "bar"');
     }
 
-    public function testPropertyAlsoLoadMayOverwriteDefaultPropertyValue()
+    public function testPropertyAlsoLoadMayOverwriteDefaultPropertyValue(): void
     {
         $document = ['zip' => 'zip'];
 
@@ -41,7 +41,7 @@ class AlsoLoadTest extends BaseTest
         $this->assertEquals('zip', $document->zip, '"zip" is hydrated normally');
     }
 
-    public function testPropertyAlsoLoadShortCircuitsAfterFirstFieldIsFound()
+    public function testPropertyAlsoLoadShortCircuitsAfterFirstFieldIsFound(): void
     {
         $document = [
             'bar' => null,
@@ -58,7 +58,7 @@ class AlsoLoadTest extends BaseTest
         $this->assertEquals('zip', $document->zip, '"zip" is hydrated normally');
     }
 
-    public function testPropertyAlsoLoadChecksMultipleFields()
+    public function testPropertyAlsoLoadChecksMultipleFields(): void
     {
         $document = ['zip' => 'zip'];
 
@@ -71,7 +71,7 @@ class AlsoLoadTest extends BaseTest
         $this->assertEquals('zip', $document->zip, '"zip" is hydrated normally');
     }
 
-    public function testPropertyAlsoLoadBeatsMethodAlsoLoad()
+    public function testPropertyAlsoLoadBeatsMethodAlsoLoad(): void
     {
         $document = [
             'testNew' => 'testNew',
@@ -87,7 +87,7 @@ class AlsoLoadTest extends BaseTest
         $this->assertEquals('testOld', $document->testOld, '"testOld" is hydrated normally');
     }
 
-    public function testMethodAlsoLoadDoesNotInterfereWithBasicHydration()
+    public function testMethodAlsoLoadDoesNotInterfereWithBasicHydration(): void
     {
         $document = [
             'firstName' => 'Jonathan',
@@ -103,7 +103,7 @@ class AlsoLoadTest extends BaseTest
         $this->assertEquals('Kris Wallsmith', $document->name, '"name" is hydrated normally');
     }
 
-    public function testMethodAlsoLoadMayOverwriteDefaultPropertyValue()
+    public function testMethodAlsoLoadMayOverwriteDefaultPropertyValue(): void
     {
         $document = ['testOld' => null];
 
@@ -115,7 +115,7 @@ class AlsoLoadTest extends BaseTest
         $this->assertNull($document->testOld, '"testOld" is hydrated normally"');
     }
 
-    public function testMethodAlsoLoadShortCircuitsAfterFirstFieldIsFound()
+    public function testMethodAlsoLoadShortCircuitsAfterFirstFieldIsFound(): void
     {
         $document = [
             'name' => 'Jonathan Wage',
@@ -138,7 +138,7 @@ class AlsoLoadTest extends BaseTest
         $this->assertEquals('testOlder', $document->testOlder, '"testOlder" is hydrated normally');
     }
 
-    public function testMethodAlsoLoadChecksMultipleFields()
+    public function testMethodAlsoLoadChecksMultipleFields(): void
     {
         $document = [
             'fullName' => 'Kris Wallsmith',
@@ -159,7 +159,7 @@ class AlsoLoadTest extends BaseTest
         $this->assertEquals('testOlder', $document->testOlder, '"testOlder" is hydrated normally');
     }
 
-    public function testNotSaved()
+    public function testNotSaved(): void
     {
         $document            = new AlsoLoadDocument();
         $document->baz       = 'baz';
@@ -178,7 +178,7 @@ class AlsoLoadTest extends BaseTest
         $this->assertArrayNotHasKey('baz', $document, '"baz" was not saved');
     }
 
-    public function testMethodAlsoLoadParentInheritance()
+    public function testMethodAlsoLoadParentInheritance(): void
     {
         $document = [
             'buzz' => 'buzz',
@@ -195,7 +195,7 @@ class AlsoLoadTest extends BaseTest
         $this->assertEquals('test', $document->test, '"test" is hydrated normally, since "testOldest" was missing and parent method was overridden');
     }
 
-    public function testMethodAlsoLoadGrandparentInheritance()
+    public function testMethodAlsoLoadGrandparentInheritance(): void
     {
         $document = [
             'buzz' => 'buzz',
@@ -269,7 +269,7 @@ class AlsoLoadDocument
     public $testOlder;
 
     /** @ODM\AlsoLoad({"name", "fullName"}) */
-    public function populateFirstAndLastName($name)
+    public function populateFirstAndLastName($name): void
     {
         [$this->firstName, $this->lastName] = explode(' ', $name);
     }
@@ -288,7 +288,7 @@ class AlsoLoadChild extends AlsoLoadDocument
     public $fizz;
 
     /** @ODM\AlsoLoad("buzz") */
-    public function populateFizz($fizz)
+    public function populateFizz($fizz): void
     {
         $this->fizz = $fizz;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AlsoLoadTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AlsoLoadTest.php
@@ -274,7 +274,11 @@ class AlsoLoadDocument
         [$this->firstName, $this->lastName] = explode(' ', $name);
     }
 
-    /** @ODM\AlsoLoad({"testOld", "testOlder"}) */
+    /**
+     * @ODM\AlsoLoad ({"testOld", "testOlder"})
+     *
+     * @return void
+     */
     public function populateTest($test)
     {
         $this->test = $test;
@@ -293,7 +297,11 @@ class AlsoLoadChild extends AlsoLoadDocument
         $this->fizz = $fizz;
     }
 
-    /** @ODM\AlsoLoad("testOldest") */
+    /**
+     * @ODM\AlsoLoad ("testOldest")
+     *
+     * @return void
+     */
     public function populateTest($test)
     {
         $this->test = $test;
@@ -303,7 +311,11 @@ class AlsoLoadChild extends AlsoLoadDocument
 /** @ODM\Document */
 class AlsoLoadGrandchild extends AlsoLoadChild
 {
-    /** @ODM\AlsoLoad("testReallyOldest") */
+    /**
+     * @ODM\AlsoLoad ("testReallyOldest")
+     *
+     * @return void
+     */
     public function populateTest($test)
     {
         $this->test = $test;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
@@ -43,7 +43,7 @@ class AtomicSetTest extends BaseTest
         parent::tearDown();
     }
 
-    public function testAtomicInsertAndUpdate()
+    public function testAtomicInsertAndUpdate(): void
     {
         $user                 = new AtomicSetUser('Maciej');
         $user->phonenumbers[] = new Phonenumber('12345678');
@@ -72,7 +72,7 @@ class AtomicSetTest extends BaseTest
         $this->assertEquals('87654321', $user->phonenumbers[1]->getPhonenumber());
     }
 
-    public function testAtomicUpsert()
+    public function testAtomicUpsert(): void
     {
         $user                 = new AtomicSetUser('Maciej');
         $user->id             = new ObjectId();
@@ -91,7 +91,7 @@ class AtomicSetTest extends BaseTest
     /**
      * @dataProvider provideAtomicCollectionUnset
      */
-    public function testAtomicCollectionUnset($clearWith)
+    public function testAtomicCollectionUnset($clearWith): void
     {
         $user                 = new AtomicSetUser('Maciej');
         $user->phonenumbers[] = new Phonenumber('12345678');
@@ -118,7 +118,7 @@ class AtomicSetTest extends BaseTest
         $this->assertCount(0, $user->phonenumbers);
     }
 
-    public function provideAtomicCollectionUnset()
+    public function provideAtomicCollectionUnset(): array
     {
         return [
             [null],
@@ -127,7 +127,7 @@ class AtomicSetTest extends BaseTest
         ];
     }
 
-    public function testAtomicCollectionClearAndUpdate()
+    public function testAtomicCollectionClearAndUpdate(): void
     {
         $user                 = new AtomicSetUser('Maciej');
         $user->phonenumbers[] = new Phonenumber('12345678');
@@ -150,7 +150,7 @@ class AtomicSetTest extends BaseTest
         $this->assertEquals('87654321', $user->phonenumbers[0]->getPhonenumber());
     }
 
-    public function testAtomicCollectionReplacedAndUpdated()
+    public function testAtomicCollectionReplacedAndUpdated(): void
     {
         $user                 = new AtomicSetUser('Maciej');
         $user->phonenumbers[] = new Phonenumber('12345678');
@@ -173,7 +173,7 @@ class AtomicSetTest extends BaseTest
         $this->assertEquals('87654321', $user->phonenumbers[0]->getPhonenumber());
     }
 
-    public function testAtomicSetArray()
+    public function testAtomicSetArray(): void
     {
         $user                       = new AtomicSetUser('Maciej');
         $user->phonenumbersArray[1] = new Phonenumber('12345678');
@@ -201,7 +201,7 @@ class AtomicSetTest extends BaseTest
         $this->assertFalse(isset($user->phonenumbersArray[1]));
     }
 
-    public function testAtomicCollectionWithAnotherNested()
+    public function testAtomicCollectionWithAnotherNested(): void
     {
         $user        = new AtomicSetUser('Maciej');
         $privateBook = new Phonebook('Private');
@@ -257,7 +257,7 @@ class AtomicSetTest extends BaseTest
         $this->assertEquals('10203040', $publicBook->getPhonenumbers()->get(0)->getPhonenumber());
     }
 
-    public function testWeNeedToGoDeeper()
+    public function testWeNeedToGoDeeper(): void
     {
         $user                                          = new AtomicSetUser('Maciej');
         $user->inception[0]                            = new AtomicSetInception('start');
@@ -317,7 +317,7 @@ class AtomicSetTest extends BaseTest
         $this->assertEquals('start.one.one.many.0.many.1', $user->inception[0]->one->one->many[0]->many[1]->value);
     }
 
-    public function testUpdatingNestedCollectionWhileDeletingParent()
+    public function testUpdatingNestedCollectionWhileDeletingParent(): void
     {
         $user                                 = new AtomicSetUser('Jon');
         $user->inception[0]                   = new AtomicSetInception('start');
@@ -363,7 +363,7 @@ class AtomicSetTest extends BaseTest
         $this->assertEquals('start.many.1.many.0-new', $user->inception[0]->many[1]->many[0]->value);
     }
 
-    public function testAtomicRefMany()
+    public function testAtomicRefMany(): void
     {
         $malarzm = new AtomicSetUser('Maciej');
         $jmikola = new AtomicSetUser('Jeremy');
@@ -403,7 +403,7 @@ class AtomicSetTest extends BaseTest
         $this->dm->clear();
     }
 
-    public function testAtomicSetUpdatesAllNestedCollectionsInOneQuery()
+    public function testAtomicSetUpdatesAllNestedCollectionsInOneQuery(): void
     {
         // Create a book which has one chapter with one page.
         $chapter1 = new Chapter();
@@ -435,7 +435,7 @@ class AtomicSetTest extends BaseTest
         $this->assertEquals(2, $book->chapters->first()->pages->count(), 'Two page objects are expected in the first chapter of the book.');
     }
 
-    public function testReplacementOfEmbedManyElements()
+    public function testReplacementOfEmbedManyElements(): void
     {
         // Create a book with a single chapter.
         $book = new Book();
@@ -470,7 +470,7 @@ class AtomicSetTest extends BaseTest
         $this->assertEquals('Second chapter B', $book->chapters[1]->name);
     }
 
-    public function testReplacementOfIdentifiedEmbedManyElements()
+    public function testReplacementOfIdentifiedEmbedManyElements(): void
     {
         $book = new Book();
         $book->identifiedChapters->add(new IdentifiedChapter('A'));
@@ -496,7 +496,7 @@ class AtomicSetTest extends BaseTest
         $this->assertEquals('Second chapter B', $book->identifiedChapters[1]->name);
     }
 
-    public function testOnlyEmbeddedDocumentUpdated()
+    public function testOnlyEmbeddedDocumentUpdated(): void
     {
         // Create a book with a single chapter.
         $book = new Book();
@@ -522,7 +522,7 @@ class AtomicSetTest extends BaseTest
         $this->assertEquals('First chapter A', $book->chapters[0]->name, 'The chapter title failed to update.');
     }
 
-    public function testUpdatedEmbeddedDocumentAndDirtyCollectionInside()
+    public function testUpdatedEmbeddedDocumentAndDirtyCollectionInside(): void
     {
         $book = new Book();
         $book->chapters->add(new Chapter('A'));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/BidirectionalInheritanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/BidirectionalInheritanceTest.php
@@ -13,7 +13,7 @@ class BidirectionalInheritanceTest extends BaseTest
     /**
      * Test bi-directional reference "one to many", both owning sides and with inheritance maps.
      */
-    public function testOneToManyWithoutSides()
+    public function testOneToManyWithoutSides(): void
     {
         $tournament = new TournamentFootball('tournament_name');
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
@@ -15,7 +15,7 @@ class BinDataTest extends BaseTest
     /**
      * @dataProvider provideData
      */
-    public function testBinData($field, $data, $type)
+    public function testBinData($field, $data, $type): void
     {
         $test         = new BinDataTestUser();
         $test->$field = $data;
@@ -28,7 +28,7 @@ class BinDataTest extends BaseTest
         $this->assertEquals($data, $check[$field]->getData());
     }
 
-    public function provideData()
+    public function provideData(): array
     {
         return [
             ['bin', 'test', Binary::TYPE_GENERIC],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionsTest.php
@@ -12,7 +12,7 @@ use Documents\Bars\Location;
 
 class CollectionsTest extends BaseTest
 {
-    public function testCollections()
+    public function testCollections(): void
     {
         $bar = new Bar("Jon's Pub");
         $bar->addLocation(new Location('West Nashville'));
@@ -79,7 +79,7 @@ class CollectionsTest extends BaseTest
         $this->assertSame($bar->getLocations(), $changeSet['locations'][1]);
     }
 
-    public function testCreateCollectionsBasic()
+    public function testCreateCollectionsBasic(): void
     {
         $sm = $this->dm->getSchemaManager();
         $sm->dropDocumentCollection(CollectionTestBasic::class);
@@ -97,7 +97,7 @@ class CollectionsTest extends BaseTest
         $this->assertCount(3, $data);
     }
 
-    public function testCreateCollectionsCapped()
+    public function testCreateCollectionsCapped(): void
     {
         $sm = $this->dm->getSchemaManager();
         $sm->dropDocumentCollection(CollectionTestCapped::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
@@ -8,6 +8,7 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\APM\CommandLogger;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\LockException;
+use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Phonebook;
 use Documents\Phonenumber;
@@ -36,7 +37,7 @@ class CommitImprovementTest extends BaseTest
         parent::tearDown();
     }
 
-    public function testInsertIncludesAllNestedCollections()
+    public function testInsertIncludesAllNestedCollections(): void
     {
         $user = new User();
         $user->setUsername('malarzm');
@@ -56,7 +57,7 @@ class CommitImprovementTest extends BaseTest
         $this->assertEquals('12345678', $user->getPhonebooks()->first()->getPhonenumbers()->first()->getPhonenumber());
     }
 
-    public function testCollectionsAreUpdatedJustAfterOwningDocument()
+    public function testCollectionsAreUpdatedJustAfterOwningDocument(): void
     {
         $user = new VersionedUser();
         $user->setUsername('malarzm');
@@ -91,7 +92,7 @@ class CommitImprovementTest extends BaseTest
      *  - if collection snapshot would be taken after post* events, collection
      *    wouldn't be dirty and wouldn't be updated in next flush
      */
-    public function testChangingCollectionInPostEventsHasNoIllEffects()
+    public function testChangingCollectionInPostEventsHasNoIllEffects(): void
     {
         $this->dm->getEventManager()->addEventSubscriber(new PhonenumberMachine());
 
@@ -101,6 +102,7 @@ class CommitImprovementTest extends BaseTest
         $this->dm->flush();
 
         $this->assertCount(1, $user->getPhonenumbers()); // so we got a number on postPersist
+        $this->assertInstanceOf(PersistentCollectionInterface::class, $user->getPhonenumbers()); // so we got a number on postPersist
         $this->assertTrue($user->getPhonenumbers()->isDirty()); // but they should be dirty
 
         $collection = $this->dm->getDocumentCollection(get_class($user));
@@ -115,7 +117,7 @@ class CommitImprovementTest extends BaseTest
         $this->assertCount(1, $inDb['phonenumbers'], 'Collection changes from postUpdate should not be in database');
     }
 
-    public function testSchedulingCollectionDeletionAfterSchedulingForUpdate()
+    public function testSchedulingCollectionDeletionAfterSchedulingForUpdate(): void
     {
         $user = new User();
         $user->addPhonenumber(new Phonenumber('12345678'));
@@ -146,7 +148,7 @@ class PhonenumberMachine implements EventSubscriber
 
     private $numberId = 0;
 
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [
             Events::postPersist,

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php
@@ -21,21 +21,21 @@ use function get_class;
 
 class CustomCollectionsTest extends BaseTest
 {
-    public function testMappingNamespaceIsAdded()
+    public function testMappingNamespaceIsAdded(): void
     {
         $d  = new DocumentWithCustomCollection();
         $cm = $this->dm->getClassMetadata(get_class($d));
         $this->assertSame(MyEmbedsCollection::class, $cm->fieldMappings['coll']['collectionClass']);
     }
 
-    public function testLeadingBackslashIsRemoved()
+    public function testLeadingBackslashIsRemoved(): void
     {
         $d  = new DocumentWithCustomCollection();
         $cm = $this->dm->getClassMetadata(get_class($d));
         $this->assertSame(MyDocumentsCollection::class, $cm->fieldMappings['inverseRefMany']['collectionClass']);
     }
 
-    public function testCollectionClassHasToImplementCommonInterface()
+    public function testCollectionClassHasToImplementCommonInterface(): void
     {
         $cm = new ClassMetadata('stdClass');
 
@@ -52,7 +52,7 @@ class CustomCollectionsTest extends BaseTest
         ]);
     }
 
-    public function testGeneratedClassExtendsBaseCollection()
+    public function testGeneratedClassExtendsBaseCollection(): void
     {
         $coll  = new MyEmbedsCollection();
         $pcoll = $this->dm->getConfiguration()->getPersistentCollectionFactory()->create(
@@ -65,7 +65,7 @@ class CustomCollectionsTest extends BaseTest
         $this->assertSame($coll, $pcoll->unwrap());
     }
 
-    public function testEmbedMany()
+    public function testEmbedMany(): void
     {
         $d = new DocumentWithCustomCollection();
         $d->coll->add(new EmbeddedDocumentInCustomCollection('#1', true));
@@ -91,7 +91,7 @@ class CustomCollectionsTest extends BaseTest
         $this->assertCount(2, $d->boring);
     }
 
-    public function testReferenceMany()
+    public function testReferenceMany(): void
     {
         $d = new DocumentWithCustomCollection();
         $d->coll->add(new EmbeddedDocumentInCustomCollection('#1', true));
@@ -112,7 +112,7 @@ class CustomCollectionsTest extends BaseTest
         $this->assertCount(1, $d2->refMany->havingEmbeds());
     }
 
-    public function testInverseSideOfReferenceMany()
+    public function testInverseSideOfReferenceMany(): void
     {
         $d = new DocumentWithCustomCollection();
         $this->dm->persist($d);
@@ -128,7 +128,7 @@ class CustomCollectionsTest extends BaseTest
         $this->assertInstanceOf(MyDocumentsCollection::class, $d2->inverseRefMany);
     }
 
-    public function testModifyingCollectionByCustomMethod()
+    public function testModifyingCollectionByCustomMethod(): void
     {
         $d = new DocumentWithCustomCollection();
         $d->coll->add($e1 = new EmbeddedDocumentInCustomCollection('#1', true));
@@ -147,7 +147,7 @@ class CustomCollectionsTest extends BaseTest
         $this->assertEquals($e1, $d->coll[1]);
     }
 
-    public function testModifyingCollectionInChangeTrackingNotifyDocument()
+    public function testModifyingCollectionInChangeTrackingNotifyDocument(): void
     {
         $repository = $this->dm->getRepository(File::class);
         assert($repository instanceof GridFSRepository);
@@ -175,7 +175,7 @@ class CustomCollectionsTest extends BaseTest
     /**
      * @doesNotPerformAssertions
      */
-    public function testMethodWithVoidReturnType()
+    public function testMethodWithVoidReturnType(): void
     {
         $d = new DocumentWithCustomCollection();
         $this->dm->persist($d);
@@ -270,7 +270,7 @@ class MyEmbedsCollection extends ArrayCollection
         });
     }
 
-    public function move($i, $j)
+    public function move($i, $j): void
     {
         $tmp = $this->get($i);
         $this->set($i, $this->get($j));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomFieldNameTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomFieldNameTest.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class CustomFieldNameTest extends BaseTest
 {
-    public function testInsertSetsLoginInsteadOfUsername()
+    public function testInsertSetsLoginInsteadOfUsername(): void
     {
         $test           = new CustomFieldName();
         $test->username = 'test';
@@ -22,7 +22,7 @@ class CustomFieldNameTest extends BaseTest
         $this->assertEquals('test', $test['login']);
     }
 
-    public function testHydration()
+    public function testHydration(): void
     {
         $test           = new CustomFieldName();
         $test->username = 'test';
@@ -36,7 +36,7 @@ class CustomFieldNameTest extends BaseTest
         $this->assertEquals('test', $test->username);
     }
 
-    public function testUpdateSetsLoginInsteadOfUsername()
+    public function testUpdateSetsLoginInsteadOfUsername(): void
     {
         $test           = new CustomFieldName();
         $test->username = 'test';
@@ -55,7 +55,7 @@ class CustomFieldNameTest extends BaseTest
         $this->assertEquals('ok', $test['login']);
     }
 
-    public function testFindOneQueryIsPrepared()
+    public function testFindOneQueryIsPrepared(): void
     {
         $test           = new CustomFieldName();
         $test->username = 'test';
@@ -69,7 +69,7 @@ class CustomFieldNameTest extends BaseTest
         $this->assertEquals('test', $test->username);
     }
 
-    public function testFindQueryIsPrepared()
+    public function testFindQueryIsPrepared(): void
     {
         $test           = new CustomFieldName();
         $test->username = 'test';
@@ -83,7 +83,7 @@ class CustomFieldNameTest extends BaseTest
         $this->assertEquals('test', $test->username);
     }
 
-    public function testQueryBuilderAndDqlArePrepared()
+    public function testQueryBuilderAndDqlArePrepared(): void
     {
         $test           = new CustomFieldName();
         $test->username = 'test';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomIdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomIdTest.php
@@ -11,7 +11,7 @@ use Documents\User;
 
 class CustomIdTest extends BaseTest
 {
-    public function testSetId()
+    public function testSetId(): void
     {
         $account = new Account();
         $account->setName('Jon Test Account');
@@ -47,7 +47,7 @@ class CustomIdTest extends BaseTest
         $this->assertEquals('userId', $user->getId());
     }
 
-    public function testBatchInsertCustomId()
+    public function testBatchInsertCustomId(): void
     {
         $account = new Account();
         $account->setName('Jon Test Account');
@@ -108,7 +108,7 @@ class CustomIdTest extends BaseTest
         $this->assertCount(3, $results['ids']);
     }
 
-    public function testFindUser()
+    public function testFindUser(): void
     {
         $account = new Account();
         $account->setName('Jon Test Account');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
@@ -22,7 +22,7 @@ class CustomTypeTest extends BaseTest
         Type::addType('date_collection', DateCollectionType::class);
     }
 
-    public function testCustomTypeValueConversions()
+    public function testCustomTypeValueConversions(): void
     {
         $country                   = new Country();
         $country->nationalHolidays = [new DateTime(), new DateTime()];
@@ -37,7 +37,7 @@ class CustomTypeTest extends BaseTest
         $this->assertContainsOnly('DateTime', $country->nationalHolidays);
     }
 
-    public function testConvertToDatabaseValueExpectsArray()
+    public function testConvertToDatabaseValueExpectsArray(): void
     {
         $country                   = new Country();
         $country->nationalHolidays = new DateTime();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DatabasesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DatabasesTest.php
@@ -4,22 +4,23 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class DatabasesTest extends BaseTest
 {
-    public function testCustomDatabase()
+    public function testCustomDatabase(): void
     {
         $this->assertEquals('test_custom', $this->dm->getDocumentDatabase(CustomDatabaseTest::class)->getDatabaseName());
     }
 
-    public function testDefaultDatabase()
+    public function testDefaultDatabase(): void
     {
         $this->assertEquals('test_default', $this->dm->getDocumentDatabase(DefaultDatabaseTest::class)->getDatabaseName());
     }
 
-    protected function getConfiguration()
+    protected function getConfiguration(): Configuration
     {
         $config = parent::getConfiguration();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
@@ -51,7 +51,7 @@ class DateTest extends BaseTest
         $user = $this->dm->getRepository(get_class($user))->findOneBy([]);
         $user->setCreatedAt($newValue);
         $this->dm->getUnitOfWork()->computeChangeSets();
-        $changeset = $this->dm->getUnitOfWork()->getDocumentChangeset($user);
+        $changeset = $this->dm->getUnitOfWork()->getDocumentChangeSet($user);
         $this->assertEmpty($changeset);
     }
 
@@ -79,7 +79,7 @@ class DateTest extends BaseTest
         $user->getCreatedAt()->setTimestamp(time() - 3600);
 
         $this->dm->getUnitOfWork()->computeChangeSets();
-        $changeset = $this->dm->getUnitOfWork()->getDocumentChangeset($user);
+        $changeset = $this->dm->getUnitOfWork()->getDocumentChangeSet($user);
         $this->assertNotEmpty($changeset);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
@@ -17,7 +17,7 @@ use const PHP_INT_SIZE;
 
 class DateTest extends BaseTest
 {
-    public function testDates()
+    public function testDates(): void
     {
         $user = new User();
         $user->setUsername('w00ting');
@@ -40,7 +40,7 @@ class DateTest extends BaseTest
     /**
      * @dataProvider provideEquivalentDates
      */
-    public function testDateInstanceChangeDoesNotCauseUpdateIfValueIsTheSame($oldValue, $newValue)
+    public function testDateInstanceChangeDoesNotCauseUpdateIfValueIsTheSame($oldValue, $newValue): void
     {
         $user = new User();
         $user->setCreatedAt($oldValue);
@@ -55,7 +55,7 @@ class DateTest extends BaseTest
         $this->assertEmpty($changeset);
     }
 
-    public function provideEquivalentDates()
+    public function provideEquivalentDates(): array
     {
         return [
             [new DateTime('1985-09-01 00:00:00'), new DateTime('1985-09-01 00:00:00')],
@@ -67,7 +67,7 @@ class DateTest extends BaseTest
         ];
     }
 
-    public function testDateInstanceValueChangeDoesCauseUpdateIfValueIsTheSame()
+    public function testDateInstanceValueChangeDoesCauseUpdateIfValueIsTheSame(): void
     {
         $user = new User();
         $user->setCreatedAt(new DateTime('1985-09-01'));
@@ -83,7 +83,7 @@ class DateTest extends BaseTest
         $this->assertNotEmpty($changeset);
     }
 
-    public function testOldDate()
+    public function testOldDate(): void
     {
         if (PHP_INT_SIZE === 4) {
             $this->expectException(InvalidArgumentException::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DetachedDocumentTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DetachedDocumentTest.php
@@ -15,7 +15,7 @@ use function unserialize;
 
 class DetachedDocumentTest extends BaseTest
 {
-    public function testSimpleDetachMerge()
+    public function testSimpleDetachMerge(): void
     {
         $user           = new CmsUser();
         $user->name     = 'Roman';
@@ -40,7 +40,7 @@ class DetachedDocumentTest extends BaseTest
         $this->assertEquals('Roman B.', $user2->name);
     }
 
-    public function testSerializeUnserializeModifyMerge()
+    public function testSerializeUnserializeModifyMerge(): void
     {
         $user           = new CmsUser();
         $user->name     = 'Guilherme';
@@ -90,7 +90,7 @@ class DetachedDocumentTest extends BaseTest
         $this->assertTrue($this->dm->contains($phonenumbers[1]));
     }
 
-    public function testMergeWithReference()
+    public function testMergeWithReference(): void
     {
         $cmsUser           = new CmsUser();
         $cmsUser->username = 'alcaeus';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
@@ -17,7 +17,7 @@ class ReferenceDiscriminatorsDefaultValueTest extends BaseTest
     /**
      * This test demonstrates a document without discriminator being treated with defaultDiscriminatorValue
      */
-    public function testLoadDocumentWithDefaultValue()
+    public function testLoadDocumentWithDefaultValue(): void
     {
         // Create referenced document without discriminator value
         $this->dm->persist($firstChildWithoutDiscriminator  = new ChildDocumentWithoutDiscriminator('firstWithoutDiscriminator'));
@@ -44,7 +44,7 @@ class ReferenceDiscriminatorsDefaultValueTest extends BaseTest
     /**
      * This test ensures that a discriminatorValue is stored in the database and overrides the default
      */
-    public function testLoadDocumentWithDifferentChild()
+    public function testLoadDocumentWithDifferentChild(): void
     {
         $this->dm->persist($firstChildWithDiscriminator  = new ChildDocumentWithDiscriminatorComplex('firstWithDiscriminator', 'veryComplex'));
         $this->dm->persist($secondChildWithDiscriminator = new ChildDocumentWithDiscriminatorSimple('secondWithDiscriminator'));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -633,12 +633,11 @@ class DocumentPersisterTest extends BaseTest
     }
 
     /**
-     * @param string $class
-     * @param string $writeConcern
+     * @param int|string $writeConcern
      *
      * @dataProvider dataProviderTestWriteConcern
      */
-    public function testExecuteInsertsRespectsWriteConcern($class, $writeConcern)
+    public function testExecuteInsertsRespectsWriteConcern(string $class, $writeConcern)
     {
         $documentPersister = $this->uow->getDocumentPersister($class);
 
@@ -657,12 +656,11 @@ class DocumentPersisterTest extends BaseTest
     }
 
     /**
-     * @param string $class
-     * @param string $writeConcern
+     * @param int|string $writeConcern
      *
      * @dataProvider dataProviderTestWriteConcern
      */
-    public function testExecuteUpsertsRespectsWriteConcern($class, $writeConcern)
+    public function testExecuteUpsertsRespectsWriteConcern(string $class, $writeConcern)
     {
         $documentPersister = $this->uow->getDocumentPersister($class);
 
@@ -682,12 +680,11 @@ class DocumentPersisterTest extends BaseTest
     }
 
     /**
-     * @param string $class
-     * @param string $writeConcern
+     * @param int|string $writeConcern
      *
      * @dataProvider dataProviderTestWriteConcern
      */
-    public function testRemoveRespectsWriteConcern($class, $writeConcern)
+    public function testRemoveRespectsWriteConcern(string $class, $writeConcern)
     {
         $documentPersister = $this->uow->getDocumentPersister($class);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -51,7 +51,7 @@ class DocumentPersisterTest extends BaseTest
         $this->documentPersister = $this->uow->getDocumentPersister($this->class);
     }
 
-    public function testExecuteUpsertShouldNeverReplaceDocuments()
+    public function testExecuteUpsertShouldNeverReplaceDocuments(): void
     {
         $originalData = $this->dm->getDocumentCollection($this->class)->findOne();
 
@@ -66,7 +66,7 @@ class DocumentPersisterTest extends BaseTest
         $this->assertEquals($originalData, $updatedData);
     }
 
-    public function testExistsReturnsTrueForExistentDocuments()
+    public function testExistsReturnsTrueForExistentDocuments(): void
     {
         foreach (['a', 'b', 'c', 'd'] as $name) {
             $document = $this->documentPersister->load(['name' => $name]);
@@ -74,7 +74,7 @@ class DocumentPersisterTest extends BaseTest
         }
     }
 
-    public function testExistsReturnsFalseForNonexistentDocuments()
+    public function testExistsReturnsFalseForNonexistentDocuments(): void
     {
         $document     = new DocumentPersisterTestDocument();
         $document->id = new ObjectId();
@@ -82,7 +82,7 @@ class DocumentPersisterTest extends BaseTest
         $this->assertFalse($this->documentPersister->exists($document));
     }
 
-    public function testLoadPreparesCriteriaAndSort()
+    public function testLoadPreparesCriteriaAndSort(): void
     {
         $criteria = ['name' => ['$in' => ['a', 'b']]];
         $sort     = ['name' => -1];
@@ -93,7 +93,7 @@ class DocumentPersisterTest extends BaseTest
         $this->assertEquals('b', $document->name);
     }
 
-    public function testLoadAllPreparesCriteriaAndSort()
+    public function testLoadAllPreparesCriteriaAndSort(): void
     {
         $criteria = ['name' => ['$in' => ['a', 'b']]];
         $sort     = ['name' => -1];
@@ -107,7 +107,7 @@ class DocumentPersisterTest extends BaseTest
         $this->assertEquals('a', $documents[1]->name);
     }
 
-    public function testLoadAllWithSortLimitAndSkip()
+    public function testLoadAllWithSortLimitAndSkip(): void
     {
         $sort = ['name' => -1];
 
@@ -122,12 +122,12 @@ class DocumentPersisterTest extends BaseTest
     /**
      * @dataProvider getTestPrepareFieldNameData
      */
-    public function testPrepareFieldName($fieldName, $expected)
+    public function testPrepareFieldName($fieldName, $expected): void
     {
         $this->assertEquals($expected, $this->documentPersister->prepareFieldName($fieldName));
     }
 
-    public function getTestPrepareFieldNameData()
+    public function getTestPrepareFieldNameData(): array
     {
         return [
             ['name', 'dbName'],
@@ -143,7 +143,7 @@ class DocumentPersisterTest extends BaseTest
         ];
     }
 
-    public function testCurrentDateInQuery()
+    public function testCurrentDateInQuery(): void
     {
         $qb = $this->dm->createQueryBuilder(Article::class)
             ->updateMany()
@@ -155,7 +155,7 @@ class DocumentPersisterTest extends BaseTest
         );
     }
 
-    public function testExistsInQuery()
+    public function testExistsInQuery(): void
     {
         $qb = $this->dm->createQueryBuilder(Article::class)
             ->field('title')->exists(false)
@@ -173,7 +173,7 @@ class DocumentPersisterTest extends BaseTest
     /**
      * @dataProvider provideHashIdentifiers
      */
-    public function testPrepareQueryOrNewObjWithHashId($hashId)
+    public function testPrepareQueryOrNewObjWithHashId($hashId): void
     {
         $class             = DocumentPersisterTestHashIdDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
@@ -187,7 +187,7 @@ class DocumentPersisterTest extends BaseTest
     /**
      * @dataProvider provideHashIdentifiers
      */
-    public function testPrepareQueryOrNewObjWithHashIdAndInOperators($hashId)
+    public function testPrepareQueryOrNewObjWithHashIdAndInOperators($hashId): void
     {
         $class             = DocumentPersisterTestHashIdDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
@@ -221,7 +221,7 @@ class DocumentPersisterTest extends BaseTest
     /**
      * @dataProvider queryProviderForCustomTypeId
      */
-    public function testPrepareQueryOrNewObjWithCustomTypedId(array $expected, array $query)
+    public function testPrepareQueryOrNewObjWithCustomTypedId(array $expected, array $query): void
     {
         $class             = DocumentPersisterTestDocumentWithCustomId::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
@@ -237,7 +237,7 @@ class DocumentPersisterTest extends BaseTest
     /**
      * @dataProvider queryProviderForDocumentWithReferenceToDocumentWithCustomTypedId
      */
-    public function testPrepareQueryOrNewObjWithReferenceToDocumentWithCustomTypedId(Closure $getTestCase)
+    public function testPrepareQueryOrNewObjWithReferenceToDocumentWithCustomTypedId(Closure $getTestCase): void
     {
         Type::registerType('DocumentPersisterCustomId', DocumentPersisterCustomIdType::class);
 
@@ -252,7 +252,7 @@ class DocumentPersisterTest extends BaseTest
         );
     }
 
-    public function provideHashIdentifiers()
+    public function provideHashIdentifiers(): array
     {
         return [
             [['key' => 'value']],
@@ -261,7 +261,7 @@ class DocumentPersisterTest extends BaseTest
         ];
     }
 
-    public function testPrepareQueryOrNewObjWithSimpleReferenceToTargetDocumentWithNormalIdType()
+    public function testPrepareQueryOrNewObjWithSimpleReferenceToTargetDocumentWithNormalIdType(): void
     {
         $class             = DocumentPersisterTestHashIdDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
@@ -380,7 +380,7 @@ class DocumentPersisterTest extends BaseTest
     /**
      * @dataProvider provideHashIdentifiers
      */
-    public function testPrepareQueryOrNewObjWithSimpleReferenceToTargetDocumentWithHashIdType($hashId)
+    public function testPrepareQueryOrNewObjWithSimpleReferenceToTargetDocumentWithHashIdType($hashId): void
     {
         $class             = DocumentPersisterTestDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
@@ -416,7 +416,7 @@ class DocumentPersisterTest extends BaseTest
         $this->assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
     }
 
-    public function testPrepareQueryOrNewObjWithDBRefReferenceToTargetDocumentWithNormalIdType()
+    public function testPrepareQueryOrNewObjWithDBRefReferenceToTargetDocumentWithNormalIdType(): void
     {
         $class             = DocumentPersisterTestHashIdDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
@@ -457,7 +457,7 @@ class DocumentPersisterTest extends BaseTest
     /**
      * @dataProvider provideHashIdentifiers
      */
-    public function testPrepareQueryOrNewObjWithDBRefReferenceToTargetDocumentWithHashIdType($hashId)
+    public function testPrepareQueryOrNewObjWithDBRefReferenceToTargetDocumentWithHashIdType($hashId): void
     {
         $class             = DocumentPersisterTestDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
@@ -496,7 +496,7 @@ class DocumentPersisterTest extends BaseTest
     /**
      * @dataProvider queryProviderForComplexRefWithObjectValue
      */
-    public function testPrepareQueryOrNewObjWithComplexRefToTargetDocumentFieldWithObjectValue(array $expected, array $query)
+    public function testPrepareQueryOrNewObjWithComplexRefToTargetDocumentFieldWithObjectValue(array $expected, array $query): void
     {
         $class             = DocumentPersisterTestDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
@@ -530,7 +530,7 @@ class DocumentPersisterTest extends BaseTest
         ];
     }
 
-    public function testPrepareQueryOrNewObjWithEmbeddedReferenceToTargetDocumentWithNormalIdType()
+    public function testPrepareQueryOrNewObjWithEmbeddedReferenceToTargetDocumentWithNormalIdType(): void
     {
         $class             = DocumentPersisterTestHashIdDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
@@ -571,7 +571,7 @@ class DocumentPersisterTest extends BaseTest
     /**
      * @dataProvider provideHashIdentifiers
      */
-    public function testPrepareQueryOrNewObjWithEmbeddedReferenceToTargetDocumentWithHashIdType($hashId)
+    public function testPrepareQueryOrNewObjWithEmbeddedReferenceToTargetDocumentWithHashIdType($hashId): void
     {
         $class             = DocumentPersisterTestDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
@@ -610,7 +610,7 @@ class DocumentPersisterTest extends BaseTest
     /**
      * @return array
      */
-    public static function dataProviderTestWriteConcern()
+    public static function dataProviderTestWriteConcern(): array
     {
         return [
             'default' => [
@@ -637,7 +637,7 @@ class DocumentPersisterTest extends BaseTest
      *
      * @dataProvider dataProviderTestWriteConcern
      */
-    public function testExecuteInsertsRespectsWriteConcern(string $class, $writeConcern)
+    public function testExecuteInsertsRespectsWriteConcern(string $class, $writeConcern): void
     {
         $documentPersister = $this->uow->getDocumentPersister($class);
 
@@ -660,7 +660,7 @@ class DocumentPersisterTest extends BaseTest
      *
      * @dataProvider dataProviderTestWriteConcern
      */
-    public function testExecuteUpsertsRespectsWriteConcern(string $class, $writeConcern)
+    public function testExecuteUpsertsRespectsWriteConcern(string $class, $writeConcern): void
     {
         $documentPersister = $this->uow->getDocumentPersister($class);
 
@@ -684,7 +684,7 @@ class DocumentPersisterTest extends BaseTest
      *
      * @dataProvider dataProviderTestWriteConcern
      */
-    public function testRemoveRespectsWriteConcern(string $class, $writeConcern)
+    public function testRemoveRespectsWriteConcern(string $class, $writeConcern): void
     {
         $documentPersister = $this->uow->getDocumentPersister($class);
 
@@ -705,7 +705,7 @@ class DocumentPersisterTest extends BaseTest
         $this->dm->flush();
     }
 
-    public function testDefaultWriteConcernIsRespected()
+    public function testDefaultWriteConcernIsRespected(): void
     {
         $class             = DocumentPersisterTestDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
@@ -726,7 +726,7 @@ class DocumentPersisterTest extends BaseTest
         $this->dm->flush();
     }
 
-    public function testDefaultWriteConcernIsRespectedBackwardCompatibility()
+    public function testDefaultWriteConcernIsRespectedBackwardCompatibility(): void
     {
         $class             = DocumentPersisterTestDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
@@ -747,7 +747,7 @@ class DocumentPersisterTest extends BaseTest
         $this->dm->flush();
     }
 
-    public function testVersionIncrementOnUpdateSuccess()
+    public function testVersionIncrementOnUpdateSuccess(): void
     {
         $testDocument = new DocumentPersisterTestDocumentWithVersion();
         $this->dm->persist($testDocument);
@@ -760,7 +760,7 @@ class DocumentPersisterTest extends BaseTest
         $this->assertEquals(2, $testDocument->revision);
     }
 
-    public function testNoVersionIncrementOnUpdateFailure()
+    public function testNoVersionIncrementOnUpdateFailure(): void
     {
         $class = DocumentPersisterTestDocumentWithVersion::class;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EcommerceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EcommerceTest.php
@@ -43,7 +43,7 @@ class EcommerceTest extends BaseTest
         unset($currencies, $product);
     }
 
-    public function testEmbedding()
+    public function testEmbedding(): void
     {
         $product  = $this->getProduct();
         $price    =  $product->getOption('small')->getPrice(true);
@@ -61,7 +61,7 @@ class EcommerceTest extends BaseTest
         $this->assertEquals(12.99 * 2, $product->getOption('small')->getPrice());
     }
 
-    public function testMoneyDocumentsAvailableForReference()
+    public function testMoneyDocumentsAvailableForReference(): void
     {
         $product  = $this->getProduct();
         $price    =  $product->getOption('small')->getPrice(true);
@@ -71,7 +71,7 @@ class EcommerceTest extends BaseTest
         $this->assertEquals($currency, $this->dm->getRepository(Currency::class)->findOneBy(['name' => Currency::USD]));
     }
 
-    public function testRemoveOption()
+    public function testRemoveOption(): void
     {
         $product = $this->getProduct();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedIdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedIdTest.php
@@ -11,7 +11,7 @@ use MongoDB\BSON\ObjectId;
 
 class EmbeddedIdTest extends BaseTest
 {
-    public function testEmbeddedIdsAreGenerated()
+    public function testEmbeddedIdsAreGenerated(): void
     {
         $test = new DefaultIdEmbeddedDocument();
 
@@ -20,7 +20,7 @@ class EmbeddedIdTest extends BaseTest
         $this->assertNotNull($test->id);
     }
 
-    public function testEmbeddedIdsAreNotOverwritten()
+    public function testEmbeddedIdsAreNotOverwritten(): void
     {
         $id       = (string) new ObjectId();
         $test     = new DefaultIdEmbeddedDocument();
@@ -31,7 +31,7 @@ class EmbeddedIdTest extends BaseTest
         $this->assertEquals($id, $test->id);
     }
 
-    public function testEmbedOneDocumentWithMissingIdentifier()
+    public function testEmbedOneDocumentWithMissingIdentifier(): void
     {
         $user           = new EmbeddedStrategyNoneIdTestUser();
         $user->embedOne = new DefaultIdStrategyNoneEmbeddedDocument();
@@ -44,7 +44,7 @@ class EmbeddedIdTest extends BaseTest
         $this->dm->persist($user);
     }
 
-    public function testEmbedManyDocumentWithMissingIdentifier()
+    public function testEmbedManyDocumentWithMissingIdentifier(): void
     {
         $user              = new EmbeddedStrategyNoneIdTestUser();
         $user->embedMany[] = new DefaultIdStrategyNoneEmbeddedDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedReferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedReferenceTest.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class EmbeddedReferenceTest extends BaseTest
 {
-    public function testReferencedDocumentInsideEmbeddedDocument()
+    public function testReferencedDocumentInsideEmbeddedDocument(): void
     {
         /* PARENT DOCUMENT */
         $offer = new Offer('My Offer');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
@@ -27,7 +27,7 @@ use function get_class;
 
 class EmbeddedTest extends BaseTest
 {
-    public function testSetEmbeddedToNull()
+    public function testSetEmbeddedToNull(): void
     {
         $user = new User();
         $user->setId((string) new ObjectId());
@@ -44,7 +44,7 @@ class EmbeddedTest extends BaseTest
         $this->assertNull($user->getAddress());
     }
 
-    public function testFlushEmbedded()
+    public function testFlushEmbedded(): void
     {
         $test       = new EmbeddedTestLevel0();
         $test->name = 'test';
@@ -89,7 +89,7 @@ class EmbeddedTest extends BaseTest
         $this->assertCount(1, $test->level1);
     }
 
-    public function testOneEmbedded()
+    public function testOneEmbedded(): void
     {
         $address = new Address();
         $address->setAddress('6512 Mercomatic Ct.');
@@ -129,7 +129,7 @@ class EmbeddedTest extends BaseTest
         $this->assertSame($user->getAddress(), $changeSet['address'][1]);
     }
 
-    public function testRemoveOneEmbedded()
+    public function testRemoveOneEmbedded(): void
     {
         $address = new Address();
         $address->setAddress('6512 Mercomatic Ct.');
@@ -156,7 +156,7 @@ class EmbeddedTest extends BaseTest
         $this->assertNull($user->getAddress());
     }
 
-    public function testManyEmbedded()
+    public function testManyEmbedded(): void
     {
         $user = new User();
         $user->addPhonenumber(new Phonenumber('6155139185'));
@@ -175,7 +175,7 @@ class EmbeddedTest extends BaseTest
         $this->assertEquals($user->getPhonenumbers()->toArray(), $user2->getPhonenumbers()->toArray());
     }
 
-    public function testPostRemoveEventOnEmbeddedManyDocument()
+    public function testPostRemoveEventOnEmbeddedManyDocument(): void
     {
         // create a test document
         $test       = new EmbeddedTestLevel0b();
@@ -211,7 +211,7 @@ class EmbeddedTest extends BaseTest
         $this->assertTrue($level1->postRemove, 'the removed embedded document executed the PostRemove lifecycle callback');
     }
 
-    public function testRemoveEmbeddedManyDocument()
+    public function testRemoveEmbeddedManyDocument(): void
     {
         // create a test document
         $test       = new EmbeddedTestLevel0b();
@@ -259,7 +259,7 @@ class EmbeddedTest extends BaseTest
         $this->assertEquals(0, $test->level1->count());
     }
 
-    public function testRemoveDeepEmbeddedManyDocument()
+    public function testRemoveDeepEmbeddedManyDocument(): void
     {
         // create a test document
         $test       = new EmbeddedTestLevel0b();
@@ -312,7 +312,7 @@ class EmbeddedTest extends BaseTest
         $this->assertEquals(0, $level1->level2->count());
     }
 
-    public function testPostRemoveEventOnDeepEmbeddedManyDocument()
+    public function testPostRemoveEventOnDeepEmbeddedManyDocument(): void
     {
         // create a test document
         $test       = new EmbeddedTestLevel0b();
@@ -354,7 +354,7 @@ class EmbeddedTest extends BaseTest
         $this->assertTrue($level2->postRemove, 'the removed embedded document executed the PostRemove lifecycle callback');
     }
 
-    public function testEmbeddedLoadEvents()
+    public function testEmbeddedLoadEvents(): void
     {
         // create a test document
         $test       = new EmbeddedTestLevel0b();
@@ -386,7 +386,7 @@ class EmbeddedTest extends BaseTest
         $this->assertTrue($level2->postLoad);
     }
 
-    public function testEmbeddedDocumentChangesParent()
+    public function testEmbeddedDocumentChangesParent(): void
     {
         $address = new Address();
         $address->setAddress('6512 Mercomatic Ct.');
@@ -409,7 +409,7 @@ class EmbeddedTest extends BaseTest
         $this->assertEquals('changed', $user->getAddress()->getAddress());
     }
 
-    public function testRemoveEmbeddedDocument()
+    public function testRemoveEmbeddedDocument(): void
     {
         $address = new Address();
         $address->setAddress('6512 Mercomatic Ct.');
@@ -434,7 +434,7 @@ class EmbeddedTest extends BaseTest
         $this->assertArrayNotHasKey('address', $check);
     }
 
-    public function testRemoveAddDeepEmbedded()
+    public function testRemoveAddDeepEmbedded(): void
     {
         $vhost = new VirtualHost();
 
@@ -468,7 +468,7 @@ class EmbeddedTest extends BaseTest
         }
     }
 
-    public function testEmbeddedDocumentNotSavedFields()
+    public function testEmbeddedDocumentNotSavedFields(): void
     {
         $document                     = new NotSaved();
         $document->embedded           = new NotSavedEmbedded();
@@ -485,7 +485,7 @@ class EmbeddedTest extends BaseTest
         $this->assertNull($document->embedded->notSaved);
     }
 
-    public function testChangeEmbedOneDocumentId()
+    public function testChangeEmbedOneDocumentId(): void
     {
         $originalId = (string) new ObjectId();
 
@@ -508,7 +508,7 @@ class EmbeddedTest extends BaseTest
         $this->assertEquals($newId, $test->embed->id);
     }
 
-    public function testChangeEmbedManyDocumentId()
+    public function testChangeEmbedManyDocumentId(): void
     {
         $originalId = (string) new ObjectId();
 
@@ -531,7 +531,7 @@ class EmbeddedTest extends BaseTest
         $this->assertEquals($newId, $test->embedMany[0]->id);
     }
 
-    public function testEmbeddedDocumentsWithSameIdAreNotSameInstance()
+    public function testEmbeddedDocumentsWithSameIdAreNotSameInstance(): void
     {
         $originalId = (string) new ObjectId();
 
@@ -550,7 +550,7 @@ class EmbeddedTest extends BaseTest
         $this->assertNotSame($test->embed, $test->embedMany[1]);
     }
 
-    public function testWhenCopyingManyEmbedSubDocumentsFromOneDocumentToAnotherWillNotAffectTheSourceDocument()
+    public function testWhenCopyingManyEmbedSubDocumentsFromOneDocumentToAnotherWillNotAffectTheSourceDocument(): void
     {
         $test1 = new ChangeEmbeddedIdTest();
 
@@ -581,7 +581,7 @@ class EmbeddedTest extends BaseTest
         $this->assertCount(1, $test1->embedMany);
     }
 
-    public function testReusedEmbeddedDocumentsAreClonedInFact()
+    public function testReusedEmbeddedDocumentsAreClonedInFact(): void
     {
         $test1 = new ChangeEmbeddedIdTest();
         $test2 = new ChangeEmbeddedIdTest();
@@ -605,7 +605,7 @@ class EmbeddedTest extends BaseTest
         $this->assertSame($originalTest2['embed'], $test2->embed);
     }
 
-    public function testEmbeddedDocumentWithDifferentFieldNameAnnotation()
+    public function testEmbeddedDocumentWithDifferentFieldNameAnnotation(): void
     {
         $test1 = new ChangeEmbeddedWithNameAnnotationTest();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
@@ -24,7 +24,7 @@ class EnsureShardingTest extends BaseTest
         $this->skipTestIfNotSharded(ShardedOne::class);
     }
 
-    public function testEnsureShardingForNewCollection()
+    public function testEnsureShardingForNewCollection(): void
     {
         $class = ShardedOne::class;
         $this->dm->getSchemaManager()->ensureDocumentIndexes($class);
@@ -39,7 +39,7 @@ class EnsureShardingTest extends BaseTest
         $this->assertTrue($stats['sharded']);
     }
 
-    public function testEnsureShardingForNewCollectionWithoutCreatingIndexes()
+    public function testEnsureShardingForNewCollectionWithoutCreatingIndexes(): void
     {
         $class = ShardedOne::class;
         $this->dm->getSchemaManager()->ensureDocumentSharding($class);
@@ -53,7 +53,7 @@ class EnsureShardingTest extends BaseTest
         $this->assertTrue($stats['sharded']);
     }
 
-    public function testEnsureShardingForCollectionWithDocuments()
+    public function testEnsureShardingForCollectionWithDocuments(): void
     {
         $class = ShardedOne::class;
 
@@ -70,7 +70,7 @@ class EnsureShardingTest extends BaseTest
         $this->assertTrue($stats['sharded']);
     }
 
-    public function testEnsureShardingForCollectionWithDocumentsThrowsIndexError()
+    public function testEnsureShardingForCollectionWithDocumentsThrowsIndexError(): void
     {
         $class = ShardedOne::class;
 
@@ -89,7 +89,7 @@ class EnsureShardingTest extends BaseTest
         $this->assertFalse($stats['sharded']);
     }
 
-    public function testEnsureShardingForCollectionWithShardingEnabled()
+    public function testEnsureShardingForCollectionWithShardingEnabled(): void
     {
         $class = ShardedOneWithDifferentKey::class;
         $this->dm->getSchemaManager()->ensureDocumentIndexes($class);
@@ -103,7 +103,7 @@ class EnsureShardingTest extends BaseTest
         $this->assertTrue($stats['sharded']);
     }
 
-    public function testEnsureDocumentShardingWithShardByReference()
+    public function testEnsureDocumentShardingWithShardByReference(): void
     {
         $class = ShardedByUser::class;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilterTest.php
@@ -31,7 +31,7 @@ class FilterTest extends BaseTest
         $groupB = new Group('groupB');
 
         $profile = new Profile();
-        $profile->setFirstname('Timothy');
+        $profile->setFirstName('Timothy');
 
         $tim = new User();
         $tim->setUsername('Tim');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilterTest.php
@@ -55,7 +55,7 @@ class FilterTest extends BaseTest
         $this->fc = $this->dm->getFilterCollection();
     }
 
-    protected function enableUserFilter()
+    protected function enableUserFilter(): void
     {
         $this->fc->enable('testFilter');
         $testFilter = $this->fc->getFilter('testFilter');
@@ -64,7 +64,7 @@ class FilterTest extends BaseTest
         $testFilter->setParameter('value', 'Tim');
     }
 
-    protected function enableGroupFilter()
+    protected function enableGroupFilter(): void
     {
         $this->fc->enable('testFilter');
         $testFilter = $this->fc->getFilter('testFilter');
@@ -73,7 +73,7 @@ class FilterTest extends BaseTest
         $testFilter->setParameter('value', 'groupA');
     }
 
-    protected function enableProfileFilter()
+    protected function enableProfileFilter(): void
     {
         $this->fc->enable('testFilter');
         $testFilter = $this->fc->getFilter('testFilter');
@@ -82,7 +82,7 @@ class FilterTest extends BaseTest
         $testFilter->setParameter('value', 'Something Else');
     }
 
-    public function testRepositoryFind()
+    public function testRepositoryFind(): void
     {
         $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithFind());
 
@@ -95,7 +95,7 @@ class FilterTest extends BaseTest
         $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithFind());
     }
 
-    protected function getUsernamesWithFind()
+    protected function getUsernamesWithFind(): array
     {
         $repository = $this->dm->getRepository(User::class);
 
@@ -117,7 +117,7 @@ class FilterTest extends BaseTest
         return $usernames;
     }
 
-    public function testRepositoryFindBy()
+    public function testRepositoryFindBy(): void
     {
         $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithFindBy());
 
@@ -130,7 +130,7 @@ class FilterTest extends BaseTest
         $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithFindBy());
     }
 
-    protected function getUsernamesWithFindBy()
+    protected function getUsernamesWithFindBy(): array
     {
         $all = $this->dm->getRepository(User::class)->findBy(['hits' => 10]);
 
@@ -144,7 +144,7 @@ class FilterTest extends BaseTest
         return $usernames;
     }
 
-    public function testRepositoryFindOneBy()
+    public function testRepositoryFindOneBy(): void
     {
         $this->assertEquals('John', $this->getJohnsUsernameWithFindOneBy());
 
@@ -164,7 +164,7 @@ class FilterTest extends BaseTest
         return isset($john) ? $john->getUsername() : null;
     }
 
-    public function testRepositoryFindAll()
+    public function testRepositoryFindAll(): void
     {
         $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithFindAll());
 
@@ -177,7 +177,7 @@ class FilterTest extends BaseTest
         $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithFindAll());
     }
 
-    protected function getUsernamesWithFindAll()
+    protected function getUsernamesWithFindAll(): array
     {
         $all = $this->dm->getRepository(User::class)->findAll();
 
@@ -191,7 +191,7 @@ class FilterTest extends BaseTest
         return $usernames;
     }
 
-    public function testReferenceMany()
+    public function testReferenceMany(): void
     {
         $this->assertEquals(['groupA', 'groupB'], $this->getGroupsByReference());
 
@@ -204,7 +204,7 @@ class FilterTest extends BaseTest
         $this->assertEquals(['groupA', 'groupB'], $this->getGroupsByReference());
     }
 
-    protected function getGroupsByReference()
+    protected function getGroupsByReference(): array
     {
         $tim = $this->dm->getRepository(User::class)->find($this->ids['tim']);
 
@@ -222,7 +222,7 @@ class FilterTest extends BaseTest
         return $groupnames;
     }
 
-    public function testReferenceOne()
+    public function testReferenceOne(): void
     {
         $this->assertEquals('Timothy', $this->getProfileByReference());
 
@@ -248,7 +248,7 @@ class FilterTest extends BaseTest
         }
     }
 
-    public function testDocumentManagerRef()
+    public function testDocumentManagerRef(): void
     {
         $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithDocumentManager());
 
@@ -261,7 +261,7 @@ class FilterTest extends BaseTest
         $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithDocumentManager());
     }
 
-    protected function getUsernamesWithDocumentManager()
+    protected function getUsernamesWithDocumentManager(): array
     {
         $tim  = $this->dm->getReference(User::class, $this->ids['tim']);
         $john = $this->dm->getReference(User::class, $this->ids['john']);
@@ -285,7 +285,7 @@ class FilterTest extends BaseTest
         return $usernames;
     }
 
-    public function testQuery()
+    public function testQuery(): void
     {
         $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithQuery());
 
@@ -298,7 +298,7 @@ class FilterTest extends BaseTest
         $this->assertEquals(['John', 'Tim'], $this->getUsernamesWithQuery());
     }
 
-    protected function getUsernamesWithQuery()
+    protected function getUsernamesWithQuery(): array
     {
         $qb    = $this->dm->createQueryBuilder(User::class);
         $query = $qb->getQuery();
@@ -314,7 +314,7 @@ class FilterTest extends BaseTest
         return $usernames;
     }
 
-    public function testMultipleFiltersOnSameField()
+    public function testMultipleFiltersOnSameField(): void
     {
         $this->fc->enable('testFilter');
         $testFilter = $this->fc->getFilter('testFilter');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FindAndModifyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FindAndModifyTest.php
@@ -9,7 +9,7 @@ use Documents\User;
 
 class FindAndModifyTest extends BaseTest
 {
-    public function testFindAndModify()
+    public function testFindAndModify(): void
     {
         $coll = $this->dm->getDocumentCollection(User::class);
         $docs = [['count' => 0], ['count' => 0]];
@@ -42,7 +42,7 @@ class FindAndModifyTest extends BaseTest
         $this->assertEquals(1, $this->dm->getDocumentCollection(User::class)->count());
     }
 
-    public function testFindAndModifyAlt()
+    public function testFindAndModifyAlt(): void
     {
         $doc = new User();
         $doc->setUsername('jwage');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FlushTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FlushTest.php
@@ -22,7 +22,7 @@ class FlushTest extends BaseTest
      *
      * Each flush fetches and registers the relations of the known objects.
      */
-    public function testFlush()
+    public function testFlush(): void
     {
         $userA = new FriendUser('userA');
         $userB = new FriendUser('userB');
@@ -59,7 +59,7 @@ class FlushTest extends BaseTest
         $this->assertSize(1);
     }
 
-    protected function assertSize($size)
+    protected function assertSize($size): void
     {
         $this->assertEquals($size, $this->dm->getUnitOfWork()->size());
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -81,7 +81,7 @@ class FunctionalTest extends BaseTest
         bcscale($this->initialScale);
     }
 
-    public function provideUpsertObjects()
+    public function provideUpsertObjects(): array
     {
         return [
             [UserUpsert::class, new ObjectId('4f18f593acee41d724000005'), 'user'],
@@ -93,7 +93,7 @@ class FunctionalTest extends BaseTest
     /**
      * @dataProvider provideUpsertObjects
      */
-    public function testUpsertObject($className, $id, $discriminator)
+    public function testUpsertObject($className, $id, $discriminator): void
     {
         $user           = new $className();
         $user->id       = (string) $id;
@@ -154,13 +154,13 @@ class FunctionalTest extends BaseTest
         $this->assertEquals('foo', $check['nullableField']);
     }
 
-    public function testInheritedAssociationMappings()
+    public function testInheritedAssociationMappings(): void
     {
         $class = $this->dm->getClassMetadata(UserUpsertChild::class);
         $this->assertTrue(isset($class->associationMappings['groups']));
     }
 
-    public function testNestedCategories()
+    public function testNestedCategories(): void
     {
         $root   = new Category('Root');
         $child1 = new SubCategory('Child 1');
@@ -182,7 +182,7 @@ class FunctionalTest extends BaseTest
         $this->assertEquals('Root Changed', $test['name']);
     }
 
-    public function testManyEmbedded()
+    public function testManyEmbedded(): void
     {
         $album = new Album('Jon');
         $album->addSong(new Song('Song #1'));
@@ -223,7 +223,7 @@ class FunctionalTest extends BaseTest
         $this->assertFalse(isset($test['songs']));
     }
 
-    public function testNewEmbedded()
+    public function testNewEmbedded(): void
     {
         $subAddress = new Address();
         $subAddress->setCity('Old Sub-City');
@@ -247,7 +247,7 @@ class FunctionalTest extends BaseTest
         $this->assertEquals('New City', $test['address']['city']);
     }
 
-    public function testPersistingNewDocumentWithOnlyOneReference()
+    public function testPersistingNewDocumentWithOnlyOneReference(): void
     {
         $server       = new GuestServer();
         $server->name = 'test';
@@ -272,7 +272,7 @@ class FunctionalTest extends BaseTest
         $this->assertEquals('server_guest', $test['server']['_doctrine_class_name']);
     }
 
-    public function testCollection()
+    public function testCollection(): void
     {
         $user = new User();
         $user->setUsername('joncolltest');
@@ -302,7 +302,7 @@ class FunctionalTest extends BaseTest
         $this->assertEquals(['ok', 'test'], $document->getLogs());
     }
 
-    public function testSameObjectValuesInCollection()
+    public function testSameObjectValuesInCollection(): void
     {
         $user = new User();
         $user->setUsername('testing');
@@ -316,7 +316,7 @@ class FunctionalTest extends BaseTest
         $this->assertCount(2, $user->getPhonenumbers());
     }
 
-    public function testIncrement()
+    public function testIncrement(): void
     {
         $user = new User();
         $user->setUsername('jon');
@@ -353,7 +353,7 @@ class FunctionalTest extends BaseTest
         $this->assertSame('9.99', $user->getDecimal128Count());
     }
 
-    public function testIncrementWithFloat()
+    public function testIncrementWithFloat(): void
     {
         $user = new User();
         $user->setUsername('jon');
@@ -385,7 +385,7 @@ class FunctionalTest extends BaseTest
         $this->assertSame(110.5, $user->getFloatCount());
     }
 
-    public function testIncrementSetsNull()
+    public function testIncrementSetsNull(): void
     {
         $user = new User();
         $user->setUsername('jon');
@@ -425,7 +425,7 @@ class FunctionalTest extends BaseTest
         $this->assertNull($user->getDecimal128Count());
     }
 
-    public function testTest()
+    public function testTest(): void
     {
         $employee = new Employee();
         $employee->setName('Employee');
@@ -473,7 +473,7 @@ class FunctionalTest extends BaseTest
         $this->assertEquals('Gave user 100k a year raise', $result['notes'][0]);
     }
 
-    public function testNotAnnotatedDocument()
+    public function testNotAnnotatedDocument(): void
     {
         $this->dm->getDocumentCollection(NotAnnotatedDocument::class)->drop();
 
@@ -489,7 +489,7 @@ class FunctionalTest extends BaseTest
         $this->assertFalse(isset($test->transientField));
     }
 
-    public function testNullFieldValuesAllowed()
+    public function testNullFieldValuesAllowed(): void
     {
         $this->dm->getDocumentCollection(NullFieldValues::class)->drop();
 
@@ -525,7 +525,7 @@ class FunctionalTest extends BaseTest
         $this->assertFalse(isset($test['transientField']));
     }
 
-    public function testSimplerEmbedAndReference()
+    public function testSimplerEmbedAndReference(): void
     {
         $class = $this->dm->getClassMetadata(SimpleEmbedAndReference::class);
         $this->assertEquals('many', $class->fieldMappings['embedMany']['type']);
@@ -534,7 +534,7 @@ class FunctionalTest extends BaseTest
         $this->assertEquals('one', $class->fieldMappings['referenceOne']['type']);
     }
 
-    public function testNotSavedFields()
+    public function testNotSavedFields(): void
     {
         $collection = $this->dm->getDocumentCollection(NotSaved::class);
         $collection->drop();
@@ -560,7 +560,7 @@ class FunctionalTest extends BaseTest
         $this->assertFalse(isset($notSaved['notSaved']));
     }
 
-    public function testTypeClassMissing()
+    public function testTypeClassMissing(): void
     {
         $project = new Project('Test Project');
         $this->dm->persist($project);
@@ -587,7 +587,7 @@ class FunctionalTest extends BaseTest
         $collection->getTypeClass();
     }
 
-    public function testTypeClass()
+    public function testTypeClass(): void
     {
         $bar = new Bar("Jon's Pub");
         $bar->addLocation(new Location('West Nashville'));
@@ -605,7 +605,7 @@ class FunctionalTest extends BaseTest
         $this->assertInstanceOf(ClassMetadata::class, $collection->getTypeClass());
     }
 
-    public function testFavoritesReference()
+    public function testFavoritesReference(): void
     {
         $project = new Project('Test Project');
         $this->dm->persist($project);
@@ -657,7 +657,7 @@ class FunctionalTest extends BaseTest
         $this->assertInstanceOf(Project::class, $user->getFavorite());
     }
 
-    public function testPreUpdate()
+    public function testPreUpdate(): void
     {
         $product       = new PreUpdateTestProduct();
         $product->name = 'Product';
@@ -704,7 +704,7 @@ class FunctionalTest extends BaseTest
         $this->assertEquals('Product2', $product->sellable->getProduct()->getName());
     }
 
-    public function testSameCollectionTest()
+    public function testSameCollectionTest(): void
     {
         $test1       = new SameCollection1();
         $test1->name = 'test1';
@@ -752,7 +752,7 @@ class FunctionalTest extends BaseTest
         $this->assertCount(2, $test);
     }
 
-    public function testNotSameCollectionThrowsException()
+    public function testNotSameCollectionThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->dm->createQueryBuilder([
@@ -761,7 +761,7 @@ class FunctionalTest extends BaseTest
         ])->getQuery()->execute();
     }
 
-    public function testEmbeddedNesting()
+    public function testEmbeddedNesting(): void
     {
         $test       = new EmbeddedTestLevel0();
         $test->name = 'test';
@@ -796,7 +796,7 @@ class FunctionalTest extends BaseTest
         $this->assertCount(2, $check->level1[1]->level2);
     }
 
-    public function testEmbeddedInheritance()
+    public function testEmbeddedInheritance(): void
     {
         // create a level0b (inherits from level0)
         $test       = new EmbeddedTestLevel0b();
@@ -834,7 +834,7 @@ class FunctionalTest extends BaseTest
         $this->assertCount(1, $test->oneLevel1->level2);
     }
 
-    public function testModifyGroupsArrayDirectly()
+    public function testModifyGroupsArrayDirectly(): void
     {
         $account = new Account();
         $account->setName('Jon Test Account');
@@ -871,7 +871,7 @@ class FunctionalTest extends BaseTest
         $this->assertCount(1, $user->getGroups());
     }
 
-    public function testReplaceEntireGroupsArray()
+    public function testReplaceEntireGroupsArray(): void
     {
         $account = new Account();
         $account->setName('Jon Test Account');
@@ -912,7 +912,7 @@ class FunctionalTest extends BaseTest
         $this->assertCount(1, $user->getGroups());
     }
 
-    public function testFunctionalParentAssociations()
+    public function testFunctionalParentAssociations(): void
     {
         $a                    = new ParentAssociationTestA('a');
         $a->child             = new ParentAssociationTestB('b');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/HasLifecycleCallbacksTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/HasLifecycleCallbacksTest.php
@@ -115,7 +115,11 @@ abstract class HasLifecycleCallbacksSuper
 
     public $invoked = [];
 
-    /** @ODM\PrePersist */
+    /**
+     * @ODM\PrePersist
+     *
+     * @return void
+     */
     public function prePersist()
     {
         $this->invoked[] = 'super';
@@ -130,7 +134,11 @@ abstract class HasLifecycleCallbacksSuperAnnotated
 
     public $invoked = [];
 
-    /** @ODM\PrePersist */
+    /**
+     * @ODM\PrePersist
+     *
+     * @return void
+     */
     public function prePersist()
     {
         $this->invoked[] = 'super';
@@ -160,7 +168,11 @@ class HasLifecycleCallbacksSubAnnotatedExtendsSuperAnnotated extends HasLifecycl
 /** @ODM\Document */
 class HasLifecycleCallbacksSubOverrideExtendsSuper extends HasLifecycleCallbacksSuper
 {
-    /** @ODM\PrePersist */
+    /**
+     * @ODM\PrePersist
+     *
+     * @return void
+     */
     public function prePersist()
     {
         $this->invoked[] = 'sub';
@@ -170,7 +182,11 @@ class HasLifecycleCallbacksSubOverrideExtendsSuper extends HasLifecycleCallbacks
 /** @ODM\Document */
 class HasLifecycleCallbacksSubOverrideExtendsSuperAnnotated extends HasLifecycleCallbacksSuperAnnotated
 {
-    /** @ODM\PrePersist */
+    /**
+     * @ODM\PrePersist
+     *
+     * @return void
+     */
     public function prePersist()
     {
         $this->invoked[] = 'sub';
@@ -180,7 +196,11 @@ class HasLifecycleCallbacksSubOverrideExtendsSuperAnnotated extends HasLifecycle
 /** @ODM\Document @ODM\HasLifecycleCallbacks */
 class HasLifecycleCallbacksSubOverrideAnnotatedExtendsSuper extends HasLifecycleCallbacksSuper
 {
-    /** @ODM\PrePersist */
+    /**
+     * @ODM\PrePersist
+     *
+     * @return void
+     */
     public function prePersist()
     {
         $this->invoked[] = 'sub';
@@ -190,7 +210,11 @@ class HasLifecycleCallbacksSubOverrideAnnotatedExtendsSuper extends HasLifecycle
 /** @ODM\Document @ODM\HasLifecycleCallbacks */
 class HasLifecycleCallbacksSubOverrideAnnotatedExtendsSuperAnnotated extends HasLifecycleCallbacksSuperAnnotated
 {
-    /** @ODM\PrePersist */
+    /**
+     * @ODM\PrePersist
+     *
+     * @return void
+     */
     public function prePersist()
     {
         $this->invoked[] = 'sub';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/HasLifecycleCallbacksTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/HasLifecycleCallbacksTest.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class HasLifecycleCallbacksTest extends BaseTest
 {
-    public function testHasLifecycleCallbacksSubExtendsSuper()
+    public function testHasLifecycleCallbacksSubExtendsSuper(): void
     {
         $document = new HasLifecycleCallbacksSubExtendsSuper();
         $this->dm->persist($document);
@@ -19,7 +19,7 @@ class HasLifecycleCallbacksTest extends BaseTest
         $this->assertCount(0, $document->invoked);
     }
 
-    public function testHasLifecycleCallbacksSubExtendsSuperAnnotated()
+    public function testHasLifecycleCallbacksSubExtendsSuperAnnotated(): void
     {
         $document = new HasLifecycleCallbacksSubExtendsSuperAnnotated();
         $this->dm->persist($document);
@@ -32,7 +32,7 @@ class HasLifecycleCallbacksTest extends BaseTest
         $this->assertEquals('super', $document->invoked[0]);
     }
 
-    public function testHasLifecycleCallbacksSubAnnotatedExtendsSuper()
+    public function testHasLifecycleCallbacksSubAnnotatedExtendsSuper(): void
     {
         $document = new HasLifecycleCallbacksSubAnnotatedExtendsSuper();
         $this->dm->persist($document);
@@ -44,7 +44,7 @@ class HasLifecycleCallbacksTest extends BaseTest
         $this->assertCount(0, $document->invoked);
     }
 
-    public function testHasLifecycleCallbacksSubAnnotatedExtendsSuperAnnotated()
+    public function testHasLifecycleCallbacksSubAnnotatedExtendsSuperAnnotated(): void
     {
         $document = new HasLifecycleCallbacksSubAnnotatedExtendsSuperAnnotated();
         $this->dm->persist($document);
@@ -57,7 +57,7 @@ class HasLifecycleCallbacksTest extends BaseTest
         $this->assertEquals('super', $document->invoked[0]);
     }
 
-    public function testHasLifecycleCallbacksSubOverrideExtendsSuper()
+    public function testHasLifecycleCallbacksSubOverrideExtendsSuper(): void
     {
         $document = new HasLifecycleCallbacksSubOverrideExtendsSuper();
         $this->dm->persist($document);
@@ -67,7 +67,7 @@ class HasLifecycleCallbacksTest extends BaseTest
         $this->assertCount(0, $document->invoked);
     }
 
-    public function testHasLifecycleCallbacksSubOverrideExtendsSuperAnnotated()
+    public function testHasLifecycleCallbacksSubOverrideExtendsSuperAnnotated(): void
     {
         $document = new HasLifecycleCallbacksSubOverrideExtendsSuperAnnotated();
         $this->dm->persist($document);
@@ -80,7 +80,7 @@ class HasLifecycleCallbacksTest extends BaseTest
         $this->assertEquals('sub', $document->invoked[0]);
     }
 
-    public function testHasLifecycleCallbacksSubOverrideAnnotatedExtendsSuper()
+    public function testHasLifecycleCallbacksSubOverrideAnnotatedExtendsSuper(): void
     {
         $document = new HasLifecycleCallbacksSubOverrideAnnotatedExtendsSuper();
         $this->dm->persist($document);
@@ -93,7 +93,7 @@ class HasLifecycleCallbacksTest extends BaseTest
         $this->assertEquals('sub', $document->invoked[0]);
     }
 
-    public function testHasLifecycleCallbacksSubOverrideAnnotatedExtendsSuperAnnotated()
+    public function testHasLifecycleCallbacksSubOverrideAnnotatedExtendsSuperAnnotated(): void
     {
         $document = new HasLifecycleCallbacksSubOverrideAnnotatedExtendsSuperAnnotated();
         $this->dm->persist($document);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
@@ -356,7 +356,7 @@ class IdTest extends BaseTest
         $this->dm->persist($user);
     }
 
-    private function createIdTestClass($type, $strategy)
+    private function createIdTestClass($type, $strategy): string
     {
         $shortClassName = sprintf('TestIdTypes%s%sUser', ucfirst($type), ucfirst($strategy));
         $className      = sprintf(__NAMESPACE__ . '\\%s', $shortClassName);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
@@ -27,7 +27,7 @@ use function unserialize;
 
 class IdTest extends BaseTest
 {
-    public function testUuidId()
+    public function testUuidId(): void
     {
         $user = new UuidUser('Jonathan H. Wage');
         $this->dm->persist($user);
@@ -49,7 +49,7 @@ class IdTest extends BaseTest
         $this->assertSame($check2, $check3);
     }
 
-    public function testAlnumIdChars()
+    public function testAlnumIdChars(): void
     {
         $user = new AlnumCharsUser('Jonathan H. Wage');
         $this->dm->persist($user);
@@ -72,7 +72,7 @@ class IdTest extends BaseTest
         $this->assertSame($check2, $check3);
     }
 
-    public function testCollectionId()
+    public function testCollectionId(): void
     {
         $user1            = new CollectionIdUser('Jonathan H. Wage');
         $reference1       = new ReferencedCollectionId('referenced 1');
@@ -106,7 +106,7 @@ class IdTest extends BaseTest
         $this->assertNotNull($check);
     }
 
-    public function testCollectionIdWithStartingId()
+    public function testCollectionIdWithStartingId(): void
     {
         $user1 = new CollectionIdUserWithStartingId('Jonathan H. Wage');
         $user2 = new CollectionIdUserWithStartingId('Jonathan H. Wage');
@@ -120,7 +120,7 @@ class IdTest extends BaseTest
         $this->assertEquals(11, $user2->id);
     }
 
-    public function testEmbeddedDocumentWithId()
+    public function testEmbeddedDocumentWithId(): void
     {
         $user1             = new CollectionIdUser('Jonathan H. Wage');
         $user1->embedded[] = new EmbeddedCollectionId('embedded #1');
@@ -144,7 +144,7 @@ class IdTest extends BaseTest
         $this->assertEquals(4, $user2->embedded[1]->id);
     }
 
-    public function testIdGeneratorInstance()
+    public function testIdGeneratorInstance(): void
     {
         $class = $this->dm->getClassMetadata(UuidUser::class);
         $this->assertEquals(ClassMetadata::GENERATOR_TYPE_UUID, $class->generatorType);
@@ -164,7 +164,7 @@ class IdTest extends BaseTest
     /**
      * @dataProvider provideEqualButNotIdenticalIds
      */
-    public function testEqualButNotIdenticalIds($user1Id, $user2Id)
+    public function testEqualButNotIdenticalIds($user1Id, $user2Id): void
     {
         $this->assertNotSame($user1Id, $user2Id);
 
@@ -190,7 +190,7 @@ class IdTest extends BaseTest
         $this->assertSame($user2->id, $user2Id);
     }
 
-    public function provideEqualButNotIdenticalIds()
+    public function provideEqualButNotIdenticalIds(): array
     {
         /* MongoDB allows comparisons between different numeric types, so we
          * cannot test integer and floating point values (e.g. 123 and 123.0).
@@ -208,7 +208,7 @@ class IdTest extends BaseTest
     /**
      * @dataProvider getTestIdTypesAndStrategiesData
      */
-    public function testIdTypesAndStrategies($type, $strategy, $id = null, $expected = null, $expectedMongoType = null)
+    public function testIdTypesAndStrategies($type, $strategy, $id = null, $expected = null, $expectedMongoType = null): void
     {
         $className = $this->createIdTestClass($type, $strategy);
 
@@ -245,7 +245,7 @@ class IdTest extends BaseTest
         $this->assertEquals('changed', $object->test);
     }
 
-    public function getTestIdTypesAndStrategiesData()
+    public function getTestIdTypesAndStrategiesData(): array
     {
         $identifier = new ObjectId();
 
@@ -305,7 +305,7 @@ class IdTest extends BaseTest
     /**
      * @dataProvider getTestBinIdsData
      */
-    public function testBinIds($type, $expectedMongoBinDataType, $id)
+    public function testBinIds($type, $expectedMongoBinDataType, $id): void
     {
         $className = $this->createIdTestClass($type, 'none');
 
@@ -322,7 +322,7 @@ class IdTest extends BaseTest
         $this->assertEquals($expectedMongoBinDataType, $check['_id']->getType());
     }
 
-    public function getTestBinIdsData()
+    public function getTestBinIdsData(): array
     {
         return [
             ['bin', 0, 'test-data'],
@@ -334,7 +334,7 @@ class IdTest extends BaseTest
         ];
     }
 
-    public function testStrategyNoneAndNoIdThrowsException()
+    public function testStrategyNoneAndNoIdThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -344,7 +344,7 @@ class IdTest extends BaseTest
         $this->dm->persist(new CustomIdUser('Maciej'));
     }
 
-    public function testStrategyAutoWithNotValidIdThrowsException()
+    public function testStrategyAutoWithNotValidIdThrowsException(): void
     {
         $user     = new TestIdTypesIdAutoUser();
         $user->id = 1;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdentifiersTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdentifiersTest.php
@@ -13,7 +13,7 @@ use function get_class;
 
 class IdentifiersTest extends BaseTest
 {
-    public function testGetIdentifierValue()
+    public function testGetIdentifierValue(): void
     {
         $user = new User();
         $user->setUsername('jwage');
@@ -43,7 +43,7 @@ class IdentifiersTest extends BaseTest
         $this->assertTrue($test->getUser()->isProxyInitialized());
     }
 
-    public function testIdentifiersAreSet()
+    public function testIdentifiersAreSet(): void
     {
         $user = new User();
         $user->setUsername('jwage');
@@ -55,7 +55,7 @@ class IdentifiersTest extends BaseTest
         $this->assertNotSame('', $user->getId());
     }
 
-    public function testIdentityMap()
+    public function testIdentityMap(): void
     {
         $user = new User();
         $user->setUsername('jwage');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
@@ -10,7 +10,7 @@ use MongoDB\Driver\Exception\BulkWriteException;
 
 class IndexesTest extends BaseTest
 {
-    private function uniqueTest($class)
+    private function uniqueTest($class): void
     {
         $this->dm->getSchemaManager()->ensureDocumentIndexes($class);
 
@@ -34,7 +34,7 @@ class IndexesTest extends BaseTest
         $this->dm->flush();
     }
 
-    public function testEmbeddedIndexes()
+    public function testEmbeddedIndexes(): void
     {
         $class   = $this->dm->getClassMetadata(DocumentWithEmbeddedIndexes::class);
         $sm      = $this->dm->getSchemaManager();
@@ -53,7 +53,7 @@ class IndexesTest extends BaseTest
         $this->assertEquals(1, $indexes[3]['keys']['embeddedSecondary.embeddedMany.name']);
     }
 
-    public function testDiscriminatedEmbeddedIndexes()
+    public function testDiscriminatedEmbeddedIndexes(): void
     {
         $class   = $this->dm->getClassMetadata(DocumentWithIndexInDiscriminatedEmbeds::class);
         $sm      = $this->dm->getSchemaManager();
@@ -69,7 +69,7 @@ class IndexesTest extends BaseTest
         $this->assertEquals(1, $indexes[2]['keys']['embedded.value']);
     }
 
-    public function testDiscriminatorIndexes()
+    public function testDiscriminatorIndexes(): void
     {
         $class   = $this->dm->getClassMetadata(DocumentWithDiscriminatorIndex::class);
         $sm      = $this->dm->getSchemaManager();
@@ -79,7 +79,7 @@ class IndexesTest extends BaseTest
         $this->assertEquals(1, $indexes[0]['keys']['type']);
     }
 
-    public function testMultipleIndexAnnotations()
+    public function testMultipleIndexAnnotations(): void
     {
         $class   = $this->dm->getClassMetadata(DocumentWithMultipleIndexAnnotations::class);
         $sm      = $this->dm->getSchemaManager();
@@ -101,7 +101,7 @@ class IndexesTest extends BaseTest
         $this->assertEquals(true, $indexes[2]['options']['sparse']);
     }
 
-    public function testIndexDefinitions()
+    public function testIndexDefinitions(): void
     {
         $class   = $this->dm->getClassMetadata(UniqueOnFieldTest::class);
         $indexes = $class->getIndexes();
@@ -192,42 +192,42 @@ class IndexesTest extends BaseTest
         $this->assertEquals('test', $indexes[0]['options']['name']);
     }
 
-    public function testUniqueIndexOnField()
+    public function testUniqueIndexOnField(): void
     {
         $this->expectException(BulkWriteException::class);
         $this->expectExceptionMessage('duplicate key error');
         $this->uniqueTest(UniqueOnFieldTest::class);
     }
 
-    public function testUniqueIndexOnDocument()
+    public function testUniqueIndexOnDocument(): void
     {
         $this->expectException(BulkWriteException::class);
         $this->expectExceptionMessage('duplicate key error');
         $this->uniqueTest(UniqueOnDocumentTest::class);
     }
 
-    public function testIndexesOnDocument()
+    public function testIndexesOnDocument(): void
     {
         $this->expectException(BulkWriteException::class);
         $this->expectExceptionMessage('duplicate key error');
         $this->uniqueTest(IndexesOnDocumentTest::class);
     }
 
-    public function testMultipleFieldsUniqueIndexOnDocument()
+    public function testMultipleFieldsUniqueIndexOnDocument(): void
     {
         $this->expectException(BulkWriteException::class);
         $this->expectExceptionMessage('duplicate key error');
         $this->uniqueTest(MultipleFieldsUniqueIndexTest::class);
     }
 
-    public function testMultipleFieldIndexes()
+    public function testMultipleFieldIndexes(): void
     {
         $this->expectException(BulkWriteException::class);
         $this->expectExceptionMessage('duplicate key error');
         $this->uniqueTest(MultipleFieldIndexes::class);
     }
 
-    public function testPartialIndexCreation()
+    public function testPartialIndexCreation(): void
     {
         $className = PartialIndexOnDocumentTest::class;
         $this->dm->getSchemaManager()->ensureDocumentIndexes($className);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/InheritanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/InheritanceTest.php
@@ -15,7 +15,7 @@ use Documents\User;
 
 class InheritanceTest extends BaseTest
 {
-    public function testCollectionPerClassInheritance()
+    public function testCollectionPerClassInheritance(): void
     {
         $profile = new Profile();
         $profile->setFirstName('Jon');
@@ -47,7 +47,7 @@ class InheritanceTest extends BaseTest
         $this->assertInstanceOf(SpecialUser::class, $user);
     }
 
-    public function testSingleCollectionInhertiance()
+    public function testSingleCollectionInhertiance(): void
     {
         $subProject = new SubProject('Sub Project');
         $this->dm->persist($subProject);
@@ -85,7 +85,7 @@ class InheritanceTest extends BaseTest
         $this->assertInstanceOf(OtherSubProject::class, $document);
     }
 
-    public function testPrePersistIsCalledFromMappedSuperClass()
+    public function testPrePersistIsCalledFromMappedSuperClass(): void
     {
         $user = new User();
         $user->setUsername('test');
@@ -94,7 +94,7 @@ class InheritanceTest extends BaseTest
         $this->assertTrue($user->persisted);
     }
 
-    public function testInheritanceProxy()
+    public function testInheritanceProxy(): void
     {
         $developer = new Developer('avalanche123');
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/CachingIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/CachingIteratorTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Iterator;
 
 use Doctrine\ODM\MongoDB\Iterator\CachingIterator;
 use Exception;
+use Generator;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
@@ -16,7 +17,7 @@ class CachingIteratorTest extends TestCase
     /**
      * Sanity check for all following tests.
      */
-    public function testTraversingGeneratorConsumesIt()
+    public function testTraversingGeneratorConsumesIt(): void
     {
         $iterator = $this->getTraversable([1, 2, 3]);
         $this->assertSame([1, 2, 3], iterator_to_array($iterator));
@@ -25,7 +26,7 @@ class CachingIteratorTest extends TestCase
         $this->assertSame([1, 2, 3], iterator_to_array($iterator));
     }
 
-    public function testConstructorRewinds()
+    public function testConstructorRewinds(): void
     {
         $iterator = new CachingIterator($this->getTraversable([1, 2, 3]));
 
@@ -34,7 +35,7 @@ class CachingIteratorTest extends TestCase
         $this->assertSame(1, $iterator->current());
     }
 
-    public function testIteration()
+    public function testIteration(): void
     {
         $iterator = new CachingIterator($this->getTraversable([1, 2, 3]));
 
@@ -49,7 +50,7 @@ class CachingIteratorTest extends TestCase
         $this->assertFalse($iterator->valid());
     }
 
-    public function testIterationWithEmptySet()
+    public function testIterationWithEmptySet(): void
     {
         $iterator = new CachingIterator($this->getTraversable([]));
 
@@ -57,7 +58,7 @@ class CachingIteratorTest extends TestCase
         $this->assertFalse($iterator->valid());
     }
 
-    public function testPartialIterationDoesNotExhaust()
+    public function testPartialIterationDoesNotExhaust(): void
     {
         $traversable = $this->getTraversableThatThrows([1, 2, new Exception()]);
         $iterator    = new CachingIterator($traversable);
@@ -77,7 +78,7 @@ class CachingIteratorTest extends TestCase
         $this->assertTrue($iterator->valid());
     }
 
-    public function testRewindAfterPartialIteration()
+    public function testRewindAfterPartialIteration(): void
     {
         $iterator = new CachingIterator($this->getTraversable([1, 2, 3]));
 
@@ -90,13 +91,13 @@ class CachingIteratorTest extends TestCase
         $this->assertSame([1, 2, 3], iterator_to_array($iterator));
     }
 
-    public function testToArray()
+    public function testToArray(): void
     {
         $iterator = new CachingIterator($this->getTraversable([1, 2, 3]));
         $this->assertSame([1, 2, 3], $iterator->toArray());
     }
 
-    public function testToArrayAfterPartialIteration()
+    public function testToArrayAfterPartialIteration(): void
     {
         $iterator = new CachingIterator($this->getTraversable([1, 2, 3]));
 
@@ -109,14 +110,14 @@ class CachingIteratorTest extends TestCase
         $this->assertSame([1, 2, 3], $iterator->toArray());
     }
 
-    private function getTraversable($items)
+    private function getTraversable($items): Generator
     {
         foreach ($items as $item) {
             yield $item;
         }
     }
 
-    private function getTraversableThatThrows($items)
+    private function getTraversableThatThrows($items): Generator
     {
         foreach ($items as $item) {
             if ($item instanceof Exception) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/HydratingIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/HydratingIteratorTest.php
@@ -7,13 +7,14 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Iterator;
 use Doctrine\ODM\MongoDB\Iterator\HydratingIterator;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\User;
+use Generator;
 use MongoDB\BSON\ObjectId;
 
 use function is_array;
 
 final class HydratingIteratorTest extends BaseTest
 {
-    public function testConstructorRewinds()
+    public function testConstructorRewinds(): void
     {
         $iterator = new HydratingIterator($this->getTraversable(), $this->uow, $this->dm->getClassMetadata(User::class));
 
@@ -22,7 +23,7 @@ final class HydratingIteratorTest extends BaseTest
         $this->assertInstanceOf(User::class, $iterator->current());
     }
 
-    public function testIteration()
+    public function testIteration(): void
     {
         $iterator = new HydratingIterator($this->getTraversable(), $this->uow, $this->dm->getClassMetadata(User::class));
 
@@ -39,7 +40,7 @@ final class HydratingIteratorTest extends BaseTest
         $this->assertFalse($iterator->valid());
     }
 
-    public function testIterationWithEmptySet()
+    public function testIterationWithEmptySet(): void
     {
         $iterator = new HydratingIterator($this->getTraversable([]), $this->uow, $this->dm->getClassMetadata(User::class));
 
@@ -47,7 +48,7 @@ final class HydratingIteratorTest extends BaseTest
         $this->assertFalse($iterator->valid());
     }
 
-    private function getTraversable($items = null)
+    private function getTraversable($items = null): Generator
     {
         if (! is_array($items)) {
             $items = [

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/PrimingIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/PrimingIteratorTest.php
@@ -21,7 +21,7 @@ final class PrimingIteratorTest extends BaseTest
 {
     private $callbackCalls = [];
 
-    public function testPrimerIsCalledOnceForEveryField()
+    public function testPrimerIsCalledOnceForEveryField(): void
     {
         $primer   = new ReferencePrimer($this->dm, $this->uow);
         $class    = $this->dm->getClassMetadata(User::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/UnrewindableIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/UnrewindableIteratorTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Iterator;
 
 use Doctrine\ODM\MongoDB\Iterator\UnrewindableIterator;
 use Exception;
+use Generator;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -17,7 +18,7 @@ class UnrewindableIteratorTest extends TestCase
     /**
      * Sanity check for all following tests.
      */
-    public function testTraversingGeneratorConsumesIt()
+    public function testTraversingGeneratorConsumesIt(): void
     {
         $iterator = $this->getTraversable([1, 2, 3]);
         $this->assertSame([1, 2, 3], iterator_to_array($iterator));
@@ -26,7 +27,7 @@ class UnrewindableIteratorTest extends TestCase
         $this->assertSame([1, 2, 3], iterator_to_array($iterator));
     }
 
-    public function testConstructorRewinds()
+    public function testConstructorRewinds(): void
     {
         $iterator = new UnrewindableIterator($this->getTraversable([1, 2, 3]));
 
@@ -35,7 +36,7 @@ class UnrewindableIteratorTest extends TestCase
         $this->assertSame(1, $iterator->current());
     }
 
-    public function testIteration()
+    public function testIteration(): void
     {
         $iterator = new UnrewindableIterator($this->getTraversable([1, 2, 3]));
 
@@ -50,7 +51,7 @@ class UnrewindableIteratorTest extends TestCase
         $this->assertFalse($iterator->valid());
     }
 
-    public function testIterationWithEmptySet()
+    public function testIterationWithEmptySet(): void
     {
         $iterator = new UnrewindableIterator($this->getTraversable([]));
 
@@ -58,14 +59,14 @@ class UnrewindableIteratorTest extends TestCase
         $this->assertFalse($iterator->valid());
     }
 
-    public function testToArrayWithEmptySet()
+    public function testToArrayWithEmptySet(): void
     {
         $iterator = new UnrewindableIterator($this->getTraversable([]));
 
         $this->assertEquals([], $iterator->toArray());
     }
 
-    public function testPartialIterationDoesNotExhaust()
+    public function testPartialIterationDoesNotExhaust(): void
     {
         $traversable = $this->getTraversableThatThrows([1, 2, new Exception()]);
         $iterator    = new UnrewindableIterator($traversable);
@@ -85,7 +86,7 @@ class UnrewindableIteratorTest extends TestCase
         $this->assertTrue($iterator->valid());
     }
 
-    public function testRewindAfterPartialIteration()
+    public function testRewindAfterPartialIteration(): void
     {
         $iterator = new UnrewindableIterator($this->getTraversable([1, 2, 3]));
 
@@ -99,13 +100,13 @@ class UnrewindableIteratorTest extends TestCase
         iterator_to_array($iterator);
     }
 
-    public function testToArray()
+    public function testToArray(): void
     {
         $iterator = new UnrewindableIterator($this->getTraversable([1, 2, 3]));
         $this->assertSame([1, 2, 3], $iterator->toArray());
     }
 
-    public function testToArrayAfterPartialIteration()
+    public function testToArrayAfterPartialIteration(): void
     {
         $iterator = new UnrewindableIterator($this->getTraversable([1, 2, 3]));
 
@@ -119,14 +120,14 @@ class UnrewindableIteratorTest extends TestCase
         $iterator->toArray();
     }
 
-    private function getTraversable($items)
+    private function getTraversable($items): Generator
     {
         foreach ($items as $item) {
             yield $item;
         }
     }
 
-    private function getTraversableThatThrows($items)
+    private function getTraversableThatThrows($items): Generator
     {
         foreach ($items as $item) {
             if ($item instanceof Exception) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LifecycleTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LifecycleTest.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class LifecycleTest extends BaseTest
 {
-    public function testEventOnDoubleFlush()
+    public function testEventOnDoubleFlush(): void
     {
         $parent = new ParentObject('parent', new ChildObject('child'), new ChildEmbeddedObject('child embedded'));
         $this->dm->persist($parent);
@@ -33,7 +33,7 @@ class LifecycleTest extends BaseTest
         $this->assertEquals('changed', $parent->getChildEmbedded()->getName());
     }
 
-    public function testEventEmptyFlush()
+    public function testEventEmptyFlush(): void
     {
         $parent = new ParentObject('parent', new ChildObject('child'), new ChildEmbeddedObject('child embedded'));
 
@@ -86,13 +86,13 @@ class ParentObject
     }
 
     /** @ODM\PrePersist @ODM\PreUpdate */
-    public function prePersistPreUpdate()
+    public function prePersistPreUpdate(): void
     {
         $this->children = [$this->child];
     }
 
     /** @ODM\PreUpdate */
-    public function preUpdate()
+    public function preUpdate(): void
     {
         $this->childEmbedded->setName('changed');
     }
@@ -102,12 +102,12 @@ class ParentObject
         return $this->children;
     }
 
-    public function getChildEmbedded()
+    public function getChildEmbedded(): ChildEmbeddedObject
     {
         return $this->childEmbedded;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -149,7 +149,7 @@ class ChildEmbeddedObject
         $this->name = $name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
@@ -22,7 +22,7 @@ use function time;
 
 class LockTest extends BaseTest
 {
-    public function testOptimisticLockIntSetInitialVersion()
+    public function testOptimisticLockIntSetInitialVersion(): void
     {
         $article = new LockInt('Test LockInt');
         $this->dm->persist($article);
@@ -36,7 +36,7 @@ class LockTest extends BaseTest
         $this->assertEquals(2, $article->version);
     }
 
-    public function testOptimisticLockIntSetInitialVersionOnUpsert()
+    public function testOptimisticLockIntSetInitialVersionOnUpsert(): void
     {
         $id = new ObjectId();
 
@@ -55,7 +55,7 @@ class LockTest extends BaseTest
         $this->assertEquals(2, $article->version);
     }
 
-    public function testOptimisticLockingIntThrowsException()
+    public function testOptimisticLockingIntThrowsException(): void
     {
         $article = new LockInt('Test LockInt');
         $this->dm->persist($article);
@@ -72,7 +72,7 @@ class LockTest extends BaseTest
         $this->dm->flush();
     }
 
-    public function testMultipleFlushesDoIncrementalUpdates()
+    public function testMultipleFlushesDoIncrementalUpdates(): void
     {
         $test = new LockInt();
 
@@ -86,7 +86,7 @@ class LockTest extends BaseTest
         }
     }
 
-    public function testLockDateSetsDefaultValue()
+    public function testLockDateSetsDefaultValue(): LockDate
     {
         $test        = new LockDate();
         $test->title = 'Testing';
@@ -108,7 +108,7 @@ class LockTest extends BaseTest
         return $test;
     }
 
-    public function testLockDateImmutableSetsDefaultValue()
+    public function testLockDateImmutableSetsDefaultValue(): LockDateImmutable
     {
         $test        = new LockDateImmutable();
         $test->title = 'Testing';
@@ -130,7 +130,7 @@ class LockTest extends BaseTest
         return $test;
     }
 
-    public function testLockDecimal128SetsDefaultValue()
+    public function testLockDecimal128SetsDefaultValue(): LockDecimal128
     {
         $test        = new LockDecimal128();
         $test->title = 'Testing';
@@ -152,7 +152,7 @@ class LockTest extends BaseTest
         return $test;
     }
 
-    public function testLockDateSetsDefaultValueOnUpsert()
+    public function testLockDateSetsDefaultValueOnUpsert(): LockDate
     {
         $id = new ObjectId();
 
@@ -178,7 +178,7 @@ class LockTest extends BaseTest
         return $test;
     }
 
-    public function testLockDateImmutableSetsDefaultValueOnUpsert()
+    public function testLockDateImmutableSetsDefaultValueOnUpsert(): LockDateImmutable
     {
         $id = new ObjectId();
 
@@ -204,7 +204,7 @@ class LockTest extends BaseTest
         return $test;
     }
 
-    public function testLockDecimal128SetsDefaultValueOnUpsert()
+    public function testLockDecimal128SetsDefaultValueOnUpsert(): LockDecimal128
     {
         $id = new ObjectId();
 
@@ -230,7 +230,7 @@ class LockTest extends BaseTest
         return $test;
     }
 
-    public function testLockDateThrowsException()
+    public function testLockDateThrowsException(): void
     {
         $article = new LockDate('Test LockInt');
         $this->dm->persist($article);
@@ -247,7 +247,7 @@ class LockTest extends BaseTest
         $this->dm->flush();
     }
 
-    public function testLockDateImmutableThrowsException()
+    public function testLockDateImmutableThrowsException(): void
     {
         $article = new LockDateImmutable('Test LockInt');
         $this->dm->persist($article);
@@ -264,7 +264,7 @@ class LockTest extends BaseTest
         $this->dm->flush();
     }
 
-    public function testLockDecimal128ThrowsException()
+    public function testLockDecimal128ThrowsException(): void
     {
         $article = new LockDecimal128('Test LockDecimal128');
         $this->dm->persist($article);
@@ -284,7 +284,7 @@ class LockTest extends BaseTest
     /**
      * @doesNotPerformAssertions
      */
-    public function testLockVersionedDocument()
+    public function testLockVersionedDocument(): void
     {
         $article        = new LockInt();
         $article->title = 'my article';
@@ -295,7 +295,7 @@ class LockTest extends BaseTest
         $this->dm->lock($article, LockMode::OPTIMISTIC, $article->version);
     }
 
-    public function testLockVersionedDocumentMissmatchThrowsException()
+    public function testLockVersionedDocumentMissmatchThrowsException(): void
     {
         $article        = new LockInt();
         $article->title = 'my article';
@@ -308,7 +308,7 @@ class LockTest extends BaseTest
         $this->dm->lock($article, LockMode::OPTIMISTIC, $article->version + 1);
     }
 
-    public function testLockUnversionedDocumentThrowsException()
+    public function testLockUnversionedDocumentThrowsException(): void
     {
         $user = new User();
         $user->setUsername('test');
@@ -322,7 +322,7 @@ class LockTest extends BaseTest
         $this->dm->lock($user, LockMode::OPTIMISTIC);
     }
 
-    public function testLockUnmanagedDocumentThrowsException()
+    public function testLockUnmanagedDocumentThrowsException(): void
     {
         $article = new LockInt();
 
@@ -332,7 +332,7 @@ class LockTest extends BaseTest
         $this->dm->lock($article, LockMode::OPTIMISTIC, $article->version + 1);
     }
 
-    public function testLockPessimisticWrite()
+    public function testLockPessimisticWrite(): void
     {
         $article        = new LockInt();
         $article->title = 'my article';
@@ -346,7 +346,7 @@ class LockTest extends BaseTest
         $this->assertEquals(LockMode::PESSIMISTIC_WRITE, $check['locked']);
     }
 
-    public function testLockPessimisticRead()
+    public function testLockPessimisticRead(): void
     {
         $article        = new LockInt();
         $article->title = 'my article';
@@ -360,7 +360,7 @@ class LockTest extends BaseTest
         $this->assertEquals(LockMode::PESSIMISTIC_READ, $check['locked']);
     }
 
-    public function testUnlock()
+    public function testUnlock(): void
     {
         $article        = new LockInt();
         $article->title = 'my article';
@@ -381,7 +381,7 @@ class LockTest extends BaseTest
         $this->assertNull($article->locked);
     }
 
-    public function testPessimisticReadLockThrowsExceptionOnRemove()
+    public function testPessimisticReadLockThrowsExceptionOnRemove(): void
     {
         $article        = new LockInt();
         $article->title = 'my article';
@@ -398,7 +398,7 @@ class LockTest extends BaseTest
         $this->dm->flush();
     }
 
-    public function testPessimisticReadLockThrowsExceptionOnUpdate()
+    public function testPessimisticReadLockThrowsExceptionOnUpdate(): void
     {
         $article        = new LockInt();
         $article->title = 'my article';
@@ -415,7 +415,7 @@ class LockTest extends BaseTest
         $this->dm->flush();
     }
 
-    public function testPessimisticWriteLockThrowExceptionOnRemove()
+    public function testPessimisticWriteLockThrowExceptionOnRemove(): void
     {
         $article        = new LockInt();
         $article->title = 'my article';
@@ -432,7 +432,7 @@ class LockTest extends BaseTest
         $this->dm->flush();
     }
 
-    public function testPessimisticWriteLockThrowExceptionOnUpdate()
+    public function testPessimisticWriteLockThrowExceptionOnUpdate(): void
     {
         $article        = new LockInt();
         $article->title = 'my article';
@@ -449,7 +449,7 @@ class LockTest extends BaseTest
         $this->dm->flush();
     }
 
-    public function testPessimisticWriteLockThrowExceptionOnRead()
+    public function testPessimisticWriteLockThrowExceptionOnRead(): void
     {
         $article        = new LockInt();
         $article->title = 'my article';
@@ -466,7 +466,7 @@ class LockTest extends BaseTest
         $article = $this->dm->find(LockInt::class, $article->id);
     }
 
-    public function testPessimisticReadLockFunctional()
+    public function testPessimisticReadLockFunctional(): void
     {
         $article        = new LockInt();
         $article->title = 'my article';
@@ -485,7 +485,7 @@ class LockTest extends BaseTest
         $this->assertEquals('test', $check['title']);
     }
 
-    public function testPessimisticWriteLockFunctional()
+    public function testPessimisticWriteLockFunctional(): void
     {
         $article        = new LockInt();
         $article->title = 'my article';
@@ -504,21 +504,21 @@ class LockTest extends BaseTest
         $this->assertEquals('test', $check['title']);
     }
 
-    public function testInvalidLockDocument()
+    public function testInvalidLockDocument(): void
     {
         $this->expectException(MongoDBException::class);
         $this->expectExceptionMessage('Invalid lock field type string. Lock field must be int.');
         $this->dm->getClassMetadata(InvalidLockDocument::class);
     }
 
-    public function testInvalidVersionDocument()
+    public function testInvalidVersionDocument(): void
     {
         $this->expectException(MongoDBException::class);
         $this->expectExceptionMessage('Type string does not implement Versionable interface.');
         $this->dm->getClassMetadata(InvalidVersionDocument::class);
     }
 
-    public function testUpdatingCollectionRespectsVersionNumber()
+    public function testUpdatingCollectionRespectsVersionNumber(): void
     {
         $d = new LockInt('test');
         $d->issues->add(new Issue('hi', 'ohai'));
@@ -537,7 +537,7 @@ class LockTest extends BaseTest
         $this->uow->getCollectionPersister()->update($d, [$d->issues], []);
     }
 
-    public function testDeletingCollectionRespectsVersionNumber()
+    public function testDeletingCollectionRespectsVersionNumber(): void
     {
         $d = new LockInt('test');
         $d->issues->add(new Issue('hi', 'ohai'));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/MappedSuperclassTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/MappedSuperclassTest.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class MappedSuperclassTest extends BaseTest
 {
-    public function testCRUD()
+    public function testCRUD(): void
     {
         $e = new DocumentSubClass();
         $e->setId(1);
@@ -50,7 +50,7 @@ class MappedSuperclassBase
     /** @ODM\ReferenceOne(targetDocument=MappedSuperclassRelated1::class) */
     private $mappedRelated1;
 
-    public function setMapped1($val)
+    public function setMapped1($val): void
     {
         $this->mapped1 = $val;
     }
@@ -60,7 +60,7 @@ class MappedSuperclassBase
         return $this->mapped1;
     }
 
-    public function setMapped2($val)
+    public function setMapped2($val): void
     {
         $this->mapped2 = $val;
     }
@@ -70,7 +70,7 @@ class MappedSuperclassBase
         return $this->mapped2;
     }
 
-    public function setMappedRelated1($mappedRelated1)
+    public function setMappedRelated1($mappedRelated1): void
     {
         $this->mappedRelated1 = $mappedRelated1;
     }
@@ -90,7 +90,7 @@ class MappedSuperclassRelated1
     /** @ODM\Field(type="string") */
     private $name;
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -100,7 +100,7 @@ class MappedSuperclassRelated1
         return $this->name;
     }
 
-    public function setId($id)
+    public function setId($id): void
     {
         $this->id = $id;
     }
@@ -120,7 +120,7 @@ class DocumentSubClass extends MappedSuperclassBase
     /** @ODM\Field(type="string") */
     private $name;
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -130,7 +130,7 @@ class DocumentSubClass extends MappedSuperclassBase
         return $this->name;
     }
 
-    public function setId($id)
+    public function setId($id): void
     {
         $this->id = $id;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/MemoryUsageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/MemoryUsageTest.php
@@ -26,7 +26,7 @@ class MemoryUsageTest extends BaseTest
     /**
      * Output for jwage "Memory increased by 14.09 kb"
      */
-    public function testMemoryUsage()
+    public function testMemoryUsage(): void
     {
         $memoryUsage = [];
         for ($i = 0; $i < 100; $i++) {
@@ -57,7 +57,7 @@ class MemoryUsageTest extends BaseTest
         echo sprintf('Memory increased by %s', $this->formatMemory($increase));
     }
 
-    private function formatMemory($size)
+    private function formatMemory($size): string
     {
         $unit = ['b', 'kb', 'mb', 'gb', 'tb', 'pb'];
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedCollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedCollectionsTest.php
@@ -17,7 +17,7 @@ class NestedCollectionsTest extends BaseTest
     /**
      * @dataProvider provideStrategy
      */
-    public function testStrategy($field)
+    public function testStrategy($field): void
     {
         $doc         = new DocWithNestedCollections();
         $privateBook = new Phonebook('Private');
@@ -66,7 +66,7 @@ class NestedCollectionsTest extends BaseTest
         $this->assertEquals('10203040', $publicBook->getPhonenumbers()->get(0)->getPhonenumber());
     }
 
-    public function provideStrategy()
+    public function provideStrategy(): array
     {
         return [
             [ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use MongoDB\BSON\ObjectId;
@@ -14,7 +15,7 @@ use function is_string;
 
 class NestedDocumentsTest extends BaseTest
 {
-    public function testSimple()
+    public function testSimple(): void
     {
         $product        = new Product();
         $product->title = 'Product';
@@ -68,7 +69,7 @@ class NestedDocumentsTest extends BaseTest
         $this->assertNotEquals($product->title, $order->product->title);
     }
 
-    public function testNestedCategories()
+    public function testNestedCategories(): void
     {
         $category = new Category('Root');
         $child1   = $category->addChild('Child 1');
@@ -97,7 +98,7 @@ class NestedDocumentsTest extends BaseTest
         $this->assertCount(2, $category->getChildren());
     }
 
-    public function testNestedReference()
+    public function testNestedReference(): void
     {
         $test   = new Hierarchy('Root');
         $child1 = $test->addChild('Child 1');
@@ -161,7 +162,7 @@ class Hierarchy
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -197,7 +198,7 @@ class Hierarchy
         return $child;
     }
 
-    public function getChildren()
+    public function getChildren(): array
     {
         return $this->children;
     }
@@ -218,7 +219,7 @@ class BaseCategory
         $this->children = new ArrayCollection();
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -254,7 +255,7 @@ class BaseCategory
         return $child;
     }
 
-    public function getChildren()
+    public function getChildren(): Collection
     {
         return $this->children;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalEmbedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalEmbedTest.php
@@ -18,7 +18,7 @@ class OrphanRemovalEmbedTest extends BaseTest
     /**
      * Test unsetting an embedOne relationship
      */
-    public function testUnsettingEmbedOne()
+    public function testUnsettingEmbedOne(): void
     {
         $profile          = new OrphanRemovalCascadeProfile();
         $address          = new OrphanRemovalCascadeAddress();
@@ -40,7 +40,7 @@ class OrphanRemovalEmbedTest extends BaseTest
     /**
      * Test Collection::remove() method on an embedMany relationship
      */
-    public function testRemoveEmbedMany()
+    public function testRemoveEmbedMany(): void
     {
         $profile1          = new OrphanRemovalCascadeProfile();
         $address1          = new OrphanRemovalCascadeAddress();
@@ -75,7 +75,7 @@ class OrphanRemovalEmbedTest extends BaseTest
     /**
      * Test Collection::clear() method on an embedMany relationship
      */
-    public function testClearEmbedMany()
+    public function testClearEmbedMany(): void
     {
         $profile1          = new OrphanRemovalCascadeProfile();
         $address1          = new OrphanRemovalCascadeAddress();
@@ -104,7 +104,7 @@ class OrphanRemovalEmbedTest extends BaseTest
     /**
      * Test clearing and adding on an embedMany relationship
      */
-    public function testClearAndAddEmbedMany()
+    public function testClearAndAddEmbedMany(): void
     {
         $profile1          = new OrphanRemovalCascadeProfile();
         $address1          = new OrphanRemovalCascadeAddress();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
@@ -12,7 +12,7 @@ use function assert;
 
 class OrphanRemovalTest extends BaseTest
 {
-    public function testOrphanRemoval()
+    public function testOrphanRemoval(): void
     {
         $profile1      = new OrphanRemovalProfile();
         $user          = new OrphanRemovalUser();
@@ -38,7 +38,7 @@ class OrphanRemovalTest extends BaseTest
         $this->assertNull($this->getProfileRepository()->find($profile2->id), 'Profile 2 should have been removed');
     }
 
-    public function testNoOrphanRemoval()
+    public function testNoOrphanRemoval(): void
     {
         $profile1                     = new OrphanRemovalProfile();
         $user                         = new OrphanRemovalUser();
@@ -64,7 +64,7 @@ class OrphanRemovalTest extends BaseTest
         $this->assertNotNull($this->getProfileRepository()->find($profile2->id), 'Profile 2 should have been left as-is');
     }
 
-    public function testOrphanRemovalOnReferenceMany()
+    public function testOrphanRemovalOnReferenceMany(): void
     {
         $profile1 = new OrphanRemovalProfile();
         $profile2 = new OrphanRemovalProfile();
@@ -84,7 +84,7 @@ class OrphanRemovalTest extends BaseTest
         $this->assertNotNull($this->getProfileRepository()->find($profile2->id), 'Profile 2 should have been left as-is');
     }
 
-    public function testNoOrphanRemovalOnReferenceMany()
+    public function testNoOrphanRemovalOnReferenceMany(): void
     {
         $profile1 = new OrphanRemovalProfile();
         $profile2 = new OrphanRemovalProfile();
@@ -104,7 +104,7 @@ class OrphanRemovalTest extends BaseTest
         $this->assertNotNull($this->getProfileRepository()->find($profile2->id), 'Profile 2 should have been left as-is');
     }
 
-    public function testOrphanRemovalOnReferenceManyUsingClear()
+    public function testOrphanRemovalOnReferenceManyUsingClear(): void
     {
         $profile1 = new OrphanRemovalProfile();
         $profile2 = new OrphanRemovalProfile();
@@ -125,7 +125,7 @@ class OrphanRemovalTest extends BaseTest
         $this->assertNull($this->getProfileRepository()->find($profile2->id), 'Profile 2 should have been removed');
     }
 
-    public function testOrphanRemovalOnReferenceManyUsingClearUninitialized()
+    public function testOrphanRemovalOnReferenceManyUsingClearUninitialized(): void
     {
         $profile1 = new OrphanRemovalProfile();
         $profile2 = new OrphanRemovalProfile();
@@ -150,7 +150,7 @@ class OrphanRemovalTest extends BaseTest
         $this->assertNull($this->getProfileRepository()->find($profile2->id), 'Profile 2 should have been removed');
     }
 
-    public function testOrphanRemovalOnReferenceManyUsingClearAndAddingNewElements()
+    public function testOrphanRemovalOnReferenceManyUsingClearAndAddingNewElements(): void
     {
         $profile1 = new OrphanRemovalProfile();
         $profile2 = new OrphanRemovalProfile();
@@ -176,7 +176,7 @@ class OrphanRemovalTest extends BaseTest
         $this->assertNotNull($this->getProfileRepository()->find($profile3->id), 'Profile 3 should have been created');
     }
 
-    public function testOrphanRemovalOnReferenceManyRemovingAndAddingNewElements()
+    public function testOrphanRemovalOnReferenceManyRemovingAndAddingNewElements(): void
     {
         $profile1 = new OrphanRemovalProfile();
         $profile2 = new OrphanRemovalProfile();
@@ -202,7 +202,7 @@ class OrphanRemovalTest extends BaseTest
         $this->assertNotNull($this->getProfileRepository()->find($profile3->id), 'Profile 3 should have been created');
     }
 
-    public function testOrphanRemovalOnReferenceManyUsingSet()
+    public function testOrphanRemovalOnReferenceManyUsingSet(): void
     {
         $profile1 = new OrphanRemovalProfile();
         $profile2 = new OrphanRemovalProfile();
@@ -227,7 +227,7 @@ class OrphanRemovalTest extends BaseTest
         $this->assertNotNull($this->getProfileRepository()->find($profile3->id), 'Profile 3 should have been created');
     }
 
-    public function testOrphanRemovalWhenRemovingAndAddingSameElement()
+    public function testOrphanRemovalWhenRemovingAndAddingSameElement(): void
     {
         $profile = new OrphanRemovalProfile();
 
@@ -246,7 +246,7 @@ class OrphanRemovalTest extends BaseTest
         $this->assertNotNull($this->getProfileRepository()->find($profile->id), 'Profile 1 should not have been removed');
     }
 
-    public function testOrphanRemovalOnRemoveWithoutCascade()
+    public function testOrphanRemovalOnRemoveWithoutCascade(): void
     {
         $profile1      = new OrphanRemovalProfile();
         $user          = new OrphanRemovalUser();
@@ -261,7 +261,7 @@ class OrphanRemovalTest extends BaseTest
         $this->assertNull($this->getProfileRepository()->find($profile1->id), 'Profile 1 should have been removed');
     }
 
-    public function testOrphanRemovalReferenceManyOnRemoveWithoutCascade()
+    public function testOrphanRemovalReferenceManyOnRemoveWithoutCascade(): void
     {
         $profile1 = new OrphanRemovalProfile();
         $profile2 = new OrphanRemovalProfile();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OwningAndInverseReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OwningAndInverseReferencesTest.php
@@ -22,7 +22,7 @@ use function strtotime;
 
 class OwningAndInverseReferencesTest extends BaseTest
 {
-    public function testOneToOne()
+    public function testOneToOne(): void
     {
         // cart stores reference to customer
         // customer does not store reference to cart
@@ -65,7 +65,7 @@ class OwningAndInverseReferencesTest extends BaseTest
         $this->assertEquals('ok', $customer->cartTest);
     }
 
-    public function testOneToManyBiDirectional()
+    public function testOneToManyBiDirectional(): void
     {
         $product = new Product('Book');
         $product->addFeature(new Feature('Pages'));
@@ -90,7 +90,7 @@ class OwningAndInverseReferencesTest extends BaseTest
         $this->assertEquals('Cover', $features[1]->name);
     }
 
-    public function testOneToManySelfReferencing()
+    public function testOneToManySelfReferencing(): void
     {
         $node = new BrowseNode('Root');
         $node->addChild(new BrowseNode('Child 1'));
@@ -121,7 +121,7 @@ class OwningAndInverseReferencesTest extends BaseTest
         $this->assertCount(2, $root->children);
     }
 
-    public function testManyToMany()
+    public function testManyToMany(): void
     {
         $baseballTag    = new Tag('baseball');
         $blogPost       = new BlogPost();
@@ -154,7 +154,7 @@ class OwningAndInverseReferencesTest extends BaseTest
         $this->assertEquals('Test', $tag->blogPosts[0]->name);
     }
 
-    public function testManyToManySelfReferencing()
+    public function testManyToManySelfReferencing(): void
     {
         $jwage  = new FriendUser('jwage');
         $fabpot = new FriendUser('fabpot');
@@ -213,7 +213,7 @@ class OwningAndInverseReferencesTest extends BaseTest
         $this->dm->clear();
     }
 
-    public function testSortLimitAndSkipReferences()
+    public function testSortLimitAndSkipReferences(): void
     {
         $date1 = new DateTime();
         $date1->setTimestamp(strtotime('-20 seconds'));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionCloneTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionCloneTest.php
@@ -45,7 +45,7 @@ class PersistentCollectionCloneTest extends BaseTest
         $this->user2 = $this->dm->find(get_class($user1), $user2->id);
     }
 
-    public function testClonePersistentCollectionAndReuse()
+    public function testClonePersistentCollectionAndReuse(): void
     {
         $user1 = $this->user1;
 
@@ -59,7 +59,7 @@ class PersistentCollectionCloneTest extends BaseTest
         $this->assertCount(2, $user1->groups);
     }
 
-    public function testClonePersistentCollectionAndShare()
+    public function testClonePersistentCollectionAndShare(): void
     {
         $user1 = $this->user1;
         $user2 = $this->user2;
@@ -76,7 +76,7 @@ class PersistentCollectionCloneTest extends BaseTest
         $this->assertCount(2, $user2->groups);
     }
 
-    public function testCloneThenDirtyPersistentCollection()
+    public function testCloneThenDirtyPersistentCollection(): void
     {
         $user1 = $this->user1;
         $user2 = $this->user2;
@@ -97,7 +97,7 @@ class PersistentCollectionCloneTest extends BaseTest
         $this->assertCount(2, $user1->groups);
     }
 
-    public function testNotCloneAndPassAroundFlush()
+    public function testNotCloneAndPassAroundFlush(): void
     {
         $user1 = $this->user1;
         $user2 = $this->user2;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistingTest.php
@@ -10,7 +10,7 @@ use Documents\User;
 
 class PersistingTest extends BaseTest
 {
-    public function testCascadeInsertUpdateAndRemove()
+    public function testCascadeInsertUpdateAndRemove(): void
     {
         $account = new Account();
         $account->setName('Jon Test Account');
@@ -33,7 +33,7 @@ class PersistingTest extends BaseTest
         $this->dm->clear();
     }
 
-    public function testUpdate()
+    public function testUpdate(): void
     {
         $user = new User();
         $user->setInheritedProperty('cool');
@@ -57,7 +57,7 @@ class PersistingTest extends BaseTest
         $this->assertEquals('cool', $user->getInheritedProperty());
     }
 
-    public function testDetach()
+    public function testDetach(): void
     {
         $user = new User();
         $user->setUsername('jon');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PrePersistTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PrePersistTest.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class PrePersistTest extends BaseTest
 {
-    public function testPrePersist()
+    public function testPrePersist(): void
     {
         $test = new PrePersistTestDocument();
         $this->dm->persist($test);
@@ -41,13 +41,13 @@ class PrePersistTestDocument
     public $field;
 
     /** @ODM\PrePersist */
-    public function prePersist()
+    public function prePersist(): void
     {
         $this->prePersist++;
     }
 
     /** @ODM\PreUpdate */
-    public function preUpdate()
+    public function preUpdate(): void
     {
         $this->preUpdate++;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
@@ -40,7 +40,7 @@ class QueryTest extends BaseTest
         $this->dm->flush();
     }
 
-    public function testAddElemMatch()
+    public function testAddElemMatch(): void
     {
         $user = new User();
         $user->setUsername('boo');
@@ -59,7 +59,7 @@ class QueryTest extends BaseTest
         $this->assertNotNull($user);
     }
 
-    public function testAddElemMatchWithDeepFields()
+    public function testAddElemMatchWithDeepFields(): void
     {
         $user1 = new User();
         $user1->setUsername('ben');
@@ -82,7 +82,7 @@ class QueryTest extends BaseTest
         $this->assertNotNull($user);
     }
 
-    public function testAddNot()
+    public function testAddNot(): void
     {
         $user = new User();
         $user->setUsername('boo');
@@ -102,7 +102,7 @@ class QueryTest extends BaseTest
         $this->assertNotNull($user);
     }
 
-    public function testDistinct()
+    public function testDistinct(): void
     {
         $user = new User();
         $user->setUsername('distinct_test');
@@ -140,7 +140,7 @@ class QueryTest extends BaseTest
         $this->assertEquals([1, 2, 3], $results);
     }
 
-    public function testDistinctWithDifferentDbName()
+    public function testDistinctWithDifferentDbName(): void
     {
         $c1           = new CmsComment();
         $c1->authorIp = '127.0.0.1';
@@ -160,7 +160,7 @@ class QueryTest extends BaseTest
         $this->assertEquals(['127.0.0.1', '192.168.0.1'], $results);
     }
 
-    public function testFindQuery()
+    public function testFindQuery(): void
     {
         $qb    = $this->dm->createQueryBuilder(User::class)
             ->where("function() { return this.username == 'boo' }");
@@ -169,7 +169,7 @@ class QueryTest extends BaseTest
         $this->assertEquals('boo', $user->getUsername());
     }
 
-    public function testUpdateQuery()
+    public function testUpdateQuery(): void
     {
         $qb     = $this->dm->createQueryBuilder(User::class)
             ->updateOne()
@@ -183,7 +183,7 @@ class QueryTest extends BaseTest
         $this->assertEquals('crap', $this->user->getUsername());
     }
 
-    public function testUpsertUpdateQuery()
+    public function testUpsertUpdateQuery(): void
     {
         $qb     = $this->dm->createQueryBuilder(User::class)
             ->updateOne()
@@ -202,7 +202,7 @@ class QueryTest extends BaseTest
         $this->assertNotNull($user);
     }
 
-    public function testMultipleUpdateQuery()
+    public function testMultipleUpdateQuery(): void
     {
         $user = new User();
         $user->setUsername('multiple_test');
@@ -241,7 +241,7 @@ class QueryTest extends BaseTest
         $this->assertCount(4, $users);
     }
 
-    public function testRemoveQuery()
+    public function testRemoveQuery(): void
     {
         $this->dm->remove($this->user);
 
@@ -250,7 +250,7 @@ class QueryTest extends BaseTest
         $this->dm->refresh($this->user);
     }
 
-    public function testIncUpdateQuery()
+    public function testIncUpdateQuery(): void
     {
         $qb    = $this->dm->createQueryBuilder(User::class)
             ->updateOne()
@@ -267,7 +267,7 @@ class QueryTest extends BaseTest
         $this->assertEquals(10, $user['hits']);
     }
 
-    public function testUnsetFieldUpdateQuery()
+    public function testUnsetFieldUpdateQuery(): void
     {
         $qb     = $this->dm->createQueryBuilder(User::class)
             ->updateOne()
@@ -283,7 +283,7 @@ class QueryTest extends BaseTest
         $this->assertArrayNotHasKey('hits', $user);
     }
 
-    public function testUnsetField()
+    public function testUnsetField(): void
     {
         $qb    = $this->dm->createQueryBuilder()
             ->updateOne(User::class)
@@ -300,7 +300,7 @@ class QueryTest extends BaseTest
         $this->assertNull($user);
     }
 
-    public function testDateRange()
+    public function testDateRange(): void
     {
         $article1 = new Article();
         $article1->setTitle('test');
@@ -342,7 +342,7 @@ class QueryTest extends BaseTest
         $this->assertEquals('1985-09-03', $articles[1]->getCreatedAt()->format('Y-m-d'));
     }
 
-    public function testQueryIsIterable()
+    public function testQueryIsIterable(): void
     {
         $article = new Article();
         $article->setTitle('test');
@@ -357,7 +357,7 @@ class QueryTest extends BaseTest
         }
     }
 
-    public function testQueryReferences()
+    public function testQueryReferences(): void
     {
         $group = new Group('Test Group');
 
@@ -375,7 +375,7 @@ class QueryTest extends BaseTest
         $this->assertSame($user, $user2);
     }
 
-    public function testNestedQueryReference()
+    public function testNestedQueryReference(): void
     {
         $referencedUser = new User();
         $referencedUser->setUsername('boo');
@@ -408,7 +408,7 @@ class QueryTest extends BaseTest
         $this->assertSame($user, $referencedUsers[0]);
     }
 
-    public function testQueryWhereIn()
+    public function testQueryWhereIn(): void
     {
         $qb      = $this->dm->createQueryBuilder(User::class);
         $choices = ['a', 'b'];
@@ -419,7 +419,7 @@ class QueryTest extends BaseTest
         $this->assertSame($expected, $qb->getQueryArray());
     }
 
-    public function testQueryWhereInReferenceId()
+    public function testQueryWhereInReferenceId(): void
     {
         $qb      = $this->dm->createQueryBuilder(User::class);
         $choices = [new ObjectId(), new ObjectId()];
@@ -431,7 +431,7 @@ class QueryTest extends BaseTest
         $this->assertSame($expected, $qb->getQuery()->debug('query'));
     }
 
-    public function testQueryWhereOneValueOfCollection()
+    public function testQueryWhereOneValueOfCollection(): void
     {
         $qb = $this->dm->createQueryBuilder(Article::class);
         $qb->field('tags')->equals('pet');
@@ -441,7 +441,7 @@ class QueryTest extends BaseTest
     }
 
     /** search for articles where tags exactly equal [pet, blue] */
-    public function testQueryWhereAllValuesOfCollection()
+    public function testQueryWhereAllValuesOfCollection(): void
     {
         $qb = $this->dm->createQueryBuilder(Article::class);
         $qb->field('tags')->equals(['pet', 'blue']);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RawTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RawTypeTest.php
@@ -16,7 +16,7 @@ class RawTypeTest extends BaseTest
     /**
      * @dataProvider getTestRawTypeData
      */
-    public function testRawType($value)
+    public function testRawType($value): void
     {
         $test      = new RawType();
         $test->raw = $value;
@@ -28,7 +28,7 @@ class RawTypeTest extends BaseTest
         $this->assertEquals($value, $result['raw']);
     }
 
-    public function getTestRawTypeData()
+    public function getTestRawTypeData(): array
     {
         return [
             ['test'],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadOnlyDocumentTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadOnlyDocumentTest.php
@@ -10,7 +10,7 @@ use MongoDB\BSON\ObjectId;
 
 class ReadOnlyDocumentTest extends BaseTest
 {
-    public function testCanBeInserted()
+    public function testCanBeInserted(): void
     {
         $rod = new ReadOnlyDocument('yay');
         $this->dm->persist($rod);
@@ -22,7 +22,7 @@ class ReadOnlyDocumentTest extends BaseTest
         $this->assertSame('yay', $rod->value);
     }
 
-    public function testCanBeUpserted()
+    public function testCanBeUpserted(): void
     {
         $rod     = new ReadOnlyDocument('yay');
         $rod->id = new ObjectId();
@@ -35,7 +35,7 @@ class ReadOnlyDocumentTest extends BaseTest
         $this->assertSame('yay', $rod->value);
     }
 
-    public function testCanBeRemoved()
+    public function testCanBeRemoved(): void
     {
         $rod = new ReadOnlyDocument('yay');
         $this->dm->persist($rod);
@@ -51,7 +51,7 @@ class ReadOnlyDocumentTest extends BaseTest
         $this->assertNull($rod);
     }
 
-    public function testChangingValueDoesNotProduceChangeSet()
+    public function testChangingValueDoesNotProduceChangeSet(): void
     {
         $rod = new ReadOnlyDocument('yay');
         $this->dm->persist($rod);
@@ -61,7 +61,7 @@ class ReadOnlyDocumentTest extends BaseTest
         $this->assertEmpty($this->uow->getDocumentChangeSet($rod));
     }
 
-    public function testCantBeUpdated()
+    public function testCantBeUpdated(): void
     {
         $rod = new ReadOnlyDocument('yay');
         $this->dm->persist($rod);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
@@ -26,7 +26,7 @@ class ReadPreferenceTest extends BaseTest
         $this->dm->clear();
     }
 
-    public function testHintIsNotSetByDefault()
+    public function testHintIsNotSetByDefault(): void
     {
         $query = $this->dm->getRepository(User::class)
             ->createQueryBuilder()
@@ -44,7 +44,7 @@ class ReadPreferenceTest extends BaseTest
     /**
      * @dataProvider provideReadPreferenceHints
      */
-    public function testHintIsSetOnQuery($readPreference, array $tags = [])
+    public function testHintIsSetOnQuery($readPreference, array $tags = []): void
     {
         $this->skipTestIfSharded(User::class);
 
@@ -62,7 +62,7 @@ class ReadPreferenceTest extends BaseTest
         $this->assertReadPreferenceHint($readPreference, $user->getGroups()->getHints()[Query::HINT_READ_PREFERENCE], $tags);
     }
 
-    public function provideReadPreferenceHints()
+    public function provideReadPreferenceHints(): array
     {
         return [
             [ReadPreference::RP_PRIMARY, []],
@@ -71,7 +71,7 @@ class ReadPreferenceTest extends BaseTest
         ];
     }
 
-    public function testDocumentLevelReadPreferenceIsSetInCollection()
+    public function testDocumentLevelReadPreferenceIsSetInCollection(): void
     {
         $coll = $this->dm->getDocumentCollection(DocumentWithReadPreference::class);
 
@@ -79,7 +79,7 @@ class ReadPreferenceTest extends BaseTest
         $this->assertSame([['dc' => 'east']], $coll->getReadPreference()->getTagSets());
     }
 
-    public function testDocumentLevelReadPreferenceIsAppliedInQueryBuilder()
+    public function testDocumentLevelReadPreferenceIsAppliedInQueryBuilder(): void
     {
         $query = $this->dm->getRepository(DocumentWithReadPreference::class)
             ->createQueryBuilder()
@@ -88,7 +88,7 @@ class ReadPreferenceTest extends BaseTest
         $this->assertReadPreferenceHint(ReadPreference::RP_NEAREST, $query->getQuery()['readPreference'], [['dc' => 'east']]);
     }
 
-    public function testDocumentLevelReadPreferenceCanBeOverriddenInQueryBuilder()
+    public function testDocumentLevelReadPreferenceCanBeOverriddenInQueryBuilder(): void
     {
         $query = $this->dm->getRepository(DocumentWithReadPreference::class)
             ->createQueryBuilder()
@@ -98,7 +98,7 @@ class ReadPreferenceTest extends BaseTest
         $this->assertReadPreferenceHint(ReadPreference::RP_SECONDARY, $query->getQuery()['readPreference']);
     }
 
-    private function assertReadPreferenceHint($mode, $readPreference, array $tags = [])
+    private function assertReadPreferenceHint($mode, $readPreference, array $tags = []): void
     {
         $this->assertInstanceOf(ReadPreference::class, $readPreference);
         $this->assertEquals($mode, $readPreference->getMode());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
@@ -22,7 +22,7 @@ class ReferenceDiscriminatorsTest extends BaseTest
     /**
      * This test demonstrates a CommentableAction being published to activity streams.
      */
-    public function testReferenceDiscriminators()
+    public function testReferenceDiscriminators(): void
     {
         $this->dm->persist($commentableAction           = new CommentableAction('actionType'));
         $this->dm->persist($groupMainActivityStreamItem = new GroupMainActivityStreamItem($commentableAction, 'groupId'));
@@ -49,7 +49,7 @@ class ReferenceDiscriminatorsTest extends BaseTest
      * This tests demonstrates a race condition between two requests which are
      * both publishing a CommentableAction to activity streams.
      */
-    public function testReferenceDiscriminatorsRaceCondition()
+    public function testReferenceDiscriminatorsRaceCondition(): void
     {
         $this->dm->persist($commentableAction1           = new CommentableAction('actionType'));
         $this->dm->persist($groupMainActivityStreamItem1 = new GroupMainActivityStreamItem($commentableAction1, 'groupId'));
@@ -132,7 +132,7 @@ class CommentableAction extends Action
         $this->comments = $comments;
     }
 
-    public function getComments()
+    public function getComments(): array
     {
         return $this->comments;
     }
@@ -157,7 +157,7 @@ abstract class ActivityStreamItem
         return $this->id;
     }
 
-    public function getAction()
+    public function getAction(): Action
     {
         return $this->action;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceEmbeddedDocumentsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceEmbeddedDocumentsTest.php
@@ -12,7 +12,7 @@ use Documents\SubProject;
 
 class ReferenceEmbeddedDocumentsTest extends BaseTest
 {
-    public function testSavesEmbeddedDocumentsInReferencedDocument()
+    public function testSavesEmbeddedDocumentsInReferencedDocument(): void
     {
         $project = new Project('OpenSky');
 
@@ -55,13 +55,13 @@ class ReferenceEmbeddedDocumentsTest extends BaseTest
         $this->assertLastSubProject($subProjects->last());
     }
 
-    private function assertFirstSubProject(SubProject $project)
+    private function assertFirstSubProject(SubProject $project): void
     {
         $this->assertEquals('Sub Project #1', $project->getName());
         $this->assertEquals(2, $project->getIssues()->count());
     }
 
-    private function assertLastSubProject(SubProject $project)
+    private function assertLastSubProject(SubProject $project): void
     {
         $this->assertEquals('Sub Project #2', $project->getName());
         $this->assertEquals(2, $project->getIssues()->count());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
@@ -38,7 +38,7 @@ use function func_get_args;
 
 class ReferencePrimerTest extends BaseTest
 {
-    public function testPrimeReferencesShouldRequireReferenceMapping()
+    public function testPrimeReferencesShouldRequireReferenceMapping(): void
     {
         $user = new User();
 
@@ -53,7 +53,7 @@ class ReferencePrimerTest extends BaseTest
             ->toArray();
     }
 
-    public function testPrimeReferencesShouldRequireOwningSideReferenceMapping()
+    public function testPrimeReferencesShouldRequireOwningSideReferenceMapping(): void
     {
         $user = new User();
 
@@ -71,7 +71,7 @@ class ReferencePrimerTest extends BaseTest
     /**
      * @doesNotPerformAssertions
      */
-    public function testFieldPrimingCanBeToggled()
+    public function testFieldPrimingCanBeToggled(): void
     {
         $this->dm->createQueryBuilder(User::class)
             ->field('account')
@@ -79,7 +79,7 @@ class ReferencePrimerTest extends BaseTest
             ->prime(false);
     }
 
-    public function testPrimeReferencesWithDBRefObjects()
+    public function testPrimeReferencesWithDBRefObjects(): void
     {
         $user = new User();
         $user->addGroup(new Group());
@@ -110,7 +110,7 @@ class ReferencePrimerTest extends BaseTest
         }
     }
 
-    public function testPrimeReferencesWithSimpleReferences()
+    public function testPrimeReferencesWithSimpleReferences(): void
     {
         $user1 = new User();
         $user2 = new User();
@@ -145,7 +145,7 @@ class ReferencePrimerTest extends BaseTest
         }
     }
 
-    public function testPrimeReferencesNestedInNamedEmbeddedReference()
+    public function testPrimeReferencesNestedInNamedEmbeddedReference(): void
     {
         $root = new EmbedNamed();
 
@@ -208,7 +208,7 @@ class ReferencePrimerTest extends BaseTest
         }
     }
 
-    public function testPrimeReferencesWithDifferentStoreAsReferences()
+    public function testPrimeReferencesWithDifferentStoreAsReferences(): void
     {
         $referenceUser = new ReferenceUser();
         $this->dm->persist($referenceUser);
@@ -288,7 +288,7 @@ class ReferencePrimerTest extends BaseTest
         }
     }
 
-    public function testPrimeReferencesWithDiscriminatedReferenceMany()
+    public function testPrimeReferencesWithDiscriminatedReferenceMany(): void
     {
         $group   = new Group();
         $project = new Project('foo');
@@ -317,7 +317,7 @@ class ReferencePrimerTest extends BaseTest
         }
     }
 
-    public function testPrimeReferencesWithDiscriminatedReferenceOne()
+    public function testPrimeReferencesWithDiscriminatedReferenceOne(): void
     {
         $agent         = new Agent();
         $agent->server = new GuestServer();
@@ -336,7 +336,7 @@ class ReferencePrimerTest extends BaseTest
         }
     }
 
-    public function testPrimeReferencesIgnoresInitializedProxyObjects()
+    public function testPrimeReferencesIgnoresInitializedProxyObjects(): void
     {
         $user = new User();
         $user->addGroup(new Group());
@@ -368,7 +368,7 @@ class ReferencePrimerTest extends BaseTest
         $this->assertEquals(0, $invoked, 'Primer was not invoked when all references were already managed.');
     }
 
-    public function testPrimeReferencesInvokesPrimer()
+    public function testPrimeReferencesInvokesPrimer(): void
     {
         $group1  = new Group();
         $group2  = new Group();
@@ -407,7 +407,7 @@ class ReferencePrimerTest extends BaseTest
         $this->assertEquals($groupIds, $invokedArgs[1][2]);
     }
 
-    public function testPrimeReferencesInFindAndModifyResult()
+    public function testPrimeReferencesInFindAndModifyResult(): void
     {
         $group = new Group();
         $user  = new User();
@@ -437,7 +437,7 @@ class ReferencePrimerTest extends BaseTest
         }
     }
 
-    public function testPrimeEmbeddedReferenceOneLevelDeep()
+    public function testPrimeEmbeddedReferenceOneLevelDeep(): void
     {
         $user1 = new User();
         $user2 = new User();
@@ -468,7 +468,7 @@ class ReferencePrimerTest extends BaseTest
         $this->assertInstanceOf(Phonenumber::class, $phonenumber);
     }
 
-    public function testPrimeEmbeddedReferenceTwoLevelsDeep()
+    public function testPrimeEmbeddedReferenceTwoLevelsDeep(): void
     {
         $product = new ConfigurableProduct('Bundle');
 
@@ -522,7 +522,7 @@ class ReferencePrimerTest extends BaseTest
         $this->assertTrue($currency->isProxyInitialized());
     }
 
-    public function testPrimeReferencesInReferenceMany()
+    public function testPrimeReferencesInReferenceMany(): void
     {
         $commentAuthor = new User();
         $this->dm->persist($commentAuthor);
@@ -550,7 +550,7 @@ class ReferencePrimerTest extends BaseTest
         $this->assertTrue($comment->author->isProxyInitialized());
     }
 
-    public function testPrimeReferencesInReferenceManyWithRepositoryMethodEager()
+    public function testPrimeReferencesInReferenceManyWithRepositoryMethodEager(): void
     {
         $commentAuthor = new User();
         $this->dm->persist($commentAuthor);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceRepositoryMethodTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceRepositoryMethodTest.php
@@ -15,7 +15,7 @@ use function strtotime;
 
 class ReferenceRepositoryMethodTest extends BaseTest
 {
-    public function testOneToOne()
+    public function testOneToOne(): void
     {
         $date1 = new DateTime();
         $date1->setTimestamp(strtotime('-20 seconds'));
@@ -46,7 +46,7 @@ class ReferenceRepositoryMethodTest extends BaseTest
      *
      * @url http://docs.doctrine-project.org/projects/doctrine-mongodb-odm/en/latest/reference/bidirectional-references.html
      */
-    public function testOneToMany()
+    public function testOneToMany(): void
     {
         $user = new User();
         $user->setUsername('w00ting');
@@ -76,7 +76,7 @@ class ReferenceRepositoryMethodTest extends BaseTest
         $this->assertNull($post1->user);
     }
 
-    public function testSetStrategy()
+    public function testSetStrategy(): void
     {
         $repo = $this->dm->getRepository(BlogPost::class);
 
@@ -94,7 +94,7 @@ class ReferenceRepositoryMethodTest extends BaseTest
         $this->assertEquals('Comment', $blogPost->repoCommentsSet[0]->getText());
     }
 
-    public function testRepositoryMethodWithoutMappedBy()
+    public function testRepositoryMethodWithoutMappedBy(): void
     {
         $blogPost = new BlogPost('Test');
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
@@ -28,7 +28,7 @@ use function get_class;
 
 class ReferencesTest extends BaseTest
 {
-    public function testManyDeleteReference()
+    public function testManyDeleteReference(): void
     {
         $user = new User();
 
@@ -57,7 +57,7 @@ class ReferencesTest extends BaseTest
         $this->assertCount(0, $groups->toArray());
     }
 
-    public function testLazyLoadReference()
+    public function testLazyLoadReference(): void
     {
         $user    = new User();
         $profile = new Profile();
@@ -89,7 +89,7 @@ class ReferencesTest extends BaseTest
         $this->assertEquals('Wage', $profile->getLastName());
     }
 
-    public function testLazyLoadedWithNotifyPropertyChanged()
+    public function testLazyLoadedWithNotifyPropertyChanged(): void
     {
         $user    = new User();
         $profile = new ProfileNotify();
@@ -114,7 +114,7 @@ class ReferencesTest extends BaseTest
         $this->assertEquals('Malarz', $profile->getLastName());
     }
 
-    public function testOneEmbedded()
+    public function testOneEmbedded(): void
     {
         $address = new Address();
         $address->setAddress('6512 Mercomatic Ct.');
@@ -141,7 +141,7 @@ class ReferencesTest extends BaseTest
         $this->assertEquals($user->getAddress(), $user2->getAddress());
     }
 
-    public function testManyEmbedded()
+    public function testManyEmbedded(): void
     {
         $user = new User();
         $user->addPhonenumber(new Phonenumber('6155139185'));
@@ -159,7 +159,7 @@ class ReferencesTest extends BaseTest
         $this->assertEquals($user->getPhonenumbers()->toArray(), $user2->getPhonenumbers()->toArray());
     }
 
-    public function testOneReference()
+    public function testOneReference(): void
     {
         $account = new Account();
         $account->setName('Test Account');
@@ -182,7 +182,7 @@ class ReferencesTest extends BaseTest
         $this->assertInstanceOf(User::class, $user2);
     }
 
-    public function testManyReference()
+    public function testManyReference(): void
     {
         $user = new User();
         $user->addGroup(new Group('Group 1'));
@@ -238,7 +238,7 @@ class ReferencesTest extends BaseTest
         $this->assertCount(1, $groups);
     }
 
-    public function testFlushInitializesEmptyPersistentCollection()
+    public function testFlushInitializesEmptyPersistentCollection(): void
     {
         $user = new User();
 
@@ -259,7 +259,7 @@ class ReferencesTest extends BaseTest
         $this->assertCount(2, $user->getGroups()->toArray());
     }
 
-    public function testFlushInitializesNotEmptyPersistentCollection()
+    public function testFlushInitializesNotEmptyPersistentCollection(): void
     {
         $user = new User();
         $user->addGroup(new Group('Group'));
@@ -281,7 +281,7 @@ class ReferencesTest extends BaseTest
         $this->assertCount(3, $user->getGroups()->toArray());
     }
 
-    public function testManyReferenceWithAddToSetStrategy()
+    public function testManyReferenceWithAddToSetStrategy(): void
     {
         $user = new User();
         $user->addUniqueGroup($group1 = new Group('Group 1'));
@@ -340,7 +340,7 @@ class ReferencesTest extends BaseTest
         $this->assertCount(1, $groups);
     }
 
-    public function testSortReferenceManyOwningSide()
+    public function testSortReferenceManyOwningSide(): void
     {
         $user = new User();
         $user->addGroup(new Group('Group 1'));
@@ -365,7 +365,7 @@ class ReferencesTest extends BaseTest
         $this->assertEquals('Group 1', $groups[1]->getName());
     }
 
-    public function testDocumentNotFoundExceptionWithArrayId()
+    public function testDocumentNotFoundExceptionWithArrayId(): void
     {
         $test                   = new DocumentWithArrayReference();
         $test->referenceOne     = new DocumentWithArrayId();
@@ -396,7 +396,7 @@ class ReferencesTest extends BaseTest
         $test->referenceOne->initializeProxy();
     }
 
-    public function testDocumentNotFoundExceptionWithObjectId()
+    public function testDocumentNotFoundExceptionWithObjectId(): void
     {
         $profile = new Profile();
         $user    = new User();
@@ -427,7 +427,7 @@ class ReferencesTest extends BaseTest
         $profile->initializeProxy();
     }
 
-    public function testDocumentNotFoundExceptionWithMongoBinDataId()
+    public function testDocumentNotFoundExceptionWithMongoBinDataId(): void
     {
         $test                   = new DocumentWithMongoBinDataReference();
         $test->referenceOne     = new DocumentWithMongoBinDataId();
@@ -458,7 +458,7 @@ class ReferencesTest extends BaseTest
         $test->referenceOne->initializeProxy();
     }
 
-    public function testDocumentNotFoundEvent()
+    public function testDocumentNotFoundEvent(): void
     {
         $profile = new Profile();
         $user    = new User();
@@ -539,7 +539,7 @@ class DocumentNotFoundListener
         $this->closure = $closure;
     }
 
-    public function documentNotFound(DocumentNotFoundEventArgs $eventArgs)
+    public function documentNotFound(DocumentNotFoundEventArgs $eventArgs): void
     {
         $closure = $this->closure;
         $closure($eventArgs);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RemoveTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RemoveTest.php
@@ -18,7 +18,7 @@ use Documents\User;
 
 class RemoveTest extends BaseTest
 {
-    public function testRemove()
+    public function testRemove(): void
     {
         $account = new Account();
         $account->setName('Jon Test Account');
@@ -41,7 +41,7 @@ class RemoveTest extends BaseTest
         $this->assertNull($user);
     }
 
-    public function testUnsetFromEmbeddedCollection()
+    public function testUnsetFromEmbeddedCollection(): void
     {
         $userRepository = $this->dm->getRepository(User::class);
 
@@ -67,7 +67,7 @@ class RemoveTest extends BaseTest
         $this->assertCount(2, $user->getGroups());
     }
 
-    public function testUnsetFromReferencedCollectionWithCascade()
+    public function testUnsetFromReferencedCollectionWithCascade(): void
     {
         $developerRepository = $this->dm->getRepository(Developer::class);
         $projectRepository   = $this->dm->getRepository(Project::class);
@@ -124,7 +124,7 @@ class RemoveTest extends BaseTest
         $this->assertNull($project2);
     }
 
-    public function testUnsetFromReferencedCollectionWithoutCascade()
+    public function testUnsetFromReferencedCollectionWithoutCascade(): void
     {
         $articleRepository = $this->dm->getRepository(CmsArticle::class);
         $commentRepository = $this->dm->getRepository(CmsComment::class);
@@ -183,7 +183,7 @@ class RemoveTest extends BaseTest
         $this->assertNotNull($comment2);
     }
 
-    public function testUnsetFromReferencedCollectionWithCascadeAndMappedBy()
+    public function testUnsetFromReferencedCollectionWithCascadeAndMappedBy(): void
     {
         $blogPostRepository = $this->dm->getRepository(BlogPost::class);
         $commentRepository  = $this->dm->getRepository(Comment::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RepositoriesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RepositoriesTest.php
@@ -30,7 +30,7 @@ class RepositoriesTest extends BaseTest
         $this->repository = $this->dm->getRepository(User::class);
     }
 
-    public function testFindAll()
+    public function testFindAll(): void
     {
         $users = $this->repository->findAll();
 
@@ -38,7 +38,7 @@ class RepositoriesTest extends BaseTest
         $this->assertCount(1, $users);
     }
 
-    public function testFind()
+    public function testFind(): void
     {
         $user2 = $this->repository->find($this->user->getId());
         $this->assertSame($this->user, $user2);
@@ -47,7 +47,7 @@ class RepositoriesTest extends BaseTest
         $this->assertSame($user2, $user3);
     }
 
-    public function testCriteria()
+    public function testCriteria(): void
     {
         $exprBuilder = Criteria::expr();
         $expr        = $exprBuilder->eq('username', 'lolcat');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
@@ -42,7 +42,7 @@ class ShardKeyTest extends BaseTest
         parent::tearDown();
     }
 
-    public function testUpdateAfterSave()
+    public function testUpdateAfterSave(): void
     {
         $o = new ShardedOne();
         $this->dm->persist($o);
@@ -62,7 +62,7 @@ class ShardKeyTest extends BaseTest
         $this->assertEquals($o->key, $command->updates[0]->q->k);
     }
 
-    public function testUpsert()
+    public function testUpsert(): void
     {
         $o     = new ShardedOne();
         $o->id = new ObjectId();
@@ -79,7 +79,7 @@ class ShardKeyTest extends BaseTest
         $this->assertTrue($command->updates[0]->upsert);
     }
 
-    public function testRemove()
+    public function testRemove(): void
     {
         $o = new ShardedOne();
         $this->dm->persist($o);
@@ -96,7 +96,7 @@ class ShardKeyTest extends BaseTest
         $this->assertEquals($o->key, $command->deletes[0]->q->k);
     }
 
-    public function testRefresh()
+    public function testRefresh(): void
     {
         $o = new ShardedOne();
         $this->dm->persist($o);
@@ -112,7 +112,7 @@ class ShardKeyTest extends BaseTest
         $this->assertEquals($o->key, $command->filter->k);
     }
 
-    public function testUpdateWithShardKeyChangeException()
+    public function testUpdateWithShardKeyChangeException(): void
     {
         $o = new ShardedOne();
         $this->dm->persist($o);
@@ -123,7 +123,7 @@ class ShardKeyTest extends BaseTest
         $this->dm->flush();
     }
 
-    public function testUpdateWithUpsertTrue()
+    public function testUpdateWithUpsertTrue(): void
     {
         $o = new ShardedOne();
         $this->dm->persist($o);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SimpleReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SimpleReferencesTest.php
@@ -40,13 +40,13 @@ class SimpleReferencesTest extends BaseTest
         $this->dm->clear();
     }
 
-    public function testIndexes()
+    public function testIndexes(): void
     {
         $indexes = $this->dm->getSchemaManager()->getDocumentIndexes(SimpleReferenceUser::class);
         $this->assertEquals(['userId' => 1], $indexes[0]['keys']);
     }
 
-    public function testStorage()
+    public function testStorage(): void
     {
         $test = $this->dm->getDocumentCollection(SimpleReferenceUser::class)->findOne();
         $this->assertNotNull($test);
@@ -54,7 +54,7 @@ class SimpleReferencesTest extends BaseTest
         $this->assertInstanceOf(ObjectId::class, $test['users'][0]);
     }
 
-    public function testQuery()
+    public function testQuery(): void
     {
         $this->user = $this->dm->getRepository(User::class)->findOneBy(['username' => 'jwage']);
 
@@ -71,7 +71,7 @@ class SimpleReferencesTest extends BaseTest
         $this->assertEquals(['userId' => ['$in' => [new ObjectId($this->user->getId())]]], $qb->getQuery()->debug('query'));
     }
 
-    public function testProxy()
+    public function testProxy(): void
     {
         $this->user = $this->dm->getRepository(User::class)->findOneBy(['username' => 'jwage']);
 
@@ -95,7 +95,7 @@ class SimpleReferencesTest extends BaseTest
         $this->assertTrue($user->isProxyInitialized());
     }
 
-    public function testPersistentCollectionOwningSide()
+    public function testPersistentCollectionOwningSide(): void
     {
         $test  = $this->dm->getRepository(SimpleReferenceUser::class)->findOneBy([]);
         $users = $test->getUsers()->toArray();
@@ -104,21 +104,21 @@ class SimpleReferencesTest extends BaseTest
         $this->assertEquals('jwage', end($users)->getUsername());
     }
 
-    public function testPersistentCollectionInverseSide()
+    public function testPersistentCollectionInverseSide(): void
     {
         $user = $this->dm->getRepository(User::class)->findOneBy([]);
         $test = $user->getSimpleReferenceManyInverse()->toArray();
         $this->assertEquals('test', current($test)->getName());
     }
 
-    public function testOneInverseSide()
+    public function testOneInverseSide(): void
     {
         $user = $this->dm->getRepository(User::class)->findOneBy([]);
         $test = $user->getSimpleReferenceOneInverse();
         $this->assertEquals('test', $test->getName());
     }
 
-    public function testQueryForNonIds()
+    public function testQueryForNonIds(): void
     {
         $qb = $this->dm->createQueryBuilder(SimpleReferenceUser::class);
         $qb->field('user')->equals(null);
@@ -133,7 +133,7 @@ class SimpleReferencesTest extends BaseTest
         $this->assertEquals(['userId' => ['$exists' => true]], $qb->getQueryArray());
     }
 
-    public function testRemoveDocumentByEmptyRefMany()
+    public function testRemoveDocumentByEmptyRefMany(): void
     {
         $qb = $this->dm->createQueryBuilder(SimpleReferenceUser::class);
         $qb->field('users')->equals([]);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SimpleTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SimpleTest.php
@@ -10,7 +10,7 @@ use Documents\Bars\Location;
 
 class SimpleTest extends BaseTest
 {
-    public function testSimple()
+    public function testSimple(): void
     {
         $bar = new Bar("Jon's Pub");
         $bar->addLocation(new Location('West Nashville'));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
@@ -16,7 +16,7 @@ class SplObjectHashCollisionsTest extends BaseTest
     /**
      * @dataProvider provideParentAssociationsIsCleared
      */
-    public function testParentAssociationsIsCleared($f)
+    public function testParentAssociationsIsCleared($f): void
     {
         $d         = new SplColDoc();
         $d->one    = new SplColEmbed('d.one.v1');
@@ -34,7 +34,7 @@ class SplObjectHashCollisionsTest extends BaseTest
     /**
      * @dataProvider provideParentAssociationsIsCleared
      */
-    public function testParentAssociationsLeftover($f, $leftover)
+    public function testParentAssociationsLeftover($f, $leftover): void
     {
         $d         = new SplColDoc();
         $d->one    = new SplColEmbed('d.one.v1');
@@ -51,7 +51,7 @@ class SplObjectHashCollisionsTest extends BaseTest
         $this->expectCount('embeddedDocumentsRegistry', $leftover);
     }
 
-    public function provideParentAssociationsIsCleared()
+    public function provideParentAssociationsIsCleared(): array
     {
         return [
             [
@@ -75,7 +75,7 @@ class SplObjectHashCollisionsTest extends BaseTest
         ];
     }
 
-    private function expectCount($prop, $expected)
+    private function expectCount($prop, $expected): void
     {
         $ro = new ReflectionObject($this->uow);
         $rp = $ro->getProperty($prop);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TestTargetDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TestTargetDocument.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class TargetDocumentTest extends BaseTest
 {
-    public function testMappedSuperClassAsTargetDocument()
+    public function testMappedSuperClassAsTargetDocument(): void
     {
         $test            = new TargetDocumentTestDocument();
         $test->reference = new TargetDocumentTestReference();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php
@@ -12,7 +12,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH1011Test extends BaseTest
 {
-    public function testClearCollection()
+    public function testClearCollection(): void
     {
         $doc = new GH1011Document();
         $doc->embeds->add(new GH1011Embedded('test1'));
@@ -26,7 +26,7 @@ class GH1011Test extends BaseTest
         $this->assertFalse($this->uow->isCollectionScheduledForDeletion($doc->embeds));
     }
 
-    public function testReplaceCollection()
+    public function testReplaceCollection(): void
     {
         $doc = new GH1011Document();
         $doc->embeds->add(new GH1011Embedded('test1'));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1017Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1017Test.php
@@ -13,7 +13,7 @@ use function spl_object_hash;
 
 class GH1017Test extends BaseTest
 {
-    public function testSPLObjectHashCollisionOnReplacingEmbeddedDoc()
+    public function testSPLObjectHashCollisionOnReplacingEmbeddedDoc(): void
     {
         $usedHashes = [];
         $owner      = new GH1017Document();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
@@ -19,7 +19,7 @@ class GH1058Test extends BaseTest
     /**
      * @doesNotPerformAssertions
      */
-    public function testModifyingDuringOnFlushEventNewDocument()
+    public function testModifyingDuringOnFlushEventNewDocument(): void
     {
         $this->dm->getEventManager()->addEventListener([Events::onFlush], new GH1058Listener());
         $document = new GH1058PersistDocument();
@@ -31,7 +31,7 @@ class GH1058Test extends BaseTest
     /**
      * @doesNotPerformAssertions
      */
-    public function testModifyingDuringOnFlushEventNewDocumentWithId()
+    public function testModifyingDuringOnFlushEventNewDocumentWithId(): void
     {
         $this->dm->getEventManager()->addEventListener([Events::onFlush], new GH1058Listener());
         $document = new GH1058UpsertDocument();
@@ -44,7 +44,7 @@ class GH1058Test extends BaseTest
 
 class GH1058Listener
 {
-    public function onFlush(OnFlushEventArgs $args)
+    public function onFlush(OnFlushEventArgs $args): void
     {
         $dm  = $args->getDocumentManager();
         $uow = $dm->getUnitOfWork();
@@ -75,7 +75,7 @@ class GH1058PersistDocument
         return $this->id;
     }
 
-    public function setValue($value)
+    public function setValue($value): void
     {
         $this->value = $value;
     }
@@ -95,7 +95,7 @@ class GH1058UpsertDocument
         return $this->id;
     }
 
-    final public function generateId()
+    final public function generateId(): void
     {
         if (isset($this->id)) {
             return;
@@ -104,7 +104,7 @@ class GH1058UpsertDocument
         $this->id = (string) new ObjectId();
     }
 
-    public function setValue($value)
+    public function setValue($value): void
     {
         $this->value = $value;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1107Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1107Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH1107Test extends BaseTest
 {
-    public function testOverrideIdStrategy()
+    public function testOverrideIdStrategy(): void
     {
         $childObj       = new GH1107ChildClass();
         $childObj->name = 'ChildObject';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php
@@ -12,7 +12,7 @@ use function get_class;
 
 class GH1117Test extends BaseTest
 {
-    public function testAddOnUninitializedCollection()
+    public function testAddOnUninitializedCollection(): void
     {
         $doc = new GH1117Document();
         $doc->embeds->add(new GH1117EmbeddedDocument('one'));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1132Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1132Test.php
@@ -12,7 +12,7 @@ use function get_class;
 
 class GH1132Test extends BaseTest
 {
-    public function testClonedPersistentCollectionCanBeClearedAndUsedInNewDocument()
+    public function testClonedPersistentCollectionCanBeClearedAndUsedInNewDocument(): void
     {
         $u = new User();
         $u->getPhonenumbers()->add(new Phonenumber('123456'));
@@ -33,7 +33,7 @@ class GH1132Test extends BaseTest
         $this->assertCount(0, $u2->getPhonenumbers());
     }
 
-    public function testClonedPersistentCollectionCanBeClearedAndUsedInManagedDocument()
+    public function testClonedPersistentCollectionCanBeClearedAndUsedInManagedDocument(): void
     {
         $u = new User();
         $u->getPhonenumbers()->add(new Phonenumber('123456'));
@@ -55,7 +55,7 @@ class GH1132Test extends BaseTest
         $this->assertCount(0, $u2->getPhonenumbers());
     }
 
-    public function testClonedPersistentCollectionUpdatesCorrectly()
+    public function testClonedPersistentCollectionUpdatesCorrectly(): void
     {
         $u = new User();
         $u->getPhonenumbers()->add(new Phonenumber('123456'));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1138Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1138Test.php
@@ -30,7 +30,7 @@ class GH1138Test extends BaseTest
         parent::tearDown();
     }
 
-    public function testUpdatingDocumentBeforeItsInsertionShouldNotEntailMultipleQueries()
+    public function testUpdatingDocumentBeforeItsInsertionShouldNotEntailMultipleQueries(): void
     {
         $listener = new GH1138Listener();
         $this->dm->getEventManager()->addEventListener(Events::onFlush, $listener);
@@ -63,7 +63,7 @@ class GH1138Listener
     public $inserts = 0;
     public $updates = 0;
 
-    public function onFlush(OnFlushEventArgs $args)
+    public function onFlush(OnFlushEventArgs $args): void
     {
         $dm  = $args->getDocumentManager();
         $uow = $dm->getUnitOfWork();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1152Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1152Test.php
@@ -11,7 +11,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH1152Test extends BaseTest
 {
-    public function testParentAssociationsInPostLoad()
+    public function testParentAssociationsInPostLoad(): void
     {
         $listener = new GH1152Listener();
         $this->dm->getEventManager()->addEventListener(Events::postLoad, $listener);
@@ -54,7 +54,7 @@ class GH1152Child
 
 class GH1152Listener
 {
-    public function postLoad(LifecycleEventArgs $args)
+    public function postLoad(LifecycleEventArgs $args): void
     {
         $dm       = $args->getDocumentManager();
         $document = $args->getDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
@@ -12,7 +12,7 @@ use function get_class;
 
 class GH1225Test extends BaseTest
 {
-    public function testRemoveAddEmbeddedDocToExistingDocumentWithPreUpdateHook()
+    public function testRemoveAddEmbeddedDocToExistingDocumentWithPreUpdateHook(): void
     {
         $doc = new GH1225Document();
         $doc->embeds->add(new GH1225EmbeddedDocument('foo'));
@@ -52,7 +52,7 @@ class GH1225Document
     /**
      * @ODM\PreUpdate
      */
-    public function exampleHook()
+    public function exampleHook(): void
     {
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
@@ -43,7 +43,7 @@ class GH1229Test extends BaseTest
     /**
      * @group m
      */
-    public function testMethodAWithoutClone()
+    public function testMethodAWithoutClone(): void
     {
         $firstParent = $this->dm->find(GH1229Parent::CLASSNAME, $this->firstParentId);
         assert($firstParent instanceof GH1229Parent);
@@ -91,7 +91,7 @@ class GH1229Test extends BaseTest
     /**
      * @group m
      */
-    public function testMethodAWithClone()
+    public function testMethodAWithClone(): void
     {
         $firstParent = $this->dm->find(GH1229Parent::CLASSNAME, $this->firstParentId);
         assert($firstParent instanceof GH1229Parent);
@@ -150,24 +150,24 @@ class GH1229Parent
     /**
      * @return GH1229Child[]
      */
-    public function getChildren()
+    public function getChildren(): array
     {
         return $this->children->toArray();
     }
 
-    public function addChild(GH1229Child $child)
+    public function addChild(GH1229Child $child): void
     {
         $child->setOrder(count($this->children));
         $this->children->add($child);
     }
 
-    public function removeChild(GH1229Child $child)
+    public function removeChild(GH1229Child $child): void
     {
         $this->children->removeElement($child);
         $this->reorderChildren($child->getOrder(), -1);
     }
 
-    public function reorderChildren(int $starting, int $change)
+    public function reorderChildren(int $starting, int $change): void
     {
         foreach ($this->children as $child) {
             if ($child->getOrder() < $starting) {
@@ -195,10 +195,7 @@ class GH1229Child
         $this->name = $name;
     }
 
-    /**
-     * @return int
-     */
-    public function getOrder()
+    public function getOrder(): int
     {
         return $this->order;
     }
@@ -206,7 +203,7 @@ class GH1229Child
     /**
      * @return $this
      */
-    public function setOrder(int $order)
+    public function setOrder(int $order): self
     {
         $this->order = $order;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
@@ -167,11 +167,7 @@ class GH1229Parent
         $this->reorderChildren($child->getOrder(), -1);
     }
 
-    /**
-     * @param int $starting
-     * @param int $change
-     */
-    public function reorderChildren($starting, $change)
+    public function reorderChildren(int $starting, int $change)
     {
         foreach ($this->children as $child) {
             if ($child->getOrder() < $starting) {
@@ -194,10 +190,7 @@ class GH1229Child
     /** @ODM\Field(type="int") */
     public $order = 0;
 
-    /**
-     * @param string $name
-     */
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }
@@ -211,11 +204,9 @@ class GH1229Child
     }
 
     /**
-     * @param int $order
-     *
      * @return $this
      */
-    public function setOrder($order)
+    public function setOrder(int $order)
     {
         $this->order = $order;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
@@ -14,7 +14,7 @@ class GH1232Test extends BaseTest
     /**
      * @doesNotPerformAssertions
      */
-    public function testRemoveDoesNotCauseErrors()
+    public function testRemoveDoesNotCauseErrors(): void
     {
         $post = new GH1232Post();
         $this->dm->persist($post);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
@@ -70,6 +70,9 @@ class GH1232Comment
 
 class GH1232CommentRepository extends DocumentRepository
 {
+    /**
+     * @return array|int|object|null
+     */
     public function getLongComments(GH1232Post $post)
     {
         return $this

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
@@ -328,10 +328,10 @@ class Container
         $this->items->set($a, $itemB);
     }
 
-    public function move(Item $item, $move)
+    public function move(Item $item, $move): void
     {
         if ($move === 0) {
-            return $this;
+            return;
         }
 
         $currentPosition = $this->items->indexOf($item);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
@@ -14,7 +14,7 @@ use function array_map;
 
 class GH1275Test extends BaseTest
 {
-    public function testResortAtomicCollectionsFlipItems()
+    public function testResortAtomicCollectionsFlipItems(): void
     {
         $getNameCallback = static function (Item $item) {
             return $item->name;
@@ -55,7 +55,7 @@ class GH1275Test extends BaseTest
         );
     }
 
-    public function testResortAtomicCollections()
+    public function testResortAtomicCollections(): void
     {
         $getNameCallback = static function (Item $item) {
             return $item->name;
@@ -136,7 +136,7 @@ class GH1275Test extends BaseTest
         $this->assertCount(3, $container->items);
     }
 
-    public static function getCollectionStrategies()
+    public static function getCollectionStrategies(): array
     {
         return [
             'testResortWithStrategyAddToSet' => [ClassMetadata::STORAGE_STRATEGY_ADD_TO_SET],
@@ -151,7 +151,7 @@ class GH1275Test extends BaseTest
     /**
      * @dataProvider getCollectionStrategies
      */
-    public function testResortEmbedManyCollection($strategy)
+    public function testResortEmbedManyCollection($strategy): void
     {
         $getNameCallback = static function (Element $element) {
             return $element->name;
@@ -309,7 +309,7 @@ class Container
         $this->atomicSetArray = new ArrayCollection();
     }
 
-    public function add(Item $item)
+    public function add(Item $item): void
     {
         $this->items->add($item);
         if ($this->items->count() !== 1) {
@@ -319,7 +319,7 @@ class Container
         $this->firstItem = $item;
     }
 
-    public function flip($a, $b)
+    public function flip($a, $b): void
     {
         $itemA = $this->items->get($a);
         $itemB = $this->items->get($b);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1294Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1294Test.php
@@ -10,7 +10,7 @@ use MongoDB\BSON\Regex;
 
 class GH1294Test extends BaseTest
 {
-    public function testRegexSearchOnIdentifierWithUuidStrategy()
+    public function testRegexSearchOnIdentifierWithUuidStrategy(): void
     {
         $user1       = new GH1294User();
         $user1->id   = 'aaa111aaa';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1344Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1344Test.php
@@ -10,7 +10,7 @@ use MongoDB\Driver\Exception\CommandException;
 
 class GH1344Test extends BaseTest
 {
-    public function testGeneratingIndexesDoesNotThrowException()
+    public function testGeneratingIndexesDoesNotThrowException(): void
     {
         $indexes = $this->dm->getSchemaManager()->getDocumentIndexes(GH1344Main::class);
         self::assertCount(4, $indexes);
@@ -22,7 +22,7 @@ class GH1344Test extends BaseTest
         $this->dm->getSchemaManager()->ensureDocumentIndexes(GH1344Main::class);
     }
 
-    public function testGeneratingIndexesWithTooLongIndexNameThrowsExceptionBeforeMongoDB42()
+    public function testGeneratingIndexesWithTooLongIndexNameThrowsExceptionBeforeMongoDB42(): void
     {
         $this->skipOnMongoDB42('Index name restrictions were removed in MongoDB 4.2.');
 
@@ -34,7 +34,7 @@ class GH1344Test extends BaseTest
         $this->dm->getSchemaManager()->ensureDocumentIndexes(GH1344LongIndexName::class);
     }
 
-    public function testGeneratingIndexesWithLongIndexNameDoesNotThrowExceptionAfterMongoDB42()
+    public function testGeneratingIndexesWithLongIndexNameDoesNotThrowExceptionAfterMongoDB42(): void
     {
         $this->requireMongoDB42('Index name length is limited before MongoDB 4.2.');
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1346Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1346Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
@@ -13,7 +14,7 @@ class GH1346Test extends BaseTest
     /**
      * @group GH1346Test
      */
-    public function testPublicProperty()
+    public function testPublicProperty(): void
     {
         $referenced1    = new GH1346ReferencedDocument();
         $referenced2    = new GH1346ReferencedDocument();
@@ -62,12 +63,12 @@ class GH1346Document
         return $this->id;
     }
 
-    public function addReference($otherReference)
+    public function addReference($otherReference): void
     {
         $this->references->add($otherReference);
     }
 
-    public function getReferences()
+    public function getReferences(): Collection
     {
         return $this->references;
     }
@@ -84,7 +85,7 @@ class GH1346ReferencedDocument
     /** @ODM\Id */
     protected $id;
 
-    public function setTest($test)
+    public function setTest($test): void
     {
         $this->test = $test;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
@@ -12,7 +12,7 @@ use function assert;
 
 class GH1418Test extends BaseTest
 {
-    public function testManualHydrateAndMerge()
+    public function testManualHydrateAndMerge(): void
     {
         $document = new GH1418Document();
         $this->dm->getHydratorFactory()->hydrate($document, [
@@ -40,7 +40,7 @@ class GH1418Test extends BaseTest
         $this->assertEquals(2, $document->embedMany->first()->id);
     }
 
-    public function testReadDocumentAndManage()
+    public function testReadDocumentAndManage(): void
     {
         $document     = new GH1418Document();
         $document->id = 1;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1428Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1428Test.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Error\Notice;
 
 class GH1428Test extends BaseTest
 {
-    public function testShortNameLossOnReplacingMiddleEmbeddedDocOfNestedEmbedding()
+    public function testShortNameLossOnReplacingMiddleEmbeddedDocOfNestedEmbedding(): void
     {
         $owner          = new GH1428Document();
         $nestedEmbedded = new GH1428NestedEmbeddedDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1435Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1435Test.php
@@ -9,7 +9,7 @@ use MongoDB\BSON\ObjectId;
 
 class GH1435Test extends BaseTest
 {
-    public function testUpsert()
+    public function testUpsert(): void
     {
         $id = (string) new ObjectId();
 
@@ -26,7 +26,7 @@ class GH1435Test extends BaseTest
         $this->assertEquals('test', $document->name);
     }
 
-    public function testUpsertWithIncrement()
+    public function testUpsertWithIncrement(): void
     {
         $id = 10;
 
@@ -43,7 +43,7 @@ class GH1435Test extends BaseTest
         $this->assertEquals('test', $document->name);
     }
 
-    public function testUpdateWithIncrement()
+    public function testUpdateWithIncrement(): void
     {
         $document       = new GH1435DocumentIncrement();
         $document->name = 'test';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1525Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1525Test.php
@@ -11,7 +11,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH1525Test extends BaseTest
 {
-    public function testEmbedCloneTwoFlushesPerDocument()
+    public function testEmbedCloneTwoFlushesPerDocument(): void
     {
         $embedded = new GH1525Embedded('embedded');
 
@@ -43,7 +43,7 @@ class GH1525Test extends BaseTest
         }
     }
 
-    public function testEmbedCloneWithIdStrategyNoneOnParentAndEarlyPersist()
+    public function testEmbedCloneWithIdStrategyNoneOnParentAndEarlyPersist(): void
     {
         $uuidGen  = new UuidGenerator();
         $embedded = new GH1525Embedded('embedded');
@@ -68,7 +68,7 @@ class GH1525Test extends BaseTest
         }
     }
 
-    public function testEmbedCloneWithIdStrategyNoneOnParentAndLatePersist()
+    public function testEmbedCloneWithIdStrategyNoneOnParentAndLatePersist(): void
     {
         $uuidGen  = new UuidGenerator();
         $embedded = new GH1525Embedded('embedded');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1572Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1572Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
+use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
@@ -11,7 +12,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH1572Test extends BaseTest
 {
-    public function testPersistentCollectionCount()
+    public function testPersistentCollectionCount(): void
     {
         $blog = new GH1572Blog();
         $this->dm->persist($blog);
@@ -75,7 +76,7 @@ class GH1572Post
 
 class GH1572PostRepository extends DocumentRepository
 {
-    public function getPostsForBlog($blog)
+    public function getPostsForBlog($blog): Iterator
     {
         return $this->createQueryBuilder()
             ->field('blog')

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1674Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1674Test.php
@@ -11,7 +11,7 @@ use MongoDB\BSON\ObjectId;
 
 class GH1674Test extends BaseTest
 {
-    public function testElemMatchUsesCorrectMapping()
+    public function testElemMatchUsesCorrectMapping(): void
     {
         $builder = $this->dm->createQueryBuilder(GH1674Document::class);
         $builder

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1775Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1775Test.php
@@ -12,7 +12,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH1775Test extends BaseTest
 {
-    public function testProxyInitializationDoesNotLoseData()
+    public function testProxyInitializationDoesNotLoseData(): void
     {
         $image = new GH1775Image();
         $this->dm->persist($image);
@@ -106,7 +106,7 @@ class GH1775Post extends GH1775MetaDocument
         $this->images = new ArrayCollection($images);
     }
 
-    public function addReferences()
+    public function addReferences(): void
     {
         foreach ($this->blogs as $blog) {
             if ($blog->posts->contains($this)) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1962Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1962Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH1962Test extends BaseTest
 {
-    public function testDiscriminatorMaps()
+    public function testDiscriminatorMaps(): void
     {
         $metadata = $this->dm->getClassMetadata(GH1962Superclass::class);
         self::assertCount(3, $metadata->discriminatorMap);
@@ -18,7 +18,7 @@ class GH1962Test extends BaseTest
         self::assertCount(2, $metadata->discriminatorMap);
     }
 
-    public function testFetchingDiscriminatedDocuments()
+    public function testFetchingDiscriminatedDocuments(): void
     {
         $foo = new GH1962FooDocument();
         $bar = new GH1962BarDocument();
@@ -39,7 +39,7 @@ class GH1962Test extends BaseTest
         self::assertCount(1, $this->dm->getRepository(GH1962BazDocument::class)->findAll());
     }
 
-    public function testFetchingDiscriminatedDocumentsWithoutDiscriminatorMap()
+    public function testFetchingDiscriminatedDocumentsWithoutDiscriminatorMap(): void
     {
         $foo = new GH1962FooDocumentWithoutDiscriminatorMap();
         $bar = new GH1962BarDocumentWithoutDiscriminatorMap();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1964Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1964Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH1964Test extends BaseTest
 {
-    public function testSortMetaShouldReturnCorrectQuery()
+    public function testSortMetaShouldReturnCorrectQuery(): void
     {
         $builder = $this->dm->createQueryBuilder(GH1964Document::class);
         $builder->sort(['someField1' => 1, 'someField2' => -1]);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2002Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2002Test.php
@@ -16,7 +16,7 @@ class GH2002Test extends BaseTest
     /**
      * @dataProvider getValidReferenceData
      */
-    public function testBuildingReferenceCreatesCorrectStructure(array $expectedReference, $document)
+    public function testBuildingReferenceCreatesCorrectStructure(array $expectedReference, $document): void
     {
         $this->dm->persist($document);
 
@@ -28,7 +28,7 @@ class GH2002Test extends BaseTest
         self::assertArraySubset($expectedReference, $data['parentDocument']);
     }
 
-    public function getValidReferenceData()
+    public function getValidReferenceData(): array
     {
         return [
             'discriminatedDocument' => [
@@ -61,7 +61,7 @@ class GH2002Test extends BaseTest
     /**
      * @dataProvider getInvalidReferenceData
      */
-    public function testBuildingReferenceForUnlistedClassCausesException(string $expectedExceptionMessage, $document)
+    public function testBuildingReferenceForUnlistedClassCausesException(string $expectedExceptionMessage, $document): void
     {
         $this->dm->persist($document);
 
@@ -73,7 +73,7 @@ class GH2002Test extends BaseTest
         $this->dm->getUnitOfWork()->getPersistenceBuilder()->prepareInsertData($document);
     }
 
-    public function getInvalidReferenceData()
+    public function getInvalidReferenceData(): array
     {
         return [
             'referenceWithPartialDiscriminatorMapUnlistedDocument' => [

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2157Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2157Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH2157Test extends BaseTest
 {
-    public function testFacetDiscriminatorMapCreation()
+    public function testFacetDiscriminatorMapCreation(): void
     {
         $this->dm->persist(new GH2157FirstType());
         $this->dm->persist(new GH2157FirstType());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2251Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2251Test.php
@@ -14,7 +14,7 @@ class GH2251Test extends BaseTest
      * @testWith ["groups"]
      *           ["groupsSimple"]
      */
-    public function testElemMatchQuery(string $fieldName)
+    public function testElemMatchQuery(string $fieldName): void
     {
         $builder = $this->dm->createQueryBuilder(User::class);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH232Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH232Test.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH232Test extends BaseTest
 {
-    public function testReferencedDocumentInsideEmbeddedDocument()
+    public function testReferencedDocumentInsideEmbeddedDocument(): void
     {
         /* PARENT DOCUMENT */
         $product = new Product('Product');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH245Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH245Test.php
@@ -11,7 +11,7 @@ use function get_class;
 
 class GH245Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $order     = new GH245Order();
         $order->id = 1;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH267Test extends BaseTest
 {
-    public function testNestedReferences()
+    public function testNestedReferences(): void
     {
         // Users
         $user1 = new GH267User('Tom Petty');
@@ -75,7 +75,7 @@ class GH267User
         $this->name = $name;
     }
 
-    public function setId($id)
+    public function setId($id): void
     {
         $this->id = $id;
     }
@@ -85,7 +85,7 @@ class GH267User
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -95,7 +95,7 @@ class GH267User
         return $this->name;
     }
 
-    public function setCompany($company)
+    public function setCompany($company): void
     {
         $this->company = $company;
     }
@@ -120,7 +120,7 @@ class GH267Company
     /** @ODM\ReferenceMany(targetDocument=GH267User::class, mappedBy="company") */
     protected $users;
 
-    public function setId($id)
+    public function setId($id): void
     {
         $this->id = $id;
     }
@@ -130,7 +130,7 @@ class GH267Company
         return $this->id;
     }
 
-    public function setUsers($users)
+    public function setUsers($users): void
     {
         $this->users = $users;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH385Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH385Test.php
@@ -9,7 +9,7 @@ use MongoDB\BSON\ObjectId;
 
 class GH385Test extends BaseTest
 {
-    public function testQueryBuilderShouldPrepareUnmappedFields()
+    public function testQueryBuilderShouldPrepareUnmappedFields(): void
     {
         $identifier = new ObjectId();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH389Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH389Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH389Test extends BaseTest
 {
-    public function testDiscriminatorEmptyEmbeddedDocument()
+    public function testDiscriminatorEmptyEmbeddedDocument(): void
     {
         //Create root document (with empty embedded document)
         $rootDocument = new RootDocument();
@@ -50,7 +50,7 @@ class RootDocument
         return $this->id;
     }
 
-    public function getEmptyEmbeddedDocument()
+    public function getEmptyEmbeddedDocument(): EmptyEmbeddedDocument
     {
         return $this->emptyEmbeddedDocument;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH426Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH426Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH426Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $form           = new GH426Form();
         $form->fields[] = new GH426Field($form);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH435Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH435Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH435Test extends BaseTest
 {
-    public function testOverridingFieldsType()
+    public function testOverridingFieldsType(): void
     {
         $parent = $this->dm->getClassMetadata(GH435Parent::class);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH453Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH453Test.php
@@ -14,7 +14,7 @@ use function sprintf;
 
 class GH453Test extends BaseTest
 {
-    public function testHashWithStringKeys()
+    public function testHashWithStringKeys(): void
     {
         $hash = ['a' => 'x', 'b' => 'y', 'c' => 'z'];
 
@@ -45,7 +45,7 @@ class GH453Test extends BaseTest
         $this->assertBsonObjectAndValue($hash, $doc->id, 'hash');
     }
 
-    public function testHashWithNumericKeys()
+    public function testHashWithNumericKeys(): void
     {
         $hash = [0 => 'x', 1 => 'y', 2 => 'z'];
 
@@ -76,7 +76,7 @@ class GH453Test extends BaseTest
         $this->assertBsonObjectAndValue($hash, $doc->id, 'hash');
     }
 
-    public function testCollection()
+    public function testCollection(): void
     {
         $col = ['x', 'y', 'z'];
 
@@ -112,7 +112,7 @@ class GH453Test extends BaseTest
         $this->assertBsonArrayAndValue($col, $doc->id, 'colSet');
     }
 
-    public function testEmbedMany()
+    public function testEmbedMany(): void
     {
         $colPush     = new ArrayCollection([
             new GH453EmbeddedDocument(),
@@ -162,7 +162,7 @@ class GH453Test extends BaseTest
         $this->assertBsonArray($doc->id, 'embedManyAddToSet');
     }
 
-    public function testReferenceMany()
+    public function testReferenceMany(): void
     {
         $colPush     = new ArrayCollection([
             new GH453ReferencedDocument(),
@@ -239,17 +239,17 @@ class GH453Test extends BaseTest
         $this->assertBsonArray($doc->id, 'referenceManyAddToSet');
     }
 
-    private function assertBsonArray($documentId, $fieldName)
+    private function assertBsonArray($documentId, $fieldName): void
     {
         $this->assertBsonType(4, $documentId, $fieldName);
     }
 
-    private function assertBsonObject($documentId, $fieldName)
+    private function assertBsonObject($documentId, $fieldName): void
     {
         $this->assertBsonType(3, $documentId, $fieldName);
     }
 
-    private function assertBsonType($bsonType, $documentId, $fieldName)
+    private function assertBsonType($bsonType, $documentId, $fieldName): void
     {
         $criteria = ['_id' => $documentId];
 
@@ -263,17 +263,17 @@ class GH453Test extends BaseTest
         $this->assertNotNull($this->dm->getRepository(GH453Document::class)->findOneBy($criteria));
     }
 
-    private function assertBsonArrayAndValue($expectedValue, $documentId, $fieldName)
+    private function assertBsonArrayAndValue($expectedValue, $documentId, $fieldName): void
     {
         $this->assertBsonTypeAndValue(4, $expectedValue, $documentId, $fieldName);
     }
 
-    private function assertBsonObjectAndValue($expectedValue, $documentId, $fieldName)
+    private function assertBsonObjectAndValue($expectedValue, $documentId, $fieldName): void
     {
         $this->assertBsonTypeAndValue(3, $expectedValue, $documentId, $fieldName);
     }
 
-    private function assertBsonTypeAndValue($bsonType, $expectedValue, $documentId, $fieldName)
+    private function assertBsonTypeAndValue($bsonType, $expectedValue, $documentId, $fieldName): void
     {
         if ($bsonType === 4) {
             $expectedValue = array_values((array) $expectedValue);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH467Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH467Test.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH467Test extends BaseTest
 {
-    public function testMergeDocumentWithUnsetCollectionFields()
+    public function testMergeDocumentWithUnsetCollectionFields(): void
     {
         $doc = new GH467Document();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH499Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH499Test.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use MongoDB\BSON\ObjectId;
 
 class GH499Test extends BaseTest
 {
-    public function testSetRefMany()
+    public function testSetRefMany(): void
     {
         $a = new GH499Document(new ObjectId());
         $b = new GH499Document(new ObjectId());
@@ -50,22 +51,22 @@ class GH499Document
         $this->refMany = new ArrayCollection();
     }
 
-    public function getId()
+    public function getId(): string
     {
         return $this->id;
     }
 
-    public function getRefMany()
+    public function getRefMany(): Collection
     {
         return $this->refMany;
     }
 
-    public function addRef(GH499Document $doc)
+    public function addRef(GH499Document $doc): void
     {
         $this->refMany->set($doc->getId(), $doc);
     }
 
-    public function removeRef(GH499Document $doc)
+    public function removeRef(GH499Document $doc): void
     {
         $this->refMany->remove($doc->getId());
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH520Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH520Test.php
@@ -11,7 +11,7 @@ use ProxyManager\Proxy\GhostObjectInterface;
 
 class GH520Test extends BaseTest
 {
-    public function testPrimeWithGetSingleResult()
+    public function testPrimeWithGetSingleResult(): void
     {
         $document      = new GH520Document();
         $document->ref = new GH520Document();
@@ -31,7 +31,7 @@ class GH520Test extends BaseTest
         $this->assertTrue($document->ref->isProxyInitialized());
     }
 
-    public function testPrimeWithGetSingleResultWillNotPrimeEntireResultSet()
+    public function testPrimeWithGetSingleResultWillNotPrimeEntireResultSet(): void
     {
         $document1 = new GH520Document();
         $document2 = new GH520Document();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH529Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH529Test.php
@@ -12,7 +12,7 @@ use function get_class;
 
 class GH529Test extends BaseTest
 {
-    public function testAutoIdWithConsistentValues()
+    public function testAutoIdWithConsistentValues(): void
     {
         $identifier = new ObjectId();
         $doc        = new GH529AutoIdDocument();
@@ -28,7 +28,7 @@ class GH529Test extends BaseTest
         $this->assertEquals($identifier, $doc->id);
     }
 
-    public function testCustomIdType()
+    public function testCustomIdType(): void
     {
         /* All values are consistent for CustomIdType, since the PHP and DB
          * conversions return the value as-is.
@@ -46,7 +46,7 @@ class GH529Test extends BaseTest
         $this->assertSame('foo', $doc->id);
     }
 
-    public function testIntIdWithConsistentValues()
+    public function testIntIdWithConsistentValues(): void
     {
         $doc     = new GH529IntIdDocument();
         $doc->id = 1;
@@ -61,7 +61,7 @@ class GH529Test extends BaseTest
         $this->assertSame(1, $doc->id);
     }
 
-    public function testIntIdWithInconsistentValues()
+    public function testIntIdWithInconsistentValues(): void
     {
         $doc     = new GH529IntIdDocument();
         $doc->id = 3.14;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
@@ -16,7 +16,7 @@ class GH560Test extends BaseTest
     /**
      * @dataProvider provideDocumentIds
      */
-    public function testPersistListenersAreCalled($id)
+    public function testPersistListenersAreCalled($id): void
     {
         $listener = new GH560EventSubscriber([
             Events::prePersist,
@@ -41,7 +41,7 @@ class GH560Test extends BaseTest
     /**
      * @dataProvider provideDocumentIds
      */
-    public function testDocumentWithCustomIdStrategyIsSavedAndFoundFromDatabase($id)
+    public function testDocumentWithCustomIdStrategyIsSavedAndFoundFromDatabase($id): void
     {
         $doc = new GH560Document($id, 'test');
         $this->dm->persist($doc);
@@ -55,7 +55,7 @@ class GH560Test extends BaseTest
     /**
      * @dataProvider provideDocumentIds
      */
-    public function testUpdateListenersAreCalled($id)
+    public function testUpdateListenersAreCalled($id): void
     {
         $listener = new GH560EventSubscriber([
             Events::preUpdate,
@@ -80,7 +80,7 @@ class GH560Test extends BaseTest
         $this->assertEquals($called, $listener->called);
     }
 
-    public function provideDocumentIds()
+    public function provideDocumentIds(): array
     {
         return [
             [123456],
@@ -100,7 +100,7 @@ class GH560EventSubscriber implements EventSubscriber
         $this->events = $events;
     }
 
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return $this->events;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH561Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH561Test.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH561Test extends BaseTest
 {
-    public function testPersistMainDocument()
+    public function testPersistMainDocument(): void
     {
         $embeddedDocument = new GH561EmbeddedDocument();
         $embeddedDocument->embeddedDocuments->add(new GH561AnotherEmbeddedDocument('foo'));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH566Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH566Test.php
@@ -12,7 +12,7 @@ use function iterator_to_array;
 
 class GH566Test extends BaseTest
 {
-    public function testFoo()
+    public function testFoo(): void
     {
         $class = GH566Document::class;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
@@ -10,7 +10,7 @@ use MongoDB\Driver\Exception\BulkWriteException;
 
 class GH580Test extends BaseTest
 {
-    public function testDocumentPersisterShouldClearQueuedInsertsOnMongoException()
+    public function testDocumentPersisterShouldClearQueuedInsertsOnMongoException(): void
     {
         $class = GH580Document::class;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH593Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH593Test.php
@@ -26,7 +26,7 @@ class GH593Test extends BaseTest
         $filter->setParameter('value', false);
     }
 
-    public function testReferenceManyOwningSidePreparesFilterCriteria()
+    public function testReferenceManyOwningSidePreparesFilterCriteria(): void
     {
         $class = GH593User::class;
 
@@ -70,7 +70,7 @@ class GH593Test extends BaseTest
         $user1following[1]->initializeProxy();
     }
 
-    public function testReferenceManyInverseSidePreparesFilterCriteria()
+    public function testReferenceManyInverseSidePreparesFilterCriteria(): void
     {
         $class = GH593User::class;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH596Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH596Test.php
@@ -20,7 +20,7 @@ class GH596Test extends BaseTest
         $filter->setParameter('value', false);
     }
 
-    public function testExpressionPreparationDoesNotInjectFilterCriteria()
+    public function testExpressionPreparationDoesNotInjectFilterCriteria(): void
     {
         $class = GH596Document::class;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH597Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH597Test.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use MongoDB\BSON\ObjectId;
 
 class GH597Test extends BaseTest
 {
-    public function testEmbedManyGetsUnset()
+    public function testEmbedManyGetsUnset(): void
     {
         $post = new GH597Post();
         $this->dm->persist($post);
@@ -58,7 +59,7 @@ class GH597Test extends BaseTest
         $this->assertPostDocument($expectedDocument, $post);
     }
 
-    public function testReferenceManyGetsUnset()
+    public function testReferenceManyGetsUnset(): void
     {
         $post = new GH597Post();
         $this->dm->persist($post);
@@ -111,7 +112,7 @@ class GH597Test extends BaseTest
      *
      * @param array $expected
      */
-    private function assertPostDocument(array $expected, GH597Post $post)
+    private function assertPostDocument(array $expected, GH597Post $post): void
     {
         $collection = $this->dm->getDocumentCollection(GH597Post::class);
         $document   = $collection->findOne(['_id' => new ObjectId($post->getId())]);
@@ -142,12 +143,12 @@ class GH597Post
         return $this->id;
     }
 
-    public function getComments()
+    public function getComments(): Collection
     {
         return $this->comments;
     }
 
-    public function getReferenceMany()
+    public function getReferenceMany(): Collection
     {
         return $this->referenceMany;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
@@ -15,7 +15,7 @@ use function iterator_to_array;
 
 class GH602Test extends BaseTest
 {
-    public function testReferenceManyOwningSidePreparesFilterCriteriaForDifferentClass()
+    public function testReferenceManyOwningSidePreparesFilterCriteriaForDifferentClass(): void
     {
         $thingClass = GH602Thing::class;
         $userClass  = GH602User::class;
@@ -61,7 +61,7 @@ class GH602Test extends BaseTest
         $user1likes[1]->initializeProxy();
     }
 
-    public function testReferenceManyInverseSidePreparesFilterCriteriaForDifferentClass()
+    public function testReferenceManyInverseSidePreparesFilterCriteriaForDifferentClass(): void
     {
         $thingClass = GH602Thing::class;
         $userClass  = GH602User::class;
@@ -92,7 +92,7 @@ class GH602Test extends BaseTest
         $this->assertEquals($user1->getId(), $thing1likedBy[0]->getId());
     }
 
-    private function enableDeletedFilter($class)
+    private function enableDeletedFilter($class): void
     {
         $this->dm->getFilterCollection()->enable('testFilter');
         $filter = $this->dm->getFilterCollection()->getFilter('testFilter');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH611Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH611Test.php
@@ -9,7 +9,7 @@ use MongoDB\BSON\ObjectId;
 
 class GH611Test extends BaseTest
 {
-    public function testPreparationofEmbeddedDocumentValues()
+    public function testPreparationofEmbeddedDocumentValues(): void
     {
         $documentId = (string) (new ObjectId());
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH628Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH628Test.php
@@ -8,7 +8,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 class GH628Test extends BaseTest
 {
-    public function testQueryBuilderShouldOnlyPrepareFirstPartOfRawFields()
+    public function testQueryBuilderShouldOnlyPrepareFirstPartOfRawFields(): void
     {
         $query = $this->dm->createQueryBuilder(GH628Document::class)
             ->field('foo.bar.baz')->equals(1)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH665Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH665Test.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH665Test extends BaseTest
 {
-    public function testUseAddToSetStrategyOnEmbeddedDocument()
+    public function testUseAddToSetStrategyOnEmbeddedDocument(): void
     {
         $document = new GH665Document();
         $document->embeddedPushAll->add(new GH665Embedded('foo'));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH683Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH683Test.php
@@ -14,7 +14,7 @@ use function get_class;
 
 class GH683Test extends BaseTest
 {
-    public function testEmbedOne()
+    public function testEmbedOne(): void
     {
         $parent       = new ParentDocument();
         $parent->name = 'Parent';
@@ -34,7 +34,7 @@ class GH683Test extends BaseTest
         $this->assertInstanceOf(get_class($sub1), $parent->embedOne);
     }
 
-    public function testEmbedMany()
+    public function testEmbedMany(): void
     {
         $parent       = new ParentDocument();
         $parent->name = 'Parent';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH774Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH774Test.php
@@ -11,7 +11,7 @@ use function get_class;
 
 class GH774Test extends BaseTest
 {
-    public function testUpsert()
+    public function testUpsert(): void
     {
         $id = (string) new ObjectId();
 
@@ -28,7 +28,7 @@ class GH774Test extends BaseTest
         $this->assertEquals('test', $thread->permalink);
     }
 
-    protected function createMetadataDriverImpl()
+    protected function createMetadataDriverImpl(): XmlDriver
     {
         return new XmlDriver(__DIR__ . '/GH774');
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH774Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH774Test.php
@@ -28,7 +28,7 @@ class GH774Test extends BaseTest
         $this->assertEquals('test', $thread->permalink);
     }
 
-    protected function createMetadataDriverImpl(): XmlDriver
+    protected function createMetadataDriverImpl()
     {
         return new XmlDriver(__DIR__ . '/GH774');
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH788Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH788Test.php
@@ -12,7 +12,7 @@ use function get_class;
 
 class GH788Test extends BaseTest
 {
-    public function testDocumentWithDiscriminatorMap()
+    public function testDocumentWithDiscriminatorMap(): void
     {
         $listed       = new GH788DocumentListed();
         $listed->name = 'listed';
@@ -35,7 +35,7 @@ class GH788Test extends BaseTest
         $this->dm->flush();
     }
 
-    public function testEmbedManyWithExternalDiscriminatorMap()
+    public function testEmbedManyWithExternalDiscriminatorMap(): void
     {
         $doc = new GH788Document();
 
@@ -54,7 +54,7 @@ class GH788Test extends BaseTest
         $this->dm->flush();
     }
 
-    public function testEmbedManyWithInlineDiscriminatorMap()
+    public function testEmbedManyWithInlineDiscriminatorMap(): void
     {
         $doc = new GH788Document();
 
@@ -73,7 +73,7 @@ class GH788Test extends BaseTest
         $this->dm->flush();
     }
 
-    public function testEmbedManyWithNoTargetAndExternalDiscriminatorMap()
+    public function testEmbedManyWithNoTargetAndExternalDiscriminatorMap(): void
     {
         $doc = new GH788Document();
 
@@ -92,7 +92,7 @@ class GH788Test extends BaseTest
         $this->dm->flush();
     }
 
-    public function testEmbedOneWithExternalDiscriminatorMap()
+    public function testEmbedOneWithExternalDiscriminatorMap(): void
     {
         $doc = new GH788Document();
 
@@ -107,7 +107,7 @@ class GH788Test extends BaseTest
         $this->dm->flush();
     }
 
-    public function testEmbedOneWithInlineDiscriminatorMap()
+    public function testEmbedOneWithInlineDiscriminatorMap(): void
     {
         $doc = new GH788Document();
 
@@ -122,7 +122,7 @@ class GH788Test extends BaseTest
         $this->dm->flush();
     }
 
-    public function testEmbedOneWithNoTargetAndExternalDiscriminatorMap()
+    public function testEmbedOneWithNoTargetAndExternalDiscriminatorMap(): void
     {
         $doc = new GH788Document();
 
@@ -137,7 +137,7 @@ class GH788Test extends BaseTest
         $this->dm->flush();
     }
 
-    public function testRefManyWithExternalDiscriminatorMap()
+    public function testRefManyWithExternalDiscriminatorMap(): void
     {
         $doc = new GH788Document();
 
@@ -156,7 +156,7 @@ class GH788Test extends BaseTest
         $this->dm->flush();
     }
 
-    public function testRefManyWithInlineDiscriminatorMap()
+    public function testRefManyWithInlineDiscriminatorMap(): void
     {
         $doc = new GH788Document();
 
@@ -175,7 +175,7 @@ class GH788Test extends BaseTest
         $this->dm->flush();
     }
 
-    public function testRefManyWithNoTargetAndExternalDiscriminatorMap()
+    public function testRefManyWithNoTargetAndExternalDiscriminatorMap(): void
     {
         $doc = new GH788Document();
 
@@ -194,7 +194,7 @@ class GH788Test extends BaseTest
         $this->dm->flush();
     }
 
-    public function testRefOneWithExternalDiscriminatorMap()
+    public function testRefOneWithExternalDiscriminatorMap(): void
     {
         $doc = new GH788Document();
 
@@ -209,7 +209,7 @@ class GH788Test extends BaseTest
         $this->dm->flush();
     }
 
-    public function testRefOneWithInlineDiscriminatorMap()
+    public function testRefOneWithInlineDiscriminatorMap(): void
     {
         $doc = new GH788Document();
 
@@ -224,7 +224,7 @@ class GH788Test extends BaseTest
         $this->dm->flush();
     }
 
-    public function testRefOneWithNoTargetAndExternalDiscriminatorMap()
+    public function testRefOneWithNoTargetAndExternalDiscriminatorMap(): void
     {
         $doc = new GH788Document();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH816Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH816Test.php
@@ -9,7 +9,7 @@ use MongoDB\BSON\ObjectId;
 
 class GH816Test extends BaseTest
 {
-    public function testPersistAfterDetachWithIdSet()
+    public function testPersistAfterDetachWithIdSet(): void
     {
         $d     = new GH816Document();
         $d->id = new ObjectId();
@@ -20,7 +20,7 @@ class GH816Test extends BaseTest
         $this->assertEmpty($this->dm->getRepository(GH816Document::class)->findAll());
     }
 
-    public function testPersistAfterDetachWithTitleSet()
+    public function testPersistAfterDetachWithTitleSet(): void
     {
         $d        = new GH816Document();
         $d->title = 'Test';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH850Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH850Test.php
@@ -10,7 +10,7 @@ use InvalidArgumentException;
 
 class GH850Test extends BaseTest
 {
-    public function testPersistWrongReference()
+    public function testPersistWrongReference(): void
     {
         $d = new GH850Document();
         $this->dm->persist($d);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
@@ -19,7 +19,7 @@ class GH852Test extends BaseTest
     /**
      * @dataProvider provideIdGenerators
      */
-    public function testA(Closure $idGenerator)
+    public function testA(Closure $idGenerator): void
     {
         $parent       = new GH852Document();
         $parent->id   = $idGenerator('parent');
@@ -92,7 +92,7 @@ class GH852Test extends BaseTest
         $this->assertCount(4, $docs);
     }
 
-    public function provideIdGenerators()
+    public function provideIdGenerators(): array
     {
         $binDataType = Binary::TYPE_GENERIC;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH878Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH878Test.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\UnitOfWork;
 
 class GH878Test extends BaseTest
 {
-    public function testSPLObjectHashCollisionOnDoubleMerge()
+    public function testSPLObjectHashCollisionOnDoubleMerge(): void
     {
         $document = $this->getPersistedButDetachedDocument();
 
@@ -39,10 +39,7 @@ class GH878Test extends BaseTest
         $this->assertEquals(UnitOfWork::STATE_NEW, $state);
     }
 
-    /**
-     * @return GH878Document
-     */
-    private function getPersistedButDetachedDocument()
+    private function getPersistedButDetachedDocument(): GH878Document
     {
         $document                = new GH878Document();
         $document->embeddedField = new GH878SubDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH880Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH880Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH880Test extends BaseTest
 {
-    public function test880()
+    public function test880(): void
     {
         $docs   = [];
         $docs[] = new GH880Document('hello', 1);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH897Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH897Test.php
@@ -11,7 +11,7 @@ use function get_class;
 
 class GH897Test extends BaseTest
 {
-    public function testRecomputeSingleDocumentChangesetForManagedDocumentWithoutChangeset()
+    public function testRecomputeSingleDocumentChangesetForManagedDocumentWithoutChangeset(): void
     {
         $documentA       = new GH897A();
         $documentA->name = 'a';
@@ -66,7 +66,7 @@ class GH897B
     public $dm;
 
     /** @ODM\PreFlush */
-    public function preFlush()
+    public function preFlush(): void
     {
         if (! $this->refOne instanceof GH897A) {
             return;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH909Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH909Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
+use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Group;
 use Documents\Phonenumber;
@@ -11,7 +12,7 @@ use Documents\User;
 
 class GH909Test extends BaseTest
 {
-    public function testManyReferenceAddAndPersist()
+    public function testManyReferenceAddAndPersist(): void
     {
         $user = new User();
         $user->addGroup(new Group('Group A'));
@@ -49,7 +50,7 @@ class GH909Test extends BaseTest
         $this->assertTrue($groups->isInitialized());
     }
 
-    public function testManyEmbeddedAddAndPersist()
+    public function testManyEmbeddedAddAndPersist(): void
     {
         $user = new User();
         $user->addPhoneNumber(new Phonenumber('111-111-1111'));
@@ -62,6 +63,7 @@ class GH909Test extends BaseTest
         $user = $this->dm->find(User::class, $user->getId());
 
         $phoneNumbers = $user->getPhoneNumbers();
+        $this->assertInstanceOf(PersistentCollectionInterface::class, $phoneNumbers);
         $this->assertCount(2, $phoneNumbers);
         $this->assertTrue($phoneNumbers->isInitialized());
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH921Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH921Test.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH921Test extends BaseTest
 {
-    public function testPersistentCollectionCountAndIterationShouldBeConsistent()
+    public function testPersistentCollectionCountAndIterationShouldBeConsistent(): void
     {
         $user = new GH921User();
         $user->setName('smith');
@@ -27,6 +29,7 @@ class GH921Test extends BaseTest
         $this->dm->persist($postA);
         $this->dm->flush();
 
+        $this->assertInstanceOf(PersistentCollectionInterface::class, $user->getPosts());
         $this->assertFalse($user->getPosts()->isDirty(), 'A flushed collection should not be dirty');
         $this->assertTrue($user->getPosts()->isInitialized(), 'A flushed collection should be initialized');
         $this->assertCount(1, $user->getPosts());
@@ -34,6 +37,7 @@ class GH921Test extends BaseTest
 
         $this->dm->refresh($user);
 
+        $this->assertInstanceOf(PersistentCollectionInterface::class, $user->getPosts());
         $this->assertFalse($user->getPosts()->isDirty(), 'A refreshed collection should not be dirty');
         $this->assertFalse($user->getPosts()->isInitialized(), 'A refreshed collection should not be initialized');
         $this->assertCount(1, $user->getPosts());
@@ -45,6 +49,7 @@ class GH921Test extends BaseTest
         $user->addPost($postB);
         $this->dm->persist($postB);
 
+        $this->assertInstanceOf(PersistentCollectionInterface::class, $user->getPosts());
         $this->assertTrue($user->getPosts()->isDirty(), 'A refreshed collection then modified should be dirty');
         $this->assertFalse($user->getPosts()->isInitialized(), 'A refreshed collection then modified should not be initialized');
         $this->assertCount(2, $user->getPosts());
@@ -52,6 +57,7 @@ class GH921Test extends BaseTest
 
         $user->getPosts()->initialize();
 
+        $this->assertInstanceOf(PersistentCollectionInterface::class, $user->getPosts());
         $this->assertTrue($user->getPosts()->isDirty(), 'A dirty collection then initialized should remain dirty');
         $this->assertCount(2, $user->getPosts());
         $this->assertCount(2, $user->getPosts()->toArray());
@@ -85,17 +91,17 @@ class GH921User
         return $this->name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
 
-    public function addPost(GH921Post $post)
+    public function addPost(GH921Post $post): void
     {
         $this->posts[] = $post;
     }
 
-    public function getPosts()
+    public function getPosts(): Collection
     {
         return $this->posts;
     }
@@ -120,7 +126,7 @@ class GH921Post
         return $this->name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH927Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH927Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH927Test extends BaseTest
 {
-    public function testInheritedClassHasAssociationMapping()
+    public function testInheritedClassHasAssociationMapping(): void
     {
         $parentMetadata = $this->dm->getClassMetadata(GH927Parent::class);
         $this->assertArrayHasKey('reference', $parentMetadata->associationMappings);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH928Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH928Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH928Test extends BaseTest
 {
-    public function testNullIdCriteriaShouldNotRemoveEverything()
+    public function testNullIdCriteriaShouldNotRemoveEverything(): void
     {
         $docA = new GH928Document();
         $docB = new GH928Document();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH936Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH936Test.php
@@ -12,7 +12,7 @@ use ProxyManager\Proxy\GhostObjectInterface;
 
 class GH936Test extends BaseTest
 {
-    public function testRemoveCascadesThroughProxyDocuments()
+    public function testRemoveCascadesThroughProxyDocuments(): void
     {
         $listener = new GH936Listener();
         $this->dm->getEventManager()->addEventListener(Events::postRemove, $listener);
@@ -58,7 +58,7 @@ class GH936Listener
 {
     public $removed = [];
 
-    public function postRemove(LifecycleEventArgs $args)
+    public function postRemove(LifecycleEventArgs $args): void
     {
         $this->removed[] = $args->getDocument();
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH942Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH942Test.php
@@ -11,7 +11,7 @@ use MongoDB\BSON\ObjectId;
 
 class GH942Test extends BaseTest
 {
-    public function testDiscriminatorValueUsesClassNameIfMapIsNotDefined()
+    public function testDiscriminatorValueUsesClassNameIfMapIsNotDefined(): void
     {
         $doc       = new GH942Document();
         $doc->name = 'foo';
@@ -27,7 +27,7 @@ class GH942Test extends BaseTest
         $this->assertSame(GH942Document::CLASSNAME, $doc['type']);
     }
 
-    public function testDiscriminatorValueUsesClassNameIfNotInMap()
+    public function testDiscriminatorValueUsesClassNameIfNotInMap(): void
     {
         $parent       = new GH942DocumentParent();
         $parent->name = 'parent';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH944Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH944Test.php
@@ -12,7 +12,7 @@ use function get_class;
 
 class GH944Test extends BaseTest
 {
-    public function testIssue()
+    public function testIssue(): void
     {
         $d = new GH944Document();
         $d->data->add(new GH944Embedded('1'));
@@ -55,7 +55,7 @@ class GH944Document
         $this->data = new ArrayCollection();
     }
 
-    public function removeByText($text)
+    public function removeByText($text): void
     {
         foreach ($this->data as $d) {
             if ($d->text !== $text) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
@@ -10,7 +10,7 @@ use InvalidArgumentException;
 
 class GH971Test extends BaseTest
 {
-    public function testUpdateOfInheritedDocumentUsingFindAndUpdate()
+    public function testUpdateOfInheritedDocumentUsingFindAndUpdate(): void
     {
         $name     = 'Ferrari';
         $features = [
@@ -40,7 +40,7 @@ class GH971Test extends BaseTest
         $this->assertCount(1, $results);
     }
 
-    public function testUpsertThrowsExceptionWithIndecisiveDiscriminator()
+    public function testUpsertThrowsExceptionWithIndecisiveDiscriminator(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -55,7 +55,7 @@ class GH971Test extends BaseTest
             ->getQuery()->execute();
     }
 
-    public function testUpsertWillUseProvidedDiscriminator()
+    public function testUpsertWillUseProvidedDiscriminator(): void
     {
         $this->dm->createQueryBuilder(Bicycle::class)
             ->findAndUpdate()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH977Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH977Test.php
@@ -11,7 +11,7 @@ use function get_class;
 
 class GH977Test extends BaseTest
 {
-    public function testAutoRecompute()
+    public function testAutoRecompute(): void
     {
         $d         = new GH977TestDocument();
         $d->value1 = 'Value 1';
@@ -35,7 +35,7 @@ class GH977Test extends BaseTest
         $this->assertEquals('v1 has changed', $d->value2);
     }
 
-    public function testRefreshClearsChangeSet()
+    public function testRefreshClearsChangeSet(): void
     {
         $d         = new GH977TestDocument();
         $d->value1 = 'Value 1';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH978Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH978Test.php
@@ -16,7 +16,7 @@ use Documents\Ecommerce\StockItem;
  */
 class GH978Test extends BaseTest
 {
-    public function testDetach()
+    public function testDetach(): void
     {
         $document = new ConfigurableProduct('foo bar');
         //option 1

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH999Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH999Test.php
@@ -14,7 +14,7 @@ use function get_class;
 
 class GH999Test extends BaseTest
 {
-    public function testModifyingInFlushHandler()
+    public function testModifyingInFlushHandler(): void
     {
         $this->dm->getEventManager()->addEventListener([Events::onFlush], new GH999Listener());
 
@@ -31,7 +31,7 @@ class GH999Test extends BaseTest
 
 class GH999Listener
 {
-    public function onFlush(OnFlushEventArgs $args)
+    public function onFlush(OnFlushEventArgs $args): void
     {
         $dm = $args->getDocumentManager();
 
@@ -67,13 +67,13 @@ class GH999Document
         return $this->name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
 
     /** @ODM\PostUpdate */
-    public function postUpdate()
+    public function postUpdate(): void
     {
         throw new Exception('Did not expect postUpdate to be called when persisting a new document');
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
@@ -12,7 +12,7 @@ use function get_class;
 
 class MODM116Test extends BaseTest
 {
-    public function testIssue()
+    public function testIssue(): void
     {
         $parent = new MODM116Parent();
         $parent->setName('test');
@@ -61,7 +61,7 @@ class MODM116Parent
         return $this->name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -71,7 +71,7 @@ class MODM116Parent
         return $this->child;
     }
 
-    public function setChild(MODM116Child $child)
+    public function setChild(MODM116Child $child): void
     {
         $this->child = $child;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM140Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM140Test.php
@@ -13,7 +13,7 @@ use Documents\Functional\EmbeddedTestLevel2;
 
 class MODM140Test extends BaseTest
 {
-    public function testInsertingNestedEmbeddedCollections()
+    public function testInsertingNestedEmbeddedCollections(): void
     {
         $category       = new Category();
         $category->name = 'My Category';
@@ -44,7 +44,7 @@ class MODM140Test extends BaseTest
         $this->assertEquals(2, $category->posts->get(1)->versions->count());
     }
 
-    public function testInsertingEmbeddedCollectionWithRefMany()
+    public function testInsertingEmbeddedCollectionWithRefMany(): void
     {
         $comment = new Comment();
 
@@ -66,7 +66,7 @@ class MODM140Test extends BaseTest
         $this->assertEquals(1, $category->posts->get(0)->comments->count());
     }
 
-    public function testAddingAnotherEmbeddedDocument()
+    public function testAddingAnotherEmbeddedDocument(): void
     {
         $test       = new EmbeddedTestLevel0();
         $test->name = 'test';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM160Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM160Test.php
@@ -12,7 +12,7 @@ class MODM160Test extends BaseTest
     /**
      * @doesNotPerformAssertions
      */
-    public function testEmbedManyInArrayMergeNew()
+    public function testEmbedManyInArrayMergeNew(): void
     {
         // create a test document
         $test       = new MODM160\EmbedManyInArrayLevel0();
@@ -32,7 +32,7 @@ class MODM160Test extends BaseTest
     /**
      * @doesNotPerformAssertions
      */
-    public function testEmbedManyInArrayCollectionMergeNew()
+    public function testEmbedManyInArrayCollectionMergeNew(): void
     {
         // create a test document
         $test       = new MODM160\EmbedManyInArrayCollectionLevel0();
@@ -52,7 +52,7 @@ class MODM160Test extends BaseTest
     /**
      * @doesNotPerformAssertions
      */
-    public function testEmbedOneMergeNew()
+    public function testEmbedOneMergeNew(): void
     {
         // create a test document
         $test       = new MODM160\EmbedOneLevel0();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM166Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM166Test.php
@@ -27,7 +27,7 @@ class MODM166Test extends BaseTest
         $evm->addEventListener(Events::onFlush, $this->listener);
     }
 
-    public function testUpdateCollectionDuringOnFlushAndRecomputSingleDocumentChangeSet()
+    public function testUpdateCollectionDuringOnFlushAndRecomputSingleDocumentChangeSet(): void
     {
         // create a test document
         $test = new User();
@@ -57,7 +57,7 @@ class MODM166Test extends BaseTest
 
 class MODM166EventListener
 {
-    public function onFlush(OnFlushEventArgs $eventArgs)
+    public function onFlush(OnFlushEventArgs $eventArgs): void
     {
         $documentManager = $eventArgs->getDocumentManager();
         $unitOfWork      = $documentManager->getUnitOfWork();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM167Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM167Test.php
@@ -25,7 +25,7 @@ class MODM167Test extends BaseTest
         $evm->addEventListener(Events::onFlush, $this->listener);
     }
 
-    public function testDetatchNewDocumentDuringOnFlush()
+    public function testDetatchNewDocumentDuringOnFlush(): void
     {
         // create a test document
         $test = new User();
@@ -44,7 +44,7 @@ class MODM167Test extends BaseTest
 
 class MODM167EventListener
 {
-    public function onFlush(OnFlushEventArgs $eventArgs)
+    public function onFlush(OnFlushEventArgs $eventArgs): void
     {
         $documentManager = $eventArgs->getDocumentManager();
         $unitOfWork      = $documentManager->getUnitOfWork();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM29Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM29Test.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class MODM29Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $collection = new ArrayCollection([
             new MODM29Embedded('0'),
@@ -64,7 +64,7 @@ class MODM29Doc
         $this->set($c);
     }
 
-    public function set($c)
+    public function set($c): void
     {
         $this->collection = $c;
     }
@@ -91,7 +91,7 @@ class MODM29Embedded
         return $this->val;
     }
 
-    public function set($val)
+    public function set($val): void
     {
         $this->val = $val;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM43Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM43Test.php
@@ -13,7 +13,7 @@ use function explode;
 
 class MODM43Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $person = [
             '_id' => new ObjectId(),
@@ -39,7 +39,7 @@ class Person
     public $lastName;
 
     /** @ODM\PreLoad */
-    public function preLoad(PreLoadEventArgs $e)
+    public function preLoad(PreLoadEventArgs $e): void
     {
         $data =& $e->getData();
         if (! isset($data['name'])) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM45Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM45Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class MODM45Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $a = new MODM45A();
         $a->setB(new MODM45B());
@@ -43,7 +43,7 @@ class MODM45A
         return $this->b;
     }
 
-    public function setB($b)
+    public function setB($b): void
     {
         $this->b = $b;
     }
@@ -55,7 +55,7 @@ class MODM45B
     /** @ODM\Field(type="string") */
     protected $val;
 
-    public function setVal($val)
+    public function setVal($val): void
     {
         $this->val = $val;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM46Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM46Test.php
@@ -10,7 +10,7 @@ use MongoDB\BSON\ObjectId;
 
 class MODM46Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $a = [
             '_id' => new ObjectId(),

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM47Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM47Test.php
@@ -10,7 +10,7 @@ use MongoDB\BSON\ObjectId;
 
 class MODM47Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $a = [
             '_id' => new ObjectId(),
@@ -33,7 +33,7 @@ class MODM47A
     public $b = 'tmp';
 
     /** @ODM\AlsoLoad("c") */
-    public function renameC($c)
+    public function renameC($c): void
     {
         $this->b = $c;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM48Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM48Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class MODM48Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $a    = new MODM48A();
         $a->b = new MODM48B();
@@ -49,7 +49,7 @@ class MODM48A
         return $this->b;
     }
 
-    public function setB($b)
+    public function setB($b): void
     {
         $this->b = $b;
     }
@@ -61,7 +61,7 @@ class MODM48B
     /** @ODM\Field(type="string") */
     public $val;
 
-    public function setVal($val)
+    public function setVal($val): void
     {
         $this->val = $val;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM52Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM52Test.php
@@ -11,7 +11,7 @@ use function count;
 
 class MODM52Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $emb = new MODM52Embedded([new MODM52Embedded(null, 'c1'), new MODM52Embedded(null, 'c2')], 'b');
         $doc = new MODM52Doc([$emb], 'a');
@@ -65,7 +65,7 @@ class MODM52Container
         return $this->items[$index];
     }
 
-    public function removeItem($i)
+    public function removeItem($i): void
     {
         unset($this->items[$i]);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM56Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM56Test.php
@@ -11,7 +11,7 @@ use MongoDB\BSON\UTCDateTime;
 
 class MODM56Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $parent = new MODM56Parent('Parent');
         $this->dm->persist($parent);
@@ -55,7 +55,7 @@ class MODM56Parent
     }
 
     /** @ODM\PreUpdate */
-    public function preUpdate()
+    public function preUpdate(): void
     {
         $this->updatedAt = new DateTime();
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM62Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM62Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class MODM62Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $test = new MODM62Document();
         $this->dm->persist($test);
@@ -34,7 +34,7 @@ class MODM62Document
     /** @ODM\Field(type="collection") */
     public $b = ['ok'];
 
-    public function setB($b)
+    public function setB($b): void
     {
         $this->b = $b;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM65Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM65Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class MODM65Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $user                               = new MODM65User();
         $user->socialNetworkUser            = new MODM65SocialNetworkUser();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM66Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM66Test.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class MODM66Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $b1 = new MODM52B('first');
         $a  = new MODM52A([$b1]);
@@ -34,7 +35,7 @@ class MODM66Test extends BaseTest
         ]);
     }
 
-    public function testRefresh()
+    public function testRefresh(): void
     {
         $b1 = new MODM52B('first');
         $a  = new MODM52A([$b1]);
@@ -75,7 +76,7 @@ class MODM52A
         $this->b = new ArrayCollection($b);
     }
 
-    public function getB()
+    public function getB(): Collection
     {
         return $this->b;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM67Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM67Test.php
@@ -15,7 +15,7 @@ class MODM67Test extends BaseTest
     /** @var MODM67TestEventListener */
     private $listener;
 
-    private function getDocumentManager()
+    private function getDocumentManager(): ?DocumentManager
     {
         $this->listener = new MODM67TestEventListener($this->dm);
         $evm            = $this->dm->getEventManager();
@@ -30,7 +30,7 @@ class MODM67Test extends BaseTest
         return $this->dm;
     }
 
-    public function testDerivedClassListener()
+    public function testDerivedClassListener(): void
     {
         $dm = $this->getDocumentManager();
 
@@ -66,7 +66,7 @@ class MODM67TestEventListener
         $this->documentManager = $documentManager;
     }
 
-    public function prePersist(LifecycleEventArgs $eventArgs)
+    public function prePersist(LifecycleEventArgs $eventArgs): void
     {
         $document = $eventArgs->getDocument();
         if (! ($document instanceof MODM67EmbeddedObject)) {
@@ -76,7 +76,7 @@ class MODM67TestEventListener
         $document->prePersist = true;
     }
 
-    public function postPersist(LifecycleEventArgs $eventArgs)
+    public function postPersist(LifecycleEventArgs $eventArgs): void
     {
         $document = $eventArgs->getDocument();
         if (! ($document instanceof MODM67EmbeddedObject)) {
@@ -86,7 +86,7 @@ class MODM67TestEventListener
         $document->postPersist = true;
     }
 
-    public function preUpdate(LifecycleEventArgs $eventArgs)
+    public function preUpdate(LifecycleEventArgs $eventArgs): void
     {
         $document = $eventArgs->getDocument();
         if (! ($document instanceof MODM67EmbeddedObject)) {
@@ -96,7 +96,7 @@ class MODM67TestEventListener
         $document->preUpdate = true;
     }
 
-    public function postUpdate(LifecycleEventArgs $eventArgs)
+    public function postUpdate(LifecycleEventArgs $eventArgs): void
     {
         $document = $eventArgs->getDocument();
         if (! ($document instanceof MODM67EmbeddedObject)) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
@@ -137,7 +137,7 @@ class AvatarPart
         $this->color = $color;
     }
 
-    public function getColor()
+    public function getColor(): string
     {
         return $this->color;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
@@ -11,7 +11,7 @@ use function array_search;
 
 class MODM70Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $avatar = new Avatar('Test', 1, [new AvatarPart('#000')]);
 
@@ -74,22 +74,22 @@ class Avatar
         return $this->id;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
 
-    public function getSex()
+    public function getSex(): int
     {
         return $this->sex;
     }
 
-    public function setSex($sex)
+    public function setSex($sex): void
     {
         $this->sex = $sex;
     }
@@ -99,17 +99,17 @@ class Avatar
         return $this->avatarParts;
     }
 
-    public function addAvatarPart($part)
+    public function addAvatarPart($part): void
     {
         $this->avatarParts[] = $part;
     }
 
-    public function setAvatarParts($parts)
+    public function setAvatarParts($parts): void
     {
         $this->avatarParts = $parts;
     }
 
-    public function removeAvatarPart($part)
+    public function removeAvatarPart($part): void
     {
         $key = array_search($this->avatarParts, $part);
         if ($key === false) {
@@ -142,7 +142,7 @@ class AvatarPart
         return $this->color;
     }
 
-    public function setColor($color)
+    public function setColor($color): void
     {
         $this->color = $color;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM72Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM72Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class MODM72Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $class = $this->dm->getClassMetadata(MODM72User::class);
         $this->assertEquals(['test' => 'test'], $class->fieldMappings['name']['options']);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM76Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM76Test.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class MODM76Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $c1 = new MODM76C();
         $c2 = new MODM76C();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
@@ -87,10 +87,7 @@ class MODM81TestDocument
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     */
-    public function setName($name)
+    public function setName(string $name)
     {
         $this->name = $name;
     }
@@ -106,7 +103,7 @@ class MODM81TestDocument
     /**
      * @param array $documents
      */
-    public function setEmbeddedDocuments($documents)
+    public function setEmbeddedDocuments(array $documents)
     {
         $this->embeddedDocuments = new ArrayCollection($documents);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
@@ -16,7 +17,7 @@ class MODM81Test extends BaseTest
         return $this->dm;
     }
 
-    public function testDocumentIdWithSameProxyId()
+    public function testDocumentIdWithSameProxyId(): void
     {
         $dm = $this->getDocumentManager();
 
@@ -68,34 +69,29 @@ class MODM81TestDocument
     /** @ODM\Field(type="string") */
     protected $name;
 
-    /** @ODM\EmbedMany(targetDocument=MODM81TestEmbeddedDocument::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=MODM81TestEmbeddedDocument::class)
+     *
+     * @var Collection<int, MODM81TestEmbeddedDocument>
+     */
     protected $embeddedDocuments;
 
-    /**
-     * @return string
-     */
-    public function getId()
+    public function getId(): string
     {
         return $this->id;
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function setName(string $name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    /**
-     * @return ArrayCollection
-     */
-    public function getEmbeddedDocuments()
+    public function getEmbeddedDocuments(): Collection
     {
         return $this->embeddedDocuments;
     }
@@ -103,7 +99,7 @@ class MODM81TestDocument
     /**
      * @param array $documents
      */
-    public function setEmbeddedDocuments(array $documents)
+    public function setEmbeddedDocuments(array $documents): void
     {
         $this->embeddedDocuments = new ArrayCollection($documents);
     }
@@ -128,26 +124,17 @@ class MODM81TestEmbeddedDocument
         $this->message        = $message;
     }
 
-    /**
-     * @return string
-     */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->message;
     }
 
-    /**
-     * @return MODM81TestDocument
-     */
-    public function getRefTodocument1()
+    public function getRefTodocument1(): MODM81TestDocument
     {
         return $this->refTodocument1;
     }
 
-    /**
-     * @return MODM81TestDocument
-     */
-    public function getRefTodocument2()
+    public function getRefTodocument2(): MODM81TestDocument
     {
         return $this->refTodocument2;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM83Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM83Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
+use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
@@ -15,7 +16,7 @@ class MODM83Test extends BaseTest
     /** @var MODM83EventListener */
     private $listener;
 
-    private function getDocumentManager()
+    private function getDocumentManager(): ?DocumentManager
     {
         $this->listener = new MODM83EventListener();
         $evm            = $this->dm->getEventManager();
@@ -28,7 +29,7 @@ class MODM83Test extends BaseTest
         return $this->dm;
     }
 
-    public function testDocumentWithEmbeddedDocumentNotUpdated()
+    public function testDocumentWithEmbeddedDocumentNotUpdated(): void
     {
         $dm = $this->getDocumentManager();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM88Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM88Test.php
@@ -9,7 +9,7 @@ use Documents\Article;
 
 class MODM88Test extends BaseTest
 {
-    public function testTest()
+    public function testTest(): void
     {
         $article = new Article();
         $article->setTitle('Test Title');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM90Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM90Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
+use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
@@ -15,7 +16,7 @@ class MODM90Test extends BaseTest
     /** @var MODM90EventListener */
     private $listener;
 
-    private function getDocumentManager()
+    private function getDocumentManager(): ?DocumentManager
     {
         $this->listener = new MODM90EventListener();
         $evm            = $this->dm->getEventManager();
@@ -28,7 +29,7 @@ class MODM90Test extends BaseTest
         return $this->dm;
     }
 
-    public function testDocumentWithEmbeddedDocumentNotUpdatedOnFlush()
+    public function testDocumentWithEmbeddedDocumentNotUpdatedOnFlush(): void
     {
         $dm = $this->getDocumentManager();
 
@@ -55,7 +56,7 @@ class MODM90Test extends BaseTest
      * Ensures that the descriminator field is not unset if it's a
      * real property on the document.
      */
-    public function testDiscriminatorFieldValuePresentIfRealProperty()
+    public function testDiscriminatorFieldValuePresentIfRealProperty(): void
     {
         $dm = $this->getDocumentManager();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM91Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM91Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
+use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
@@ -15,7 +16,7 @@ class MODM91Test extends BaseTest
     /** @var MODM91EventListener */
     private $listener;
 
-    private function getDocumentManager()
+    private function getDocumentManager(): ?DocumentManager
     {
         $this->listener = new MODM91EventListener();
         $evm            = $this->dm->getEventManager();
@@ -28,7 +29,7 @@ class MODM91Test extends BaseTest
         return $this->dm;
     }
 
-    public function testDocumentWithEmbeddedDocumentNotUpdated()
+    public function testDocumentWithEmbeddedDocumentNotUpdated(): void
     {
         $dm = $this->getDocumentManager();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM92Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM92Test.php
@@ -13,7 +13,7 @@ use function is_array;
 
 class MODM92Test extends BaseTest
 {
-    public function testDocumentWithEmbeddedDocuments()
+    public function testDocumentWithEmbeddedDocuments(): void
     {
         $embeddedDocuments = [new MODM92TestEmbeddedDocument('foo')];
 
@@ -65,7 +65,7 @@ class MODM92TestDocument
      *
      * @param array|Traversable $embeddedDocuments
      */
-    public function setEmbeddedDocuments($embeddedDocuments)
+    public function setEmbeddedDocuments($embeddedDocuments): void
     {
         $this->embeddedDocuments->clear();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM95Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM95Test.php
@@ -13,7 +13,7 @@ use function is_array;
 
 class MODM95Test extends BaseTest
 {
-    public function testDocumentWithEmbeddedDocuments()
+    public function testDocumentWithEmbeddedDocuments(): void
     {
         $embeddedDocuments = [new MODM95TestEmbeddedDocument('foo')];
 
@@ -71,7 +71,7 @@ class MODM95TestDocument
      *
      * @param array|Traversable $embeddedDocuments
      */
-    public function setEmbeddedDocuments($embeddedDocuments)
+    public function setEmbeddedDocuments($embeddedDocuments): void
     {
         $this->embeddedDocuments->clear();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/UpsertTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/UpsertTest.php
@@ -15,7 +15,7 @@ class UpsertTest extends BaseTest
      *
      * Embedded document with provided id should not be upserted.
      */
-    public function testUpsertEmbedManyDoesNotCreateObject()
+    public function testUpsertEmbedManyDoesNotCreateObject(): void
     {
         $test     = new UpsertTestUser();
         $test->id = (string) new ObjectId();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ValidationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ValidationTest.php
@@ -16,7 +16,7 @@ use function MongoDB\BSON\toPHP;
 
 class ValidationTest extends BaseTest
 {
-    public function testCreateUpdateValidatedDocument()
+    public function testCreateUpdateValidatedDocument(): void
     {
         $this->requireVersion($this->getServerVersion(), '3.6.0', '<', 'MongoDB cannot perform JSON schema validation before version 3.6');
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class VersionTest extends BaseTest
 {
-    public function testVersioningWhenManipulatingEmbedMany()
+    public function testVersioningWhenManipulatingEmbedMany(): void
     {
         $expectedVersion  = 1;
         $doc              = new VersionedDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ViewTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ViewTest.php
@@ -32,7 +32,7 @@ class ViewTest extends BaseTest
         $this->dm->clear();
     }
 
-    public function testViewAggregationPipeline()
+    public function testViewAggregationPipeline(): void
     {
         $repository = $this->dm->getRepository(UserName::class);
         assert($repository instanceof ViewRepository);
@@ -50,7 +50,7 @@ class ViewTest extends BaseTest
         $this->assertSame($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testQueryOnView()
+    public function testQueryOnView(): void
     {
         $results = $this->dm->createQueryBuilder(UserName::class)
             ->sort('username')
@@ -67,7 +67,7 @@ class ViewTest extends BaseTest
         $this->assertSame(UnitOfWork::STATE_MANAGED, $this->dm->getUnitOfWork()->getDocumentState($user));
     }
 
-    public function testViewReferences()
+    public function testViewReferences(): void
     {
         $alcaeus = $this->dm->getRepository(UserName::class)->findOneBy(['username' => 'alcaeus']);
         $this->assertInstanceOf(UserName::class, $alcaeus);

--- a/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
@@ -14,7 +14,7 @@ use ProxyManager\Proxy\GhostObjectInterface;
 
 class HydratorTest extends BaseTest
 {
-    public function testHydrator()
+    public function testHydrator(): void
     {
         $class = $this->dm->getClassMetadata(HydrationClosureUser::class);
 
@@ -50,7 +50,7 @@ class HydratorTest extends BaseTest
         $this->assertEquals('jon', $user->embedMany[0]->name);
     }
 
-    public function testHydrateProxyWithMissingAssociations()
+    public function testHydrateProxyWithMissingAssociations(): void
     {
         $user = $this->dm->getReference(HydrationClosureUser::class, 1);
         $this->assertInstanceOf(GhostObjectInterface::class, $user);
@@ -71,7 +71,7 @@ class HydratorTest extends BaseTest
         $this->assertInstanceOf(PersistentCollection::class, $user->embedMany);
     }
 
-    public function testReadOnly()
+    public function testReadOnly(): void
     {
         $class = $this->dm->getClassMetadata(HydrationClosureUser::class);
 
@@ -91,7 +91,7 @@ class HydratorTest extends BaseTest
         $this->assertFalse($this->uow->isInIdentityMap($user->embedMany[0]));
     }
 
-    public function testEmbedOneWithWrongType()
+    public function testEmbedOneWithWrongType(): void
     {
         $user = new HydrationClosureUser();
 
@@ -104,7 +104,7 @@ class HydratorTest extends BaseTest
         ]);
     }
 
-    public function testEmbedManyWithWrongType()
+    public function testEmbedManyWithWrongType(): void
     {
         $user = new HydrationClosureUser();
 
@@ -117,7 +117,7 @@ class HydratorTest extends BaseTest
         ]);
     }
 
-    public function testEmbedManyWithWrongElementType()
+    public function testEmbedManyWithWrongElementType(): void
     {
         $user = new HydrationClosureUser();
 
@@ -134,7 +134,7 @@ class HydratorTest extends BaseTest
         $user->embedMany->initialize();
     }
 
-    public function testReferenceOneWithWrongType()
+    public function testReferenceOneWithWrongType(): void
     {
         $user = new HydrationClosureUser();
 
@@ -147,7 +147,7 @@ class HydratorTest extends BaseTest
         ]);
     }
 
-    public function testReferenceManyWithWrongType()
+    public function testReferenceManyWithWrongType(): void
     {
         $user = new HydrationClosureUser();
 
@@ -160,7 +160,7 @@ class HydratorTest extends BaseTest
         ]);
     }
 
-    public function testReferenceManyWithWrongElementType()
+    public function testReferenceManyWithWrongElementType(): void
     {
         $user = new HydrationClosureUser();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Id/IncrementGeneratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Id/IncrementGeneratorTest.php
@@ -12,7 +12,7 @@ use const DOCTRINE_MONGODB_DATABASE;
 
 class IncrementGeneratorTest extends BaseTest
 {
-    public function testIdGeneratorWithStartingValue()
+    public function testIdGeneratorWithStartingValue(): void
     {
         $generator = new IncrementGenerator();
         $generator->setStartingId(10);
@@ -28,7 +28,7 @@ class IncrementGeneratorTest extends BaseTest
         self::assertSame(11, $result['current_id']);
     }
 
-    public function testUsesOneAsStartingValueIfNotOverridden()
+    public function testUsesOneAsStartingValueIfNotOverridden(): void
     {
         $generator = new IncrementGenerator();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -32,7 +32,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @doesNotPerformAssertions
      */
-    public function testLoadMapping()
+    public function testLoadMapping(): ClassMetadata
     {
         return $this->dm->getClassMetadata(AbstractMappingDriverUser::class);
     }
@@ -40,7 +40,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testLoadMapping
      */
-    public function testDocumentCollectionNameAndInheritance(ClassMetadata $class)
+    public function testDocumentCollectionNameAndInheritance(ClassMetadata $class): ClassMetadata
     {
         $this->assertEquals('cms_users', $class->getCollection());
         $this->assertEquals(ClassMetadata::INHERITANCE_TYPE_NONE, $class->inheritanceType);
@@ -51,7 +51,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testLoadMapping
      */
-    public function testDocumentMarkedAsReadOnly(ClassMetadata $class)
+    public function testDocumentMarkedAsReadOnly(ClassMetadata $class): ClassMetadata
     {
         $this->assertTrue($class->isReadOnly);
 
@@ -61,7 +61,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testDocumentCollectionNameAndInheritance
      */
-    public function testDocumentLevelReadPreference(ClassMetadata $class)
+    public function testDocumentLevelReadPreference(ClassMetadata $class): ClassMetadata
     {
         $this->assertEquals('primaryPreferred', $class->readPreference);
         $this->assertEquals([
@@ -76,7 +76,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testDocumentCollectionNameAndInheritance
      */
-    public function testDocumentLevelWriteConcern(ClassMetadata $class)
+    public function testDocumentLevelWriteConcern(ClassMetadata $class): ClassMetadata
     {
         $this->assertEquals(1, $class->getWriteConcern());
 
@@ -86,7 +86,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testDocumentLevelWriteConcern
      */
-    public function testFieldMappings(ClassMetadata $class)
+    public function testFieldMappings(ClassMetadata $class): ClassMetadata
     {
         $this->assertCount(14, $class->fieldMappings);
         $this->assertTrue(isset($class->fieldMappings['identifier']));
@@ -102,7 +102,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testDocumentCollectionNameAndInheritance
      */
-    public function testAssociationMappings(ClassMetadata $class)
+    public function testAssociationMappings(ClassMetadata $class): void
     {
         $this->assertCount(6, $class->associationMappings);
         $this->assertTrue(isset($class->associationMappings['address']));
@@ -116,7 +116,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testDocumentCollectionNameAndInheritance
      */
-    public function testGetAssociationTargetClass(ClassMetadata $class)
+    public function testGetAssociationTargetClass(ClassMetadata $class): void
     {
         $this->assertEquals(Address::class, $class->getAssociationTargetClass('address'));
         $this->assertEquals(Group::class, $class->getAssociationTargetClass('groups'));
@@ -129,7 +129,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testDocumentCollectionNameAndInheritance
      */
-    public function testGetAssociationTargetClassThrowsExceptionWhenEmpty(ClassMetadata $class)
+    public function testGetAssociationTargetClassThrowsExceptionWhenEmpty(ClassMetadata $class): void
     {
         $this->expectException(InvalidArgumentException::class);
         $class->getAssociationTargetClass('invalid_association');
@@ -138,7 +138,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testDocumentCollectionNameAndInheritance
      */
-    public function testStringFieldMappings(ClassMetadata $class)
+    public function testStringFieldMappings(ClassMetadata $class): ClassMetadata
     {
         $this->assertEquals('string', $class->fieldMappings['name']['type']);
 
@@ -148,7 +148,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testFieldMappings
      */
-    public function testIdentifier(ClassMetadata $class)
+    public function testIdentifier(ClassMetadata $class): ClassMetadata
     {
         $this->assertEquals('identifier', $class->identifier);
 
@@ -158,7 +158,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testFieldMappings
      */
-    public function testVersionFieldMappings(ClassMetadata $class)
+    public function testVersionFieldMappings(ClassMetadata $class): ClassMetadata
     {
         $this->assertEquals('int', $class->fieldMappings['version']['type']);
         $this->assertNotEmpty($class->fieldMappings['version']['version']);
@@ -169,7 +169,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testFieldMappings
      */
-    public function testLockFieldMappings(ClassMetadata $class)
+    public function testLockFieldMappings(ClassMetadata $class): ClassMetadata
     {
         $this->assertEquals('int', $class->fieldMappings['lock']['type']);
         $this->assertNotEmpty($class->fieldMappings['lock']['lock']);
@@ -180,7 +180,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testIdentifier
      */
-    public function testAssocations(ClassMetadata $class)
+    public function testAssocations(ClassMetadata $class): ClassMetadata
     {
         $this->assertCount(14, $class->fieldMappings);
 
@@ -190,7 +190,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testAssocations
      */
-    public function testOwningOneToOneAssocation(ClassMetadata $class)
+    public function testOwningOneToOneAssocation(ClassMetadata $class): ClassMetadata
     {
         $this->assertTrue(isset($class->fieldMappings['address']));
         $this->assertIsArray($class->fieldMappings['address']);
@@ -207,7 +207,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testOwningOneToOneAssocation
      */
-    public function testLifecycleCallbacks(ClassMetadata $class)
+    public function testLifecycleCallbacks(ClassMetadata $class): ClassMetadata
     {
         $expectedLifecycleCallbacks = [
             'prePersist' => ['doStuffOnPrePersist', 'doOtherStuffOnPrePersistToo'],
@@ -222,7 +222,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testLifecycleCallbacks
      */
-    public function testCustomFieldName(ClassMetadata $class)
+    public function testCustomFieldName(ClassMetadata $class): ClassMetadata
     {
         $this->assertEquals('name', $class->fieldMappings['name']['fieldName']);
         $this->assertEquals('username', $class->fieldMappings['name']['name']);
@@ -233,7 +233,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testCustomFieldName
      */
-    public function testCustomReferenceFieldName(ClassMetadata $class)
+    public function testCustomReferenceFieldName(ClassMetadata $class): ClassMetadata
     {
         $this->assertEquals('morePhoneNumbers', $class->fieldMappings['morePhoneNumbers']['fieldName']);
         $this->assertEquals('more_phone_numbers', $class->fieldMappings['morePhoneNumbers']['name']);
@@ -244,7 +244,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testCustomReferenceFieldName
      */
-    public function testCustomEmbedFieldName(ClassMetadata $class)
+    public function testCustomEmbedFieldName(ClassMetadata $class): ClassMetadata
     {
         $this->assertEquals('embeddedPhonenumber', $class->fieldMappings['embeddedPhonenumber']['fieldName']);
         $this->assertEquals('embedded_phone_number', $class->fieldMappings['embeddedPhonenumber']['name']);
@@ -255,7 +255,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testCustomEmbedFieldName
      */
-    public function testDiscriminator(ClassMetadata $class)
+    public function testDiscriminator(ClassMetadata $class): ClassMetadata
     {
         $this->assertTrue(isset($class->discriminatorField));
         $this->assertTrue(isset($class->discriminatorMap));
@@ -270,7 +270,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testDiscriminator
      */
-    public function testEmbedDiscriminator(ClassMetadata $class)
+    public function testEmbedDiscriminator(ClassMetadata $class): ClassMetadata
     {
         $this->assertTrue(isset($class->fieldMappings['otherPhonenumbers']['discriminatorField']));
         $this->assertTrue(isset($class->fieldMappings['otherPhonenumbers']['discriminatorMap']));
@@ -288,7 +288,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testEmbedDiscriminator
      */
-    public function testReferenceDiscriminator(ClassMetadata $class)
+    public function testReferenceDiscriminator(ClassMetadata $class): ClassMetadata
     {
         $this->assertTrue(isset($class->fieldMappings['phonenumbers']['discriminatorField']));
         $this->assertTrue(isset($class->fieldMappings['phonenumbers']['discriminatorMap']));
@@ -306,7 +306,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testCustomFieldName
      */
-    public function testIndexes(ClassMetadata $class)
+    public function testIndexes(ClassMetadata $class): ClassMetadata
     {
         $indexes = $class->indexes;
 
@@ -352,7 +352,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
     /**
      * @depends testIndexes
      */
-    public function testShardKey(ClassMetadata $class)
+    public function testShardKey(ClassMetadata $class): void
     {
         $shardKey = $class->getShardKey();
 
@@ -365,7 +365,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
         $this->assertEquals(4096, $shardKey['options']['numInitialChunks'], 'Shard key option has wrong value');
     }
 
-    public function testGridFSMapping()
+    public function testGridFSMapping(): void
     {
         $class = $this->dm->getClassMetadata(AbstractMappingDriverFile::class);
 
@@ -410,7 +410,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
         ], $class->getFieldMapping('metadata'), true);
     }
 
-    public function testGridFSMappingWithCustomRepository()
+    public function testGridFSMappingWithCustomRepository(): void
     {
         $class = $this->dm->getClassMetadata(AbstractMappingDriverFileWithCustomRepository::class);
 
@@ -418,7 +418,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
         $this->assertSame(AbstractMappingDriverGridFSRepository::class, $class->customRepositoryClassName);
     }
 
-    public function testDuplicateDatabaseNameInMappingCauseErrors()
+    public function testDuplicateDatabaseNameInMappingCauseErrors(): void
     {
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage(
@@ -428,7 +428,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
         $this->dm->getClassMetadata(AbstractMappingDriverDuplicateDatabaseName::class);
     }
 
-    public function testDuplicateDatabaseNameWithNotSavedDoesNotThrowExeption()
+    public function testDuplicateDatabaseNameWithNotSavedDoesNotThrowExeption(): void
     {
         $metadata = $this->dm->getClassMetadata(AbstractMappingDriverDuplicateDatabaseNameNotSaved::class);
 
@@ -437,7 +437,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
         $this->assertTrue($metadata->fieldMappings['bar']['notSaved']);
     }
 
-    public function testViewWithoutRepository()
+    public function testViewWithoutRepository(): void
     {
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage(sprintf(
@@ -450,7 +450,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
         $this->dm->getRepository(AbstractMappingDriverViewWithoutRepository::class);
     }
 
-    public function testViewWithWrongRepository()
+    public function testViewWithWrongRepository(): void
     {
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage(sprintf(
@@ -463,7 +463,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
         $this->dm->getRepository(AbstractMappingDriverViewWithWrongRepository::class);
     }
 
-    public function testViewWithoutRootClass()
+    public function testViewWithoutRootClass(): void
     {
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage(sprintf(
@@ -474,7 +474,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
         $this->dm->getClassMetadata(AbstractMappingDriverViewWithoutRootClass::class);
     }
 
-    public function testViewWithNonExistingRootClass()
+    public function testViewWithNonExistingRootClass(): void
     {
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage(sprintf(
@@ -486,7 +486,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
         $this->dm->getClassMetadata(AbstractMappingDriverViewWithNonExistingRootClass::class);
     }
 
-    public function testView()
+    public function testView(): void
     {
         $metadata = $this->dm->getClassMetadata(AbstractMappingDriverView::class);
 
@@ -603,25 +603,25 @@ class AbstractMappingDriverUser
     /**
      * @ODM\PrePersist
      */
-    public function doStuffOnPrePersist()
+    public function doStuffOnPrePersist(): void
     {
     }
 
     /**
      * @ODM\PrePersist
      */
-    public function doOtherStuffOnPrePersistToo()
+    public function doOtherStuffOnPrePersistToo(): void
     {
     }
 
     /**
      * @ODM\PostPersist
      */
-    public function doStuffOnPostPersist()
+    public function doStuffOnPostPersist(): void
     {
     }
 
-    public static function loadMetadata(ClassMetadata $metadata)
+    public static function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_NONE);
         $metadata->setCollection('cms_users');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -38,11 +38,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testLoadMapping
      */
-    public function testDocumentCollectionNameAndInheritance($class)
+    public function testDocumentCollectionNameAndInheritance(ClassMetadata $class)
     {
         $this->assertEquals('cms_users', $class->getCollection());
         $this->assertEquals(ClassMetadata::INHERITANCE_TYPE_NONE, $class->inheritanceType);
@@ -51,11 +49,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testLoadMapping
      */
-    public function testDocumentMarkedAsReadOnly($class)
+    public function testDocumentMarkedAsReadOnly(ClassMetadata $class)
     {
         $this->assertTrue($class->isReadOnly);
 
@@ -63,11 +59,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testDocumentCollectionNameAndInheritance
      */
-    public function testDocumentLevelReadPreference($class)
+    public function testDocumentLevelReadPreference(ClassMetadata $class)
     {
         $this->assertEquals('primaryPreferred', $class->readPreference);
         $this->assertEquals([
@@ -80,11 +74,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testDocumentCollectionNameAndInheritance
      */
-    public function testDocumentLevelWriteConcern($class)
+    public function testDocumentLevelWriteConcern(ClassMetadata $class)
     {
         $this->assertEquals(1, $class->getWriteConcern());
 
@@ -92,11 +84,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testDocumentLevelWriteConcern
      */
-    public function testFieldMappings($class)
+    public function testFieldMappings(ClassMetadata $class)
     {
         $this->assertCount(14, $class->fieldMappings);
         $this->assertTrue(isset($class->fieldMappings['identifier']));
@@ -110,11 +100,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testDocumentCollectionNameAndInheritance
      */
-    public function testAssociationMappings($class)
+    public function testAssociationMappings(ClassMetadata $class)
     {
         $this->assertCount(6, $class->associationMappings);
         $this->assertTrue(isset($class->associationMappings['address']));
@@ -126,11 +114,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testDocumentCollectionNameAndInheritance
      */
-    public function testGetAssociationTargetClass($class)
+    public function testGetAssociationTargetClass(ClassMetadata $class)
     {
         $this->assertEquals(Address::class, $class->getAssociationTargetClass('address'));
         $this->assertEquals(Group::class, $class->getAssociationTargetClass('groups'));
@@ -141,22 +127,18 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testDocumentCollectionNameAndInheritance
      */
-    public function testGetAssociationTargetClassThrowsExceptionWhenEmpty($class)
+    public function testGetAssociationTargetClassThrowsExceptionWhenEmpty(ClassMetadata $class)
     {
         $this->expectException(InvalidArgumentException::class);
         $class->getAssociationTargetClass('invalid_association');
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testDocumentCollectionNameAndInheritance
      */
-    public function testStringFieldMappings($class)
+    public function testStringFieldMappings(ClassMetadata $class)
     {
         $this->assertEquals('string', $class->fieldMappings['name']['type']);
 
@@ -164,11 +146,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testFieldMappings
      */
-    public function testIdentifier($class)
+    public function testIdentifier(ClassMetadata $class)
     {
         $this->assertEquals('identifier', $class->identifier);
 
@@ -176,11 +156,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testFieldMappings
      */
-    public function testVersionFieldMappings($class)
+    public function testVersionFieldMappings(ClassMetadata $class)
     {
         $this->assertEquals('int', $class->fieldMappings['version']['type']);
         $this->assertNotEmpty($class->fieldMappings['version']['version']);
@@ -189,11 +167,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testFieldMappings
      */
-    public function testLockFieldMappings($class)
+    public function testLockFieldMappings(ClassMetadata $class)
     {
         $this->assertEquals('int', $class->fieldMappings['lock']['type']);
         $this->assertNotEmpty($class->fieldMappings['lock']['lock']);
@@ -202,11 +178,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testIdentifier
      */
-    public function testAssocations($class)
+    public function testAssocations(ClassMetadata $class)
     {
         $this->assertCount(14, $class->fieldMappings);
 
@@ -214,11 +188,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testAssocations
      */
-    public function testOwningOneToOneAssocation($class)
+    public function testOwningOneToOneAssocation(ClassMetadata $class)
     {
         $this->assertTrue(isset($class->fieldMappings['address']));
         $this->assertIsArray($class->fieldMappings['address']);
@@ -233,11 +205,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testOwningOneToOneAssocation
      */
-    public function testLifecycleCallbacks($class)
+    public function testLifecycleCallbacks(ClassMetadata $class)
     {
         $expectedLifecycleCallbacks = [
             'prePersist' => ['doStuffOnPrePersist', 'doOtherStuffOnPrePersistToo'],
@@ -250,11 +220,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testLifecycleCallbacks
      */
-    public function testCustomFieldName($class)
+    public function testCustomFieldName(ClassMetadata $class)
     {
         $this->assertEquals('name', $class->fieldMappings['name']['fieldName']);
         $this->assertEquals('username', $class->fieldMappings['name']['name']);
@@ -263,11 +231,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testCustomFieldName
      */
-    public function testCustomReferenceFieldName($class)
+    public function testCustomReferenceFieldName(ClassMetadata $class)
     {
         $this->assertEquals('morePhoneNumbers', $class->fieldMappings['morePhoneNumbers']['fieldName']);
         $this->assertEquals('more_phone_numbers', $class->fieldMappings['morePhoneNumbers']['name']);
@@ -276,11 +242,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testCustomReferenceFieldName
      */
-    public function testCustomEmbedFieldName($class)
+    public function testCustomEmbedFieldName(ClassMetadata $class)
     {
         $this->assertEquals('embeddedPhonenumber', $class->fieldMappings['embeddedPhonenumber']['fieldName']);
         $this->assertEquals('embedded_phone_number', $class->fieldMappings['embeddedPhonenumber']['name']);
@@ -289,11 +253,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testCustomEmbedFieldName
      */
-    public function testDiscriminator($class)
+    public function testDiscriminator(ClassMetadata $class)
     {
         $this->assertTrue(isset($class->discriminatorField));
         $this->assertTrue(isset($class->discriminatorMap));
@@ -306,11 +268,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testDiscriminator
      */
-    public function testEmbedDiscriminator($class)
+    public function testEmbedDiscriminator(ClassMetadata $class)
     {
         $this->assertTrue(isset($class->fieldMappings['otherPhonenumbers']['discriminatorField']));
         $this->assertTrue(isset($class->fieldMappings['otherPhonenumbers']['discriminatorMap']));
@@ -326,11 +286,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testEmbedDiscriminator
      */
-    public function testReferenceDiscriminator($class)
+    public function testReferenceDiscriminator(ClassMetadata $class)
     {
         $this->assertTrue(isset($class->fieldMappings['phonenumbers']['discriminatorField']));
         $this->assertTrue(isset($class->fieldMappings['phonenumbers']['discriminatorMap']));
@@ -346,11 +304,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testCustomFieldName
      */
-    public function testIndexes($class)
+    public function testIndexes(ClassMetadata $class)
     {
         $indexes = $class->indexes;
 
@@ -394,11 +350,9 @@ abstract class AbstractMappingDriverTest extends BaseTest
     }
 
     /**
-     * @param ClassMetadata $class
-     *
      * @depends testIndexes
      */
-    public function testShardKey($class)
+    public function testShardKey(ClassMetadata $class)
     {
         $shardKey = $class->getShardKey();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
@@ -10,13 +10,14 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Documents\CmsUser;
+use Generator;
 use stdClass;
 
 use function get_class;
 
 class AnnotationDriverTest extends AbstractMappingDriverTest
 {
-    public function testFieldInheritance()
+    public function testFieldInheritance(): void
     {
         // @TODO: This can be a generic test for all drivers
         $super  = $this->dm->getClassMetadata(AnnotationDriverTestSuper::class);
@@ -71,7 +72,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
     /**
      * @group DDC-268
      */
-    public function testLoadMetadataForNonDocumentThrowsException()
+    public function testLoadMetadataForNonDocumentThrowsException(): void
     {
         $cm               = new ClassMetadata('stdClass');
         $reader           = new AnnotationReader();
@@ -84,7 +85,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
     /**
      * @group DDC-268
      */
-    public function testColumnWithMissingTypeDefaultsToString()
+    public function testColumnWithMissingTypeDefaultsToString(): void
     {
         $cm               = new ClassMetadata(ColumnWithoutType::class);
         $reader           = new AnnotationReader();
@@ -97,7 +98,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
     /**
      * @group DDC-318
      */
-    public function testGetAllClassNamesIsIdempotent()
+    public function testGetAllClassNamesIsIdempotent(): void
     {
         $annotationDriver = $this->loadDriverForCMSDocuments();
         $original         = $annotationDriver->getAllClassNames();
@@ -111,7 +112,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
     /**
      * @group DDC-318
      */
-    public function testGetAllClassNamesIsIdempotentEvenWithDifferentDriverInstances()
+    public function testGetAllClassNamesIsIdempotentEvenWithDifferentDriverInstances(): void
     {
         $annotationDriver = $this->loadDriverForCMSDocuments();
         $original         = $annotationDriver->getAllClassNames();
@@ -125,7 +126,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
     /**
      * @group DDC-318
      */
-    public function testGetAllClassNamesReturnsAlreadyLoadedClassesIfAppropriate()
+    public function testGetAllClassNamesReturnsAlreadyLoadedClassesIfAppropriate(): void
     {
         $annotationDriver = $this->loadDriverForCMSDocuments();
         $classes          = $annotationDriver->getAllClassNames();
@@ -136,7 +137,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
     /**
      * @group DDC-318
      */
-    public function testGetClassNamesReturnsOnlyTheAppropriateClasses()
+    public function testGetClassNamesReturnsOnlyTheAppropriateClasses(): void
     {
         $extraneousClassName = ColumnWithoutType::class;
 
@@ -146,14 +147,14 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $this->assertNotContains($extraneousClassName, $classes);
     }
 
-    public function testEmbeddedClassCantHaveShardKey()
+    public function testEmbeddedClassCantHaveShardKey(): void
     {
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage('Embedded document can\'t have shard key');
         $this->dm->getClassMetadata(AnnotationDriverEmbeddedWithShardKey::class);
     }
 
-    public function testDocumentAnnotationCanSpecifyWriteConcern()
+    public function testDocumentAnnotationCanSpecifyWriteConcern(): void
     {
         $cm = $this->dm->getClassMetadata(AnnotationDriverTestWriteConcernMajority::class);
         $this->assertEquals('majority', $cm->writeConcern);
@@ -168,7 +169,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
     /**
      * @dataProvider provideClassCanBeMappedByOneAbstractDocument
      */
-    public function testClassCanBeMappedByOneAbstractDocument(object $wrong, string $messageRegExp)
+    public function testClassCanBeMappedByOneAbstractDocument(object $wrong, string $messageRegExp): void
     {
         $this->expectException(MappingException::class);
         $this->expectExceptionMessageMatches($messageRegExp);
@@ -180,7 +181,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $annotationDriver->loadMetadataForClass(get_class($wrong), $cm);
     }
 
-    public function provideClassCanBeMappedByOneAbstractDocument()
+    public function provideClassCanBeMappedByOneAbstractDocument(): Generator
     {
         yield [
             /**
@@ -243,7 +244,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         ];
     }
 
-    public function testWrongValueForValidationValidatorShouldThrowException()
+    public function testWrongValueForValidationValidatorShouldThrowException(): void
     {
         $annotationDriver = $this->loadDriver();
         $classMetadata    = new ClassMetadata(WrongValueForValidationValidator::class);
@@ -252,7 +253,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $annotationDriver->loadMetadataForClass($classMetadata->name, $classMetadata);
     }
 
-    protected function loadDriverForCMSDocuments()
+    protected function loadDriverForCMSDocuments(): AnnotationDriver
     {
         $annotationDriver = $this->loadDriver();
         $annotationDriver->addPaths([__DIR__ . '/../../../../../Documents']);
@@ -260,7 +261,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         return $annotationDriver;
     }
 
-    protected function loadDriver()
+    protected function loadDriver(): AnnotationDriver
     {
         $reader = new AnnotationReader();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Annotations/ValidationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Annotations/ValidationTest.php
@@ -10,35 +10,35 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class ValidationTest extends BaseTest
 {
-    public function testWrongTypeForValidationValidatorShouldThrowException()
+    public function testWrongTypeForValidationValidatorShouldThrowException(): void
     {
         $this->expectException(AnnotationException::class);
         $this->expectExceptionMessage('[Type Error] Attribute "validator" of @ODM\Validation declared on class Doctrine\ODM\MongoDB\Tests\Mapping\Annotations\WrongTypeForValidationValidator expects a(n) string, but got array.');
         $this->dm->getClassMetadata(WrongTypeForValidationValidator::class);
     }
 
-    public function testWrongTypeForValidationActionShouldThrowException()
+    public function testWrongTypeForValidationActionShouldThrowException(): void
     {
         $this->expectException(AnnotationException::class);
         $this->expectExceptionMessage('[Type Error] Attribute "action" of @ODM\Validation declared on class Doctrine\ODM\MongoDB\Tests\Mapping\Annotations\WrongTypeForValidationAction expects a(n) string, but got boolean.');
         $this->dm->getClassMetadata(WrongTypeForValidationAction::class);
     }
 
-    public function testWrongValueForValidationActionShouldThrowException()
+    public function testWrongValueForValidationActionShouldThrowException(): void
     {
         $this->expectException(AnnotationException::class);
         $this->expectExceptionMessageMatches('#^\[Enum Error\] Attribute "action" of @Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\Annotations\\\\Validation declared on class Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\Annotations\\\\WrongValueForValidationAction accepts? only \[error, warn\], but got wrong\.$#');
         $this->dm->getClassMetadata(WrongValueForValidationAction::class);
     }
 
-    public function testWrongTypeForValidationLevelShouldThrowException()
+    public function testWrongTypeForValidationLevelShouldThrowException(): void
     {
         $this->expectException(AnnotationException::class);
         $this->expectExceptionMessage('[Type Error] Attribute "level" of @ODM\Validation declared on class Doctrine\ODM\MongoDB\Tests\Mapping\Annotations\WrongTypeForValidationLevel expects a(n) string, but got boolean.');
         $this->dm->getClassMetadata(WrongTypeForValidationLevel::class);
     }
 
-    public function testWrongValueForValidationLevelShouldThrowException()
+    public function testWrongValueForValidationLevelShouldThrowException(): void
     {
         $this->expectException(AnnotationException::class);
         $this->expectExceptionMessageMatches('#^\[Enum Error\] Attribute "level" of @Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\Annotations\\\\Validation declared on class Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\Annotations\\\\WrongValueForValidationLevel accepts? only \[off, strict, moderate\], but got wrong\.$#');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
@@ -25,13 +25,13 @@ class BasicInheritanceMappingTest extends BaseTest
         $this->factory->setConfiguration($this->dm->getConfiguration());
     }
 
-    public function testGetMetadataForTransientClassThrowsException()
+    public function testGetMetadataForTransientClassThrowsException(): void
     {
         $this->expectException(MappingException::class);
         $this->factory->getMetadataFor(TransientBaseClass::class);
     }
 
-    public function testGetMetadataForSubclassWithTransientBaseClass()
+    public function testGetMetadataForSubclassWithTransientBaseClass(): void
     {
         $class = $this->factory->getMetadataFor(DocumentSubClass::class);
 
@@ -41,7 +41,7 @@ class BasicInheritanceMappingTest extends BaseTest
         $this->assertTrue(isset($class->fieldMappings['name']));
     }
 
-    public function testGetMetadataForSubclassWithMappedSuperclass()
+    public function testGetMetadataForSubclassWithMappedSuperclass(): void
     {
         $class = $this->factory->getMetadataFor(DocumentSubClass2::class);
 
@@ -63,7 +63,7 @@ class BasicInheritanceMappingTest extends BaseTest
     /**
      * @group DDC-388
      */
-    public function testSerializationWithPrivateFieldsFromMappedSuperclass()
+    public function testSerializationWithPrivateFieldsFromMappedSuperclass(): void
     {
         $class = $this->factory->getMetadataFor(DocumentSubClass2::class);
 
@@ -74,7 +74,7 @@ class BasicInheritanceMappingTest extends BaseTest
         $this->assertTrue(isset($class2->reflFields['mappedRelated1']));
     }
 
-    public function testReadPreferenceIsInherited()
+    public function testReadPreferenceIsInherited(): void
     {
         $class = $this->factory->getMetadataFor(DocumentSubClass2::class);
 
@@ -82,7 +82,7 @@ class BasicInheritanceMappingTest extends BaseTest
         $this->assertEquals([['dc' => 'east']], $class->readPreferenceTags);
     }
 
-    public function testGridFSOptionsAreInherited()
+    public function testGridFSOptionsAreInherited(): void
     {
         $class = $this->factory->getMetadataFor(GridFSChildClass::class);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
@@ -11,7 +11,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class ClassMetadataLoadEventTest extends BaseTest
 {
-    public function testEvent()
+    public function testEvent(): void
     {
         $metadataFactory = $this->dm->getMetadataFactory();
         $evm             = $this->dm->getEventManager();
@@ -20,7 +20,7 @@ class ClassMetadataLoadEventTest extends BaseTest
         $this->assertTrue($classMetadata->hasField('about'));
     }
 
-    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs): void
     {
         $classMetadata = $eventArgs->getClassMetadata();
         $field         = [

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -26,6 +26,7 @@ use Documents\SpecialUser;
 use Documents\User;
 use Documents\UserName;
 use Documents\UserRepository;
+use Generator;
 use InvalidArgumentException;
 use ProxyManager\Proxy\GhostObjectInterface;
 use ReflectionClass;
@@ -41,7 +42,7 @@ use function unserialize;
 
 class ClassMetadataTest extends BaseTest
 {
-    public function testClassMetadataInstanceSerialization()
+    public function testClassMetadataInstanceSerialization(): void
     {
         $cm = new ClassMetadata(CmsUser::class);
 
@@ -107,7 +108,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertEquals(ClassMetadata::SCHEMA_VALIDATION_LEVEL_OFF, $cm->getValidationLevel());
     }
 
-    public function testOwningSideAndInverseSide()
+    public function testOwningSideAndInverseSide(): void
     {
         $cm = new ClassMetadata(User::class);
         $cm->mapOneReference(['fieldName' => 'account', 'targetDocument' => Account::class, 'inversedBy' => 'user']);
@@ -118,7 +119,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertTrue($cm->fieldMappings['user']['isInverseSide']);
     }
 
-    public function testFieldIsNullable()
+    public function testFieldIsNullable(): void
     {
         $cm = new ClassMetadata(CmsUser::class);
 
@@ -138,7 +139,7 @@ class ClassMetadataTest extends BaseTest
     /**
      * @group DDC-115
      */
-    public function testMapAssocationInGlobalNamespace()
+    public function testMapAssocationInGlobalNamespace(): void
     {
         require_once __DIR__ . '/Documents/GlobalNamespaceDocument.php';
 
@@ -151,7 +152,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertEquals(DoctrineGlobal_User::class, $cm->fieldMappings['author']['targetDocument']);
     }
 
-    public function testMapManyToManyJoinTableDefaults()
+    public function testMapManyToManyJoinTableDefaults(): void
     {
         $cm = new ClassMetadata(CmsUser::class);
         $cm->mapManyEmbedded(
@@ -165,7 +166,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertIsArray($assoc);
     }
 
-    public function testGetAssociationTargetClassWithoutTargetDocument()
+    public function testGetAssociationTargetClassWithoutTargetDocument(): void
     {
         $cm = new ClassMetadata(CmsUser::class);
         $cm->mapManyEmbedded(
@@ -181,7 +182,7 @@ class ClassMetadataTest extends BaseTest
     /**
      * @group DDC-115
      */
-    public function testSetDiscriminatorMapInGlobalNamespace()
+    public function testSetDiscriminatorMapInGlobalNamespace(): void
     {
         require_once __DIR__ . '/Documents/GlobalNamespaceDocument.php';
 
@@ -195,7 +196,7 @@ class ClassMetadataTest extends BaseTest
     /**
      * @group DDC-115
      */
-    public function testSetSubClassesInGlobalNamespace()
+    public function testSetSubClassesInGlobalNamespace(): void
     {
         require_once __DIR__ . '/Documents/GlobalNamespaceDocument.php';
 
@@ -205,7 +206,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertEquals(DoctrineGlobal_Article::class, $cm->subClasses[0]);
     }
 
-    public function testDuplicateFieldMapping()
+    public function testDuplicateFieldMapping(): void
     {
         $cm = new ClassMetadata(CmsUser::class);
         $a1 = ['reference' => true, 'type' => 'many', 'fieldName' => 'name', 'targetDocument' => stdClass::class];
@@ -217,7 +218,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertEquals('string', $cm->fieldMappings['name']['type']);
     }
 
-    public function testDuplicateColumnNameDiscriminatorColumnThrowsMappingException()
+    public function testDuplicateColumnNameDiscriminatorColumnThrowsMappingException(): void
     {
         $cm = new ClassMetadata(CmsUser::class);
         $cm->mapField(['fieldName' => 'name', 'type' => Type::STRING]);
@@ -226,7 +227,7 @@ class ClassMetadataTest extends BaseTest
         $cm->setDiscriminatorField('name');
     }
 
-    public function testDuplicateFieldNameDiscriminatorColumn2ThrowsMappingException()
+    public function testDuplicateFieldNameDiscriminatorColumn2ThrowsMappingException(): void
     {
         $cm = new ClassMetadata(CmsUser::class);
         $cm->setDiscriminatorField('name');
@@ -235,7 +236,7 @@ class ClassMetadataTest extends BaseTest
         $cm->mapField(['fieldName' => 'name', 'type' => Type::STRING]);
     }
 
-    public function testDuplicateFieldAndAssocationMapping1()
+    public function testDuplicateFieldAndAssocationMapping1(): void
     {
         $cm = new ClassMetadata(CmsUser::class);
         $cm->mapField(['fieldName' => 'name', 'type' => Type::STRING]);
@@ -244,7 +245,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertEquals('one', $cm->fieldMappings['name']['type']);
     }
 
-    public function testDuplicateFieldAndAssocationMapping2()
+    public function testDuplicateFieldAndAssocationMapping2(): void
     {
         $cm = new ClassMetadata(CmsUser::class);
         $cm->mapOneEmbedded(['fieldName' => 'name', 'targetDocument' => CmsUser::class]);
@@ -253,7 +254,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertEquals('string', $cm->fieldMappings['name']['type']);
     }
 
-    public function testMapNotExistingFieldThrowsException()
+    public function testMapNotExistingFieldThrowsException(): void
     {
         $cm = new ClassMetadata(CmsUser::class);
         $this->expectException(ReflectionException::class);
@@ -263,7 +264,7 @@ class ClassMetadataTest extends BaseTest
     /**
      * @dataProvider dataProviderMetadataClasses
      */
-    public function testEmbeddedDocumentWithDiscriminator(ClassMetadata $cm)
+    public function testEmbeddedDocumentWithDiscriminator(ClassMetadata $cm): void
     {
         $cm->setDiscriminatorField('discriminator');
         $cm->setDiscriminatorValue('discriminatorValue');
@@ -275,7 +276,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertSame('discriminatorValue', $cm->discriminatorValue);
     }
 
-    public static function dataProviderMetadataClasses()
+    public static function dataProviderMetadataClasses(): array
     {
         $document = new ClassMetadata(CmsUser::class);
 
@@ -292,7 +293,7 @@ class ClassMetadataTest extends BaseTest
         ];
     }
 
-    public function testDefaultDiscriminatorField()
+    public function testDefaultDiscriminatorField(): void
     {
         $object = new class {
             public $assoc;
@@ -347,7 +348,7 @@ class ClassMetadataTest extends BaseTest
         );
     }
 
-    public function testGetFieldValue()
+    public function testGetFieldValue(): void
     {
         $document = new Album('ten');
         $metadata = $this->dm->getClassMetadata(Album::class);
@@ -355,7 +356,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertEquals($document->getName(), $metadata->getFieldValue($document, 'name'));
     }
 
-    public function testGetFieldValueInitializesProxy()
+    public function testGetFieldValueInitializesProxy(): void
     {
         $document = new Album('ten');
         $this->dm->persist($document);
@@ -370,7 +371,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertTrue($proxy->isProxyInitialized());
     }
 
-    public function testGetFieldValueOfIdentifierDoesNotInitializeProxy()
+    public function testGetFieldValueOfIdentifierDoesNotInitializeProxy(): void
     {
         $document = new Album('ten');
         $this->dm->persist($document);
@@ -385,7 +386,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertFalse($proxy->isProxyInitialized());
     }
 
-    public function testSetFieldValue()
+    public function testSetFieldValue(): void
     {
         $document = new Album('ten');
         $metadata = $this->dm->getClassMetadata(Album::class);
@@ -395,7 +396,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertEquals('nevermind', $document->getName());
     }
 
-    public function testSetFieldValueWithProxy()
+    public function testSetFieldValueWithProxy(): void
     {
         $document = new Album('ten');
         $this->dm->persist($document);
@@ -417,7 +418,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertEquals('nevermind', $proxy->getName());
     }
 
-    public function testSetCustomRepositoryClass()
+    public function testSetCustomRepositoryClass(): void
     {
         $cm = new ClassMetadata(self::class);
 
@@ -430,7 +431,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertEquals(TestCustomRepositoryClass::class, $cm->customRepositoryClassName);
     }
 
-    public function testEmbeddedAssociationsAlwaysCascade()
+    public function testEmbeddedAssociationsAlwaysCascade(): void
     {
         $class = $this->dm->getClassMetadata(EmbeddedAssociationsCascadeTest::class);
 
@@ -447,7 +448,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertTrue($class->fieldMappings['addresses']['isCascadeDetach']);
     }
 
-    public function testEmbedWithCascadeThrowsMappingException()
+    public function testEmbedWithCascadeThrowsMappingException(): void
     {
         $class = new ClassMetadata(EmbedWithCascadeTest::class);
         $this->expectException(MappingException::class);
@@ -461,7 +462,7 @@ class ClassMetadataTest extends BaseTest
         ]);
     }
 
-    public function testInvokeLifecycleCallbacksShouldRequireInstanceOfClass()
+    public function testInvokeLifecycleCallbacksShouldRequireInstanceOfClass(): void
     {
         $class    = $this->dm->getClassMetadata(User::class);
         $document = new stdClass();
@@ -473,7 +474,7 @@ class ClassMetadataTest extends BaseTest
         $class->invokeLifecycleCallbacks(Events::prePersist, $document);
     }
 
-    public function testInvokeLifecycleCallbacksAllowsInstanceOfClass()
+    public function testInvokeLifecycleCallbacksAllowsInstanceOfClass(): void
     {
         $class    = $this->dm->getClassMetadata(User::class);
         $document = new SpecialUser();
@@ -483,7 +484,7 @@ class ClassMetadataTest extends BaseTest
         $class->invokeLifecycleCallbacks(Events::prePersist, $document);
     }
 
-    public function testInvokeLifecycleCallbacksShouldAllowProxyOfExactClass()
+    public function testInvokeLifecycleCallbacksShouldAllowProxyOfExactClass(): void
     {
         $document = new User();
         $this->dm->persist($document);
@@ -498,7 +499,7 @@ class ClassMetadataTest extends BaseTest
         $class->invokeLifecycleCallbacks(Events::prePersist, $proxy);
     }
 
-    public function testSimpleReferenceRequiresTargetDocument()
+    public function testSimpleReferenceRequiresTargetDocument(): void
     {
         $cm = new ClassMetadata('stdClass');
 
@@ -512,7 +513,7 @@ class ClassMetadataTest extends BaseTest
         ]);
     }
 
-    public function testSimpleAsStringReferenceRequiresTargetDocument()
+    public function testSimpleAsStringReferenceRequiresTargetDocument(): void
     {
         $cm = new ClassMetadata('stdClass');
 
@@ -529,7 +530,7 @@ class ClassMetadataTest extends BaseTest
     /**
      * @dataProvider provideRepositoryMethodCanNotBeCombinedWithSkipLimitAndSort
      */
-    public function testRepositoryMethodCanNotBeCombinedWithSkipLimitAndSort($prop, $value)
+    public function testRepositoryMethodCanNotBeCombinedWithSkipLimitAndSort($prop, $value): void
     {
         $cm = new ClassMetadata('stdClass');
 
@@ -548,14 +549,14 @@ class ClassMetadataTest extends BaseTest
         ]);
     }
 
-    public function provideRepositoryMethodCanNotBeCombinedWithSkipLimitAndSort()
+    public function provideRepositoryMethodCanNotBeCombinedWithSkipLimitAndSort(): Generator
     {
         yield ['skip', 5];
         yield ['limit', 5];
         yield ['sort', ['time' => 1]];
     }
 
-    public function testStoreAsIdReferenceRequiresTargetDocument()
+    public function testStoreAsIdReferenceRequiresTargetDocument(): void
     {
         $cm = new ClassMetadata('stdClass');
 
@@ -569,7 +570,7 @@ class ClassMetadataTest extends BaseTest
         ]);
     }
 
-    public function testAtomicCollectionUpdateUsageInEmbeddedDocument()
+    public function testAtomicCollectionUpdateUsageInEmbeddedDocument(): void
     {
         $object = new class {
             public $many;
@@ -588,7 +589,7 @@ class ClassMetadataTest extends BaseTest
         ]);
     }
 
-    public function testDefaultStorageStrategyOfEmbeddedDocumentFields()
+    public function testDefaultStorageStrategyOfEmbeddedDocumentFields(): void
     {
         $object = new class {
             public $many;
@@ -608,7 +609,7 @@ class ClassMetadataTest extends BaseTest
     /**
      * @dataProvider provideOwningAndInversedRefsNeedTargetDocument
      */
-    public function testOwningAndInversedRefsNeedTargetDocument($config)
+    public function testOwningAndInversedRefsNeedTargetDocument($config): void
     {
         $config = array_merge($config, [
             'fieldName' => 'many',
@@ -622,7 +623,7 @@ class ClassMetadataTest extends BaseTest
         $cm->mapField($config);
     }
 
-    public function provideOwningAndInversedRefsNeedTargetDocument()
+    public function provideOwningAndInversedRefsNeedTargetDocument(): array
     {
         return [
             [['type' => 'one', 'mappedBy' => 'post']],
@@ -632,7 +633,7 @@ class ClassMetadataTest extends BaseTest
         ];
     }
 
-    public function testAddInheritedAssociationMapping()
+    public function testAddInheritedAssociationMapping(): void
     {
         $cm = new ClassMetadata('stdClass');
 
@@ -650,7 +651,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertEquals($expected, $cm->associationMappings);
     }
 
-    public function testIdFieldsTypeMustNotBeOverridden()
+    public function testIdFieldsTypeMustNotBeOverridden(): void
     {
         $cm = new ClassMetadata('stdClass');
         $cm->setIdentifier('id');
@@ -662,7 +663,7 @@ class ClassMetadataTest extends BaseTest
         ]);
     }
 
-    public function testReferenceManySortMustNotBeUsedWithNonSetCollectionStrategy()
+    public function testReferenceManySortMustNotBeUsedWithNonSetCollectionStrategy(): void
     {
         $cm = new ClassMetadata('stdClass');
         $this->expectException(MappingException::class);
@@ -679,7 +680,7 @@ class ClassMetadataTest extends BaseTest
         ]);
     }
 
-    public function testSetShardKeyForClassWithoutInheritance()
+    public function testSetShardKeyForClassWithoutInheritance(): void
     {
         $cm = new ClassMetadata('stdClass');
         $cm->setShardKey(['id' => 'asc']);
@@ -689,7 +690,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertEquals(['id' => 1], $shardKey['keys']);
     }
 
-    public function testSetShardKeyForClassWithSingleCollectionInheritance()
+    public function testSetShardKeyForClassWithSingleCollectionInheritance(): void
     {
         $cm                  = new ClassMetadata('stdClass');
         $cm->inheritanceType = ClassMetadata::INHERITANCE_TYPE_SINGLE_COLLECTION;
@@ -700,7 +701,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertEquals(['id' => 1], $shardKey['keys']);
     }
 
-    public function testSetShardKeyForClassWithSingleCollectionInheritanceWhichAlreadyHasIt()
+    public function testSetShardKeyForClassWithSingleCollectionInheritanceWhichAlreadyHasIt(): void
     {
         $cm = new ClassMetadata('stdClass');
         $cm->setShardKey(['id' => 'asc']);
@@ -711,7 +712,7 @@ class ClassMetadataTest extends BaseTest
         $cm->setShardKey(['foo' => 'asc']);
     }
 
-    public function testSetShardKeyForClassWithCollPerClassInheritance()
+    public function testSetShardKeyForClassWithCollPerClassInheritance(): void
     {
         $cm                  = new ClassMetadata('stdClass');
         $cm->inheritanceType = ClassMetadata::INHERITANCE_TYPE_COLLECTION_PER_CLASS;
@@ -722,14 +723,14 @@ class ClassMetadataTest extends BaseTest
         $this->assertEquals(['id' => 1], $shardKey['keys']);
     }
 
-    public function testIsNotShardedIfThereIsNoShardKey()
+    public function testIsNotShardedIfThereIsNoShardKey(): void
     {
         $cm = new ClassMetadata('stdClass');
 
         $this->assertFalse($cm->isSharded());
     }
 
-    public function testIsShardedIfThereIsAShardKey()
+    public function testIsShardedIfThereIsAShardKey(): void
     {
         $cm = new ClassMetadata('stdClass');
         $cm->setShardKey(['id' => 'asc']);
@@ -737,7 +738,7 @@ class ClassMetadataTest extends BaseTest
         $this->assertTrue($cm->isSharded());
     }
 
-    public function testEmbeddedDocumentCantHaveShardKey()
+    public function testEmbeddedDocumentCantHaveShardKey(): void
     {
         $cm                     = new ClassMetadata('stdClass');
         $cm->isEmbeddedDocument = true;
@@ -746,7 +747,7 @@ class ClassMetadataTest extends BaseTest
         $cm->setShardKey(['id' => 'asc']);
     }
 
-    public function testNoIncrementFieldsAllowedInShardKey()
+    public function testNoIncrementFieldsAllowedInShardKey(): void
     {
         $object = new class {
             public $inc;
@@ -763,7 +764,7 @@ class ClassMetadataTest extends BaseTest
         $cm->setShardKey(['inc' => 1]);
     }
 
-    public function testNoCollectionsInShardKey()
+    public function testNoCollectionsInShardKey(): void
     {
         $object = new class {
             public $collection;
@@ -779,7 +780,7 @@ class ClassMetadataTest extends BaseTest
         $cm->setShardKey(['collection' => 1]);
     }
 
-    public function testNoEmbedManyInShardKey()
+    public function testNoEmbedManyInShardKey(): void
     {
         $object = new class {
             public $embedMany;
@@ -792,7 +793,7 @@ class ClassMetadataTest extends BaseTest
         $cm->setShardKey(['embedMany' => 1]);
     }
 
-    public function testNoReferenceManyInShardKey()
+    public function testNoReferenceManyInShardKey(): void
     {
         $object = new class {
             public $referenceMany;
@@ -820,19 +821,19 @@ class ClassMetadataTest extends BaseTest
         $cm->mapField(['type' => 'string', 'fieldName' => 'contentType']);
     }
 
-    public function testDefaultValueForValidator()
+    public function testDefaultValueForValidator(): void
     {
         $cm = new ClassMetadata('stdClass');
         $this->assertNull($cm->getValidator());
     }
 
-    public function testDefaultValueForValidationAction()
+    public function testDefaultValueForValidationAction(): void
     {
         $cm = new ClassMetadata('stdClass');
         $this->assertEquals(ClassMetadata::SCHEMA_VALIDATION_ACTION_ERROR, $cm->getValidationAction());
     }
 
-    public function testDefaultValueForValidationLevel()
+    public function testDefaultValueForValidationLevel(): void
     {
         $cm = new ClassMetadata('stdClass');
         $this->assertEquals(ClassMetadata::SCHEMA_VALIDATION_LEVEL_STRICT, $cm->getValidationLevel());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -32,7 +32,7 @@ abstract class AbstractDriverTest extends TestCase
         unset($this->driver);
     }
 
-    public function testDriver()
+    public function testDriver(): void
     {
         $classMetadata = new ClassMetadata(User::class);
         $this->driver->loadMetadataForClass(User::class, $classMetadata);
@@ -295,7 +295,7 @@ abstract class AbstractDriverTest extends TestCase
         ], $classMetadata->fieldMappings['count']);
     }
 
-    public function testPartialFilterExpressions()
+    public function testPartialFilterExpressions(): void
     {
         $classMetadata = new ClassMetadata(PartialFilterDocument::class);
         $this->driver->loadMetadataForClass(PartialFilterDocument::class, $classMetadata);
@@ -333,7 +333,7 @@ abstract class AbstractDriverTest extends TestCase
         ], $classMetadata->getIndexes());
     }
 
-    public function testCollectionPrimers()
+    public function testCollectionPrimers(): void
     {
         $classMetadata = new ClassMetadata(PrimedCollectionDocument::class);
         $this->driver->loadMetadataForClass(PrimedCollectionDocument::class, $classMetadata);
@@ -395,7 +395,7 @@ abstract class AbstractDriverTest extends TestCase
         ], $classMetadata->fieldMappings['inverseMappedBy']);
     }
 
-    public function testNullableFieldsMapping()
+    public function testNullableFieldsMapping(): void
     {
         $classMetadata = new ClassMetadata(NullableFieldsDocument::class);
         $this->driver->loadMetadataForClass(NullableFieldsDocument::class, $classMetadata);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
@@ -25,7 +25,7 @@ class XmlDriverTest extends AbstractDriverTest
         $this->driver = new XmlDriver(__DIR__ . '/fixtures/xml');
     }
 
-    public function testDriverShouldReturnOptionsForCustomIdGenerator()
+    public function testDriverShouldReturnOptionsForCustomIdGenerator(): void
     {
         $classMetadata = new ClassMetadata(UserCustomIdGenerator::class);
         $this->driver->loadMetadataForClass(UserCustomIdGenerator::class, $classMetadata);
@@ -50,7 +50,7 @@ class XmlDriverTest extends AbstractDriverTest
         ], $classMetadata->fieldMappings['id']);
     }
 
-    public function testDriverShouldParseNonStringAttributes()
+    public function testDriverShouldParseNonStringAttributes(): void
     {
         $classMetadata = new ClassMetadata(UserNonStringOptions::class);
         $this->driver->loadMetadataForClass(UserNonStringOptions::class, $classMetadata);
@@ -66,7 +66,7 @@ class XmlDriverTest extends AbstractDriverTest
         $this->assertSame(2, $profileMapping['skip']);
     }
 
-    public function testInvalidPartialFilterExpressions()
+    public function testInvalidPartialFilterExpressions(): void
     {
         $classMetadata = new ClassMetadata(InvalidPartialFilterDocument::class);
 
@@ -76,7 +76,7 @@ class XmlDriverTest extends AbstractDriverTest
         $this->driver->loadMetadataForClass(InvalidPartialFilterDocument::class, $classMetadata);
     }
 
-    public function testAlsoLoadFieldMapping()
+    public function testAlsoLoadFieldMapping(): void
     {
         $classMetadata = new ClassMetadata(AlsoLoadDocument::class);
         $this->driver->loadMetadataForClass(AlsoLoadDocument::class, $classMetadata);
@@ -99,7 +99,7 @@ class XmlDriverTest extends AbstractDriverTest
         ], $classMetadata->fieldMappings['createdAt']);
     }
 
-    public function testValidationMapping()
+    public function testValidationMapping(): void
     {
         $classMetadata = new ClassMetadata(SchemaValidatedDocument::class);
         $this->driver->loadMetadataForClass($classMetadata->name, $classMetadata);
@@ -128,7 +128,7 @@ EOT;
         $this->assertEquals($expectedValidator, $classMetadata->getValidator());
     }
 
-    public function testWrongValueForValidationSchemaShouldThrowException()
+    public function testWrongValueForValidationSchemaShouldThrowException(): void
     {
         $classMetadata = new ClassMetadata(SchemaInvalidDocument::class);
         $this->expectException(MappingException::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/PrimedCollectionDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/PrimedCollectionDocument.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TestDocuments;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 
 class PrimedCollectionDocument
 {
@@ -25,12 +26,12 @@ class PrimedCollectionDocument
         return $this->id;
     }
 
-    public function getInverseMappedBy()
+    public function getInverseMappedBy(): Collection
     {
         return $this->inverseMappedBy;
     }
 
-    public function getReferences()
+    public function getReferences(): Collection
     {
         return $this->references;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/User.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/User.php
@@ -6,6 +6,8 @@ namespace TestDocuments;
 
 use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ODM\MongoDB\Tests\Mapping\Phonenumber;
 
 class User
 {
@@ -43,7 +45,7 @@ class User
         return $this->id;
     }
 
-    public function setUsername($username)
+    public function setUsername($username): void
     {
         $this->username = $username;
     }
@@ -53,7 +55,7 @@ class User
         return $this->username;
     }
 
-    public function setPassword($password)
+    public function setPassword($password): void
     {
         $this->password = $password;
     }
@@ -63,12 +65,12 @@ class User
         return $this->password;
     }
 
-    public function setCreatedAt($createdAt)
+    public function setCreatedAt($createdAt): void
     {
         $this->createdAt = $createdAt;
     }
 
-    public function getCreatedAt()
+    public function getCreatedAt(): DateTime
     {
         return $this->createdAt;
     }
@@ -78,12 +80,12 @@ class User
         return $this->address;
     }
 
-    public function setAddress(Address $address)
+    public function setAddress(Address $address): void
     {
         $this->address = $address;
     }
 
-    public function setProfile(Profile $profile)
+    public function setProfile(Profile $profile): void
     {
         $this->profile = $profile;
     }
@@ -93,7 +95,7 @@ class User
         return $this->profile;
     }
 
-    public function setAccount(Account $account)
+    public function setAccount(Account $account): void
     {
         $this->account = $account;
     }
@@ -103,22 +105,22 @@ class User
         return $this->account;
     }
 
-    public function getPhonenumbers()
+    public function getPhonenumbers(): Collection
     {
         return $this->phonenumbers;
     }
 
-    public function addPhonenumber(Phonenumber $phonenumber)
+    public function addPhonenumber(Phonenumber $phonenumber): void
     {
         $this->phonenumbers[] = $phonenumber;
     }
 
-    public function getGroups()
+    public function getGroups(): Collection
     {
         return $this->groups;
     }
 
-    public function addGroup(Group $group)
+    public function addGroup(Group $group): void
     {
         $this->groups[] = $group;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php
@@ -22,7 +22,7 @@ class ShardKeyInheritanceMappingTest extends BaseTest
         $this->factory->setConfiguration($this->dm->getConfiguration());
     }
 
-    public function testShardKeyFromMappedSuperclass()
+    public function testShardKeyFromMappedSuperclass(): void
     {
         $class = $this->factory->getMetadataFor(ShardedSubclass::class);
 
@@ -30,7 +30,7 @@ class ShardKeyInheritanceMappingTest extends BaseTest
         $this->assertEquals(['keys' => ['_id' => 1], 'options' => []], $class->getShardKey());
     }
 
-    public function testShardKeySingleCollectionInheritance()
+    public function testShardKeySingleCollectionInheritance(): void
     {
         $class = $this->factory->getMetadataFor(ShardedSingleCollInheritance2::class);
 
@@ -38,13 +38,13 @@ class ShardKeyInheritanceMappingTest extends BaseTest
         $this->assertEquals(['keys' => ['_id' => 1], 'options' => []], $class->getShardKey());
     }
 
-    public function testShardKeySingleCollectionInheritanceOverriding()
+    public function testShardKeySingleCollectionInheritanceOverriding(): void
     {
         $this->expectException(MappingException::class);
         $this->factory->getMetadataFor(ShardedSingleCollInheritance3::class);
     }
 
-    public function testShardKeyCollectionPerClassInheritance()
+    public function testShardKeyCollectionPerClassInheritance(): void
     {
         $class = $this->factory->getMetadataFor(ShardedCollectionPerClass2::class);
 
@@ -52,7 +52,7 @@ class ShardKeyInheritanceMappingTest extends BaseTest
         $this->assertEquals(['keys' => ['_id' => 1], 'options' => []], $class->getShardKey());
     }
 
-    public function testShardKeyCollectionPerClassInheritanceOverriding()
+    public function testShardKeyCollectionPerClassInheritanceOverriding(): void
     {
         $class = $this->factory->getMetadataFor(ShardedCollectionPerClass3::class);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/AbstractDriverTest.php
@@ -23,7 +23,7 @@ abstract class AbstractDriverTest extends TestCase
     /** @var string */
     protected $dir;
 
-    public function testFindMappingFile()
+    public function testFindMappingFile(): void
     {
         $driver = $this->getDriver([
             'MyNamespace\MySubnamespace\DocumentFoo' => 'foo',
@@ -34,7 +34,7 @@ abstract class AbstractDriverTest extends TestCase
         $this->assertEquals($filename, $driver->getLocator()->findMappingFile('MyNamespace\MySubnamespace\Document\Foo'));
     }
 
-    public function testFindMappingFileInSubnamespace()
+    public function testFindMappingFileInSubnamespace(): void
     {
         $driver = $this->getDriver([
             'MyNamespace\MySubnamespace\Document' => $this->dir,
@@ -44,7 +44,7 @@ abstract class AbstractDriverTest extends TestCase
         $this->assertEquals($filename, $driver->getLocator()->findMappingFile('MyNamespace\MySubnamespace\Document\Foo\Bar'));
     }
 
-    public function testFindMappingFileNamespacedFoundFileNotFound()
+    public function testFindMappingFileNamespacedFoundFileNotFound(): void
     {
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage('No mapping file found named');
@@ -56,7 +56,7 @@ abstract class AbstractDriverTest extends TestCase
         $driver->getLocator()->findMappingFile('MyNamespace\MySubnamespace\Document\Foo');
     }
 
-    public function testFindMappingNamespaceNotFound()
+    public function testFindMappingNamespaceNotFound(): void
     {
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage("No mapping file found named 'Foo" . $this->getFileExtension() . "' for class 'MyOtherNamespace\MySubnamespace\Document\Foo'.");

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/XmlDriverTest.php
@@ -13,12 +13,12 @@ use function array_flip;
  */
 class XmlDriverTest extends AbstractDriverTest
 {
-    protected function getFileExtension()
+    protected function getFileExtension(): string
     {
         return '.mongodb-odm.xml';
     }
 
-    protected function getDriver(array $paths = [])
+    protected function getDriver(array $paths = []): SimplifiedXmlDriver
     {
         return new SimplifiedXmlDriver(array_flip($paths));
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
@@ -8,7 +8,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use ReflectionMethod;
-use SimpleXmlElement;
+use SimpleXMLElement;
 use stdClass;
 
 use function get_class;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
@@ -17,12 +17,12 @@ use const DIRECTORY_SEPARATOR;
 
 class XmlMappingDriverTest extends AbstractMappingDriverTest
 {
-    protected function loadDriver()
+    protected function loadDriver(): XmlDriver
     {
         return new XmlDriver(__DIR__ . DIRECTORY_SEPARATOR . 'xml');
     }
 
-    public function testSetShardKeyOptionsByAttributes()
+    public function testSetShardKeyOptionsByAttributes(): void
     {
         $class   = new ClassMetadata(stdClass::class);
         $driver  = $this->loadDriver();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
@@ -26,7 +26,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
     {
         $class   = new ClassMetadata(stdClass::class);
         $driver  = $this->loadDriver();
-        $element = new SimpleXmlElement('<shard-key unique="true" numInitialChunks="4096"><key name="_id"/></shard-key>');
+        $element = new SimpleXMLElement('<shard-key unique="true" numInitialChunks="4096"><key name="_id"/></shard-key>');
 
         /** @uses XmlDriver::setShardKey */
         $m = new ReflectionMethod(get_class($driver), 'setShardKey');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mocks/ExceptionThrowingListenerMock.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mocks/ExceptionThrowingListenerMock.php
@@ -10,12 +10,12 @@ use Exception;
 
 class ExceptionThrowingListenerMock implements EventSubscriber
 {
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return ['onFlush'];
     }
 
-    public function onFlush(OnFlushEventArgs $args)
+    public function onFlush(OnFlushEventArgs $args): void
     {
         throw new Exception('This should not happen');
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mocks/PreUpdateListenerMock.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mocks/PreUpdateListenerMock.php
@@ -12,7 +12,7 @@ use function spl_object_hash;
 
 class PreUpdateListenerMock implements EventSubscriber
 {
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [
             'onFlush',
@@ -20,7 +20,7 @@ class PreUpdateListenerMock implements EventSubscriber
         ];
     }
 
-    public function onFlush(OnFlushEventArgs $args)
+    public function onFlush(OnFlushEventArgs $args): void
     {
         $uow = $args->getDocumentManager()->getUnitOfWork();
         foreach ($uow->getScheduledDocumentUpdates() as $document) {
@@ -28,7 +28,7 @@ class PreUpdateListenerMock implements EventSubscriber
         }
     }
 
-    public function preUpdate(PreUpdateEventArgs $args)
+    public function preUpdate(PreUpdateEventArgs $args): void
     {
         return;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/MongoCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/MongoCollectionTest.php
@@ -8,7 +8,7 @@ use Documents\File;
 
 class MongoCollectionTest extends BaseTest
 {
-    public function testGridFSEmptyResult()
+    public function testGridFSEmptyResult(): void
     {
         $mongoCollection = $this->dm->getDocumentCollection(File::class);
         $this->assertNull($mongoCollection->findOne(['_id' => 'definitelynotanid']));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/HydrationPerformanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/HydrationPerformanceTest.php
@@ -21,7 +21,7 @@ class HydrationPerformanceTest extends BaseTest
     /**
      * [jwage: 10000 objects in ~6 seconds]
      */
-    public function testHydrationPerformance()
+    public function testHydrationPerformance(): void
     {
         $s = microtime(true);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/InsertPerformanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/InsertPerformanceTest.php
@@ -21,7 +21,7 @@ class InsertPerformanceTest extends BaseTest
     /**
      * [jwage: 10000 objects in ~4 seconds]
      */
-    public function testInsertPerformance()
+    public function testInsertPerformance(): void
     {
         $s = microtime(true);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/MemoryUsageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/MemoryUsageTest.php
@@ -28,7 +28,7 @@ class MemoryUsageTest extends BaseTest
     /**
      * [jwage: Memory increased by 14.09 kb]
      */
-    public function testMemoryUsage()
+    public function testMemoryUsage(): void
     {
         $memoryUsage = [];
         for ($i = 0; $i < 100; $i++) {
@@ -59,7 +59,7 @@ class MemoryUsageTest extends BaseTest
         echo sprintf('Memory increased by %s', $this->formatMemory($increase)) . PHP_EOL;
     }
 
-    private function formatMemory($size)
+    private function formatMemory($size): string
     {
         $unit = ['b', 'kb', 'mb', 'gb', 'tb', 'pb'];
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/UnitOfWorkPerformanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/UnitOfWorkPerformanceTest.php
@@ -20,7 +20,7 @@ class UnitOfWorkPerformanceTest extends BaseTest
     /**
      * [jwage: compute changesets for 10000 objects in ~10 seconds]
      */
-    public function testComputeChanges()
+    public function testComputeChanges(): void
     {
         $n     = 10000;
         $users = [];

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/DefaultPersistentCollectionGeneratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/DefaultPersistentCollectionGeneratorTest.php
@@ -28,28 +28,28 @@ class DefaultPersistentCollectionGeneratorTest extends BaseTest
         );
     }
 
-    public function testNoReturnTypes()
+    public function testNoReturnTypes(): void
     {
         $class = $this->generator->loadClass(CollNoReturnType::class, Configuration::AUTOGENERATE_EVAL);
         $coll  = new $class(new CollNoReturnType(), $this->dm, $this->uow);
         $this->assertInstanceOf(CollNoReturnType::class, $coll);
     }
 
-    public function testWithReturnType()
+    public function testWithReturnType(): void
     {
         $class = $this->generator->loadClass(CollWithReturnType::class, Configuration::AUTOGENERATE_EVAL);
         $coll  = new $class(new CollWithReturnType(), $this->dm, $this->uow);
         $this->assertInstanceOf(CollWithReturnType::class, $coll);
     }
 
-    public function testWithNullableReturnType()
+    public function testWithNullableReturnType(): void
     {
         $class = $this->generator->loadClass(CollWithNullableReturnType::class, Configuration::AUTOGENERATE_EVAL);
         $coll  = new $class(new CollWithNullableReturnType(), $this->dm, $this->uow);
         $this->assertInstanceOf(CollWithNullableReturnType::class, $coll);
     }
 
-    public function testPHP80Types()
+    public function testPHP80Types(): void
     {
         if (version_compare((string) phpversion(), '8.0.0', '<')) {
             $this->markTestSkipped('PHP 8.0 is required to run this test');

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
@@ -137,7 +137,7 @@ class PersistentCollectionTest extends BaseTest
      *
      * @dataProvider dataGetDeletedDocuments
      */
-    public function testGetDeletedDocuments($expected, $snapshot, Closure $callback)
+    public function testGetDeletedDocuments(array $expected, array $snapshot, Closure $callback)
     {
         $collection = new PersistentCollection(new ArrayCollection(), $this->dm, $this->uow);
 
@@ -211,7 +211,7 @@ class PersistentCollectionTest extends BaseTest
      *
      * @dataProvider dataGetInsertedDocuments
      */
-    public function testGetInsertedDocuments($expected, $snapshot, Closure $callback)
+    public function testGetInsertedDocuments(array $expected, array $snapshot, Closure $callback)
     {
         $collection = new PersistentCollection(new ArrayCollection(), $this->dm, $this->uow);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
@@ -21,7 +21,7 @@ use function unserialize;
 
 class PersistentCollectionTest extends BaseTest
 {
-    public function testSlice()
+    public function testSlice(): void
     {
         [$start, $limit] = [0, 25];
         $collection      = $this->getMockCollection();
@@ -33,7 +33,7 @@ class PersistentCollectionTest extends BaseTest
         $pCollection->slice($start, $limit);
     }
 
-    public function testExceptionForGetTypeClassWithoutDocumentManager()
+    public function testExceptionForGetTypeClassWithoutDocumentManager(): void
     {
         $collection = new PersistentCollection(new ArrayCollection(), $this->dm, $this->uow);
         $owner      = new stdClass();
@@ -53,7 +53,7 @@ class PersistentCollectionTest extends BaseTest
         $unserialized->getTypeClass();
     }
 
-    public function testExceptionForGetTypeClassWithoutMapping()
+    public function testExceptionForGetTypeClassWithoutMapping(): void
     {
         $collection = new PersistentCollection(new ArrayCollection(), $this->dm, $this->uow);
 
@@ -70,7 +70,7 @@ class PersistentCollectionTest extends BaseTest
         $unserialized->getTypeClass();
     }
 
-    public function testGetTypeClassWorksAfterUnserialization()
+    public function testGetTypeClassWorksAfterUnserialization(): void
     {
         $collection = new PersistentCollection(new ArrayCollection(), $this->dm, $this->uow);
 
@@ -83,7 +83,7 @@ class PersistentCollectionTest extends BaseTest
         $this->assertInstanceOf(ClassMetadata::class, $unserialized->getTypeClass());
     }
 
-    public function testMongoDataIsPreservedDuringSerialization()
+    public function testMongoDataIsPreservedDuringSerialization(): void
     {
         $mongoData = [
             [
@@ -109,7 +109,7 @@ class PersistentCollectionTest extends BaseTest
         $this->assertCount(2, $unserialized->getMongoData());
     }
 
-    public function testSnapshotIsPreservedDuringSerialization()
+    public function testSnapshotIsPreservedDuringSerialization(): void
     {
         $collection = new PersistentCollection(new ArrayCollection(), $this->dm, $this->uow);
         $collection->add(new stdClass());
@@ -137,7 +137,7 @@ class PersistentCollectionTest extends BaseTest
      *
      * @dataProvider dataGetDeletedDocuments
      */
-    public function testGetDeletedDocuments(array $expected, array $snapshot, Closure $callback)
+    public function testGetDeletedDocuments(array $expected, array $snapshot, Closure $callback): void
     {
         $collection = new PersistentCollection(new ArrayCollection(), $this->dm, $this->uow);
 
@@ -151,7 +151,7 @@ class PersistentCollectionTest extends BaseTest
         $this->assertSame($expected, $collection->getDeletedDocuments());
     }
 
-    public static function dataGetDeletedDocuments()
+    public static function dataGetDeletedDocuments(): array
     {
         $one = new stdClass();
         $two = new stdClass();
@@ -211,7 +211,7 @@ class PersistentCollectionTest extends BaseTest
      *
      * @dataProvider dataGetInsertedDocuments
      */
-    public function testGetInsertedDocuments(array $expected, array $snapshot, Closure $callback)
+    public function testGetInsertedDocuments(array $expected, array $snapshot, Closure $callback): void
     {
         $collection = new PersistentCollection(new ArrayCollection(), $this->dm, $this->uow);
 
@@ -225,7 +225,7 @@ class PersistentCollectionTest extends BaseTest
         $this->assertSame($expected, $collection->getInsertedDocuments());
     }
 
-    public static function dataGetInsertedDocuments()
+    public static function dataGetInsertedDocuments(): array
     {
         $one = new stdClass();
         $two = new stdClass();
@@ -265,7 +265,7 @@ class PersistentCollectionTest extends BaseTest
         ];
     }
 
-    public function testOffsetExistsIsForwarded()
+    public function testOffsetExistsIsForwarded(): void
     {
         $collection = $this->getMockCollection();
         $collection->expects($this->once())->method('offsetExists')->willReturn(false);
@@ -273,7 +273,7 @@ class PersistentCollectionTest extends BaseTest
         $this->assertArrayNotHasKey(0, $pcoll);
     }
 
-    public function testOffsetGetIsForwarded()
+    public function testOffsetGetIsForwarded(): void
     {
         $collection = $this->getMockCollection();
         $object     = new stdClass();
@@ -282,7 +282,7 @@ class PersistentCollectionTest extends BaseTest
         $this->assertSame($object, $pcoll[0]);
     }
 
-    public function testOffsetUnsetIsForwarded()
+    public function testOffsetUnsetIsForwarded(): void
     {
         $collection = $this->getMockCollection();
         $collection->expects($this->once())->method('offsetUnset');
@@ -291,7 +291,7 @@ class PersistentCollectionTest extends BaseTest
         $this->assertTrue($pcoll->isDirty());
     }
 
-    public function testRemoveIsForwarded()
+    public function testRemoveIsForwarded(): void
     {
         $collection = $this->getMockCollection();
         $collection->expects($this->once())->method('remove')->willReturn(2);
@@ -300,7 +300,7 @@ class PersistentCollectionTest extends BaseTest
         $this->assertTrue($pcoll->isDirty());
     }
 
-    public function testOffsetSetIsForwarded()
+    public function testOffsetSetIsForwarded(): void
     {
         $collection = $this->getMockCollection();
         $collection->expects($this->exactly(2))->method('offsetSet');
@@ -313,7 +313,7 @@ class PersistentCollectionTest extends BaseTest
         $pcoll->set(3, new stdClass());
     }
 
-    public function testIsEmptyIsForwardedWhenCollectionIsInitialized()
+    public function testIsEmptyIsForwardedWhenCollectionIsInitialized(): void
     {
         $collection = $this->getMockCollection();
         $collection->expects($this->once())->method('isEmpty')->willReturn(true);
@@ -322,7 +322,7 @@ class PersistentCollectionTest extends BaseTest
         $this->assertTrue($pcoll->isEmpty());
     }
 
-    public function testIsEmptyUsesCountWhenCollectionIsNotInitialized()
+    public function testIsEmptyUsesCountWhenCollectionIsNotInitialized(): void
     {
         $collection = $this->getMockCollection();
         $collection->expects($this->never())->method('isEmpty');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterFilterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterFilterTest.php
@@ -12,7 +12,7 @@ use Documents\User;
 
 class DocumentPersisterFilterTest extends BaseTest
 {
-    public function testAddFilterToPreparedQuery()
+    public function testAddFilterToPreparedQuery(): void
     {
         $persister        = $this->uow->getDocumentPersister(User::class);
         $filterCollection = $this->dm->getFilterCollection();
@@ -35,7 +35,7 @@ class DocumentPersisterFilterTest extends BaseTest
         $this->assertSame($expectedCriteria, $persister->addFilterToPreparedQuery($preparedQuery));
     }
 
-    public function testFilterCrieriaShouldAndWithMappingCriteriaOwningSide()
+    public function testFilterCrieriaShouldAndWithMappingCriteriaOwningSide(): void
     {
         $blogPost = new BlogPost('Roger');
         $blogPost->addComment(new Comment('comment by normal user', new DateTime(), false));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
@@ -19,7 +19,7 @@ use function get_class;
 
 class DocumentPersisterGetShardKeyQueryTest extends BaseTest
 {
-    public function testGetShardKeyQueryScalars()
+    public function testGetShardKeyQueryScalars(): void
     {
         $o         = new ShardedByScalars();
         $o->int    = 1;
@@ -39,7 +39,7 @@ class DocumentPersisterGetShardKeyQueryTest extends BaseTest
         );
     }
 
-    public function testGetShardKeyQueryObjects()
+    public function testGetShardKeyQueryObjects(): void
     {
         $o       = new ShardedByObjects();
         $o->oid  = '54ca2c4c81fec698130041a7';
@@ -68,7 +68,7 @@ class DocumentPersisterGetShardKeyQueryTest extends BaseTest
         );
     }
 
-    public function testShardById()
+    public function testShardById(): void
     {
         $o             = new ShardedById();
         $o->identifier = new ObjectId();
@@ -83,7 +83,7 @@ class DocumentPersisterGetShardKeyQueryTest extends BaseTest
         $this->assertSame(['_id' => $o->identifier], $shardKeyQuery);
     }
 
-    public function testShardByReference()
+    public function testShardByReference(): void
     {
         $o = new ShardedByReferenceOne();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php
@@ -37,7 +37,7 @@ class PersistenceBuilderTest extends BaseTest
         parent::tearDown();
     }
 
-    public function testQueryBuilderUpdateWithDiscriminatorMap()
+    public function testQueryBuilderUpdateWithDiscriminatorMap(): void
     {
         $testCollection = new SameCollection1();
         $id             = '4f28aa84acee413889000001';
@@ -63,7 +63,7 @@ class PersistenceBuilderTest extends BaseTest
         $this->assertEquals('OK! TEST', $testCollection->test);
     }
 
-    public function testFindWithOrOnCollectionWithDiscriminatorMap()
+    public function testFindWithOrOnCollectionWithDiscriminatorMap(): void
     {
         $sameCollection1  = new SameCollection1();
         $sameCollection2a = new SameCollection2();
@@ -113,7 +113,7 @@ class PersistenceBuilderTest extends BaseTest
         $this->assertCount(2, $results->toArray());
     }
 
-    public function testPrepareUpdateDataDoesNotIncludeId()
+    public function testPrepareUpdateDataDoesNotIncludeId(): void
     {
         $article        = new CmsArticle();
         $article->topic = 'persistence builder test';
@@ -130,7 +130,7 @@ class PersistenceBuilderTest extends BaseTest
         $this->assertFalse(isset($data['$unset']['_id']));
     }
 
-    public function testPrepareInsertDataWithCreatedReferenceOne()
+    public function testPrepareInsertDataWithCreatedReferenceOne(): void
     {
         $article        = new CmsArticle();
         $article->title = 'persistence builder test';
@@ -152,7 +152,7 @@ class PersistenceBuilderTest extends BaseTest
         $this->assertDocumentInsertData($expectedData, $this->pb->prepareInsertData($comment));
     }
 
-    public function testPrepareInsertDataWithFetchedReferenceOne()
+    public function testPrepareInsertDataWithFetchedReferenceOne(): void
     {
         $article        = new CmsArticle();
         $article->title = 'persistence builder test';
@@ -177,7 +177,7 @@ class PersistenceBuilderTest extends BaseTest
         $this->assertDocumentInsertData($expectedData, $this->pb->prepareInsertData($comment));
     }
 
-    public function testPrepareUpsertData()
+    public function testPrepareUpsertData(): void
     {
         $article        = new CmsArticle();
         $article->title = 'persistence builder test';
@@ -212,7 +212,7 @@ class PersistenceBuilderTest extends BaseTest
     /**
      * @dataProvider getDocumentsAndExpectedData
      */
-    public function testPrepareInsertData($document, array $expectedData)
+    public function testPrepareInsertData($document, array $expectedData): void
     {
         $this->dm->persist($document);
         $this->uow->computeChangeSets();
@@ -225,7 +225,7 @@ class PersistenceBuilderTest extends BaseTest
      *
      * @return array
      */
-    public function getDocumentsAndExpectedData()
+    public function getDocumentsAndExpectedData(): array
     {
         return [
             [new ConfigurableProduct('Test Product'), ['name' => 'Test Product']],
@@ -233,7 +233,7 @@ class PersistenceBuilderTest extends BaseTest
         ];
     }
 
-    private function assertDocumentInsertData(array $expectedData, ?array $preparedData = null)
+    private function assertDocumentInsertData(array $expectedData, ?array $preparedData = null): void
     {
         foreach ($preparedData as $key => $value) {
             if ($key === '_id') {
@@ -252,7 +252,7 @@ class PersistenceBuilderTest extends BaseTest
         $this->assertEquals(array_keys($expectedData), array_keys($preparedData));
     }
 
-    public function testAdvancedQueriesOnReferenceWithDiscriminatorMap()
+    public function testAdvancedQueriesOnReferenceWithDiscriminatorMap(): void
     {
         $article        = new CmsArticle();
         $article->id    = '4f8373f952fbfe7411000001';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -21,6 +21,7 @@ use InvalidArgumentException;
 use IteratorAggregate;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Driver\ReadPreference;
+use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionProperty;
 
 class BuilderTest extends BaseTest
@@ -824,6 +825,9 @@ class BuilderTest extends BaseTest
         return new Builder($this->dm, User::class);
     }
 
+    /**
+     * @return MockObject&Expr
+     */
     private function getMockExpr()
     {
         return $this->getMockBuilder(Expr::class)
@@ -831,6 +835,9 @@ class BuilderTest extends BaseTest
             ->getMock();
     }
 
+    /**
+     * @return MockObject&Geometry
+     */
     private function getMockGeometry()
     {
         return $this->getMockBuilder(Geometry::class)
@@ -838,6 +845,9 @@ class BuilderTest extends BaseTest
             ->getMock();
     }
 
+    /**
+     * @return MockObject&Point
+     */
     private function getMockPoint($json)
     {
         $point = $this->getMockBuilder(Point::class)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -14,6 +14,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Documents\Feature;
 use Documents\User;
+use Generator;
 use GeoJson\Geometry\Geometry;
 use GeoJson\Geometry\Point;
 use InvalidArgumentException;
@@ -24,14 +25,14 @@ use ReflectionProperty;
 
 class BuilderTest extends BaseTest
 {
-    public function testPrimeRequiresBooleanOrCallable()
+    public function testPrimeRequiresBooleanOrCallable(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->dm->createQueryBuilder(User::class)
             ->field('groups')->prime(1);
     }
 
-    public function testReferencesGoesThroughDiscriminatorMap()
+    public function testReferencesGoesThroughDiscriminatorMap(): void
     {
         $f = new Feature('Smarter references');
         $this->dm->persist($f);
@@ -74,7 +75,7 @@ class BuilderTest extends BaseTest
         );
     }
 
-    public function testReferencesThrowsSpecializedExceptionForDiscriminatedDocuments()
+    public function testReferencesThrowsSpecializedExceptionForDiscriminatedDocuments(): void
     {
         $f = new Feature('Smarter references');
         $this->dm->persist($f);
@@ -89,7 +90,7 @@ class BuilderTest extends BaseTest
             ->getQuery();
     }
 
-    public function testReferencesThrowsSpecializedExceptionForConflictingMappings()
+    public function testReferencesThrowsSpecializedExceptionForConflictingMappings(): void
     {
         $f = new Feature('Smarter references');
         $this->dm->persist($f);
@@ -104,7 +105,7 @@ class BuilderTest extends BaseTest
             ->getQuery();
     }
 
-    public function testIncludesReferenceToGoesThroughDiscriminatorMap()
+    public function testIncludesReferenceToGoesThroughDiscriminatorMap(): void
     {
         $f = new Feature('Smarter references');
         $this->dm->persist($f);
@@ -153,7 +154,7 @@ class BuilderTest extends BaseTest
         );
     }
 
-    public function testIncludesReferenceToThrowsSpecializedExceptionForDiscriminatedDocuments()
+    public function testIncludesReferenceToThrowsSpecializedExceptionForDiscriminatedDocuments(): void
     {
         $f = new Feature('Smarter references');
         $this->dm->persist($f);
@@ -168,7 +169,7 @@ class BuilderTest extends BaseTest
             ->getQuery();
     }
 
-    public function testIncludesReferenceToThrowsSpecializedExceptionForConflictingMappings()
+    public function testIncludesReferenceToThrowsSpecializedExceptionForConflictingMappings(): void
     {
         $f = new Feature('Smarter references');
         $this->dm->persist($f);
@@ -186,7 +187,7 @@ class BuilderTest extends BaseTest
     /**
      * @dataProvider provideArrayUpdateOperatorsOnReferenceMany
      */
-    public function testArrayUpdateOperatorsOnReferenceMany($class, $field)
+    public function testArrayUpdateOperatorsOnReferenceMany($class, $field): void
     {
         $f = new Feature('Smarter references');
         $this->dm->persist($f);
@@ -200,7 +201,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $q1['newObj']['$addToSet'][$field]);
     }
 
-    public function provideArrayUpdateOperatorsOnReferenceMany()
+    public function provideArrayUpdateOperatorsOnReferenceMany(): Generator
     {
         yield [ChildA::class, 'featureFullMany'];
         yield [ChildB::class, 'featureSimpleMany'];
@@ -210,7 +211,7 @@ class BuilderTest extends BaseTest
     /**
      * @dataProvider provideArrayUpdateOperatorsOnReferenceOne
      */
-    public function testArrayUpdateOperatorsOnReferenceOne($class, $field)
+    public function testArrayUpdateOperatorsOnReferenceOne($class, $field): void
     {
         $f = new Feature('Smarter references');
         $this->dm->persist($f);
@@ -224,14 +225,14 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $q1['newObj']['$set'][$field]);
     }
 
-    public function provideArrayUpdateOperatorsOnReferenceOne()
+    public function provideArrayUpdateOperatorsOnReferenceOne(): Generator
     {
         yield [ChildA::class, 'featureFull'];
         yield [ChildB::class, 'featureSimple'];
         yield [ChildC::class, 'featurePartial'];
     }
 
-    public function testThatOrAcceptsAnotherQuery()
+    public function testThatOrAcceptsAnotherQuery(): void
     {
         $qb = $this->getTestQueryBuilder();
         $qb->addOr($qb->expr()->field('firstName')->equals('Kris'));
@@ -245,7 +246,7 @@ class BuilderTest extends BaseTest
         ], $qb->getQueryArray());
     }
 
-    public function testThatAndAcceptsAnotherQuery()
+    public function testThatAndAcceptsAnotherQuery(): void
     {
         $qb = $this->getTestQueryBuilder();
         $qb->addAnd($qb->expr()->field('hits')->gte(1));
@@ -259,7 +260,7 @@ class BuilderTest extends BaseTest
         ], $qb->getQueryArray());
     }
 
-    public function testThatNorAcceptsAnotherQuery()
+    public function testThatNorAcceptsAnotherQuery(): void
     {
         $qb = $this->getTestQueryBuilder();
         $qb->addNor($qb->expr()->field('firstName')->equals('Kris'));
@@ -273,7 +274,7 @@ class BuilderTest extends BaseTest
         ], $qb->getQueryArray());
     }
 
-    public function testAddElemMatch()
+    public function testAddElemMatch(): void
     {
         $qb = $this->getTestQueryBuilder();
         $qb->field('phonenumbers')->elemMatch($qb->expr()->field('phonenumber')->equals('6155139185'));
@@ -285,7 +286,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->getQueryArray());
     }
 
-    public function testAddNot()
+    public function testAddNot(): void
     {
         $qb = $this->getTestQueryBuilder();
         $qb->field('username')->not($qb->expr()->in(['boo']));
@@ -299,7 +300,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->getQueryArray());
     }
 
-    public function testFindQuery()
+    public function testFindQuery(): void
     {
         $qb       = $this->getTestQueryBuilder()
             ->where("function() { return this.username == 'boo' }");
@@ -307,7 +308,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->getQueryArray());
     }
 
-    public function testUpsertUpdateQuery()
+    public function testUpsertUpdateQuery(): void
     {
         $qb = $this->getTestQueryBuilder()
             ->updateOne()
@@ -321,7 +322,7 @@ class BuilderTest extends BaseTest
         $this->assertTrue($qb->debug('upsert'));
     }
 
-    public function testMultipleUpdateQuery()
+    public function testMultipleUpdateQuery(): void
     {
         $qb = $this->getTestQueryBuilder()
             ->updateMany()
@@ -334,7 +335,7 @@ class BuilderTest extends BaseTest
         $this->assertTrue($qb->debug('multiple'));
     }
 
-    public function testComplexUpdateQuery()
+    public function testComplexUpdateQuery(): void
     {
         $qb = $this->getTestQueryBuilder()
             ->updateOne()
@@ -351,7 +352,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->getNewObj());
     }
 
-    public function testIncUpdateQuery()
+    public function testIncUpdateQuery(): void
     {
         $qb = $this->getTestQueryBuilder()
             ->updateOne()
@@ -367,7 +368,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->getNewObj());
     }
 
-    public function testUnsetField()
+    public function testUnsetField(): void
     {
         $qb = $this->getTestQueryBuilder()
             ->updateOne()
@@ -383,7 +384,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->getNewObj());
     }
 
-    public function testSetOnInsert()
+    public function testSetOnInsert(): void
     {
         $createDate = new DateTime();
         $qb         = $this->getTestQueryBuilder()
@@ -403,7 +404,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->getNewObj());
     }
 
-    public function testDateRange()
+    public function testDateRange(): void
     {
         $start = new DateTime('1985-09-01 01:00:00');
         $end   = new DateTime('1985-09-04');
@@ -419,14 +420,14 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->getQueryArray());
     }
 
-    public function testQueryIsIterable()
+    public function testQueryIsIterable(): void
     {
         $qb    = $this->getTestQueryBuilder();
         $query = $qb->getQuery();
         $this->assertInstanceOf(IteratorAggregate::class, $query);
     }
 
-    public function testDeepClone()
+    public function testDeepClone(): void
     {
         $qb = $this->getTestQueryBuilder();
 
@@ -443,7 +444,7 @@ class BuilderTest extends BaseTest
     /**
      * @dataProvider provideProxiedExprMethods
      */
-    public function testProxiedExprMethods($method, array $args = [])
+    public function testProxiedExprMethods($method, array $args = []): void
     {
         $expr = $this->getMockExpr();
         $expr
@@ -459,7 +460,7 @@ class BuilderTest extends BaseTest
         $this->assertSame($qb, $qb->$method(...$args));
     }
 
-    public function provideProxiedExprMethods()
+    public function provideProxiedExprMethods(): array
     {
         return [
             'field()' => ['field', ['fieldName']],
@@ -521,7 +522,7 @@ class BuilderTest extends BaseTest
         ];
     }
 
-    public function providePoint()
+    public function providePoint(): array
     {
         $coordinates = [0, 0];
         $json        = ['type' => 'Point', 'coordinates' => $coordinates];
@@ -536,7 +537,7 @@ class BuilderTest extends BaseTest
     /**
      * @dataProvider provideSelectProjections
      */
-    public function testSelect(array $args, array $expected)
+    public function testSelect(array $args, array $expected): void
     {
         $qb = $this->getTestQueryBuilder();
         $qb->select(...$args);
@@ -544,7 +545,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->debug('select'));
     }
 
-    public function provideSelectProjections()
+    public function provideSelectProjections(): array
     {
         return $this->provideProjections(true);
     }
@@ -552,7 +553,7 @@ class BuilderTest extends BaseTest
     /**
      * @dataProvider provideExcludeProjections
      */
-    public function testExclude(array $args, array $expected)
+    public function testExclude(array $args, array $expected): void
     {
         $qb = $this->getTestQueryBuilder();
         $qb->exclude(...$args);
@@ -560,7 +561,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->debug('select'));
     }
 
-    public function provideExcludeProjections()
+    public function provideExcludeProjections(): array
     {
         return $this->provideProjections(false);
     }
@@ -572,7 +573,7 @@ class BuilderTest extends BaseTest
      *
      * @return array
      */
-    private function provideProjections(bool $include)
+    private function provideProjections(bool $include): array
     {
         $project = $include ? 1 : 0;
 
@@ -596,7 +597,7 @@ class BuilderTest extends BaseTest
         ];
     }
 
-    public function testSelectSliceWithCount()
+    public function testSelectSliceWithCount(): void
     {
         $qb = $this->getTestQueryBuilder()
             ->selectSlice('tags', 10);
@@ -606,7 +607,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->debug('select'));
     }
 
-    public function testSelectSliceWithSkipAndLimit()
+    public function testSelectSliceWithSkipAndLimit(): void
     {
         $qb = $this->getTestQueryBuilder()
             ->selectSlice('tags', -5, 5);
@@ -616,7 +617,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->debug('select'));
     }
 
-    public function testSelectElemMatchWithArray()
+    public function testSelectElemMatchWithArray(): void
     {
         $qb = $this->getTestQueryBuilder()
             ->selectElemMatch('addresses', ['state' => 'ny']);
@@ -626,7 +627,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->debug('select'));
     }
 
-    public function testSelectElemMatchWithExpr()
+    public function testSelectElemMatchWithExpr(): void
     {
         $qb = $this->getTestQueryBuilder();
         $qb->selectElemMatch('addresses', $qb->expr()->field('state')->equals('ny'));
@@ -636,7 +637,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->debug('select'));
     }
 
-    public function testSelectMeta()
+    public function testSelectMeta(): void
     {
         $qb = $this->getTestQueryBuilder()
             ->selectMeta('score', 'textScore');
@@ -646,7 +647,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->debug('select'));
     }
 
-    public function testSetReadPreference()
+    public function testSetReadPreference(): void
     {
         $qb = $this->getTestQueryBuilder();
         $qb->setReadPreference(new ReadPreference('secondary', [['dc' => 'east']]));
@@ -657,7 +658,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals([['dc' => 'east']], $readPreference->getTagSets());
     }
 
-    public function testSortWithFieldNameAndDefaultOrder()
+    public function testSortWithFieldNameAndDefaultOrder(): void
     {
         $qb = $this->getTestQueryBuilder()
             ->sort('foo');
@@ -668,7 +669,7 @@ class BuilderTest extends BaseTest
     /**
      * @dataProvider provideSortOrders
      */
-    public function testSortWithFieldNameAndOrder($order, $expectedOrder)
+    public function testSortWithFieldNameAndOrder($order, $expectedOrder): void
     {
         $qb = $this->getTestQueryBuilder()
             ->sort('foo', $order);
@@ -676,7 +677,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals(['foo' => $expectedOrder], $qb->debug('sort'));
     }
 
-    public function provideSortOrders()
+    public function provideSortOrders(): array
     {
         return [
             [1, 1],
@@ -688,7 +689,7 @@ class BuilderTest extends BaseTest
         ];
     }
 
-    public function testSortWithArrayOfFieldNameAndOrderPairs()
+    public function testSortWithArrayOfFieldNameAndOrderPairs(): void
     {
         $qb = $this->getTestQueryBuilder()
             ->sort(['foo' => 1, 'bar' => -1]);
@@ -696,7 +697,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals(['foo' => 1, 'bar' => -1], $qb->debug('sort'));
     }
 
-    public function testSortMetaDoesProjectMissingField()
+    public function testSortMetaDoesProjectMissingField(): void
     {
         $qb = $this->getTestQueryBuilder()
             ->select('score')
@@ -709,7 +710,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals(['score' => ['$meta' => 'textScore']], $qb->debug('sort'));
     }
 
-    public function testSortMetaDoesNotProjectExistingField()
+    public function testSortMetaDoesNotProjectExistingField(): void
     {
         $qb = $this->getTestQueryBuilder()
             ->sortMeta('score', 'textScore');
@@ -721,7 +722,7 @@ class BuilderTest extends BaseTest
     /**
      * @dataProvider provideCurrentDateOptions
      */
-    public function testCurrentDateUpdateQuery($type)
+    public function testCurrentDateUpdateQuery($type): void
     {
         $qb = $this->getTestQueryBuilder()
             ->updateOne()
@@ -739,7 +740,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->getNewObj());
     }
 
-    public static function provideCurrentDateOptions()
+    public static function provideCurrentDateOptions(): array
     {
         return [
             ['date'],
@@ -747,7 +748,7 @@ class BuilderTest extends BaseTest
         ];
     }
 
-    public function testCurrentDateInvalidType()
+    public function testCurrentDateInvalidType(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->getTestQueryBuilder()
@@ -755,7 +756,7 @@ class BuilderTest extends BaseTest
             ->field('lastUpdated')->currentDate('notADate');
     }
 
-    public function testBitAndUpdateQuery()
+    public function testBitAndUpdateQuery(): void
     {
         $qb = $this->getTestQueryBuilder()
             ->updateOne()
@@ -773,7 +774,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->getNewObj());
     }
 
-    public function testBitOrUpdateQuery()
+    public function testBitOrUpdateQuery(): void
     {
         $qb = $this->getTestQueryBuilder()
             ->updateOne()
@@ -791,7 +792,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->getNewObj());
     }
 
-    public function testBitXorUpdateQuery()
+    public function testBitXorUpdateQuery(): void
     {
         $qb = $this->getTestQueryBuilder()
             ->updateOne()
@@ -809,7 +810,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->getNewObj());
     }
 
-    public function testNonRewindable()
+    public function testNonRewindable(): void
     {
         $query = $this->getTestQueryBuilder()
             ->setRewindable(false)
@@ -818,7 +819,7 @@ class BuilderTest extends BaseTest
         $this->assertInstanceOf(UnrewindableIterator::class, $query->execute());
     }
 
-    private function getTestQueryBuilder()
+    private function getTestQueryBuilder(): Builder
     {
         return new Builder($this->dm, User::class);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -572,7 +572,7 @@ class BuilderTest extends BaseTest
      *
      * @return array
      */
-    private function provideProjections($include)
+    private function provideProjections(bool $include)
     {
         $project = $include ? 1 : 0;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/CriteriaMergerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/CriteriaMergerTest.php
@@ -14,12 +14,12 @@ class CriteriaMergerTest extends TestCase
     /**
      * @dataProvider provideMerge
      */
-    public function testMerge(array $args, array $merged)
+    public function testMerge(array $args, array $merged): void
     {
         $this->assertSame($merged, call_user_func_array([new CriteriaMerger(), 'merge'], $args));
     }
 
-    public function provideMerge()
+    public function provideMerge(): array
     {
         return [
             'no args' => [

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -12,6 +12,7 @@ use Documents\User;
 use GeoJson\Geometry\Point;
 use GeoJson\Geometry\Polygon;
 use MongoDB\BSON\ObjectId;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ExprTest extends BaseTest
 {
@@ -690,6 +691,9 @@ class ExprTest extends BaseTest
         return $expr;
     }
 
+    /**
+     * @return MockObject&Point
+     */
     private function getMockPoint($json)
     {
         $point = $this->getMockBuilder(Point::class)
@@ -703,6 +707,9 @@ class ExprTest extends BaseTest
         return $point;
     }
 
+    /**
+     * @return MockObject&Polygon
+     */
     private function getMockPolygon($json)
     {
         $point = $this->getMockBuilder(Polygon::class)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -15,7 +15,7 @@ use MongoDB\BSON\ObjectId;
 
 class ExprTest extends BaseTest
 {
-    public function testSelectIsPrepared()
+    public function testSelectIsPrepared(): void
     {
         $qb    = $this->dm->createQueryBuilder(User::class)
             ->select('id');
@@ -24,7 +24,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['_id' => 1], $query->debug('select'));
     }
 
-    public function testInIsPrepared()
+    public function testInIsPrepared(): void
     {
         $ids = ['4f28aa84acee41388900000a'];
 
@@ -38,7 +38,7 @@ class ExprTest extends BaseTest
         $this->assertEquals($ids[0], (string) $debug['groups.$id']['$in'][0]);
     }
 
-    public function testAllIsPrepared()
+    public function testAllIsPrepared(): void
     {
         $ids = ['4f28aa84acee41388900000a'];
 
@@ -52,7 +52,7 @@ class ExprTest extends BaseTest
         $this->assertEquals($ids[0], (string) $debug['groups.$id']['$all'][0]);
     }
 
-    public function testNotEqualIsPrepared()
+    public function testNotEqualIsPrepared(): void
     {
         $id = '4f28aa84acee41388900000a';
 
@@ -66,7 +66,7 @@ class ExprTest extends BaseTest
         $this->assertEquals($id, (string) $debug['groups.$id']['$ne']);
     }
 
-    public function testNotInIsPrepared()
+    public function testNotInIsPrepared(): void
     {
         $ids = ['4f28aa84acee41388900000a'];
 
@@ -80,7 +80,7 @@ class ExprTest extends BaseTest
         $this->assertEquals($ids[0], (string) $debug['groups.$id']['$nin'][0]);
     }
 
-    public function testAndIsPrepared()
+    public function testAndIsPrepared(): void
     {
         $ids = ['4f28aa84acee41388900000a'];
 
@@ -95,7 +95,7 @@ class ExprTest extends BaseTest
         $this->assertEquals($ids[0], (string) $debug['$and'][0]['groups.$id']['$in'][0]);
     }
 
-    public function testOrIsPrepared()
+    public function testOrIsPrepared(): void
     {
         $ids = ['4f28aa84acee41388900000a'];
 
@@ -110,7 +110,7 @@ class ExprTest extends BaseTest
         $this->assertEquals($ids[0], (string) $debug['$or'][0]['groups.$id']['$in'][0]);
     }
 
-    public function testMultipleQueryOperatorsArePrepared()
+    public function testMultipleQueryOperatorsArePrepared(): void
     {
         $all = ['4f28aa84acee41388900000a'];
         $in  = ['4f28aa84acee41388900000b'];
@@ -136,7 +136,7 @@ class ExprTest extends BaseTest
         $this->assertEquals($nin[0], (string) $debug['groups.$id']['$nin'][0]);
     }
 
-    public function testPrepareNestedDocuments()
+    public function testPrepareNestedDocuments(): void
     {
         $qb    = $this->dm->createQueryBuilder(User::class)
             ->field('address.subAddress.subAddress.subAddress.test')->equals('test');
@@ -145,7 +145,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['address.subAddress.subAddress.subAddress.testFieldName' => 'test'], $debug);
     }
 
-    public function testPreparePositionalOperator()
+    public function testPreparePositionalOperator(): void
     {
         $qb = $this->dm->createQueryBuilder(User::class)
             ->updateOne()
@@ -156,7 +156,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$set' => ['phonenumbers.$' => ['phonenumber' => 'bar']]], $qb->getNewObj());
     }
 
-    public function testSortIsPrepared()
+    public function testSortIsPrepared(): void
     {
         $qb    = $this->dm->createQueryBuilder(User::class)
             ->sort('id', 'desc');
@@ -171,7 +171,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['address.subAddress.subAddress.subAddress.testFieldName' => 1], $query['sort']);
     }
 
-    public function testNestedWithOperator()
+    public function testNestedWithOperator(): void
     {
         $qb    = $this->dm->createQueryBuilder(User::class)
             ->field('address.subAddress.subAddress.subAddress.test')->notIn(['test']);
@@ -180,7 +180,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['address.subAddress.subAddress.subAddress.testFieldName' => ['$nin' => ['test']]], $query['query']);
     }
 
-    public function testNewObjectIsPrepared()
+    public function testNewObjectIsPrepared(): void
     {
         $qb    = $this->dm->createQueryBuilder(User::class)
             ->updateOne()
@@ -190,7 +190,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$pop' => ['address.subAddress.subAddress.subAddress.testFieldName' => -1]], $query['newObj']);
     }
 
-    public function testReferencesUsesMinimalKeys()
+    public function testReferencesUsesMinimalKeys(): void
     {
         $profile = new Profile();
         $profile->setProfileId(new ObjectId());
@@ -206,7 +206,7 @@ class ExprTest extends BaseTest
         );
     }
 
-    public function testReferencesUsesAllKeys()
+    public function testReferencesUsesAllKeys(): void
     {
         $profile = new Profile();
         $profile->setProfileId(new ObjectId());
@@ -226,7 +226,7 @@ class ExprTest extends BaseTest
         );
     }
 
-    public function testReferencesUsesSomeKeys()
+    public function testReferencesUsesSomeKeys(): void
     {
         $profile = new Profile();
         $profile->setProfileId(new ObjectId());
@@ -245,7 +245,7 @@ class ExprTest extends BaseTest
         );
     }
 
-    public function testAddToSetWithValue()
+    public function testAddToSetWithValue(): void
     {
         $expr = $this->createExpr();
 
@@ -253,7 +253,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$addToSet' => ['a' => 1]], $expr->getNewObj());
     }
 
-    public function testAddToSetWithExpression()
+    public function testAddToSetWithExpression(): void
     {
         $expr     = $this->createExpr();
         $eachExpr = $this->createExpr();
@@ -263,7 +263,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$addToSet' => ['a' => ['$each' => [1, 2]]]], $expr->getNewObj());
     }
 
-    public function testLanguageWithText()
+    public function testLanguageWithText(): void
     {
         $expr = $this->createExpr();
         $expr->text('foo');
@@ -272,14 +272,14 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$text' => ['$search' => 'foo', '$language' => 'en']], $expr->getQuery());
     }
 
-    public function testLanguageRequiresTextOperator()
+    public function testLanguageRequiresTextOperator(): void
     {
         $expr = $this->createExpr();
         $this->expectException(BadMethodCallException::class);
         $expr->language('en');
     }
 
-    public function testCaseSensitiveWithText()
+    public function testCaseSensitiveWithText(): void
     {
         $expr = $this->createExpr();
         $expr->text('foo');
@@ -288,7 +288,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$text' => ['$search' => 'foo', '$caseSensitive' => true]], $expr->getQuery());
     }
 
-    public function testCaseSensitiveFalseRemovesOption()
+    public function testCaseSensitiveFalseRemovesOption(): void
     {
         $expr = $this->createExpr();
         $expr->text('foo');
@@ -298,14 +298,14 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$text' => ['$search' => 'foo']], $expr->getQuery());
     }
 
-    public function testCaseSensitiveRequiresTextOperator()
+    public function testCaseSensitiveRequiresTextOperator(): void
     {
         $expr = $this->createExpr();
         $this->expectException(BadMethodCallException::class);
         $expr->caseSensitive(false);
     }
 
-    public function testDiacriticSensitiveWithText()
+    public function testDiacriticSensitiveWithText(): void
     {
         $expr = $this->createExpr();
         $expr->text('foo');
@@ -314,7 +314,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$text' => ['$search' => 'foo', '$diacriticSensitive' => true]], $expr->getQuery());
     }
 
-    public function testDiacriticSensitiveFalseRemovesOption()
+    public function testDiacriticSensitiveFalseRemovesOption(): void
     {
         $expr = $this->createExpr();
         $expr->text('foo');
@@ -324,14 +324,14 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$text' => ['$search' => 'foo']], $expr->getQuery());
     }
 
-    public function testDiacriticSensitiveRequiresTextOperator()
+    public function testDiacriticSensitiveRequiresTextOperator(): void
     {
         $expr = $this->createExpr();
         $this->expectException(BadMethodCallException::class);
         $expr->diacriticSensitive(false);
     }
 
-    public function testOperatorWithCurrentField()
+    public function testOperatorWithCurrentField(): void
     {
         $expr = $this->createExpr();
         $expr->field('field');
@@ -340,7 +340,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['field' => ['$op' => 'value']], $expr->getQuery());
     }
 
-    public function testOperatorWithCurrentFieldWrapsEqualityCriteria()
+    public function testOperatorWithCurrentFieldWrapsEqualityCriteria(): void
     {
         $expr = $this->createExpr();
 
@@ -364,7 +364,7 @@ class ExprTest extends BaseTest
         $this->assertEquals($expectedQuery, $expr->getQuery());
     }
 
-    public function testOperatorWithoutCurrentField()
+    public function testOperatorWithoutCurrentField(): void
     {
         $expr = $this->createExpr();
 
@@ -372,7 +372,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$op' => 'value'], $expr->getQuery());
     }
 
-    public function testOperatorWithoutCurrentFieldWrapsEqualityCriteria()
+    public function testOperatorWithoutCurrentFieldWrapsEqualityCriteria(): void
     {
         $expr = $this->createExpr();
         $this->assertSame($expr, $expr->equals(1));
@@ -396,7 +396,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$in' => [['x' => 1]], '$lt' => 2], $expr->getQuery());
     }
 
-    public function provideGeoJsonPoint()
+    public function provideGeoJsonPoint(): array
     {
         $json     = ['type' => 'Point', 'coordinates' => [1, 2]];
         $expected = ['$geometry' => $json];
@@ -410,7 +410,7 @@ class ExprTest extends BaseTest
     /**
      * @dataProvider provideGeoJsonPoint
      */
-    public function testNearWithGeoJsonPoint($point, array $expected)
+    public function testNearWithGeoJsonPoint($point, array $expected): void
     {
         $expr = $this->createExpr();
 
@@ -418,7 +418,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$near' => $expected], $expr->getQuery());
     }
 
-    public function testNearWithLegacyCoordinates()
+    public function testNearWithLegacyCoordinates(): void
     {
         $expr = $this->createExpr();
 
@@ -429,7 +429,7 @@ class ExprTest extends BaseTest
     /**
      * @dataProvider provideGeoJsonPoint
      */
-    public function testNearSphereWithGeoJsonPoint($point, array $expected)
+    public function testNearSphereWithGeoJsonPoint($point, array $expected): void
     {
         $expr = $this->createExpr();
 
@@ -437,7 +437,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$nearSphere' => $expected], $expr->getQuery());
     }
 
-    public function testNearSphereWithLegacyCoordinates()
+    public function testNearSphereWithLegacyCoordinates(): void
     {
         $expr = $this->createExpr();
 
@@ -445,7 +445,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$nearSphere' => [1, 2]], $expr->getQuery());
     }
 
-    public function testPullWithValue()
+    public function testPullWithValue(): void
     {
         $expr = $this->createExpr();
 
@@ -453,7 +453,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$pull' => ['a' => 1]], $expr->getNewObj());
     }
 
-    public function testPullWithExpression()
+    public function testPullWithExpression(): void
     {
         $expr       = $this->createExpr();
         $nestedExpr = $this->createExpr();
@@ -463,7 +463,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$pull' => ['a' => ['$gt' => 3]]], $expr->getNewObj());
     }
 
-    public function testPushWithValue()
+    public function testPushWithValue(): void
     {
         $expr = $this->createExpr();
 
@@ -471,7 +471,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$push' => ['a' => 1]], $expr->getNewObj());
     }
 
-    public function testPushWithExpression()
+    public function testPushWithExpression(): void
     {
         $expr      = $this->createExpr();
         $innerExpr = $this->createExpr();
@@ -494,7 +494,7 @@ class ExprTest extends BaseTest
         $this->assertEquals($expectedNewObj, $expr->getNewObj());
     }
 
-    public function testPushWithExpressionShouldEnsureEachOperatorAppearsFirst()
+    public function testPushWithExpressionShouldEnsureEachOperatorAppearsFirst(): void
     {
         $expr      = $this->createExpr();
         $innerExpr = $this->createExpr();
@@ -517,7 +517,7 @@ class ExprTest extends BaseTest
         $this->assertSame($expectedNewObj, $expr->getNewObj());
     }
 
-    public function testPushWithPosition()
+    public function testPushWithPosition(): void
     {
         $expr      = $this->createExpr();
         $innerExpr = $this->createExpr();
@@ -541,7 +541,7 @@ class ExprTest extends BaseTest
     /**
      * @dataProvider provideGeoJsonPolygon
      */
-    public function testGeoIntersects($geometry, array $expected)
+    public function testGeoIntersects($geometry, array $expected): void
     {
         $expr = $this->createExpr();
 
@@ -549,7 +549,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$geoIntersects' => $expected], $expr->getQuery());
     }
 
-    public function provideGeoJsonPolygon()
+    public function provideGeoJsonPolygon(): array
     {
         $json = [
             'type' => 'Polygon',
@@ -567,7 +567,7 @@ class ExprTest extends BaseTest
     /**
      * @dataProvider provideGeoJsonPolygon
      */
-    public function testGeoWithin($geometry, array $expected)
+    public function testGeoWithin($geometry, array $expected): void
     {
         $expr = $this->createExpr();
 
@@ -575,7 +575,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$geoWithin' => $expected], $expr->getQuery());
     }
 
-    public function testGeoWithinBox()
+    public function testGeoWithinBox(): void
     {
         $expr = $this->createExpr();
 
@@ -583,7 +583,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$geoWithin' => ['$box' => [[1, 2], [3, 4]]]], $expr->getQuery());
     }
 
-    public function testGeoWithinCenter()
+    public function testGeoWithinCenter(): void
     {
         $expr = $this->createExpr();
 
@@ -591,7 +591,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$geoWithin' => ['$center' => [[1, 2], 3]]], $expr->getQuery());
     }
 
-    public function testGeoWithinCenterSphere()
+    public function testGeoWithinCenterSphere(): void
     {
         $expr = $this->createExpr();
 
@@ -599,7 +599,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$geoWithin' => ['$centerSphere' => [[1, 2], 3]]], $expr->getQuery());
     }
 
-    public function testGeoWithinPolygon()
+    public function testGeoWithinPolygon(): void
     {
         $expr          = $this->createExpr();
         $expectedQuery = ['$geoWithin' => ['$polygon' => [[0, 0], [1, 1], [1, 0]]]];
@@ -608,7 +608,7 @@ class ExprTest extends BaseTest
         $this->assertEquals($expectedQuery, $expr->getQuery());
     }
 
-    public function testSetWithAtomic()
+    public function testSetWithAtomic(): void
     {
         $expr = $this->createExpr();
 
@@ -616,7 +616,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$set' => ['a' => 1]], $expr->getNewObj());
     }
 
-    public function testSetWithoutAtomicWithTopLevelField()
+    public function testSetWithoutAtomicWithTopLevelField(): void
     {
         $expr = $this->createExpr();
 
@@ -624,7 +624,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['a' => 1], $expr->getNewObj());
     }
 
-    public function testSetWithoutAtomicWithNestedField()
+    public function testSetWithoutAtomicWithNestedField(): void
     {
         $expr = $this->createExpr();
 
@@ -632,7 +632,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['a' => ['b' => ['c' => 1]]], $expr->getNewObj());
     }
 
-    public function testText()
+    public function testText(): void
     {
         $expr = $this->createExpr();
 
@@ -641,7 +641,7 @@ class ExprTest extends BaseTest
         $this->assertNull($expr->getCurrentField());
     }
 
-    public function testWhere()
+    public function testWhere(): void
     {
         $expr = $this->createExpr();
 
@@ -650,7 +650,7 @@ class ExprTest extends BaseTest
         $this->assertNull($expr->getCurrentField());
     }
 
-    public function testIn()
+    public function testIn(): void
     {
         $expr = $this->createExpr();
 
@@ -658,7 +658,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$in' => ['value1', 'value2']], $expr->getQuery());
     }
 
-    public function testInWillStripKeysToYieldBsonArray()
+    public function testInWillStripKeysToYieldBsonArray(): void
     {
         $expr = $this->createExpr();
 
@@ -666,7 +666,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$in' => ['value1', 'value2']], $expr->getQuery());
     }
 
-    public function testNotIn()
+    public function testNotIn(): void
     {
         $expr = $this->createExpr();
 
@@ -674,7 +674,7 @@ class ExprTest extends BaseTest
         $this->assertEquals(['$nin' => ['value1', 'value2']], $expr->getQuery());
     }
 
-    public function testNotInWillStripKeysToYieldBsonArray()
+    public function testNotInWillStripKeysToYieldBsonArray(): void
     {
         $expr = $this->createExpr();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/BsonFilterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/BsonFilterTest.php
@@ -9,21 +9,21 @@ use InvalidArgumentException;
 
 class BsonFilterTest extends BaseTest
 {
-    public function testGetParameterInvalidArgument()
+    public function testGetParameterInvalidArgument(): void
     {
         $filter = new Filter($this->dm);
         $this->expectException(InvalidArgumentException::class);
         $filter->getParameter('doesnotexist');
     }
 
-    public function testSetParameter()
+    public function testSetParameter(): void
     {
         $filter = new Filter($this->dm);
         $filter->setParameter('username', 'Tim');
         $this->assertEquals('Tim', $filter->getParameter('username'));
     }
 
-    public function testGetNullParameter()
+    public function testGetNullParameter(): void
     {
         $filter = new Filter($this->dm);
         $filter->setParameter('foo', null);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/FilterCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/FilterCollectionTest.php
@@ -11,7 +11,7 @@ use InvalidArgumentException;
 
 class FilterCollectionTest extends BaseTest
 {
-    public function testEnable()
+    public function testEnable(): void
     {
         $filterCollection = $this->dm->getFilterCollection();
 
@@ -27,7 +27,7 @@ class FilterCollectionTest extends BaseTest
         $this->assertCount(0, $filterCollection->getEnabledFilters());
     }
 
-    public function testHasFilter()
+    public function testHasFilter(): void
     {
         $filterCollection = $this->dm->getFilterCollection();
 
@@ -38,7 +38,7 @@ class FilterCollectionTest extends BaseTest
     /**
      * @depends testEnable
      */
-    public function testIsEnabled()
+    public function testIsEnabled(): void
     {
         $filterCollection = $this->dm->getFilterCollection();
 
@@ -49,21 +49,21 @@ class FilterCollectionTest extends BaseTest
         $this->assertTrue($filterCollection->isEnabled('testFilter'));
     }
 
-    public function testGetFilterInvalidArgument()
+    public function testGetFilterInvalidArgument(): void
     {
         $filterCollection = $this->dm->getFilterCollection();
         $this->expectException(InvalidArgumentException::class);
         $filterCollection->getFilter('testFilter');
     }
 
-    public function testGetFilter()
+    public function testGetFilter(): void
     {
         $filterCollection = $this->dm->getFilterCollection();
         $filterCollection->enable('testFilter');
         $this->assertInstanceOf(Filter\Filter::class, $filterCollection->getFilter('testFilter'));
     }
 
-    public function testGetFilterCriteria()
+    public function testGetFilterCriteria(): void
     {
         $class            = $this->dm->getClassMetadata(User::class);
         $filterCollection = $this->dm->getFilterCollection();
@@ -79,7 +79,7 @@ class FilterCollectionTest extends BaseTest
         $this->assertSame(['username' => 'Tim'], $filterCollection->getFilterCriteria($class));
     }
 
-    public function testGetFilterCriteriaMergesCriteria()
+    public function testGetFilterCriteriaMergesCriteria(): void
     {
         $class            = $this->dm->getClassMetadata(User::class);
         $filterCollection = $this->dm->getFilterCollection();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/QueryExpressionVisitorTest.php
@@ -30,7 +30,7 @@ class QueryExpressionVisitorTest extends BaseTest
     /**
      * @dataProvider provideComparisons
      */
-    public function testWalkComparison(Comparison $comparison, array $expectedQuery)
+    public function testWalkComparison(Comparison $comparison, array $expectedQuery): void
     {
         $expr = $this->visitor->dispatch($comparison);
 
@@ -38,7 +38,7 @@ class QueryExpressionVisitorTest extends BaseTest
         $this->assertEquals($expectedQuery, $expr->getQuery());
     }
 
-    public function provideComparisons()
+    public function provideComparisons(): array
     {
         $builder = new ExpressionBuilder();
 
@@ -56,14 +56,14 @@ class QueryExpressionVisitorTest extends BaseTest
         ];
     }
 
-    public function testWalkComparisonShouldThrowExceptionForUnsupportedOperator()
+    public function testWalkComparisonShouldThrowExceptionForUnsupportedOperator(): void
     {
         $comparison = new Comparison('field', 'invalidOp', new Value('value'));
         $this->expectException(RuntimeException::class);
         $this->visitor->dispatch($comparison);
     }
 
-    public function testWalkCompositeExpression()
+    public function testWalkCompositeExpression(): void
     {
         $builder = new ExpressionBuilder();
 
@@ -87,14 +87,14 @@ class QueryExpressionVisitorTest extends BaseTest
         $this->assertEquals($expectedQuery, $expr->getQuery());
     }
 
-    public function testWalkCompositeExpressionShouldThrowExceptionForUnsupportedComposite()
+    public function testWalkCompositeExpressionShouldThrowExceptionForUnsupportedComposite(): void
     {
         $compositeExpr = new CompositeExpression('invalidComposite', []);
         $this->expectException(RuntimeException::class);
         $this->visitor->dispatch($compositeExpr);
     }
 
-    public function testWalkValue()
+    public function testWalkValue(): void
     {
         $this->assertEquals('value', $this->visitor->walkValue(new Value('value')));
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -29,7 +29,7 @@ use const DOCTRINE_MONGODB_DATABASE;
 
 class QueryTest extends BaseTest
 {
-    public function testSelectAndSelectSliceOnSameField()
+    public function testSelectAndSelectSliceOnSameField(): void
     {
         $qb = $this->dm->createQueryBuilder(Person::class)
             ->exclude('comments')
@@ -44,7 +44,7 @@ class QueryTest extends BaseTest
         $query->execute();
     }
 
-    public function testThatOrAcceptsAnotherQuery()
+    public function testThatOrAcceptsAnotherQuery(): void
     {
         $kris  = new Person('Kris');
         $chris = new Person('Chris');
@@ -74,7 +74,7 @@ class QueryTest extends BaseTest
         $this->assertCount(2, $users->toArray());
     }
 
-    public function testReferences()
+    public function testReferences(): void
     {
         $kris = new Person('Kris');
         $jon  = new Person('Jon');
@@ -102,7 +102,7 @@ class QueryTest extends BaseTest
         $this->assertSame($kris, $query->getSingleResult());
     }
 
-    public function testReferencesStoreAsId()
+    public function testReferencesStoreAsId(): void
     {
         $kris = new Person('Kris');
         $jon  = new Person('Jon');
@@ -128,7 +128,7 @@ class QueryTest extends BaseTest
         $this->assertSame($kris, $query->getSingleResult());
     }
 
-    public function testReferencesStoreAsDbRef()
+    public function testReferencesStoreAsDbRef(): void
     {
         $kris = new Person('Kris');
         $jon  = new Person('Jon');
@@ -155,7 +155,7 @@ class QueryTest extends BaseTest
         $this->assertSame($kris, $query->getSingleResult());
     }
 
-    public function testIncludesReferenceToWithStoreAsDbRefWithDb()
+    public function testIncludesReferenceToWithStoreAsDbRefWithDb(): void
     {
         $kris = new Person('Kris');
         $jon  = new Person('Jon');
@@ -187,7 +187,7 @@ class QueryTest extends BaseTest
         $this->assertSame($jon, $query->getSingleResult());
     }
 
-    public function testIncludesReferenceToWithStoreAsId()
+    public function testIncludesReferenceToWithStoreAsId(): void
     {
         $kris   = new Person('Kris');
         $jon    = new Person('Jon');
@@ -216,7 +216,7 @@ class QueryTest extends BaseTest
         $this->assertSame($jon, $query->getSingleResult());
     }
 
-    public function testIncludesReferenceToWithStoreAsDbRef()
+    public function testIncludesReferenceToWithStoreAsDbRef(): void
     {
         $kris = new Person('Kris');
         $jon  = new Person('Jon');
@@ -247,7 +247,7 @@ class QueryTest extends BaseTest
         $this->assertSame($jon, $query->getSingleResult());
     }
 
-    public function testQueryIdIn()
+    public function testQueryIdIn(): void
     {
         $user = new User();
         $user->setUsername('jwage');
@@ -264,7 +264,7 @@ class QueryTest extends BaseTest
         $this->assertCount(1, $results);
     }
 
-    public function testEmbeddedSet()
+    public function testEmbeddedSet(): void
     {
         $qb = $this->dm->createQueryBuilder(User::class)
             ->insert()
@@ -274,7 +274,7 @@ class QueryTest extends BaseTest
         $this->assertEquals(['testInt' => 0, 'intfields' => ['intone' => 1, 'inttwo' => 2]], $qb->getNewObj());
     }
 
-    public function testElemMatch()
+    public function testElemMatch(): void
     {
         $refId = '000000000000000000000001';
 
@@ -289,7 +289,7 @@ class QueryTest extends BaseTest
         $this->assertEquals($expectedQuery, $query->debug('query'));
     }
 
-    public function testQueryWithMultipleEmbeddedDocuments()
+    public function testQueryWithMultipleEmbeddedDocuments(): void
     {
         $qb    = $this->dm->createQueryBuilder(EmbedTest::class)
             ->find()
@@ -298,7 +298,7 @@ class QueryTest extends BaseTest
         $this->assertEquals(['eO.eO.e1.eO.n' => 'Foo'], $query->debug('query'));
     }
 
-    public function testQueryWithMultipleEmbeddedDocumentsAndReference()
+    public function testQueryWithMultipleEmbeddedDocumentsAndReference(): void
     {
         $identifier = new ObjectId();
 
@@ -312,7 +312,7 @@ class QueryTest extends BaseTest
         $this->assertEquals($identifier, $debug['eO.eO.e1.eO.eP.pO.$id']);
     }
 
-    public function testQueryWithMultipleEmbeddedDocumentsAndReferenceUsingDollarSign()
+    public function testQueryWithMultipleEmbeddedDocumentsAndReferenceUsingDollarSign(): void
     {
         $identifier = new ObjectId();
 
@@ -326,7 +326,7 @@ class QueryTest extends BaseTest
         $this->assertEquals($identifier, $debug['eO.eO.e1.eO.eP.pO.$id']);
     }
 
-    public function testSelectVsSingleCollectionInheritance()
+    public function testSelectVsSingleCollectionInheritance(): void
     {
         $p = new SubProject('SubProject');
         $this->dm->persist($p);
@@ -343,7 +343,7 @@ class QueryTest extends BaseTest
         $this->assertEquals('SubProject', $test->getName());
     }
 
-    public function testEmptySelectVsSingleCollectionInheritance()
+    public function testEmptySelectVsSingleCollectionInheritance(): void
     {
         $p = new SubProject('SubProject');
         $this->dm->persist($p);
@@ -360,7 +360,7 @@ class QueryTest extends BaseTest
         $this->assertEquals('SubProject', $test->getName());
     }
 
-    public function testDiscriminatorFieldNotAddedWithoutHydration()
+    public function testDiscriminatorFieldNotAddedWithoutHydration(): void
     {
         $p = new SubProject('SubProject');
         $this->dm->persist($p);
@@ -376,7 +376,7 @@ class QueryTest extends BaseTest
         $this->assertEquals(['_id', 'name'], array_keys($test));
     }
 
-    public function testExcludeVsSingleCollectionInheritance()
+    public function testExcludeVsSingleCollectionInheritance(): void
     {
         $p = new SubProject('SubProject');
         $this->dm->persist($p);
@@ -393,7 +393,7 @@ class QueryTest extends BaseTest
         $this->assertNull($test->getName());
     }
 
-    public function testReadOnly()
+    public function testReadOnly(): void
     {
         $p      = new Person('Maciej');
         $p->pet = new Pet('Blackie', $p);
@@ -412,7 +412,7 @@ class QueryTest extends BaseTest
         $this->assertFalse($this->uow->isInIdentityMap($readOnly->pet));
     }
 
-    public function testConstructorShouldThrowExceptionForInvalidType()
+    public function testConstructorShouldThrowExceptionForInvalidType(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new Query($this->dm, new ClassMetadata(User::class), $this->getMockCollection(), ['type' => -1], []);
@@ -421,7 +421,7 @@ class QueryTest extends BaseTest
     /**
      * @dataProvider provideQueryTypesThatDoNotReturnAnIterator
      */
-    public function testGetIteratorShouldThrowExceptionWithoutExecutingForTypesThatDoNotReturnAnIterator($type, $method)
+    public function testGetIteratorShouldThrowExceptionWithoutExecutingForTypesThatDoNotReturnAnIterator($type, $method): void
     {
         $collection = $this->getMockCollection();
         $collection->expects($this->never())->method($method);
@@ -432,7 +432,7 @@ class QueryTest extends BaseTest
         $query->getIterator();
     }
 
-    public function provideQueryTypesThatDoNotReturnAnIterator()
+    public function provideQueryTypesThatDoNotReturnAnIterator(): array
     {
         return [
             [Query::TYPE_FIND_AND_UPDATE, 'findOneAndUpdate'],
@@ -444,7 +444,7 @@ class QueryTest extends BaseTest
         ];
     }
 
-    public function testFindAndModifyOptionsAreRenamed()
+    public function testFindAndModifyOptionsAreRenamed(): void
     {
         $queryArray = [
             'type' => Query::TYPE_FIND_AND_REMOVE,
@@ -462,7 +462,7 @@ class QueryTest extends BaseTest
         $query->execute();
     }
 
-    public function testCountOptionInheritance()
+    public function testCountOptionInheritance(): void
     {
         $nearest            = new ReadPreference('nearest');
         $secondaryPreferred = new ReadPreference('secondaryPreferred');
@@ -490,7 +490,7 @@ class QueryTest extends BaseTest
         $this->assertSame(100, $query->execute());
     }
 
-    public function testFindOptionInheritance()
+    public function testFindOptionInheritance(): void
     {
         $nearest            = new ReadPreference('nearest');
         $secondaryPreferred = new ReadPreference('secondaryPreferred');

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -20,6 +20,7 @@ use LogicException;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
 use MongoDB\Driver\ReadPreference;
+use PHPUnit\Framework\MockObject\MockObject;
 use Traversable;
 
 use function array_keys;
@@ -549,6 +550,9 @@ class QueryTest extends BaseTest
         iterator_to_array($iterator);
     }
 
+    /**
+     * @return MockObject&Collection
+     */
     private function getMockCollection()
     {
         return $this->getMockBuilder(Collection::class)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Repository/DefaultGridFSRepositoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Repository/DefaultGridFSRepositoryTest.php
@@ -224,7 +224,7 @@ class DefaultGridFSRepositoryTest extends BaseTest
         self::assertSame(0, $bucket->getChunksCollection()->count());
     }
 
-    public function testUploadMetadataForFileWithoutMetadata()
+    public function testUploadMetadataForFileWithoutMetadata(): void
     {
         $uploadOptions           = new UploadOptions();
         $uploadOptions->metadata = new FileMetadata();
@@ -243,7 +243,7 @@ class DefaultGridFSRepositoryTest extends BaseTest
         }
     }
 
-    public function testUploadFileWithoutChunkSize()
+    public function testUploadFileWithoutChunkSize(): void
     {
         $file = $this->getRepository(FileWithoutChunkSize::class)->uploadFromFile(__FILE__);
         assert($file instanceof FileWithoutChunkSize);

--- a/tests/Doctrine/ODM/MongoDB/Tests/RepositoryFactoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/RepositoryFactoryTest.php
@@ -13,7 +13,7 @@ use function get_class;
 
 class RepositoryFactoryTest extends BaseTest
 {
-    public function testRepositoryFactoryCanBeReplaced()
+    public function testRepositoryFactoryCanBeReplaced(): void
     {
         $factory = $this->createMock(RepositoryFactory::class);
         $factory->expects($this->once())->method('getRepository');
@@ -25,7 +25,7 @@ class RepositoryFactoryTest extends BaseTest
         $dm->getRepository(User::class);
     }
 
-    public function testRepositoriesAreSameForSameClasses()
+    public function testRepositoriesAreSameForSameClasses(): void
     {
         $proxy = $this->dm->getPartialReference(User::class, 'abc');
         $this->assertSame(
@@ -34,7 +34,7 @@ class RepositoryFactoryTest extends BaseTest
         );
     }
 
-    public function testRepositoriesAreDifferentForDifferentDms()
+    public function testRepositoriesAreDifferentForDifferentDms(): void
     {
         $conf = $this->getConfiguration();
         $conf->setRepositoryFactory(new DefaultRepositoryFactory());

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -161,7 +161,7 @@ class SchemaManagerTest extends BaseTest
     /**
      * @dataProvider getIndexCreationWriteOptions
      */
-    public function testEnsureIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false)
+    public function testEnsureIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false): void
     {
         $indexedCollections = array_map(
             function (string $fqcn) {
@@ -210,7 +210,7 @@ class SchemaManagerTest extends BaseTest
     /**
      * @dataProvider getIndexCreationWriteOptions
      */
-    public function testEnsureDocumentIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false)
+    public function testEnsureDocumentIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false): void
     {
         $cmsArticleCollectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
         foreach ($this->documentCollections as $collectionName => $collection) {
@@ -230,7 +230,7 @@ class SchemaManagerTest extends BaseTest
     /**
      * @dataProvider getIndexCreationWriteOptions
      */
-    public function testEnsureDocumentIndexesForGridFSFile(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false)
+    public function testEnsureDocumentIndexesForGridFSFile(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false): void
     {
         foreach ($this->documentCollections as $class => $collection) {
             $collection->expects($this->never())->method('createIndex');
@@ -272,7 +272,7 @@ class SchemaManagerTest extends BaseTest
     /**
      * @dataProvider getIndexCreationWriteOptions
      */
-    public function testEnsureDocumentIndexesWithTwoLevelInheritance(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false)
+    public function testEnsureDocumentIndexesWithTwoLevelInheritance(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false): void
     {
         $collectionName = $this->dm->getClassMetadata(CmsProduct::class)->getCollection();
         $collection     = $this->documentCollections[$collectionName];
@@ -287,7 +287,7 @@ class SchemaManagerTest extends BaseTest
     /**
      * @dataProvider getWriteOptions
      */
-    public function testUpdateDocumentIndexesShouldCreateMappedIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testUpdateDocumentIndexesShouldCreateMappedIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $collectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
         $collection     = $this->documentCollections[$collectionName];
@@ -310,7 +310,7 @@ class SchemaManagerTest extends BaseTest
     /**
      * @dataProvider getWriteOptions
      */
-    public function testUpdateDocumentIndexesShouldDeleteUnmappedIndexesBeforeCreatingMappedIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testUpdateDocumentIndexesShouldDeleteUnmappedIndexesBeforeCreatingMappedIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $collectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
         $collection     = $this->documentCollections[$collectionName];
@@ -341,7 +341,7 @@ class SchemaManagerTest extends BaseTest
     /**
      * @dataProvider getWriteOptions
      */
-    public function testDeleteIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testDeleteIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $views = array_map(
             function (string $fqcn) {
@@ -367,7 +367,7 @@ class SchemaManagerTest extends BaseTest
     /**
      * @dataProvider getWriteOptions
      */
-    public function testDeleteDocumentIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testDeleteDocumentIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $cmsArticleCollectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
         foreach ($this->documentCollections as $collectionName => $collection) {
@@ -384,7 +384,7 @@ class SchemaManagerTest extends BaseTest
         $this->schemaManager->deleteDocumentIndexes(CmsArticle::class, $maxTimeMs, $writeConcern);
     }
 
-    public function testUpdateValidators()
+    public function testUpdateValidators(): void
     {
         $dbCommands = [];
         foreach ($this->dm->getMetadataFactory()->getAllMetadata() as $cm) {
@@ -409,7 +409,7 @@ class SchemaManagerTest extends BaseTest
     /**
      * @dataProvider getWriteOptions
      */
-    public function testUpdateDocumentValidator(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testUpdateDocumentValidator(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $class                 = $this->dm->getClassMetadata(SchemaValidated::class);
         $database              = $this->documentDatabases[$this->getDatabaseName($class)];
@@ -448,7 +448,7 @@ EOT;
         $this->schemaManager->updateDocumentValidator($class->name, $maxTimeMs, $writeConcern);
     }
 
-    public function testUpdateDocumentValidatorShouldThrowExceptionForMappedSuperclass()
+    public function testUpdateDocumentValidatorShouldThrowExceptionForMappedSuperclass(): void
     {
         $class = $this->dm->getClassMetadata(BaseDocument::class);
         $this->expectException(InvalidArgumentException::class);
@@ -458,7 +458,7 @@ EOT;
     /**
      * @dataProvider getWriteOptions
      */
-    public function testUpdateDocumentValidatorReset(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testUpdateDocumentValidatorReset(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $class    = $this->dm->getClassMetadata(CmsArticle::class);
         $database = $this->documentDatabases[$this->getDatabaseName($class)];
@@ -480,7 +480,7 @@ EOT;
     /**
      * @dataProvider getWriteOptions
      */
-    public function testCreateDocumentCollection(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testCreateDocumentCollection(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $cm                   = $this->dm->getClassMetadata(CmsArticle::class);
         $cm->collectionCapped = true;
@@ -507,7 +507,7 @@ EOT;
     /**
      * @dataProvider getWriteOptions
      */
-    public function testCreateDocumentCollectionForFile(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testCreateDocumentCollectionForFile(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $database = $this->documentDatabases[$this->getDatabaseName($this->dm->getClassMetadata(File::class))];
         $database
@@ -524,7 +524,7 @@ EOT;
     /**
      * @dataProvider getWriteOptions
      */
-    public function testCreateDocumentCollectionWithValidator(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testCreateDocumentCollectionWithValidator(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $expectedValidatorJson = <<<'EOT'
 {
@@ -567,7 +567,7 @@ EOT;
     /**
      * @dataProvider getWriteOptions
      */
-    public function testCreateView(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testCreateView(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $cm = $this->dm->getClassMetadata(UserName::class);
 
@@ -604,7 +604,7 @@ EOT;
     /**
      * @dataProvider getWriteOptions
      */
-    public function testCreateCollections(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testCreateCollections(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         foreach ($this->documentDatabases as $class => $database) {
             $database
@@ -624,7 +624,7 @@ EOT;
     /**
      * @dataProvider getWriteOptions
      */
-    public function testDropCollections(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testDropCollections(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         foreach ($this->documentCollections as $collection) {
             $collection->expects($this->atLeastOnce())
@@ -638,7 +638,7 @@ EOT;
     /**
      * @dataProvider getWriteOptions
      */
-    public function testDropDocumentCollection(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testDropDocumentCollection(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $cmsArticleCollectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
         foreach ($this->documentCollections as $collectionName => $collection) {
@@ -657,7 +657,7 @@ EOT;
     /**
      * @dataProvider getWriteOptions
      */
-    public function testDropDocumentCollectionForGridFSFile(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testDropDocumentCollectionForGridFSFile(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         foreach ($this->documentCollections as $collection) {
             $collection->expects($this->never())->method('drop');
@@ -692,7 +692,7 @@ EOT;
     /**
      * @dataProvider getWriteOptions
      */
-    public function testDropView(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testDropView(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $viewName = $this->dm->getClassMetadata(UserName::class)->getCollection();
         foreach ($this->documentCollections as $collectionName => $collection) {
@@ -711,7 +711,7 @@ EOT;
     /**
      * @dataProvider getWriteOptions
      */
-    public function testDropDocumentDatabase(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testDropDocumentDatabase(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $cmsArticleDatabaseName = $this->getDatabaseName($this->dm->getClassMetadata(CmsArticle::class));
         foreach ($this->documentDatabases as $databaseName => $database) {
@@ -731,7 +731,7 @@ EOT;
     /**
      * @dataProvider getWriteOptions
      */
-    public function testDropDatabases(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
+    public function testDropDatabases(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         foreach ($this->documentDatabases as $database) {
             $database
@@ -746,7 +746,7 @@ EOT;
     /**
      * @dataProvider dataIsMongoIndexEquivalentToDocumentIndex
      */
-    public function testIsMongoIndexEquivalentToDocumentIndex($expected, $mongoIndex, $documentIndex)
+    public function testIsMongoIndexEquivalentToDocumentIndex($expected, $mongoIndex, $documentIndex): void
     {
         $defaultMongoIndex    = [
             'key' => ['foo' => 1, 'bar' => -1],
@@ -762,7 +762,7 @@ EOT;
         $this->assertSame($expected, $this->schemaManager->isMongoIndexEquivalentToDocumentIndex(new IndexInfo($mongoIndex), $documentIndex));
     }
 
-    public function dataIsMongoIndexEquivalentToDocumentIndex()
+    public function dataIsMongoIndexEquivalentToDocumentIndex(): array
     {
         return [
             'keysSame' => [
@@ -956,7 +956,7 @@ EOT;
     /**
      * @dataProvider dataIsMongoTextIndexEquivalentToDocumentIndex
      */
-    public function testIsMongoIndexEquivalentToDocumentIndexWithTextIndexes($expected, $mongoIndex, $documentIndex)
+    public function testIsMongoIndexEquivalentToDocumentIndexWithTextIndexes($expected, $mongoIndex, $documentIndex): void
     {
         $defaultMongoIndex    = [
             'key' => ['_fts' => 'text', '_ftsx' => 1],
@@ -976,7 +976,7 @@ EOT;
         $this->assertSame($expected, $this->schemaManager->isMongoIndexEquivalentToDocumentIndex(new IndexInfo($mongoIndex), $documentIndex));
     }
 
-    public function dataIsMongoTextIndexEquivalentToDocumentIndex()
+    public function dataIsMongoTextIndexEquivalentToDocumentIndex(): array
     {
         return [
             'keysSame' => [

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/Console/Command/Schema/UpdateCommandTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/Console/Command/Schema/UpdateCommandTest.php
@@ -42,7 +42,7 @@ class UpdateCommandTest extends AbstractCommandTest
         unset($this->commandTester);
     }
 
-    public function testProcessValidator()
+    public function testProcessValidator(): void
     {
         $this->commandTester->execute(
             [
@@ -53,7 +53,7 @@ class UpdateCommandTest extends AbstractCommandTest
         $this->assertStringContainsString('Updated validation for Documents\SchemaValidated', $output);
     }
 
-    public function testProcessValidators()
+    public function testProcessValidators(): void
     {
         // Only load a subset of documents with legit annotations
         $annotationDriver = AnnotationDriver::create(__DIR__ . '/../../../../../../../../Documents/Ecommerce');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH1299/BaseUser.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH1299/BaseUser.php
@@ -25,7 +25,7 @@ class BaseUser
         return $this->name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/Address.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/Address.php
@@ -17,7 +17,7 @@ class Address
         return $this->street;
     }
 
-    public function setStreet($street)
+    public function setStreet($street): void
     {
         $this->street = $street;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/AddressTrait.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/AddressTrait.php
@@ -14,7 +14,7 @@ trait AddressTrait
         return $this->address;
     }
 
-    public function setAddress(Address $address)
+    public function setAddress(Address $address): void
     {
         $this->address = $address;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/User.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/User.php
@@ -27,7 +27,7 @@ class User
         return $this->name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
@@ -30,7 +30,7 @@ class ResolveTargetDocumentListenerTest extends BaseTest
         $this->factory  = $this->dm->getMetadataFactory();
     }
 
-    public function testResolveTargetDocumentListenerCanResolveTargetDocument()
+    public function testResolveTargetDocumentListenerCanResolveTargetDocument(): void
     {
         $evm = $this->dm->getEventManager();
 
@@ -57,7 +57,7 @@ class ResolveTargetDocumentListenerTest extends BaseTest
         $this->assertSame(TargetDocument::class, $meta['embedMany']['targetDocument']);
     }
 
-    public function testResolveTargetDocumentListenerCanRetrieveTargetDocumentByInterfaceName()
+    public function testResolveTargetDocumentListenerCanRetrieveTargetDocumentByInterfaceName(): void
     {
         $this->listener->addResolveTargetDocument(ResolveTargetInterface::class, ResolveTargetDocument::class, []);
 
@@ -68,7 +68,7 @@ class ResolveTargetDocumentListenerTest extends BaseTest
         $this->assertSame($this->factory->getMetadataFor(ResolveTargetDocument::class), $cm);
     }
 
-    public function testResolveTargetDocumentListenerCanRetrieveTargetDocumentByAbstractClassName()
+    public function testResolveTargetDocumentListenerCanRetrieveTargetDocumentByAbstractClassName(): void
     {
         $this->listener->addResolveTargetDocument(AbstractResolveTarget::class, ResolveTargetDocument::class, []);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/DateImmutableTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/DateImmutableTypeTest.php
@@ -22,7 +22,7 @@ use const PHP_INT_SIZE;
 
 class DateImmutableTypeTest extends TestCase
 {
-    public function testGetDateTime()
+    public function testGetDateTime(): void
     {
         $type = Type::getType(Type::DATE_IMMUTABLE);
         assert($type instanceof DateImmutableType);
@@ -36,7 +36,7 @@ class DateImmutableTypeTest extends TestCase
         $this->assertEquals($timestamp, $dateTime->format('U.u'));
     }
 
-    public function testConvertToDatabaseValue()
+    public function testConvertToDatabaseValue(): void
     {
         $type = Type::getType(Type::DATE_IMMUTABLE);
 
@@ -55,7 +55,7 @@ class DateImmutableTypeTest extends TestCase
         $this->assertEquals(null, $type->convertToDatabaseValue(null), 'null are converted to null');
     }
 
-    public function testConvertDateTime()
+    public function testConvertDateTime(): void
     {
         $type = Type::getType(Type::DATE);
 
@@ -66,7 +66,7 @@ class DateImmutableTypeTest extends TestCase
         $this->assertEquals($mongoDate, $type->convertToDatabaseValue($dateTime), 'DateTime objects are converted to MongoDate objects');
     }
 
-    public function testConvertOldDate()
+    public function testConvertOldDate(): void
     {
         $type = Type::getType(Type::DATE_IMMUTABLE);
 
@@ -78,14 +78,14 @@ class DateImmutableTypeTest extends TestCase
     /**
      * @dataProvider provideInvalidDateValues
      */
-    public function testConvertToDatabaseValueWithInvalidValues($value)
+    public function testConvertToDatabaseValueWithInvalidValues($value): void
     {
         $type = Type::getType(Type::DATE_IMMUTABLE);
         $this->expectException(InvalidArgumentException::class);
         $type->convertToDatabaseValue($value);
     }
 
-    public function provideInvalidDateValues()
+    public function provideInvalidDateValues(): array
     {
         return [
             'array'  => [[]],
@@ -99,7 +99,7 @@ class DateImmutableTypeTest extends TestCase
     /**
      * @dataProvider provideDatabaseToPHPValues
      */
-    public function testConvertToPHPValue($input, $output)
+    public function testConvertToPHPValue($input, $output): void
     {
         $type   = Type::getType(Type::DATE_IMMUTABLE);
         $return = $type->convertToPHPValue($input);
@@ -108,7 +108,7 @@ class DateImmutableTypeTest extends TestCase
         $this->assertTimestampEquals($output, $return);
     }
 
-    public function testConvertToPHPValueDoesNotConvertNull()
+    public function testConvertToPHPValueDoesNotConvertNull(): void
     {
         $type = Type::getType(Type::DATE_IMMUTABLE);
 
@@ -118,7 +118,7 @@ class DateImmutableTypeTest extends TestCase
     /**
      * @dataProvider provideDatabaseToPHPValues
      */
-    public function testClosureToPHP($input, $output)
+    public function testClosureToPHP($input, $output): void
     {
         $type = Type::getType(Type::DATE_IMMUTABLE);
 
@@ -136,7 +136,7 @@ class DateImmutableTypeTest extends TestCase
         $this->assertTimestampEquals($output, $return);
     }
 
-    public function provideDatabaseToPHPValues()
+    public function provideDatabaseToPHPValues(): array
     {
         $yesterday = strtotime('yesterday');
         $mongoDate = new UTCDateTime($yesterday * 1000);
@@ -151,7 +151,7 @@ class DateImmutableTypeTest extends TestCase
         ];
     }
 
-    public function test32bit1900Date()
+    public function test32bit1900Date(): void
     {
         if (PHP_INT_SIZE !== 4) {
             $this->markTestSkipped('Platform is not 32-bit');
@@ -162,7 +162,7 @@ class DateImmutableTypeTest extends TestCase
         $type->convertToDatabaseValue('1900-01-01');
     }
 
-    public function test64bit1900Date()
+    public function test64bit1900Date(): void
     {
         if (PHP_INT_SIZE !== 8) {
             $this->markTestSkipped('Platform is not 64-bit');
@@ -175,7 +175,7 @@ class DateImmutableTypeTest extends TestCase
         $this->assertEquals(new UTCDateTime(strtotime('1900-01-01') * 1000), $return);
     }
 
-    private function assertTimestampEquals(DateTimeImmutable $expected, DateTimeImmutable $actual)
+    private function assertTimestampEquals(DateTimeImmutable $expected, DateTimeImmutable $actual): void
     {
         $this->assertEquals($expected->format('U.u'), $actual->format('U.u'));
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
@@ -22,7 +22,7 @@ use const PHP_INT_SIZE;
 
 class DateTypeTest extends TestCase
 {
-    public function testGetDateTime()
+    public function testGetDateTime(): void
     {
         $type = Type::getType(Type::DATE);
         assert($type instanceof DateType);
@@ -36,7 +36,7 @@ class DateTypeTest extends TestCase
         $this->assertEquals($timestamp, $dateTime->format('U.u'));
     }
 
-    public function testConvertToDatabaseValue()
+    public function testConvertToDatabaseValue(): void
     {
         $type = Type::getType(Type::DATE);
 
@@ -55,7 +55,7 @@ class DateTypeTest extends TestCase
         $this->assertEquals(null, $type->convertToDatabaseValue(null), 'null are converted to null');
     }
 
-    public function testConvertDateTimeImmutable()
+    public function testConvertDateTimeImmutable(): void
     {
         $type = Type::getType(Type::DATE);
 
@@ -66,7 +66,7 @@ class DateTypeTest extends TestCase
         $this->assertEquals($mongoDate, $type->convertToDatabaseValue($dateTimeImmutable), 'DateTimeImmutable objects are converted to MongoDate objects');
     }
 
-    public function testConvertOldDate()
+    public function testConvertOldDate(): void
     {
         $type = Type::getType(Type::DATE);
 
@@ -78,14 +78,14 @@ class DateTypeTest extends TestCase
     /**
      * @dataProvider provideInvalidDateValues
      */
-    public function testConvertToDatabaseValueWithInvalidValues($value)
+    public function testConvertToDatabaseValueWithInvalidValues($value): void
     {
         $type = Type::getType(Type::DATE);
         $this->expectException(InvalidArgumentException::class);
         $type->convertToDatabaseValue($value);
     }
 
-    public function provideInvalidDateValues()
+    public function provideInvalidDateValues(): array
     {
         return [
             'array'  => [[]],
@@ -99,7 +99,7 @@ class DateTypeTest extends TestCase
     /**
      * @dataProvider provideDatabaseToPHPValues
      */
-    public function testConvertToPHPValue($input, $output)
+    public function testConvertToPHPValue($input, $output): void
     {
         $type   = Type::getType(Type::DATE);
         $return = $type->convertToPHPValue($input);
@@ -108,7 +108,7 @@ class DateTypeTest extends TestCase
         $this->assertTimestampEquals($output, $return);
     }
 
-    public function testConvertToPHPValueDoesNotConvertNull()
+    public function testConvertToPHPValueDoesNotConvertNull(): void
     {
         $type = Type::getType(Type::DATE);
 
@@ -118,7 +118,7 @@ class DateTypeTest extends TestCase
     /**
      * @dataProvider provideDatabaseToPHPValues
      */
-    public function testClosureToPHP($input, $output)
+    public function testClosureToPHP($input, $output): void
     {
         $type = Type::getType(Type::DATE);
 
@@ -136,7 +136,7 @@ class DateTypeTest extends TestCase
         $this->assertTimestampEquals($output, $return);
     }
 
-    public function provideDatabaseToPHPValues()
+    public function provideDatabaseToPHPValues(): array
     {
         $yesterday = strtotime('yesterday');
         $mongoDate = new UTCDateTime($yesterday * 1000);
@@ -151,7 +151,7 @@ class DateTypeTest extends TestCase
         ];
     }
 
-    public function test32bit1900Date()
+    public function test32bit1900Date(): void
     {
         if (PHP_INT_SIZE !== 4) {
             $this->markTestSkipped('Platform is not 32-bit');
@@ -162,7 +162,7 @@ class DateTypeTest extends TestCase
         $type->convertToDatabaseValue('1900-01-01');
     }
 
-    public function test64bit1900Date()
+    public function test64bit1900Date(): void
     {
         if (PHP_INT_SIZE !== 8) {
             $this->markTestSkipped('Platform is not 64-bit');
@@ -175,7 +175,7 @@ class DateTypeTest extends TestCase
         $this->assertEquals(new UTCDateTime(strtotime('1900-01-01') * 1000), $return);
     }
 
-    private function assertTimestampEquals(DateTime $expected, DateTime $actual)
+    private function assertTimestampEquals(DateTime $expected, DateTime $actual): void
     {
         $this->assertEquals($expected->format('U.u'), $actual->format('U.u'));
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/IdTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/IdTypeTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class IdTypeTest extends TestCase
 {
-    public function testConvertToDatabaseValue()
+    public function testConvertToDatabaseValue(): void
     {
         $identifier = new ObjectId();
         $type       = Type::getType('id');
@@ -23,14 +23,14 @@ class IdTypeTest extends TestCase
     /**
      * @dataProvider provideInvalidObjectIdConstructorArguments
      */
-    public function testConvertToDatabaseValueShouldGenerateObjectIds($value)
+    public function testConvertToDatabaseValueShouldGenerateObjectIds($value): void
     {
         $type = Type::getType('id');
 
         $this->assertInstanceOf(ObjectId::class, $type->convertToDatabaseValue($value));
     }
 
-    public function provideInvalidObjectIdConstructorArguments()
+    public function provideInvalidObjectIdConstructorArguments(): array
     {
         return [
             'integer' => [1],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/InvalidValueExceptionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/InvalidValueExceptionTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class InvalidValueExceptionTest extends TestCase
 {
-    public function testCollectionDoesntAcceptObject()
+    public function testCollectionDoesntAcceptObject(): void
     {
         $t = Type::getType('collection');
         $this->expectException(MongoDBException::class);
@@ -21,7 +21,7 @@ class InvalidValueExceptionTest extends TestCase
         $t->convertToDatabaseValue(new ArrayCollection());
     }
 
-    public function testCollectionDoesntAcceptScalar()
+    public function testCollectionDoesntAcceptScalar(): void
     {
         $t = Type::getType('collection');
         $this->expectException(MongoDBException::class);
@@ -29,7 +29,7 @@ class InvalidValueExceptionTest extends TestCase
         $t->convertToDatabaseValue(true);
     }
 
-    public function testHashDoesntAcceptObject()
+    public function testHashDoesntAcceptObject(): void
     {
         $t = Type::getType('hash');
         $this->expectException(MongoDBException::class);
@@ -39,7 +39,7 @@ class InvalidValueExceptionTest extends TestCase
         $t->convertToDatabaseValue(new ArrayCollection());
     }
 
-    public function testHashDoesntAcceptScalar()
+    public function testHashDoesntAcceptScalar(): void
     {
         $t = Type::getType('hash');
         $this->expectException(MongoDBException::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
@@ -26,12 +26,12 @@ class TypeTest extends BaseTest
     /**
      * @dataProvider provideTypes
      */
-    public function testConversion(Type $type, $test)
+    public function testConversion(Type $type, $test): void
     {
         $this->assertEquals($test, $type->convertToPHPValue($type->convertToDatabaseValue($test)));
     }
 
-    public function provideTypes()
+    public function provideTypes(): array
     {
         return [
             'id' => [Type::getType(Type::ID), '507f1f77bcf86cd799439011'],
@@ -64,12 +64,12 @@ class TypeTest extends BaseTest
     /**
      * @dataProvider provideTypesForIdempotent
      */
-    public function testConversionIsIdempotent(Type $type, $test)
+    public function testConversionIsIdempotent(Type $type, $test): void
     {
         $this->assertEquals($test, $type->convertToDatabaseValue($test));
     }
 
-    public function provideTypesForIdempotent()
+    public function provideTypesForIdempotent(): array
     {
         return [
             'id' => [Type::getType(Type::ID), new ObjectId()],
@@ -88,7 +88,7 @@ class TypeTest extends BaseTest
         ];
     }
 
-    public function testConvertDatePreservesMilliseconds()
+    public function testConvertDatePreservesMilliseconds(): void
     {
         $date         = new DateTime();
         $expectedDate = clone $date;
@@ -100,7 +100,7 @@ class TypeTest extends BaseTest
         $this->assertEquals($expectedDate, $type->convertToPHPValue($type->convertToDatabaseValue($date)));
     }
 
-    public function testConvertDateImmutablePreservesMilliseconds()
+    public function testConvertDateImmutablePreservesMilliseconds(): void
     {
         $date = new DateTimeImmutable();
 
@@ -111,7 +111,7 @@ class TypeTest extends BaseTest
         $this->assertEquals($expectedDate, $type->convertToPHPValue($type->convertToDatabaseValue($date)));
     }
 
-    public function testConvertImmutableDate()
+    public function testConvertImmutableDate(): void
     {
         $date = new DateTimeImmutable('now');
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Tests;
 use Closure;
 use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\MongoDBException;
@@ -32,7 +33,7 @@ use function sprintf;
 
 class UnitOfWorkTest extends BaseTest
 {
-    public function testIsDocumentScheduled()
+    public function testIsDocumentScheduled(): void
     {
         $class = $this->dm->getClassMetadata(ForumUser::class);
         $user  = new ForumUser();
@@ -41,7 +42,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertTrue($this->uow->isDocumentScheduled($user));
     }
 
-    public function testScheduleForInsert()
+    public function testScheduleForInsert(): void
     {
         $class = $this->dm->getClassMetadata(ForumUser::class);
         $user  = new ForumUser();
@@ -50,7 +51,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertTrue($this->uow->isScheduledForInsert($user));
     }
 
-    public function testScheduleForUpsert()
+    public function testScheduleForUpsert(): void
     {
         $class    = $this->dm->getClassMetadata(ForumUser::class);
         $user     = new ForumUser();
@@ -62,7 +63,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertTrue($this->uow->isScheduledForUpsert($user));
     }
 
-    public function testGetScheduledDocumentUpserts()
+    public function testGetScheduledDocumentUpserts(): void
     {
         $class    = $this->dm->getClassMetadata(ForumUser::class);
         $user     = new ForumUser();
@@ -72,7 +73,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertEquals([spl_object_hash($user) => $user], $this->uow->getScheduledDocumentUpserts());
     }
 
-    public function testScheduleForEmbeddedUpsert()
+    public function testScheduleForEmbeddedUpsert(): void
     {
         $test     = new EmbeddedUpsertDocument();
         $test->id = (string) new ObjectId();
@@ -83,7 +84,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertFalse($this->uow->isScheduledForUpsert($test));
     }
 
-    public function testScheduleForUpsertWithNonObjectIdValues()
+    public function testScheduleForUpsertWithNonObjectIdValues(): void
     {
         $doc     = new UowCustomIdDocument();
         $doc->id = 'string';
@@ -95,7 +96,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertTrue($this->uow->isScheduledForUpsert($doc));
     }
 
-    public function testScheduleForInsertShouldNotUpsertDocumentsWithInconsistentIdValues()
+    public function testScheduleForInsertShouldNotUpsertDocumentsWithInconsistentIdValues(): void
     {
         $class    = $this->dm->getClassMetadata(ForumUser::class);
         $user     = new ForumUser();
@@ -107,7 +108,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertFalse($this->uow->isScheduledForUpsert($user));
     }
 
-    public function testRegisterRemovedOnNewEntityIsIgnored()
+    public function testRegisterRemovedOnNewEntityIsIgnored(): void
     {
         $user           = new ForumUser();
         $user->username = 'romanb';
@@ -116,13 +117,13 @@ class UnitOfWorkTest extends BaseTest
         $this->assertFalse($this->uow->isScheduledForDelete($user));
     }
 
-    public function testThrowsOnPersistOfMappedSuperclass()
+    public function testThrowsOnPersistOfMappedSuperclass(): void
     {
         $this->expectException(MongoDBException::class);
         $this->uow->persist(new MappedSuperclass());
     }
 
-    public function testParentAssociations()
+    public function testParentAssociations(): void
     {
         $a = new ParentAssociationTest('a');
         $b = new ParentAssociationTest('b');
@@ -140,7 +141,7 @@ class UnitOfWorkTest extends BaseTest
     /**
      * @doesNotPerformAssertions
      */
-    public function testPreUpdateTriggeredWithEmptyChangeset()
+    public function testPreUpdateTriggeredWithEmptyChangeset(): void
     {
         $this->dm->getEventManager()->addEventSubscriber(
             new PreUpdateListenerMock()
@@ -156,7 +157,7 @@ class UnitOfWorkTest extends BaseTest
         $this->dm->flush();
     }
 
-    public function testNotSaved()
+    public function testNotSaved(): void
     {
         $test           = new NotSaved();
         $test->name     = 'test';
@@ -232,7 +233,7 @@ class UnitOfWorkTest extends BaseTest
     /**
      * @dataProvider getScheduleForUpdateWithArraysTests
      */
-    public function testScheduleForUpdateWithArrays($origData, $updateData, $shouldInUpdate)
+    public function testScheduleForUpdateWithArrays($origData, $updateData, $shouldInUpdate): void
     {
         $arrayTest = new ArrayTest($origData);
         $this->uow->persist($arrayTest);
@@ -249,7 +250,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertFalse($this->uow->isScheduledForUpdate($arrayTest));
     }
 
-    public function getScheduleForUpdateWithArraysTests()
+    public function getScheduleForUpdateWithArraysTests(): array
     {
         return [
             [
@@ -300,7 +301,7 @@ class UnitOfWorkTest extends BaseTest
         ];
     }
 
-    public function testRegisterManagedEmbeddedDocumentWithMappedIdAndNullValue()
+    public function testRegisterManagedEmbeddedDocumentWithMappedIdAndNullValue(): void
     {
         $document = new EmbeddedDocumentWithId();
         $oid      = spl_object_hash($document);
@@ -310,7 +311,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertEquals($oid, $this->uow->getDocumentIdentifier($document));
     }
 
-    public function testRegisterManagedEmbeddedDocumentWithoutMappedId()
+    public function testRegisterManagedEmbeddedDocumentWithoutMappedId(): void
     {
         $document = new EmbeddedDocumentWithoutId();
         $oid      = spl_object_hash($document);
@@ -320,7 +321,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertEquals($oid, $this->uow->getDocumentIdentifier($document));
     }
 
-    public function testRegisterManagedEmbeddedDocumentWithMappedIdStrategyNoneAndNullValue()
+    public function testRegisterManagedEmbeddedDocumentWithMappedIdStrategyNoneAndNullValue(): void
     {
         $document = new EmbeddedDocumentWithIdStrategyNone();
         $oid      = spl_object_hash($document);
@@ -340,7 +341,7 @@ class UnitOfWorkTest extends BaseTest
         $this->uow->persist($file);
     }
 
-    public function testPersistRemovedDocument()
+    public function testPersistRemovedDocument(): void
     {
         $user           = new ForumUser();
         $user->username = 'jwage';
@@ -363,7 +364,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertNotNull($this->dm->getRepository(get_class($user))->find($user->id));
     }
 
-    public function testRemovePersistedButNotFlushedDocument()
+    public function testRemovePersistedButNotFlushedDocument(): void
     {
         $user           = new ForumUser();
         $user->username = 'jwage';
@@ -375,7 +376,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertNull($this->dm->getRepository(get_class($user))->find($user->id));
     }
 
-    public function testPersistRemovedEmbeddedDocument()
+    public function testPersistRemovedEmbeddedDocument(): void
     {
         $test           = new PersistRemovedEmbeddedDocument();
         $test->embedded = new EmbeddedDocumentWithId();
@@ -403,7 +404,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertEquals(UnitOfWork::STATE_MANAGED, $this->uow->getDocumentState($test->embedded));
     }
 
-    public function testPersistingEmbeddedDocumentWithoutIdentifier()
+    public function testPersistingEmbeddedDocumentWithoutIdentifier(): void
     {
         $address = new Address();
         $user    = new User();
@@ -426,7 +427,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertFalse($this->uow->isScheduledForInsert($address));
     }
 
-    public function testEmbeddedDocumentChangeSets()
+    public function testEmbeddedDocumentChangeSets(): void
     {
         $address = new Address();
         $user    = new User();
@@ -450,7 +451,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertEquals('Nashville', $changeSet['city'][1]);
     }
 
-    public function testGetClassNameForAssociation()
+    public function testGetClassNameForAssociation(): void
     {
         $mapping = ClassMetadataTestUtil::getFieldMapping([
             'discriminatorField' => 'type',
@@ -462,7 +463,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertEquals(ForumUser::class, $this->uow->getClassNameForAssociation($mapping, $data));
     }
 
-    public function testGetClassNameForAssociationWithClassMetadataDiscriminatorMap()
+    public function testGetClassNameForAssociationWithClassMetadataDiscriminatorMap(): void
     {
         $mapping = ClassMetadataTestUtil::getFieldMapping(['targetDocument' => User::class]);
         $data    = ['type' => 'forum_user'];
@@ -475,13 +476,13 @@ class UnitOfWorkTest extends BaseTest
         $this->assertEquals(ForumUser::class, $this->uow->getClassNameForAssociation($mapping, $data));
     }
 
-    public function testGetClassNameForAssociationReturnsTargetDocumentWithNullData()
+    public function testGetClassNameForAssociationReturnsTargetDocumentWithNullData(): void
     {
         $mapping = ClassMetadataTestUtil::getFieldMapping(['targetDocument' => User::class]);
         $this->assertEquals(User::class, $this->uow->getClassNameForAssociation($mapping, null));
     }
 
-    public function testRecomputeChangesetForUninitializedProxyDoesNotCreateChangeset()
+    public function testRecomputeChangesetForUninitializedProxyDoesNotCreateChangeset(): void
     {
         $user           = new ForumUser();
         $user->username = '12345';
@@ -505,7 +506,7 @@ class UnitOfWorkTest extends BaseTest
         $this->assertEquals([], $this->uow->getDocumentChangeSet($user->getAvatar()));
     }
 
-    public function testCommitsInProgressIsUpdatedOnException()
+    public function testCommitsInProgressIsUpdatedOnException(): void
     {
         $this->dm->getEventManager()->addEventSubscriber(
             new ExceptionThrowingListenerMock()
@@ -571,7 +572,7 @@ class NotifyChangedDocument implements NotifyPropertyChanged
         return $this->id;
     }
 
-    public function setId($id)
+    public function setId($id): void
     {
         $this->id = $id;
     }
@@ -581,7 +582,7 @@ class NotifyChangedDocument implements NotifyPropertyChanged
         return $this->data;
     }
 
-    public function setData($data)
+    public function setData($data): void
     {
         if ($data === $this->data) {
             return;
@@ -591,12 +592,12 @@ class NotifyChangedDocument implements NotifyPropertyChanged
         $this->data = $data;
     }
 
-    public function getItems()
+    public function getItems(): Collection
     {
         return $this->items;
     }
 
-    public function setTransient($value)
+    public function setTransient($value): void
     {
         if ($value === $this->transient) {
             return;
@@ -611,7 +612,7 @@ class NotifyChangedDocument implements NotifyPropertyChanged
         $this->_listeners[] = $listener;
     }
 
-    protected function onPropertyChanged($propName, $oldValue, $newValue)
+    protected function onPropertyChanged($propName, $oldValue, $newValue): void
     {
         foreach ($this->_listeners as $listener) {
             $listener->propertyChanged($this, $propName, $oldValue, $newValue);
@@ -633,7 +634,7 @@ class NotifyChangedRelatedItem
         return $this->id;
     }
 
-    public function setId($id)
+    public function setId($id): void
     {
         $this->id = $id;
     }
@@ -643,7 +644,7 @@ class NotifyChangedRelatedItem
         return $this->owner;
     }
 
-    public function setOwner($owner)
+    public function setOwner($owner): void
     {
         $this->owner = $owner;
     }
@@ -692,7 +693,7 @@ class EmbeddedDocumentWithId
     public $id;
 
     /** @ODM\PreRemove */
-    public function preRemove()
+    public function preRemove(): void
     {
         $this->preRemove = true;
     }

--- a/tests/Documents/Account.php
+++ b/tests/Documents/Account.php
@@ -26,7 +26,7 @@ class Account
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -36,7 +36,7 @@ class Account
         return $this->name;
     }
 
-    public function setUser($user)
+    public function setUser($user): void
     {
         $this->user = $user;
     }
@@ -46,7 +46,7 @@ class Account
         return $this->user;
     }
 
-    public function setUserDbRef($userDbRef)
+    public function setUserDbRef($userDbRef): void
     {
         $this->userDbRef = $userDbRef;
     }

--- a/tests/Documents/Address.php
+++ b/tests/Documents/Address.php
@@ -30,7 +30,7 @@ class Address
     /** @ODM\Field(name="testFieldName", type="string") */
     private $test;
 
-    public function setSubAddress(Address $subAddress)
+    public function setSubAddress(Address $subAddress): void
     {
         $this->subAddress = $subAddress;
     }
@@ -45,7 +45,7 @@ class Address
         return $this->address;
     }
 
-    public function setAddress($address)
+    public function setAddress($address): void
     {
         $this->address = $address;
     }
@@ -55,7 +55,7 @@ class Address
         return $this->city;
     }
 
-    public function setCity($city)
+    public function setCity($city): void
     {
         $this->city = $city;
     }
@@ -65,7 +65,7 @@ class Address
         return $this->state;
     }
 
-    public function setState($state)
+    public function setState($state): void
     {
         $this->state = $state;
     }
@@ -75,7 +75,7 @@ class Address
         return $this->zipcode;
     }
 
-    public function setZipcode($zipcode)
+    public function setZipcode($zipcode): void
     {
         $this->zipcode = $zipcode;
     }

--- a/tests/Documents/Album.php
+++ b/tests/Documents/Album.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Documents;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\Document(collection="albums") */
@@ -15,12 +17,17 @@ class Album
     /** @ODM\Field(type="string") */
     private $name;
 
-    /** @ODM\EmbedMany(targetDocument=Song::class) */
-    private $songs = [];
+    /**
+     * @ODM\EmbedMany(targetDocument=Song::class)
+     *
+     * @var Collection<int, Song>
+     */
+    private $songs;
 
     public function __construct($name)
     {
-        $this->name = $name;
+        $this->name  = $name;
+        $this->songs = new ArrayCollection();
     }
 
     public function getId()
@@ -28,7 +35,7 @@ class Album
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -38,12 +45,12 @@ class Album
         return $this->name;
     }
 
-    public function addSong(Song $song)
+    public function addSong(Song $song): void
     {
         $this->songs[] = $song;
     }
 
-    public function getSongs()
+    public function getSongs(): Collection
     {
         return $this->songs;
     }

--- a/tests/Documents/Article.php
+++ b/tests/Documents/Article.php
@@ -39,7 +39,7 @@ class Article
         return $this->title;
     }
 
-    public function setTitle($title)
+    public function setTitle($title): void
     {
         $this->title = $title;
     }
@@ -49,7 +49,7 @@ class Article
         return $this->body;
     }
 
-    public function setBody($body)
+    public function setBody($body): void
     {
         $this->body = $body;
     }
@@ -59,17 +59,17 @@ class Article
         return $this->createdAt;
     }
 
-    public function setCreatedAt($createdAt)
+    public function setCreatedAt($createdAt): void
     {
         $this->createdAt = $createdAt;
     }
 
-    public function addTag($tag)
+    public function addTag($tag): void
     {
         $this->tags[] = $tag;
     }
 
-    public function removeTag($tag)
+    public function removeTag($tag): void
     {
         if (! in_array($tag, $this->tags)) {
             return;
@@ -78,7 +78,7 @@ class Article
         unset($this->tags[array_search($tag, $this->tags)]);
     }
 
-    public function getTags()
+    public function getTags(): array
     {
         return $this->tags;
     }

--- a/tests/Documents/Bars/Bar.php
+++ b/tests/Documents/Bars/Bar.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Documents\Bars;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\Document(collection="bars") */
@@ -15,12 +17,17 @@ class Bar
     /** @ODM\Field(type="string") */
     private $name;
 
-    /** @ODM\EmbedMany(targetDocument=Documents\Bars\Location::class) */
-    private $locations = [];
+    /**
+     * @ODM\EmbedMany(targetDocument=Documents\Bars\Location::class)
+     *
+     * @var Collection<int, Location>
+     */
+    private $locations;
 
     public function __construct($name = null)
     {
-        $this->name = $name;
+        $this->name      = $name;
+        $this->locations = new ArrayCollection();
     }
 
     public function getId()
@@ -28,7 +35,7 @@ class Bar
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -38,17 +45,17 @@ class Bar
         return $this->name;
     }
 
-    public function addLocation(Location $location)
+    public function addLocation(Location $location): void
     {
         $this->locations[] = $location;
     }
 
-    public function getLocations()
+    public function getLocations(): Collection
     {
         return $this->locations;
     }
 
-    public function setLocations($locations)
+    public function setLocations($locations): void
     {
         $this->locations = $locations;
     }

--- a/tests/Documents/Bars/Location.php
+++ b/tests/Documents/Bars/Location.php
@@ -17,7 +17,7 @@ class Location
         $this->name = $name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Documents/BaseCategory.php
+++ b/tests/Documents/BaseCategory.php
@@ -20,7 +20,7 @@ abstract class BaseCategory
         $this->name = $name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -30,12 +30,12 @@ abstract class BaseCategory
         return $this->name;
     }
 
-    public function addChild(BaseCategory $child)
+    public function addChild(BaseCategory $child): void
     {
         $this->children[] = $child;
     }
 
-    public function getChildren()
+    public function getChildren(): array
     {
         return $this->children;
     }

--- a/tests/Documents/BaseDocument.php
+++ b/tests/Documents/BaseDocument.php
@@ -14,7 +14,7 @@ abstract class BaseDocument
     /** @ODM\Field(type="string") */
     protected $inheritedProperty;
 
-    public function setInheritedProperty($value)
+    public function setInheritedProperty($value): void
     {
         $this->inheritedProperty = $value;
     }
@@ -25,7 +25,7 @@ abstract class BaseDocument
     }
 
     /** @ODM\PrePersist */
-    public function prePersist()
+    public function prePersist(): void
     {
         $this->persisted = true;
     }

--- a/tests/Documents/BaseEmployee.php
+++ b/tests/Documents/BaseEmployee.php
@@ -38,31 +38,31 @@ abstract class BaseEmployee
         return $this->id;
     }
 
-    public function setId($val)
+    public function setId($val): BaseEmployee
     {
         $this->id = $val;
 
         return $this;
     }
 
-    public function getChanges()
+    public function getChanges(): int
     {
         return $this->changes;
     }
 
-    public function incrementChanges($num)
+    public function incrementChanges($num): BaseEmployee
     {
         $this->changes += $num;
 
         return $this;
     }
 
-    public function getNotes()
+    public function getNotes(): array
     {
         return $this->notes;
     }
 
-    public function addNote($note)
+    public function addNote($note): BaseEmployee
     {
         $this->notes[] = $note;
 
@@ -74,7 +74,7 @@ abstract class BaseEmployee
         return $this->name;
     }
 
-    public function setName($val)
+    public function setName($val): BaseEmployee
     {
         $this->name = $val;
 
@@ -86,7 +86,7 @@ abstract class BaseEmployee
         return $this->salary;
     }
 
-    public function setSalary($val)
+    public function setSalary($val): BaseEmployee
     {
         $this->salary = $val;
 
@@ -98,7 +98,7 @@ abstract class BaseEmployee
         return $this->started;
     }
 
-    public function setStarted($val)
+    public function setStarted($val): BaseEmployee
     {
         $this->started = $val;
 
@@ -110,7 +110,7 @@ abstract class BaseEmployee
         return $this->left;
     }
 
-    public function setLeft($val)
+    public function setLeft($val): BaseEmployee
     {
         $this->left = $val;
 
@@ -122,7 +122,7 @@ abstract class BaseEmployee
         return $this->address;
     }
 
-    public function setAddress($val)
+    public function setAddress($val): BaseEmployee
     {
         $this->address = $val;
 

--- a/tests/Documents/BlogPost.php
+++ b/tests/Documents/BlogPost.php
@@ -61,19 +61,19 @@ class BlogPost
         return $this->name;
     }
 
-    public function addTag(Tag $tag)
+    public function addTag(Tag $tag): void
     {
         $tag->addBlogPost($this); // synchronously updating inverse side
         $this->tags[] = $tag;
     }
 
-    public function addComment(Comment $comment)
+    public function addComment(Comment $comment): void
     {
         $comment->parent  = $this;
         $this->comments[] = $comment;
     }
 
-    public function setUser(?User $user = null)
+    public function setUser(?User $user = null): void
     {
         $this->user = $user;
     }

--- a/tests/Documents/BrowseNode.php
+++ b/tests/Documents/BrowseNode.php
@@ -28,7 +28,7 @@ class BrowseNode
         $this->children = new ArrayCollection();
     }
 
-    public function addChild(BrowseNode $child)
+    public function addChild(BrowseNode $child): void
     {
         $child->parent    = $this;
         $this->children[] = $child;

--- a/tests/Documents/Chapter.php
+++ b/tests/Documents/Chapter.php
@@ -31,7 +31,7 @@ class Chapter
     /**
      * @ODM\PostUpdate
      */
-    public function doThisAfterAnUpdate()
+    public function doThisAfterAnUpdate(): void
     {
         /* Do not do this at home, it is here only to see if nothing breaks,
          * field will not be updated in database with new value unless another

--- a/tests/Documents/CmsAddress.php
+++ b/tests/Documents/CmsAddress.php
@@ -54,7 +54,7 @@ class CmsAddress
         return $this->city;
     }
 
-    public function setUser(CmsUser $user)
+    public function setUser(CmsUser $user): void
     {
         if ($this->user === $user) {
             return;

--- a/tests/Documents/CmsArticle.php
+++ b/tests/Documents/CmsArticle.php
@@ -27,12 +27,12 @@ class CmsArticle
     /** @ODM\ReferenceMany(targetDocument=CmsComment::class) */
     public $comments;
 
-    public function setAuthor(CmsUser $author)
+    public function setAuthor(CmsUser $author): void
     {
         $this->user = $author;
     }
 
-    public function addComment(CmsComment $comment)
+    public function addComment(CmsComment $comment): void
     {
         $this->comments[] = $comment;
         $comment->setArticle($this);

--- a/tests/Documents/CmsComment.php
+++ b/tests/Documents/CmsComment.php
@@ -29,7 +29,7 @@ class CmsComment
     /** @ODM\Field(type="string", nullable=true) */
     public $nullableField;
 
-    public function setArticle(CmsArticle $article)
+    public function setArticle(CmsArticle $article): void
     {
         $this->article = $article;
     }

--- a/tests/Documents/CmsGroup.php
+++ b/tests/Documents/CmsGroup.php
@@ -18,7 +18,7 @@ class CmsGroup
     /** @ODM\ReferenceMany(targetDocument=CmsUser::class) */
     public $users;
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -28,7 +28,7 @@ class CmsGroup
         return $this->name;
     }
 
-    public function addUser(CmsUser $user)
+    public function addUser(CmsUser $user): void
     {
         $this->users[] = $user;
     }

--- a/tests/Documents/CmsPhonenumber.php
+++ b/tests/Documents/CmsPhonenumber.php
@@ -17,7 +17,7 @@ class CmsPhonenumber
     /** @ODM\ReferenceOne(targetDocument=CmsUser::class, cascade={"merge"}) */
     public $user;
 
-    public function setUser(CmsUser $user)
+    public function setUser(CmsUser $user): void
     {
         $this->user = $user;
     }

--- a/tests/Documents/CmsUser.php
+++ b/tests/Documents/CmsUser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Documents;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
@@ -66,35 +67,35 @@ class CmsUser
     /**
      * Adds a phonenumber to the user.
      */
-    public function addPhonenumber(CmsPhonenumber $phone)
+    public function addPhonenumber(CmsPhonenumber $phone): void
     {
         $this->phonenumbers[] = $phone;
         $phone->setUser($this);
     }
 
-    public function getPhonenumbers()
+    public function getPhonenumbers(): Collection
     {
         return $this->phonenumbers;
     }
 
-    public function addArticle(CmsArticle $article)
+    public function addArticle(CmsArticle $article): void
     {
         $this->articles[] = $article;
         $article->setAuthor($this);
     }
 
-    public function addGroup(CmsGroup $group)
+    public function addGroup(CmsGroup $group): void
     {
         $this->groups[] = $group;
         $group->addUser($this);
     }
 
-    public function getGroups()
+    public function getGroups(): Collection
     {
         return $this->groups;
     }
 
-    public function removePhonenumber($index)
+    public function removePhonenumber($index): bool
     {
         if (isset($this->phonenumbers[$index])) {
             $ph = $this->phonenumbers[$index];
@@ -112,7 +113,7 @@ class CmsUser
         return $this->address;
     }
 
-    public function setAddress(CmsAddress $address)
+    public function setAddress(CmsAddress $address): void
     {
         if ($this->address === $address) {
             return;

--- a/tests/Documents/CommentRepository.php
+++ b/tests/Documents/CommentRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Documents;
 
+use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 
 /** FIXME: reflection chokes if this class doesn't have a doc comment */
@@ -16,7 +17,7 @@ class CommentRepository extends DocumentRepository
             ->current();
     }
 
-    public function findManyComments()
+    public function findManyComments(): Iterator
     {
         return $this->getDocumentPersister()->loadAll();
     }

--- a/tests/Documents/CommentRepository.php
+++ b/tests/Documents/CommentRepository.php
@@ -7,7 +7,11 @@ namespace Documents;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 
-/** FIXME: reflection chokes if this class doesn't have a doc comment */
+/**
+ * FIXME: reflection chokes if this class doesn't have a doc comment
+ *
+ * @template-extends DocumentRepository<Comment>
+ */
 class CommentRepository extends DocumentRepository
 {
     public function findOneComment()

--- a/tests/Documents/CustomUser.php
+++ b/tests/Documents/CustomUser.php
@@ -26,12 +26,12 @@ class CustomUser
         return $this->id;
     }
 
-    public function setId($id)
+    public function setId($id): void
     {
         $this->id = $id;
     }
 
-    public function setUsername($username)
+    public function setUsername($username): void
     {
         $this->username = $username;
     }
@@ -41,7 +41,7 @@ class CustomUser
         return $this->username;
     }
 
-    public function setPassword($password)
+    public function setPassword($password): void
     {
         $this->password = $password;
     }
@@ -51,7 +51,7 @@ class CustomUser
         return $this->password;
     }
 
-    public function setAccount(Account $account)
+    public function setAccount(Account $account): void
     {
         $this->account = $account;
         $this->account->setUser($this);

--- a/tests/Documents/Ecommerce/ConfigurableProduct.php
+++ b/tests/Documents/Ecommerce/ConfigurableProduct.php
@@ -44,7 +44,7 @@ class ConfigurableProduct
         return $this->name;
     }
 
-    public function setName($name)
+    public function setName($name): ConfigurableProduct
     {
         $name = (string) $name;
         if (empty($name)) {
@@ -64,7 +64,7 @@ class ConfigurableProduct
     /**
      * @param string|Option $name
      */
-    public function addOption($name, ?Money $price = null, ?StockItem $item = null)
+    public function addOption($name, ?Money $price = null, ?StockItem $item = null): void
     {
         if (! $name instanceof Option) {
             $name = (string) $name;
@@ -91,7 +91,7 @@ class ConfigurableProduct
         return $this->findOption($name);
     }
 
-    public function removeOption($name)
+    public function removeOption($name): ConfigurableProduct
     {
         $option = $this->findOption($name);
         if ($option === null) {
@@ -109,12 +109,12 @@ class ConfigurableProduct
         return $this;
     }
 
-    public function hasOption($name)
+    public function hasOption($name): bool
     {
         return $this->findOption($name) !== null;
     }
 
-    public function selectOption($name)
+    public function selectOption($name): ConfigurableProduct
     {
         $option = $this->findOption($name);
         if (! isset($option)) {
@@ -143,7 +143,7 @@ class ConfigurableProduct
             $this->selectedOption->getPrice() : null;
     }
 
-    protected function getStockItems()
+    protected function getStockItems(): array
     {
         return array_map(static function ($option) {
             return $option->getStockItem();

--- a/tests/Documents/Ecommerce/ConfigurableProduct.php
+++ b/tests/Documents/Ecommerce/ConfigurableProduct.php
@@ -137,6 +137,9 @@ class ConfigurableProduct
         return null;
     }
 
+    /**
+     * @return Money|float|null
+     */
     public function getPrice()
     {
         return isset($this->selectedOption) ?

--- a/tests/Documents/Ecommerce/Currency.php
+++ b/tests/Documents/Ecommerce/Currency.php
@@ -47,7 +47,7 @@ class Currency
         return $this->id;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -57,7 +57,7 @@ class Currency
         return $this->multiplier;
     }
 
-    public function setMultiplier($multiplier)
+    public function setMultiplier($multiplier): void
     {
         $multiplier = (float) $multiplier;
         if (empty($multiplier) || $multiplier <= 0) {
@@ -69,7 +69,7 @@ class Currency
         $this->multiplier = $multiplier;
     }
 
-    public static function getAll()
+    public static function getAll(): array
     {
         return [
             self::USD,

--- a/tests/Documents/Ecommerce/Money.php
+++ b/tests/Documents/Ecommerce/Money.php
@@ -39,7 +39,7 @@ class Money
         return $this->currency;
     }
 
-    public function setCurrency(Currency $currency)
+    public function setCurrency(Currency $currency): void
     {
         $this->currency = $currency;
     }

--- a/tests/Documents/Ecommerce/Option.php
+++ b/tests/Documents/Ecommerce/Option.php
@@ -51,10 +51,7 @@ class Option
         $this->stockItem = $stockItem;
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -71,10 +68,7 @@ class Option
         return $this->money->getAmount();
     }
 
-    /**
-     * @return StockItem
-     */
-    public function getStockItem()
+    public function getStockItem(): StockItem
     {
         return $this->stockItem;
     }

--- a/tests/Documents/Ecommerce/StockItem.php
+++ b/tests/Documents/Ecommerce/StockItem.php
@@ -45,7 +45,7 @@ class StockItem
         $this->setInventory($inventory);
     }
 
-    public function setName($name)
+    public function setName($name): StockItem
     {
         $this->name = (string) $name;
 
@@ -57,7 +57,7 @@ class StockItem
         return $this->name;
     }
 
-    public function setCost(Money $cost)
+    public function setCost(Money $cost): void
     {
         $this->cost = $cost;
     }
@@ -67,7 +67,7 @@ class StockItem
         return $this->cost->getAmount();
     }
 
-    public function setInventory($inventory)
+    public function setInventory($inventory): StockItem
     {
         $this->inventory = (int) $inventory;
 

--- a/tests/Documents/Employee.php
+++ b/tests/Documents/Employee.php
@@ -17,7 +17,7 @@ class Employee extends BaseEmployee
         return $this->manager;
     }
 
-    public function setManager($val)
+    public function setManager($val): Employee
     {
         $this->manager = $val;
 

--- a/tests/Documents/Event.php
+++ b/tests/Documents/Event.php
@@ -26,7 +26,7 @@ class Event
         return $this->id;
     }
 
-    public function setUser(User $user)
+    public function setUser(User $user): void
     {
         $this->user = $user;
     }
@@ -41,7 +41,7 @@ class Event
         return $this->title;
     }
 
-    public function setTitle($title)
+    public function setTitle($title): void
     {
         $this->title = $title;
     }
@@ -51,7 +51,7 @@ class Event
         return $this->type;
     }
 
-    public function setType($type)
+    public function setType($type): void
     {
         $this->type = $type;
     }

--- a/tests/Documents/ForumUser.php
+++ b/tests/Documents/ForumUser.php
@@ -33,7 +33,7 @@ class ForumUser
         return $this->avatar;
     }
 
-    public function setAvatar(ForumAvatar $avatar)
+    public function setAvatar(ForumAvatar $avatar): void
     {
         $this->avatar = $avatar;
     }

--- a/tests/Documents/FriendUser.php
+++ b/tests/Documents/FriendUser.php
@@ -29,7 +29,7 @@ class FriendUser
         $this->myFriends     = new ArrayCollection();
     }
 
-    public function addFriend(FriendUser $user)
+    public function addFriend(FriendUser $user): void
     {
         $user->friendsWithMe[] = $this;
         $this->myFriends[]     = $user;

--- a/tests/Documents/Functional/EmbeddedTestLevel1.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel1.php
@@ -20,25 +20,25 @@ class EmbeddedTestLevel1
     public $postLoad   = false;
 
     /** @ODM\PreRemove */
-    public function onPreRemove()
+    public function onPreRemove(): void
     {
         $this->preRemove = true;
     }
 
     /** @ODM\PostRemove */
-    public function onPostRemove()
+    public function onPostRemove(): void
     {
         $this->postRemove = true;
     }
 
     /** @ODM\PreLoad */
-    public function onPreLoad()
+    public function onPreLoad(): void
     {
         $this->preLoad = true;
     }
 
     /** @ODM\PostLoad */
-    public function onPostLoad()
+    public function onPostLoad(): void
     {
         $this->postLoad = true;
     }

--- a/tests/Documents/Functional/EmbeddedTestLevel2.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel2.php
@@ -18,25 +18,25 @@ class EmbeddedTestLevel2
     public $postLoad   = false;
 
     /** @ODM\PreRemove */
-    public function onPreRemove()
+    public function onPreRemove(): void
     {
         $this->preRemove = true;
     }
 
     /** @ODM\PostRemove */
-    public function onPostRemove()
+    public function onPostRemove(): void
     {
         $this->postRemove = true;
     }
 
     /** @ODM\PreLoad */
-    public function onPreLoad()
+    public function onPreLoad(): void
     {
         $this->preLoad = true;
     }
 
     /** @ODM\PostLoad */
-    public function onPostLoad()
+    public function onPostLoad(): void
     {
         $this->postLoad = true;
     }

--- a/tests/Documents/Functional/FavoritesUser.php
+++ b/tests/Documents/Functional/FavoritesUser.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Documents\Functional;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\Document(collection="favorites_user") */
@@ -24,7 +26,7 @@ class FavoritesUser
      *   }
      * )
      */
-    private $favorites = [];
+    private $favorites;
 
     /** @ODM\EmbedMany */
     private $embedded = [];
@@ -35,12 +37,17 @@ class FavoritesUser
     /** @ODM\EmbedOne */
     private $embed;
 
+    public function __construct()
+    {
+        $this->favorites = new ArrayCollection();
+    }
+
     public function getId()
     {
         return $this->id;
     }
 
-    public function setFavorite($favorite)
+    public function setFavorite($favorite): void
     {
         $this->favorite = $favorite;
     }
@@ -50,7 +57,7 @@ class FavoritesUser
         return $this->favorite;
     }
 
-    public function setEmbed($embed)
+    public function setEmbed($embed): void
     {
         $this->embed = $embed;
     }
@@ -60,7 +67,7 @@ class FavoritesUser
         return $this->embed;
     }
 
-    public function embed($document)
+    public function embed($document): void
     {
         $this->embedded[] = $document;
     }
@@ -75,17 +82,17 @@ class FavoritesUser
         return $this->name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
 
-    public function addFavorite($favorite)
+    public function addFavorite($favorite): void
     {
         $this->favorites[] = $favorite;
     }
 
-    public function getFavorites()
+    public function getFavorites(): Collection
     {
         return $this->favorites;
     }

--- a/tests/Documents/Functional/PreUpdateTestProduct.php
+++ b/tests/Documents/Functional/PreUpdateTestProduct.php
@@ -25,7 +25,7 @@ class PreUpdateTestProduct
         return $this->name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Documents/Functional/PreUpdateTestSeller.php
+++ b/tests/Documents/Functional/PreUpdateTestSeller.php
@@ -20,13 +20,13 @@ class PreUpdateTestSeller
         return $this->name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
 
     /** @ODM\PreUpdate */
-    public function preUpdate()
+    public function preUpdate(): void
     {
     }
 }

--- a/tests/Documents/Functional/VirtualHost.php
+++ b/tests/Documents/Functional/VirtualHost.php
@@ -29,7 +29,7 @@ class VirtualHost
         return $this->vhostDirective;
     }
 
-    public function setVHostDirective($value)
+    public function setVHostDirective($value): VirtualHost
     {
         $this->vhostDirective = $value;
 

--- a/tests/Documents/Functional/VirtualHostDirective.php
+++ b/tests/Documents/Functional/VirtualHostDirective.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Documents\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 use function uniqid;
@@ -37,7 +38,7 @@ class VirtualHostDirective
         return $this->recId;
     }
 
-    public function setRecId($value = null)
+    public function setRecId($value = null): void
     {
         if (! $value) {
             $value = uniqid();
@@ -51,7 +52,7 @@ class VirtualHostDirective
         return $this->name;
     }
 
-    public function setName($value)
+    public function setName($value): void
     {
         $this->name = $value;
     }
@@ -61,12 +62,12 @@ class VirtualHostDirective
         return $this->value;
     }
 
-    public function setValue($value)
+    public function setValue($value): void
     {
         $this->value = $value;
     }
 
-    public function getDirectives()
+    public function getDirectives(): Collection
     {
         if (! $this->directives) {
             $this->directives = new ArrayCollection([]);
@@ -75,14 +76,14 @@ class VirtualHostDirective
         return $this->directives;
     }
 
-    public function setDirectives($value)
+    public function setDirectives($value): VirtualHostDirective
     {
         $this->directives = $value;
 
         return $this;
     }
 
-    public function addDirective(VirtualHostDirective $d)
+    public function addDirective(VirtualHostDirective $d): VirtualHostDirective
     {
         $this->getDirectives()->add($d);
 
@@ -105,7 +106,7 @@ class VirtualHostDirective
         return $this->hasDirective($name);
     }
 
-    public function removeDirective(VirtualHostDirective $d)
+    public function removeDirective(VirtualHostDirective $d): VirtualHostDirective
     {
         $this->getDirectives()->removeElement($d);
 

--- a/tests/Documents/GraphLookup/Airport.php
+++ b/tests/Documents/GraphLookup/Airport.php
@@ -31,7 +31,7 @@ class Airport
         $this->connectionIds = new ArrayCollection();
     }
 
-    public function addConnection(Airport $airport)
+    public function addConnection(Airport $airport): void
     {
         if ($this->connections->contains($airport)) {
             return;

--- a/tests/Documents/Group.php
+++ b/tests/Documents/Group.php
@@ -25,7 +25,7 @@ class Group
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Documents/Manager.php
+++ b/tests/Documents/Manager.php
@@ -12,12 +12,12 @@ class Manager extends BaseEmployee
     /** @ODM\ReferenceMany(targetDocument=Project::class) */
     private $projects = [];
 
-    public function getProjects()
+    public function getProjects(): array
     {
         return $this->projects;
     }
 
-    public function addProject(Project $project)
+    public function addProject(Project $project): void
     {
         $this->projects[] = $project;
     }

--- a/tests/Documents/Message.php
+++ b/tests/Documents/Message.php
@@ -25,7 +25,7 @@ class Message
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Documents/Phonebook.php
+++ b/tests/Documents/Phonebook.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Documents;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\EmbeddedDocument */
@@ -27,22 +28,22 @@ class Phonebook
         return $this->title;
     }
 
-    public function setTitle($title)
+    public function setTitle($title): void
     {
         $this->title = $title;
     }
 
-    public function addPhonenumber(Phonenumber $phonenumber)
+    public function addPhonenumber(Phonenumber $phonenumber): void
     {
         $this->phonenumbers->add($phonenumber);
     }
 
-    public function getPhonenumbers()
+    public function getPhonenumbers(): Collection
     {
         return $this->phonenumbers;
     }
 
-    public function removePhonenumber(Phonenumber $phonenumber)
+    public function removePhonenumber(Phonenumber $phonenumber): void
     {
         $this->phonenumbers->removeElement($phonenumber);
     }

--- a/tests/Documents/Phonenumber.php
+++ b/tests/Documents/Phonenumber.php
@@ -26,17 +26,17 @@ class Phonenumber
         return $this->phonenumber;
     }
 
-    public function setPhonenumber($phonenumber)
+    public function setPhonenumber($phonenumber): void
     {
         $this->phonenumber = $phonenumber;
     }
 
-    public function getLastCalledBy()
+    public function getLastCalledBy(): ?User
     {
         return $this->lastCalledBy;
     }
 
-    public function setLastCalledBy(?User $lastCalledBy = null)
+    public function setLastCalledBy(?User $lastCalledBy = null): void
     {
         $this->lastCalledBy = $lastCalledBy;
     }

--- a/tests/Documents/Product.php
+++ b/tests/Documents/Product.php
@@ -25,7 +25,7 @@ class Product
         $this->features = new ArrayCollection();
     }
 
-    public function addFeature(Feature $feature)
+    public function addFeature(Feature $feature): void
     {
         $feature->product = $this;
         $this->features[] = $feature;

--- a/tests/Documents/Profile.php
+++ b/tests/Documents/Profile.php
@@ -21,7 +21,7 @@ class Profile
     /** @ODM\ReferenceOne(targetDocument=File::class, cascade={"all"}) */
     private $image;
 
-    public function setProfileId($profileId)
+    public function setProfileId($profileId): void
     {
         $this->profileId = $profileId;
     }
@@ -31,7 +31,7 @@ class Profile
         return $this->profileId;
     }
 
-    public function setFirstName($firstName)
+    public function setFirstName($firstName): void
     {
         $this->firstName = $firstName;
     }
@@ -41,7 +41,7 @@ class Profile
         return $this->firstName;
     }
 
-    public function setLastName($lastName)
+    public function setLastName($lastName): void
     {
         $this->lastName = $lastName;
     }
@@ -51,7 +51,7 @@ class Profile
         return $this->lastName;
     }
 
-    public function setImage(File $image)
+    public function setImage(File $image): void
     {
         $this->image = $image;
     }

--- a/tests/Documents/ProfileNotify.php
+++ b/tests/Documents/ProfileNotify.php
@@ -40,7 +40,7 @@ class ProfileNotify implements NotifyPropertyChanged
         $this->listeners[] = $listener;
     }
 
-    private function propertyChanged($propName, $oldValue, $newValue)
+    private function propertyChanged($propName, $oldValue, $newValue): void
     {
         foreach ($this->listeners as $listener) {
             $listener->propertyChanged($this, $propName, $oldValue, $newValue);
@@ -52,7 +52,7 @@ class ProfileNotify implements NotifyPropertyChanged
         return $this->profileId;
     }
 
-    public function setFirstName($firstName)
+    public function setFirstName($firstName): void
     {
         $this->propertyChanged('firstName', $this->firstName, $firstName);
         $this->firstName = $firstName;
@@ -63,7 +63,7 @@ class ProfileNotify implements NotifyPropertyChanged
         return $this->firstName;
     }
 
-    public function setLastName($lastName)
+    public function setLastName($lastName): void
     {
         $this->propertyChanged('lastName', $this->lastName, $lastName);
         $this->lastName = $lastName;
@@ -74,7 +74,7 @@ class ProfileNotify implements NotifyPropertyChanged
         return $this->lastName;
     }
 
-    public function setImage(File $image)
+    public function setImage(File $image): void
     {
         $this->propertyChanged('image', $this->image, $image);
         $this->image = $image;
@@ -85,7 +85,7 @@ class ProfileNotify implements NotifyPropertyChanged
         return $this->image;
     }
 
-    public function getImages()
+    public function getImages(): ProfileNotifyImagesCollection
     {
         return $this->images;
     }
@@ -93,7 +93,7 @@ class ProfileNotify implements NotifyPropertyChanged
 
 class ProfileNotifyImagesCollection extends ArrayCollection
 {
-    public function move($i, $j)
+    public function move($i, $j): void
     {
         $tmp = $this->get($i);
         $this->set($i, $this->get($j));

--- a/tests/Documents/Project.php
+++ b/tests/Documents/Project.php
@@ -19,7 +19,11 @@ class Project
     /** @ODM\Id */
     private $id;
 
-    /** @ODM\Field(type="string") */
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @var string|null
+     */
     private $name;
 
     /**
@@ -50,22 +54,22 @@ class Project
         return $this->id;
     }
 
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
 
-    public function setAddress(Address $address)
+    public function setAddress(Address $address): void
     {
         $this->address = $address;
     }
 
-    public function getAddress()
+    public function getAddress(): ?Address
     {
         return $this->address;
     }
@@ -73,7 +77,7 @@ class Project
     /**
      * @param Collection<int, SubProject> $subProjects
      */
-    public function setSubProjects(Collection $subProjects)
+    public function setSubProjects(Collection $subProjects): void
     {
         $this->subProjects = $subProjects;
     }

--- a/tests/Documents/ReferenceUser.php
+++ b/tests/Documents/ReferenceUser.php
@@ -190,10 +190,7 @@ class ReferenceUser
         return $this->referencedUsers;
     }
 
-    /**
-     * @param string $name
-     */
-    public function setName($name)
+    public function setName(string $name)
     {
         $this->name = $name;
     }

--- a/tests/Documents/ReferenceUser.php
+++ b/tests/Documents/ReferenceUser.php
@@ -86,20 +86,17 @@ class ReferenceUser
      */
     public $name;
 
-    public function setUser(User $user)
+    public function setUser(User $user): void
     {
         $this->user = $user;
     }
 
-    /**
-     * @return User
-     */
-    public function getUser()
+    public function getUser(): User
     {
         return $this->user;
     }
 
-    public function addUser(User $user)
+    public function addUser(User $user): void
     {
         $this->users[] = $user;
     }
@@ -112,20 +109,17 @@ class ReferenceUser
         return $this->users;
     }
 
-    public function setParentUser(User $parentUser)
+    public function setParentUser(User $parentUser): void
     {
         $this->parentUser = $parentUser;
     }
 
-    /**
-     * @return User
-     */
-    public function getParentUser()
+    public function getParentUser(): User
     {
         return $this->parentUser;
     }
 
-    public function addParentUser(User $parentUser)
+    public function addParentUser(User $parentUser): void
     {
         $this->parentUsers[] = $parentUser;
     }
@@ -138,20 +132,17 @@ class ReferenceUser
         return $this->parentUsers;
     }
 
-    public function setOtherUser(User $otherUser)
+    public function setOtherUser(User $otherUser): void
     {
         $this->otherUser = $otherUser;
     }
 
-    /**
-     * @return User
-     */
-    public function getOtherUser()
+    public function getOtherUser(): User
     {
         return $this->otherUser;
     }
 
-    public function addOtherUser(User $otherUser)
+    public function addOtherUser(User $otherUser): void
     {
         $this->otherUsers[] = $otherUser;
     }
@@ -164,20 +155,17 @@ class ReferenceUser
         return $this->otherUsers;
     }
 
-    public function setReferencedUser(User $referencedUser)
+    public function setReferencedUser(User $referencedUser): void
     {
         $this->referencedUser = $referencedUser;
     }
 
-    /**
-     * @return User
-     */
-    public function getreferencedUser()
+    public function getreferencedUser(): User
     {
         return $this->referencedUser;
     }
 
-    public function addReferencedUser(User $referencedUser)
+    public function addReferencedUser(User $referencedUser): void
     {
         $this->referencedUsers[] = $referencedUser;
     }
@@ -190,7 +178,7 @@ class ReferenceUser
         return $this->referencedUsers;
     }
 
-    public function setName(string $name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }

--- a/tests/Documents/SimpleReferenceUser.php
+++ b/tests/Documents/SimpleReferenceUser.php
@@ -23,7 +23,7 @@ class SimpleReferenceUser
     /** @ODM\Field(type="string") */
     public $name;
 
-    public function setUser(User $user)
+    public function setUser(User $user): void
     {
         $this->user = $user;
     }
@@ -33,7 +33,7 @@ class SimpleReferenceUser
         return $this->user;
     }
 
-    public function addUser(User $user)
+    public function addUser(User $user): void
     {
         $this->users[] = $user;
     }
@@ -43,7 +43,7 @@ class SimpleReferenceUser
         return $this->users;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Documents/Song.php
+++ b/tests/Documents/Song.php
@@ -17,7 +17,7 @@ class Song
         $this->name = $name;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Documents/SpecialUser.php
+++ b/tests/Documents/SpecialUser.php
@@ -12,12 +12,12 @@ class SpecialUser extends User
     /** @ODM\Field(type="collection") */
     private $rules = [];
 
-    public function setRules(array $rules)
+    public function setRules(array $rules): void
     {
         $this->rules = $rules;
     }
 
-    public function getRules()
+    public function getRules(): array
     {
         return $this->rules;
     }

--- a/tests/Documents/SubProject.php
+++ b/tests/Documents/SubProject.php
@@ -20,7 +20,7 @@ class SubProject extends Project
     /**
      * @return Collection<int, Issue>
      */
-    public function getIssues()
+    public function getIssues(): Collection
     {
         return $this->issues;
     }
@@ -28,7 +28,7 @@ class SubProject extends Project
     /**
      * @param Collection<int, Issue> $issues
      */
-    public function setIssues(Collection $issues)
+    public function setIssues(Collection $issues): void
     {
         $this->issues = $issues;
     }

--- a/tests/Documents/Tag.php
+++ b/tests/Documents/Tag.php
@@ -23,7 +23,7 @@ class Tag
         $this->name = $name;
     }
 
-    public function addBlogPost(BlogPost $blogPost)
+    public function addBlogPost(BlogPost $blogPost): void
     {
         $this->blogPosts[] = $blogPost;
     }

--- a/tests/Documents/Task.php
+++ b/tests/Documents/Task.php
@@ -25,7 +25,7 @@ class Task
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/tests/Documents/Tournament/Participant.php
+++ b/tests/Documents/Tournament/Participant.php
@@ -32,7 +32,7 @@ class Participant
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -42,7 +42,7 @@ class Participant
         return $this->name;
     }
 
-    public function setTournament(Tournament $tournament)
+    public function setTournament(Tournament $tournament): void
     {
         $this->tournament = $tournament;
     }

--- a/tests/Documents/Tournament/Tournament.php
+++ b/tests/Documents/Tournament/Tournament.php
@@ -32,7 +32,7 @@ class Tournament
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -42,7 +42,7 @@ class Tournament
         return $this->name;
     }
 
-    public function addParticipant(Participant $participant)
+    public function addParticipant(Participant $participant): void
     {
         $this->participants[] = $participant;
         $participant->setTournament($this);

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -6,6 +6,7 @@ namespace Documents;
 
 use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 use function bcadd;
@@ -119,22 +120,22 @@ class User extends BaseDocument
         $this->createdAt        = new DateTime();
     }
 
-    public function setId($id)
+    public function setId($id): void
     {
         $this->id = $id;
     }
 
-    public function getLogs()
+    public function getLogs(): array
     {
         return $this->logs;
     }
 
-    public function setLogs($logs)
+    public function setLogs($logs): void
     {
         $this->logs = $logs;
     }
 
-    public function log($log)
+    public function log($log): void
     {
         $this->logs[] = $log;
     }
@@ -144,7 +145,7 @@ class User extends BaseDocument
         return $this->id;
     }
 
-    public function setUsername($username)
+    public function setUsername($username): void
     {
         $this->username = $username;
     }
@@ -154,7 +155,7 @@ class User extends BaseDocument
         return $this->username;
     }
 
-    public function setPassword($password)
+    public function setPassword($password): void
     {
         $this->password = $password;
     }
@@ -164,12 +165,12 @@ class User extends BaseDocument
         return $this->password;
     }
 
-    public function setCreatedAt($createdAt)
+    public function setCreatedAt($createdAt): void
     {
         $this->createdAt = $createdAt;
     }
 
-    public function getCreatedAt()
+    public function getCreatedAt(): DateTime
     {
         return $this->createdAt;
     }
@@ -179,17 +180,17 @@ class User extends BaseDocument
         return $this->address;
     }
 
-    public function setAddress(?Address $address = null)
+    public function setAddress(?Address $address = null): void
     {
         $this->address = $address;
     }
 
-    public function removeAddress()
+    public function removeAddress(): void
     {
         $this->address = null;
     }
 
-    public function setProfile(Profile $profile)
+    public function setProfile(Profile $profile): void
     {
         $this->profile = $profile;
     }
@@ -199,7 +200,7 @@ class User extends BaseDocument
         return $this->profile;
     }
 
-    public function setProfileNotify(ProfileNotify $profile)
+    public function setProfileNotify(ProfileNotify $profile): void
     {
         $this->profileNotify = $profile;
     }
@@ -209,7 +210,7 @@ class User extends BaseDocument
         return $this->profileNotify;
     }
 
-    public function setAccount(Account $account)
+    public function setAccount(Account $account): void
     {
         $this->account = $account;
         $this->account->setUser($this);
@@ -220,7 +221,7 @@ class User extends BaseDocument
         return $this->account;
     }
 
-    public function setAccountSimple(Account $account)
+    public function setAccountSimple(Account $account): void
     {
         $this->accountSimple = $account;
         $this->accountSimple->setUser($this);
@@ -231,22 +232,22 @@ class User extends BaseDocument
         return $this->accountSimple;
     }
 
-    public function getPhonenumbers()
+    public function getPhonenumbers(): Collection
     {
         return $this->phonenumbers;
     }
 
-    public function addPhonenumber(Phonenumber $phonenumber)
+    public function addPhonenumber(Phonenumber $phonenumber): void
     {
         $this->phonenumbers[] = $phonenumber;
     }
 
-    public function getSortedAscGroups()
+    public function getSortedAscGroups(): Collection
     {
         return $this->sortedAscGroups;
     }
 
-    public function getSortedDescGroups()
+    public function getSortedDescGroups(): Collection
     {
         return $this->sortedDescGroups;
     }
@@ -256,17 +257,17 @@ class User extends BaseDocument
         return $this->groups;
     }
 
-    public function setGroups($groups)
+    public function setGroups($groups): void
     {
         $this->groups = $groups;
     }
 
-    public function addGroup(Group $group)
+    public function addGroup(Group $group): void
     {
         $this->groups[] = $group;
     }
 
-    public function removeGroup($name)
+    public function removeGroup($name): bool
     {
         foreach ($this->groups as $key => $group) {
             if ($group->getName() === $name) {
@@ -279,7 +280,7 @@ class User extends BaseDocument
         return false;
     }
 
-    public function addGroupSimple(Group $group)
+    public function addGroupSimple(Group $group): void
     {
         $this->groupsSimple[] = $group;
     }
@@ -289,22 +290,22 @@ class User extends BaseDocument
         return $this->uniqueGroups;
     }
 
-    public function setUniqueGroups($groups)
+    public function setUniqueGroups($groups): void
     {
         $this->uniqueGroups = $groups;
     }
 
-    public function addUniqueGroup(Group $group)
+    public function addUniqueGroup(Group $group): void
     {
         $this->uniqueGroups[] = $group;
     }
 
-    public function getHits()
+    public function getHits(): int
     {
         return $this->hits;
     }
 
-    public function setHits($hits)
+    public function setHits($hits): void
     {
         $this->hits = $hits;
     }
@@ -314,7 +315,7 @@ class User extends BaseDocument
         return $this->count;
     }
 
-    public function setCount($count)
+    public function setCount($count): void
     {
         $this->count = $count;
     }
@@ -324,7 +325,7 @@ class User extends BaseDocument
         return $this->floatCount;
     }
 
-    public function setFloatCount($floatCount)
+    public function setFloatCount($floatCount): void
     {
         $this->floatCount = $floatCount;
     }
@@ -334,7 +335,7 @@ class User extends BaseDocument
         return $this->decimal128Count;
     }
 
-    public function setDecimal128Count($decimal128Count)
+    public function setDecimal128Count($decimal128Count): void
     {
         $this->decimal128Count = $decimal128Count;
     }
@@ -349,7 +350,7 @@ class User extends BaseDocument
         return $this->simpleReferenceManyInverse;
     }
 
-    public function incrementCount($num = null)
+    public function incrementCount($num = null): void
     {
         if ($num === null) {
             $this->count++;
@@ -358,7 +359,7 @@ class User extends BaseDocument
         }
     }
 
-    public function incrementFloatCount($num = null)
+    public function incrementFloatCount($num = null): void
     {
         if ($num === null) {
             $this->floatCount++;
@@ -367,22 +368,22 @@ class User extends BaseDocument
         }
     }
 
-    public function incrementDecimal128Count($num = null)
+    public function incrementDecimal128Count($num = null): void
     {
         $this->decimal128Count = bcadd($this->decimal128Count, $num ?? '1');
     }
 
-    public function setPosts($posts)
+    public function setPosts($posts): void
     {
         $this->posts = $posts;
     }
 
-    public function addPost(BlogPost $post)
+    public function addPost(BlogPost $post): void
     {
         $this->posts[] = $post;
     }
 
-    public function removePost($id)
+    public function removePost($id): bool
     {
         foreach ($this->posts as $key => $post) {
             if ($post->getId() === $id) {
@@ -395,27 +396,27 @@ class User extends BaseDocument
         return false;
     }
 
-    public function getPosts()
+    public function getPosts(): Collection
     {
         return $this->posts;
     }
 
-    public function setPhonenumbers($phonenumbers)
+    public function setPhonenumbers($phonenumbers): void
     {
         $this->phonenumbers = $phonenumbers;
     }
 
-    public function addPhonebook(Phonebook $phonebook)
+    public function addPhonebook(Phonebook $phonebook): void
     {
         $this->phonebooks->add($phonebook);
     }
 
-    public function getPhonebooks()
+    public function getPhonebooks(): Collection
     {
         return $this->phonebooks;
     }
 
-    public function removePhonebook(Phonebook $phonebook)
+    public function removePhonebook(Phonebook $phonebook): void
     {
         $this->phonebooks->removeElement($phonebook);
     }

--- a/tests/Documents/VersionedUser.php
+++ b/tests/Documents/VersionedUser.php
@@ -20,7 +20,7 @@ class VersionedUser extends User
         return $this->version;
     }
 
-    public function setVersion($version)
+    public function setVersion($version): void
     {
         $this->version = $version;
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | task
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->
Adds return types (thanks to phpstorm and [psalter](https://psalm.dev/docs/manipulating_code/fixing/)). There are some other things that can be improved based on phpstorm findings, but these changes are enough 😬 .

I wanted to add just simple return types, so I've used phpstorm first because psalter was adding also some specific types for data providers in tests and then use psalter for the ones that phpstorm didn't caught and some manual changes.

I've removed `Group::expression` and `Group::field` (found because psalter was trying to add `return static`):

https://github.com/doctrine/mongodb-odm/blob/4d34a81cd99caea8b99a6df15cb2e47f4d43e803/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Group.php#L76-L101

Since they are in `Operator`:

https://github.com/doctrine/mongodb-odm/blob/4d34a81cd99caea8b99a6df15cb2e47f4d43e803/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Operator.php#L394-L419

