### PR TITLE
#2339 - Cannot assign string to property of type MongoDB\BSON\ObjectIdInterface

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
-use Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH2339Test\EmbeddedDocument;
+use Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH2339Test\InlinedDocument;
 use Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH2339Test\ParentDocument;
 
 use function phpversion;
@@ -24,10 +24,10 @@ class GH2339Test extends BaseTest
 
     public function testObjectIdInterfaceInEmbeddedDocuments()
     {
-        $parent   = new ParentDocument();
-        $embedded = new EmbeddedDocument();
+        $parent  = new ParentDocument();
+        $inlined = new InlinedDocument();
 
-        $parent->addEmbedded($embedded);
+        $parent->addInlined($inlined);
 
         $this->dm->persist($parent);
         $this->dm->flush();
@@ -36,7 +36,7 @@ class GH2339Test extends BaseTest
 
         $this->assertEquals($parent->getId(), $document->getId());
         $this->assertNotEmpty($document->getEmbedded());
-        $this->assertInstanceOf(EmbeddedDocument::class, $document->getEmbedded()[0]);
-        $this->assertEquals($embedded->getId(), $document->getEmbedded()[0]->getId());
+        $this->assertInstanceOf(InlinedDocument::class, $document->getEmbedded()[0]);
+        $this->assertEquals($inlined->getId(), $document->getEmbedded()[0]->getId());
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test.php
@@ -13,6 +13,15 @@ use function version_compare;
 
 class GH2339Test extends BaseTest
 {
+    public function setUp(): void
+    {
+        if (version_compare((string) phpversion(), '7.4', '<')) {
+            self::markTestSkipped('PHP 7.4 or higher is required to run this test');
+        }
+
+        parent::setUp();
+    }
+
     public function testObjectIdInterfaceInEmbeddedDocuments()
     {
         $parent  = new ParentDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test.php
@@ -13,15 +13,6 @@ use function version_compare;
 
 class GH2339Test extends BaseTest
 {
-    public function setUp(): void
-    {
-        if (version_compare((string) phpversion(), '8.0', '<')) {
-            self::markTestSkipped('PHP 8.0 is required to run this test');
-        }
-
-        parent::setUp();
-    }
-
     public function testObjectIdInterfaceInEmbeddedDocuments()
     {
         $parent  = new ParentDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+use MongoDB\BSON\ObjectIdInterface;
+use function phpversion;
+use function version_compare;
+
+class GH2339Test extends BaseTest
+{
+    public function setUp(): void
+    {
+        if (version_compare((string) phpversion(), '8.0', '<')) {
+            self::markTestSkipped('PHP 8.0 is required to run this test');
+        }
+
+        parent::setUp();
+    }
+
+    public function testObjectIdInterfaceInEmbeddedDocuments()
+    {
+        $parent = new ParentDocument();
+        $embedded = new EmbeddedDocument();
+
+        $parent->addEmbedded($embedded);
+
+        $this->dm->persist($parent);
+        $this->dm->flush();
+
+        $document = $this->dm->find(ParentDocument::class, $parent->getId());
+
+        $this->assertEquals($parent->getId(), $document->getId());
+        $this->assertNotEmpty($document->getEmbedded());
+        $this->assertInstanceOf(EmbeddedDocument::class, $document->getEmbedded()[0]);
+        $this->assertEquals($embedded->getId(), $document->getEmbedded()[0]->getId());
+    }
+}
+
+
+/**
+ * @ODM\Document
+ */
+class ParentDocument
+{
+    /**
+     * @ODM\Id
+     */
+    protected ObjectIdInterface $id;
+
+    /**
+     * @var EmbeddedDocument[]
+     *
+     * @ODM\EmbedMany(targetDocument=EmbeddedDocument::class)
+     */
+    protected array $embedded = [];
+
+    public function getId(): ObjectIdInterface
+    {
+        return $this->id;
+    }
+
+    public function addEmbedded(EmbeddedDocument $document)
+    {
+        $this->embedded[] = $document;
+    }
+
+    public function getEmbedded(): array
+    {
+        return $this->getEmbedded();
+    }
+}
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class EmbeddedDocument
+{
+    /**
+     * @ODM\Id
+     */
+    protected ObjectIdInterface $id;
+
+    public function getId(): ObjectIdInterface
+    {
+        return $this->id;
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH2339Test\EmbeddedDocument;
 use Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH2339Test\ParentDocument;
+
 use function phpversion;
 use function version_compare;
 
@@ -23,7 +24,7 @@ class GH2339Test extends BaseTest
 
     public function testObjectIdInterfaceInEmbeddedDocuments()
     {
-        $parent = new ParentDocument();
+        $parent   = new ParentDocument();
         $embedded = new EmbeddedDocument();
 
         $parent->addEmbedded($embedded);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
-use MongoDB\BSON\ObjectIdInterface;
+use Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH2339Test\EmbeddedDocument;
+use Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH2339Test\ParentDocument;
 use function phpversion;
 use function version_compare;
 
@@ -37,55 +37,5 @@ class GH2339Test extends BaseTest
         $this->assertNotEmpty($document->getEmbedded());
         $this->assertInstanceOf(EmbeddedDocument::class, $document->getEmbedded()[0]);
         $this->assertEquals($embedded->getId(), $document->getEmbedded()[0]->getId());
-    }
-}
-
-
-/**
- * @ODM\Document
- */
-class ParentDocument
-{
-    /**
-     * @ODM\Id
-     */
-    protected ObjectIdInterface $id;
-
-    /**
-     * @var EmbeddedDocument[]
-     *
-     * @ODM\EmbedMany(targetDocument=EmbeddedDocument::class)
-     */
-    protected array $embedded = [];
-
-    public function getId(): ObjectIdInterface
-    {
-        return $this->id;
-    }
-
-    public function addEmbedded(EmbeddedDocument $document)
-    {
-        $this->embedded[] = $document;
-    }
-
-    public function getEmbedded(): array
-    {
-        return $this->getEmbedded();
-    }
-}
-
-/**
- * @ODM\EmbeddedDocument
- */
-class EmbeddedDocument
-{
-    /**
-     * @ODM\Id
-     */
-    protected ObjectIdInterface $id;
-
-    public function getId(): ObjectIdInterface
-    {
-        return $this->id;
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use MongoDB\BSON\ObjectIdInterface;
 use function phpversion;
 use function version_compare;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test/EmbeddedDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test/EmbeddedDocument.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH2339Test;
+
+use MongoDB\BSON\ObjectIdInterface;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
+class EmbeddedDocument
+{
+    /**
+     * @ODM\Id
+     */
+    protected ObjectIdInterface $id;
+
+    public function getId(): ObjectIdInterface
+    {
+        return $this->id;
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test/EmbeddedDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test/EmbeddedDocument.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH2339Test;
 
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use MongoDB\BSON\ObjectIdInterface;
 
 /**
@@ -9,9 +12,7 @@ use MongoDB\BSON\ObjectIdInterface;
  */
 class EmbeddedDocument
 {
-    /**
-     * @ODM\Id
-     */
+    /** @ODM\Id */
     protected ObjectIdInterface $id;
 
     public function getId(): ObjectIdInterface

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test/InlinedDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test/InlinedDocument.php
@@ -10,7 +10,7 @@ use MongoDB\BSON\ObjectIdInterface;
 /**
  * @ODM\EmbeddedDocument
  */
-class EmbeddedDocument
+class InlinedDocument
 {
     /** @ODM\Id */
     protected ObjectIdInterface $id;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test/ParentDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test/ParentDocument.php
@@ -1,8 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH2339Test;
 
-use Doctrine\ODM\MongoDB\Tests\Functional\Ticket\EmbeddedDocument;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use MongoDB\BSON\ObjectIdInterface;
 
 /**
@@ -10,15 +12,13 @@ use MongoDB\BSON\ObjectIdInterface;
  */
 class ParentDocument
 {
-    /**
-     * @ODM\Id
-     */
+    /** @ODM\Id */
     protected ObjectIdInterface $id;
 
     /**
-     * @var EmbeddedDocument[]
-     *
      * @ODM\EmbedMany(targetDocument=EmbeddedDocument::class)
+     *
+     * @var EmbeddedDocument[]
      */
     protected array $embedded = [];
 
@@ -34,6 +34,6 @@ class ParentDocument
 
     public function getEmbedded(): array
     {
-        return $this->getEmbedded();
+        return $this->embedded;
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test/ParentDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test/ParentDocument.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH2339Test;
+
+use Doctrine\ODM\MongoDB\Tests\Functional\Ticket\EmbeddedDocument;
+use MongoDB\BSON\ObjectIdInterface;
+
+/**
+ * @ODM\Document
+ */
+class ParentDocument
+{
+    /**
+     * @ODM\Id
+     */
+    protected ObjectIdInterface $id;
+
+    /**
+     * @var EmbeddedDocument[]
+     *
+     * @ODM\EmbedMany(targetDocument=EmbeddedDocument::class)
+     */
+    protected array $embedded = [];
+
+    public function getId(): ObjectIdInterface
+    {
+        return $this->id;
+    }
+
+    public function addEmbedded(EmbeddedDocument $document)
+    {
+        $this->embedded[] = $document;
+    }
+
+    public function getEmbedded(): array
+    {
+        return $this->getEmbedded();
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test/ParentDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2339Test/ParentDocument.php
@@ -16,24 +16,24 @@ class ParentDocument
     protected ObjectIdInterface $id;
 
     /**
-     * @ODM\EmbedMany(targetDocument=EmbeddedDocument::class)
+     * @ODM\EmbedMany(targetDocument=InlinedDocument::class)
      *
-     * @var EmbeddedDocument[]
+     * @var InlinedDocument[]
      */
-    protected array $embedded = [];
+    protected array $inlined = [];
 
     public function getId(): ObjectIdInterface
     {
         return $this->id;
     }
 
-    public function addEmbedded(EmbeddedDocument $document)
+    public function addInlined(InlinedDocument $document)
     {
-        $this->embedded[] = $document;
+        $this->inlined[] = $document;
     }
 
-    public function getEmbedded(): array
+    public function getInlined(): array
     {
-        return $this->embedded;
+        return $this->inlined;
     }
 }


### PR DESCRIPTION
https://github.com/doctrine/mongodb-odm/issues/2339

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Issue |  2339

#### Summary

Added test for a problem "Cannot assign string to property of type MongoDB\BSON\ObjectIdInterface"
