### PR TITLE
Ignore phpstan error

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -233,3 +233,9 @@ parameters:
             message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\UnitOfWork\\:\\:getById\\(\\) should return T of object but returns object\\.$#"
             count: 1
             path: lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+
+        # That statement is never reached because DateTimeInterface is either DateTimeImmutable or DateTime
+        -
+            message: "#^Unreachable statement \\- code above always terminates\\.$#"
+            count: 1
+            path: lib/Doctrine/ODM/MongoDB/Types/DateImmutableType.php


### PR DESCRIPTION
It appeared in https://github.com/doctrine/mongodb-odm/pull/2344/checks?check_run_id=3141873310

https://github.com/doctrine/mongodb-odm/blob/e2c6dc41b8b52441eb69d0d79697f3fcc435561e/lib/Doctrine/ODM/MongoDB/Types/DateImmutableType.php#L20-L37

`parent::getDateTime($value);` returns a `DateTimeInterface`, since we are checking against `DateTimeImmutable` and `DateTime` and those are the only implementations of `DateTimeInterface`, phpstan reports the `throw new RuntimeException` as unreachable.

