### PR TITLE
add @QueryResultDocument annotation reference

### DIFF
--- a/docs/en/reference/aggregation-builder.rst
+++ b/docs/en/reference/aggregation-builder.rst
@@ -114,6 +114,8 @@ aggregation pipeline and return a cursor for you to iterate over the results:
 If you instead want to look at the built aggregation pipeline, call the
 ``Builder::getPipeline()`` method.
 
+.. _aggregation_builder_hydration:
+
 Hydration
 ~~~~~~~~~
 
@@ -275,7 +277,7 @@ You can also pass expressions as arrays:
 This allows usage of any expression operators introduced by MongoDB, even
 if Doctrine ODM does not yet wrap it with convenience methods.
 
-You can see all available expression operators at MongoDB documentation 
+You can see all available expression operators at MongoDB documentation
 `here <https://docs.mongodb.com/manual/reference/operator/aggregation/>`_.
 
 $bucket

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -1266,7 +1266,7 @@ These documents can use all features regular documents can use but they will not
     $builder
         ->hydrate(\Documents\CompanyTransactions::class)
         ->group()
-            ->field('id')
+            ->field('_id')
             ->expression('$company')
             ->field('totalAmount')
             ->sum('$amount');

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -1240,6 +1240,39 @@ the method to be registered.
 
 See :ref:`lifecycle_events` for more information.
 
+@QueryResultDocument
+--------------------
+
+Marks the document as query result document used when hydrating the aggregation query results.
+These documents can use all features regular documents can use but they will not be persisted to the database.
+
+.. code-block:: php
+
+    <?php
+
+    namespace Documents;
+
+    /** @QueryResultDocument */
+    class CompanyTransactions
+    {
+        /** @ReferenceOne(targetDocument=Company::class, name="_id") */
+        private $company;
+
+        /** @Field(type="float") */
+        private $totalAmount;
+    }
+
+    $builder = $dm->createAggregationBuilder(\Documents\Transaction::class);
+    $builder
+        ->hydrate(\Documents\CompanyTransactions::class)
+        ->group()
+            ->field('id')
+            ->expression('$company')
+            ->field('totalAmount')
+            ->sum('$amount');
+
+See :ref:`aggregation_builder_hydration` for more information.
+
 @ReadPreference
 ---------------
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

The `@QueryResultDocument` was missing from the Annotation Reference doc page. It has been documented on Aggregation Builder page only. Targeting `1.3.x` branch because it seems as oldest supported version.

BTW the Annotation Reference page seems to be missing from the sidebar in v2.2.x, even though it's defined in `sidebar.rst` file 🤔 .
