### PR TITLE
use @requires annotations to skip tests on older PHP versions

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2310Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2310Test.php
@@ -9,20 +9,11 @@ use Documents74\GH2310Container;
 use Documents74\GH2310Embedded;
 use MongoDB\BSON\ObjectId;
 
-use function phpversion;
-use function version_compare;
-
+/**
+ * @requires PHP 7.4
+ */
 class GH2310Test extends BaseTest
 {
-    public function setUp(): void
-    {
-        if (version_compare((string) phpversion(), '7.4.0', '<')) {
-            self::markTestSkipped('PHP 7.4 is required to run this test');
-        }
-
-        parent::setUp();
-    }
-
     public function testFindWithNullableEmbeddedAfterUpsert(): void
     {
         $document = new GH2310Container((string) new ObjectId(), null);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TypedPropertiesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TypedPropertiesTest.php
@@ -10,20 +10,12 @@ use Documents74\TypedEmbeddedDocument;
 use MongoDB\BSON\ObjectId;
 
 use function assert;
-use function phpversion;
-use function version_compare;
 
+/**
+ * @requires PHP 7.4
+ */
 class TypedPropertiesTest extends BaseTest
 {
-    public function setUp(): void
-    {
-        if (version_compare((string) phpversion(), '7.4.0', '<')) {
-            $this->markTestSkipped('PHP 7.4 is required to run this test');
-        }
-
-        parent::setUp();
-    }
-
     public function testPersistNew(): void
     {
         $ref       = new TypedDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/DefaultPersistentCollectionGeneratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/DefaultPersistentCollectionGeneratorTest.php
@@ -8,9 +8,6 @@ use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\PersistentCollection\DefaultPersistentCollectionGenerator;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
-use function phpversion;
-use function version_compare;
-
 /**
  * Tests aims to check if classes generated for various PHP versions are correct (i.e. parses).
  */
@@ -49,12 +46,11 @@ class DefaultPersistentCollectionGeneratorTest extends BaseTest
         $this->assertInstanceOf(CollWithNullableReturnType::class, $coll);
     }
 
+    /**
+     * @requires PHP 8.0
+     */
     public function testPHP80Types()
     {
-        if (version_compare((string) phpversion(), '8.0.0', '<')) {
-            $this->markTestSkipped('PHP 8.0 is required to run this test');
-        }
-
         $class = $this->generator->loadClass(CollWithPHP80Types::class, Configuration::AUTOGENERATE_EVAL);
         $coll  = new $class(new CollWithPHP80Types(), $this->dm, $this->uow);
         $this->assertInstanceOf(CollWithPHP80Types::class, $coll);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #2357 

#### Summary

This change simply replaces all PHP version checks with `@requires PHP x.y`.
