### PR TITLE
flip attribute driver constructor arguments

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -340,11 +340,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
      */
     public static function create($paths = [], ?Reader $reader = null): AnnotationDriver
     {
-        if ($reader === null) {
-            $reader = new AnnotationReader();
-        }
-
-        return new self($reader, $paths);
+        return new self($reader ?? new AnnotationReader(), $paths);
     }
 }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
@@ -12,6 +12,14 @@ use Doctrine\Common\Annotations\Reader;
 class AttributeDriver extends AnnotationDriver
 {
     /**
+     * @param string|string[]|null $paths
+     */
+    public function __construct($paths = null, ?Reader $reader = null)
+    {
+        parent::__construct($reader ?? new AttributeReader(), $paths);
+    }
+
+    /**
      * Factory method for the Attribute Driver
      *
      * @param string[]|string $paths
@@ -20,10 +28,6 @@ class AttributeDriver extends AnnotationDriver
      */
     public static function create($paths = [], ?Reader $reader = null): AnnotationDriver
     {
-        if ($reader === null) {
-            $reader = new AttributeReader();
-        }
-
-        return new self($reader, $paths);
+        return new self($paths, $reader);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AttributeDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AttributeDriverTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
 use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
-use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeReader;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 
 /**
@@ -15,8 +14,6 @@ class AttributeDriverTest extends AbstractAnnotationDriverTest
 {
     protected function loadDriver(): MappingDriver
     {
-        $reader = new AttributeReader();
-
-        return new AttributeDriver($reader);
+        return new AttributeDriver();
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

Because `AbstractDoctrineExtension` expects the `AttributeDriver` constructor to accept `$paths` as first argument, while `AnnotationDriver` expects `Reader` to be passed there, we need to shift the argument order to make it compatible.
https://github.com/symfony/symfony/blob/1d196159fde010590b857059b5219922031c284b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php#L209-L212

While ORM's `AttributeDriver` simply skips that argument and does not allow to customize the reader, I decided to simply shift the argument order to maintain the compatibility with `AbstractDoctrineExtension` and allow to customize the reader.
