### PR TITLE
allow to reset hydration setting for Aggregation

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -341,7 +341,7 @@ class Builder
     /**
      * Set which class to use when hydrating results as document class instances.
      */
-    public function hydrate(string $className): self
+    public function hydrate(?string $className): self
     {
         $this->hydrationClass = $className;
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

This change allows to reset the `hydrationClass` option back to `null` in Aggregation Builder.
It might be useful when cloning the builder and manipulating the stages later.
