### PR TITLE
Fix missing hint query option during find

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -424,7 +424,7 @@ final class Query implements IteratorAggregate
 
         switch ($this->query['type']) {
             case self::TYPE_FIND:
-                $queryOptions = $this->getQueryOptions('select', 'sort', 'skip', 'limit', 'readPreference');
+                $queryOptions = $this->getQueryOptions('select', 'sort', 'skip', 'limit', 'readPreference', 'hint');
                 $queryOptions = $this->renameQueryOptions($queryOptions, ['select' => 'projection']);
 
                 $cursor = $this->collection->find(

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -321,6 +321,18 @@ class BuilderTest extends BaseTest
         $this->assertEquals($expected, $qb->getQueryArray());
     }
 
+    public function testFindWithHint(): void
+    {
+        $qb = $this->getTestQueryBuilder()
+            ->find(User::class)
+            ->hint('foo');
+
+        $expected = 'foo';
+
+        $this->assertEquals($expected, $qb->debug('hint'));
+        $this->assertEquals($expected, $qb->getQuery()->debug('hint'));
+    }
+
     public function testUpsertUpdateQuery()
     {
         $qb = $this->getTestQueryBuilder()

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -490,6 +490,30 @@ class QueryTest extends BaseTest
         $this->assertSame(100, $query->execute());
     }
 
+    public function testFindWithHint(): void
+    {
+        $cursor = $this->createMock(Traversable::class);
+
+        $collection = $this->getMockCollection();
+        $collection->expects($this->once())
+            ->method('find')
+            ->with(['foo' => 'bar'], ['hint' => 'foo'])
+            ->will($this->returnValue($cursor));
+
+        // Using QueryBuilder->find adds hint to the query array
+        $queryArray = [
+            'type' => Query::TYPE_FIND,
+            'query' => ['foo' => 'bar'],
+            'hint' => 'foo',
+        ];
+
+        $query = new Query($this->dm, new ClassMetadata(User::class), $collection, $queryArray, []);
+
+        /* Do not expect the same object returned by Collection::find(), since
+         * Query::makeIterator() wraps the return value with CachingIterator. */
+        $this->assertInstanceOf(Traversable::class, $query->execute());
+    }
+
     public function testFindOptionInheritance()
     {
         $nearest            = new ReadPreference('nearest');


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixes | #2346

#### Summary
This PR fixes the missing `hint` query option during a `find` query.

I added two tests: one to make sure the hint gets correctly propagated from the query array to the find method, and one to make sure the hint is correctly carried from the query builder to the query.

