### PR TITLE
Add property type hints to functional tests

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -69,12 +69,6 @@
 
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint">
         <exclude-pattern>*/tests/Documents/*</exclude-pattern>
-        <exclude-pattern>*/tests/Doctrine/ODM/MongoDB/Tests/Functional/*</exclude-pattern>
-        <exclude-pattern>*/tools/sandbox/Documents/*</exclude-pattern>
-    </rule>
-
-    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint">
-        <exclude-pattern>*/tests/*</exclude-pattern>
         <exclude-pattern>*/tools/sandbox/Documents/*</exclude-pattern>
     </rule>
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AlsoLoadTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AlsoLoadTest.php
@@ -224,31 +224,53 @@ class AlsoLoadDocument
     /**
      * @ODM\Field(type="string")
      * @ODM\AlsoLoad({"bar", "zip"})
+     *
+     * @var string|null
      */
     public $foo;
 
     /**
      * @ODM\Field(notSaved=true)
      * @ODM\AlsoLoad({"zip", "bar"})
+     *
+     * @var string|null
      */
     public $baz;
 
-    /** @ODM\Field(notSaved=true) */
+    /**
+     * @ODM\Field(notSaved=true)
+     *
+     * @var string|null
+     */
     public $bar;
 
-    /** @ODM\Field(notSaved=true) */
+    /**
+     * @ODM\Field(notSaved=true)
+     *
+     * @var string|null
+     */
     public $zip;
 
     /**
      * @ODM\Field(type="string")
      * @ODM\AlsoLoad("zip")
+     *
+     * @var string|null
      */
     public $zap = 'zap';
 
-    /** @ODM\Field(notSaved=true) */
+    /**
+     * @ODM\Field(notSaved=true)
+     *
+     * @var string|null
+     */
     public $name;
 
-    /** @ODM\Field(notSaved=true) */
+    /**
+     * @ODM\Field(notSaved=true)
+     *
+     * @var string|null
+     */
     public $fullName;
 
     /**
@@ -268,16 +290,30 @@ class AlsoLoadDocument
     /**
      * @ODM\Field(type="string")
      * @ODM\AlsoLoad("testNew")
+     *
+     * @var string|null
      */
     public $test = 'test';
 
-    /** @ODM\Field(notSaved=true) */
+    /**
+     * @ODM\Field(notSaved=true)
+     *
+     * @var string|null
+     */
     public $testNew;
 
-    /** @ODM\Field(notSaved=true) */
+    /**
+     * @ODM\Field(notSaved=true)
+     *
+     * @var string|null
+     */
     public $testOld;
 
-    /** @ODM\Field(notSaved=true) */
+    /**
+     * @ODM\Field(notSaved=true)
+     *
+     * @var string|null
+     */
     public $testOlder;
 
     /** @ODM\AlsoLoad({"name", "fullName"}) */
@@ -288,10 +324,8 @@ class AlsoLoadDocument
 
     /**
      * @ODM\AlsoLoad ({"testOld", "testOlder"})
-     *
-     * @return void
      */
-    public function populateTest($test)
+    public function populateTest(?string $test): void
     {
         $this->test = $test;
     }
@@ -308,17 +342,15 @@ class AlsoLoadChild extends AlsoLoadDocument
     public $fizz;
 
     /** @ODM\AlsoLoad("buzz") */
-    public function populateFizz($fizz): void
+    public function populateFizz(string $fizz): void
     {
         $this->fizz = $fizz;
     }
 
     /**
      * @ODM\AlsoLoad ("testOldest")
-     *
-     * @return void
      */
-    public function populateTest($test)
+    public function populateTest(?string $test): void
     {
         $this->test = $test;
     }
@@ -329,10 +361,8 @@ class AlsoLoadGrandchild extends AlsoLoadChild
 {
     /**
      * @ODM\AlsoLoad ("testReallyOldest")
-     *
-     * @return void
      */
-    public function populateTest($test)
+    public function populateTest(?string $test): void
     {
         $this->test = $test;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
@@ -52,24 +52,52 @@ class BinDataTestUser
      */
     public $id;
 
-    /** @ODM\Field(type="bin") */
+    /**
+     * @ODM\Field(type="bin")
+     *
+     * @var string|null
+     */
     public $bin;
 
-    /** @ODM\Field(type="bin_func") */
+    /**
+     * @ODM\Field(type="bin_func")
+     *
+     * @var string|null
+     */
     public $binFunc;
 
-    /** @ODM\Field(type="bin_bytearray") */
+    /**
+     * @ODM\Field(type="bin_bytearray")
+     *
+     * @var string|null
+     */
     public $binByteArray;
 
-    /** @ODM\Field(type="bin_uuid") */
+    /**
+     * @ODM\Field(type="bin_uuid")
+     *
+     * @var string|null
+     */
     public $binUUID;
 
-    /** @ODM\Field(type="bin_uuid_rfc4122") */
+    /**
+     * @ODM\Field(type="bin_uuid_rfc4122")
+     *
+     * @var string|null
+     */
     public $binUUIDRFC4122;
 
-    /** @ODM\Field(type="bin_md5") */
+    /**
+     * @ODM\Field(type="bin_md5")
+     *
+     * @var string|null
+     */
     public $binMD5;
 
-    /** @ODM\Field(type="bin_custom") */
+    /**
+     * @ODM\Field(type="bin_custom")
+     *
+     * @var string|null
+     */
     public $binCustom;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
@@ -144,8 +144,10 @@ class CommitImprovementTest extends BaseTest
 
 class PhonenumberMachine implements EventSubscriber
 {
+    /** @var string[] */
     private $numbers = ['12345678', '87654321'];
 
+    /** @var int */
     private $numberId = 0;
 
     public function getSubscribedEvents(): array

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
@@ -117,6 +117,10 @@ class Country
      */
     public $id;
 
-    /** @ODM\Field(type="date_collection") */
+    /**
+     * @ODM\Field(type="date_collection")
+     *
+     * @var DateTime[]|DateTime|null
+     */
     public $nationalHolidays;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
@@ -89,12 +90,16 @@ abstract class ParentDocument
      */
     protected $id;
 
+    /** @var ChildDocument|null */
     protected $referencedChild;
 
+    /** @var ChildDocument[] */
     protected $referencedChildren;
 
+    /** @var ChildDocument|null */
     protected $embeddedChild;
 
+    /** @var ChildDocument[]  */
     protected $embeddedChildren;
 
     public function __construct(array $children)
@@ -105,7 +110,7 @@ abstract class ParentDocument
         $this->embeddedChildren   = $children;
     }
 
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
@@ -168,16 +173,32 @@ abstract class ChildDocument
 /** @ODM\Document(collection="discriminator_parent") */
 class ParentDocumentWithoutDiscriminator extends ParentDocument
 {
-    /** @ODM\ReferenceOne(targetDocument=ChildDocumentWithoutDiscriminator::class) */
+    /**
+     * @ODM\ReferenceOne(targetDocument=ChildDocumentWithoutDiscriminator::class)
+     *
+     * @var ChildDocumentWithDiscriminator|null
+     */
     protected $referencedChild;
 
-    /** @ODM\ReferenceMany(targetDocument=ChildDocumentWithoutDiscriminator::class) */
+    /**
+     * @ODM\ReferenceMany(targetDocument=ChildDocumentWithoutDiscriminator::class)
+     *
+     * @var Collection<int, ChildDocumentWithDiscriminator>
+     */
     protected $referencedChildren;
 
-    /** @ODM\EmbedOne(targetDocument=ChildDocumentWithoutDiscriminator::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=ChildDocumentWithoutDiscriminator::class)
+     *
+     * @var ChildDocumentWithoutDiscriminator|null
+     */
     protected $embeddedChild;
 
-    /** @ODM\EmbedMany(targetDocument=ChildDocumentWithoutDiscriminator::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=ChildDocumentWithoutDiscriminator::class)
+     *
+     * @var Collection<int, ChildDocumentWithDiscriminator>
+     */
     protected $embeddedChildren;
 }
 
@@ -190,16 +211,32 @@ class ChildDocumentWithoutDiscriminator extends ChildDocument
 /** @ODM\Document(collection="discriminator_parent") */
 class ParentDocumentWithDiscriminator extends ParentDocument
 {
-    /** @ODM\ReferenceOne(targetDocument=ChildDocumentWithDiscriminator::class) */
+    /**
+     * @ODM\ReferenceOne(targetDocument=ChildDocumentWithDiscriminator::class)
+     *
+     * @var ChildDocumentWithDiscriminator|null
+     */
     protected $referencedChild;
 
-    /** @ODM\ReferenceMany(targetDocument=ChildDocumentWithDiscriminator::class) */
+    /**
+     * @ODM\ReferenceMany(targetDocument=ChildDocumentWithDiscriminator::class)
+     *
+     * @var Collection<int, ChildDocumentWithDiscriminator>
+     */
     protected $referencedChildren;
 
-    /** @ODM\EmbedOne(targetDocument=ChildDocumentWithDiscriminator::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=ChildDocumentWithDiscriminator::class)
+     *
+     * @var ChildDocumentWithDiscriminator|null
+     */
     protected $embeddedChild;
 
-    /** @ODM\EmbedMany(targetDocument=ChildDocumentWithDiscriminator::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=ChildDocumentWithDiscriminator::class)
+     *
+     * @var Collection<int, ChildDocumentWithDiscriminator>
+     */
     protected $embeddedChildren;
 }
 
@@ -225,17 +262,17 @@ class ChildDocumentWithDiscriminatorComplex extends ChildDocumentWithDiscriminat
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     protected $value;
 
-    public function __construct($type, $value)
+    public function __construct(string $type, string $value)
     {
         parent::__construct($type);
         $this->value = $value;
     }
 
-    public function getValue()
+    public function getValue(): string
     {
         return $this->value;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedIdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedIdTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use InvalidArgumentException;
@@ -68,10 +69,18 @@ class EmbeddedIdTestUser
      */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument=DefaultIdEmbeddedDocument::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=DefaultIdEmbeddedDocument::class)
+     *
+     * @var DefaultIdEmbeddedDocument|null
+     */
     public $embedOne;
 
-    /** @ODM\EmbedMany(targetDocument=DefaultIdEmbeddedDocument::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=DefaultIdEmbeddedDocument::class)
+     *
+     * @var Collection<int, DefaultIdEmbeddedDocument>|array<DefaultIdEmbeddedDocument>
+     */
     public $embedMany = [];
 }
 
@@ -85,10 +94,18 @@ class EmbeddedStrategyNoneIdTestUser
      */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument=DefaultIdStrategyNoneEmbeddedDocument::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=DefaultIdStrategyNoneEmbeddedDocument::class)
+     *
+     * @var DefaultIdStrategyNoneEmbeddedDocument|null
+     */
     public $embedOne;
 
-    /** @ODM\EmbedMany(targetDocument=DefaultIdStrategyNoneEmbeddedDocument::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=DefaultIdStrategyNoneEmbeddedDocument::class)
+     *
+     * @var Collection<int, DefaultIdStrategyNoneEmbeddedDocument>|array<DefaultIdStrategyNoneEmbeddedDocument>
+     */
     public $embedMany = [];
 }
 
@@ -106,6 +123,10 @@ class DefaultIdEmbeddedDocument
 /** @ODM\EmbeddedDocument */
 class DefaultIdStrategyNoneEmbeddedDocument
 {
-    /** @ODM\Id(strategy="none") */
+    /**
+     * @ODM\Id(strategy="none")
+     *
+     * @var string|null
+     */
     public $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedReferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedReferenceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
@@ -70,14 +71,18 @@ class Offer
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     public $name;
 
-    /** @ODM\EmbedMany(targetDocument=Link::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=Link::class)
+     *
+     * @var Collection<int, Link>
+     */
     public $links;
 
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name  = $name;
         $this->links = new ArrayCollection();
@@ -97,14 +102,18 @@ class Link
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     public $url;
 
-    /** @ODM\ReferenceMany(targetDocument=ReferencedDocument::class) */
+    /**
+     * @ODM\ReferenceMany(targetDocument=ReferencedDocument::class)
+     *
+     * @var Collection<int, ReferencedDocument>
+     */
     public $referencedDocuments;
 
-    public function __construct($url)
+    public function __construct(string $url)
     {
         $this->url                 = $url;
         $this->referencedDocuments = new ArrayCollection();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use DateTime;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\MongoDBException;
@@ -946,13 +947,18 @@ class ParentAssociationTestA
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     public $name;
-    /** @ODM\EmbedOne */
+
+    /**
+     * @ODM\EmbedOne
+     *
+     * @var object|null
+     */
     public $child;
 
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }
@@ -967,10 +973,14 @@ class ParentAssociationTestB
      * @var string|null
      */
     public $name;
-    /** @ODM\EmbedMany */
+    /**
+     * @ODM\EmbedMany
+     *
+     * @var Collection<int, object>|array<object>
+     */
     public $children = [];
 
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }
@@ -982,11 +992,11 @@ class ParentAssociationTestC
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     public $name;
 
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/HasLifecycleCallbacksTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/HasLifecycleCallbacksTest.php
@@ -117,14 +117,13 @@ abstract class HasLifecycleCallbacksSuper
      */
     public $id;
 
+    /** @var string[] */
     public $invoked = [];
 
     /**
      * @ODM\PrePersist
-     *
-     * @return void
      */
-    public function prePersist()
+    public function prePersist(): void
     {
         $this->invoked[] = 'super';
     }
@@ -140,14 +139,13 @@ abstract class HasLifecycleCallbacksSuperAnnotated
      */
     public $id;
 
+    /** @var string[] */
     public $invoked = [];
 
     /**
      * @ODM\PrePersist
-     *
-     * @return void
      */
-    public function prePersist()
+    public function prePersist(): void
     {
         $this->invoked[] = 'super';
     }
@@ -178,10 +176,8 @@ class HasLifecycleCallbacksSubOverrideExtendsSuper extends HasLifecycleCallbacks
 {
     /**
      * @ODM\PrePersist
-     *
-     * @return void
      */
-    public function prePersist()
+    public function prePersist(): void
     {
         $this->invoked[] = 'sub';
     }
@@ -192,10 +188,8 @@ class HasLifecycleCallbacksSubOverrideExtendsSuperAnnotated extends HasLifecycle
 {
     /**
      * @ODM\PrePersist
-     *
-     * @return void
      */
-    public function prePersist()
+    public function prePersist(): void
     {
         $this->invoked[] = 'sub';
     }
@@ -206,10 +200,8 @@ class HasLifecycleCallbacksSubOverrideAnnotatedExtendsSuper extends HasLifecycle
 {
     /**
      * @ODM\PrePersist
-     *
-     * @return void
      */
-    public function prePersist()
+    public function prePersist(): void
     {
         $this->invoked[] = 'sub';
     }
@@ -220,10 +212,8 @@ class HasLifecycleCallbacksSubOverrideAnnotatedExtendsSuperAnnotated extends Has
 {
     /**
      * @ODM\PrePersist
-     *
-     * @return void
      */
-    public function prePersist()
+    public function prePersist(): void
     {
         $this->invoked[] = 'sub';
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use MongoDB\Driver\Exception\BulkWriteException;
@@ -249,7 +250,12 @@ class UniqueOnFieldTest
      */
     public $id;
 
-    /** @ODM\Field(type="string") @ODM\UniqueIndex() */
+    /**
+     * @ODM\Field(type="string")
+     * @ODM\UniqueIndex()
+     *
+     * @var string|null
+     */
     public $username;
 
     /**
@@ -377,7 +383,12 @@ class UniqueSparseOnFieldTest
      */
     public $id;
 
-    /** @ODM\Field(type="string") @ODM\UniqueIndex(sparse=true) */
+    /**
+     * @ODM\Field(type="string")
+     * @ODM\UniqueIndex(sparse=true)
+     *
+     * @var string|null
+     */
     public $username;
 
     /**
@@ -473,10 +484,20 @@ class MultipleFieldIndexes
      */
     public $id;
 
-    /** @ODM\Field(type="string") @ODM\UniqueIndex(name="test") */
+    /**
+     * @ODM\Field(type="string")
+     * @ODM\UniqueIndex(name="test")
+     *
+     * @var string|null
+     */
     public $username;
 
-    /** @ODM\Field(type="string") @ODM\Index(unique=true) */
+    /**
+     * @ODM\Field(type="string")
+     * @ODM\Index(unique=true)
+     *
+     * @var string|null
+     */
     public $email;
 }
 
@@ -497,10 +518,18 @@ class DocumentWithEmbeddedIndexes
      */
     public $name;
 
-    /** @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithIndexes::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithIndexes::class)
+     *
+     * @var EmbeddedDocumentWithIndexes|null
+     */
     public $embedded;
 
-    /** @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithIndexes::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithIndexes::class)
+     *
+     * @var EmbeddedDocumentWithIndexes|null
+     */
     public $embeddedSecondary;
 }
 
@@ -545,24 +574,43 @@ class DocumentWithMultipleIndexAnnotations
 /** @ODM\EmbeddedDocument */
 class EmbeddedDocumentWithIndexes
 {
-    /** @ODM\Field(type="string") @ODM\Index */
+    /**
+     * @ODM\Field(type="string")
+     * @ODM\Index
+     *
+     * @var string|null
+     */
     public $name;
 
-    /** @ODM\EmbedMany(targetDocument=EmbeddedManyDocumentWithIndexes::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=EmbeddedManyDocumentWithIndexes::class)
+     *
+     * @var Collection<int, EmbeddedManyDocumentWithIndexes>
+     */
     public $embeddedMany;
 }
 
 /** @ODM\EmbeddedDocument */
 class EmbeddedManyDocumentWithIndexes
 {
-    /** @ODM\Field(type="string") @ODM\Index */
+    /**
+     * @ODM\Field(type="string")
+     * @ODM\Index
+     *
+     * @var string|null
+     */
     public $name;
 }
 
 /** @ODM\EmbeddedDocument */
 class YetAnotherEmbeddedDocumentWithIndex
 {
-    /** @ODM\Field(type="string") @ODM\Index */
+    /**
+     * @ODM\Field(type="string")
+     * @ODM\Index
+     *
+     * @var string|null
+     */
     public $value;
 }
 
@@ -582,6 +630,8 @@ class DocumentWithIndexInDiscriminatedEmbeds
      *   "d1"=EmbeddedDocumentWithIndexes::class,
      *   "d2"=YetAnotherEmbeddedDocumentWithIndex::class,
      * })
+     *
+     * @var EmbeddedDocumentWithIndexes|YetAnotherEmbeddedDocumentWithIndex|null
      */
     public $embedded;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/PrimingIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/PrimingIteratorTest.php
@@ -19,6 +19,7 @@ use MongoDB\BSON\ObjectId;
 
 final class PrimingIteratorTest extends BaseTest
 {
+    /** @var class-string[] */
     private $callbackCalls = [];
 
     public function testPrimerIsCalledOnceForEveryField(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
@@ -623,7 +623,11 @@ abstract class AbstractVersionBase
 /** @ODM\Document */
 class LockInt extends AbstractVersionBase
 {
-    /** @ODM\Version @ODM\Field(type="int") */
+    /**
+     * @ODM\Version @ODM\Field(type="int")
+     *
+     * @var int|null
+     */
     public $version;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedCollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedCollectionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
@@ -91,21 +92,45 @@ class DocWithNestedCollections
      */
     public $id;
 
-    /** @ODM\EmbedMany(strategy="atomicSet", targetDocument=Documents\Phonebook::class) */
+    /**
+     * @ODM\EmbedMany(strategy="atomicSet", targetDocument=Documents\Phonebook::class)
+     *
+     * @var Collection<int, Phonebook>
+     */
     public $atomicSet;
 
-    /** @ODM\EmbedMany(strategy="atomicSetArray", targetDocument=Documents\Phonebook::class) */
+    /**
+     * @ODM\EmbedMany(strategy="atomicSetArray", targetDocument=Documents\Phonebook::class)
+     *
+     * @var Collection<int, Phonebook>
+     */
     public $atomicSetArray;
 
-    /** @ODM\EmbedMany(strategy="set", targetDocument=Documents\Phonebook::class) */
+    /**
+     * @ODM\EmbedMany(strategy="set", targetDocument=Documents\Phonebook::class)
+     *
+     * @var Collection<int, Phonebook>
+     */
     public $set;
 
-    /** @ODM\EmbedMany(strategy="setArray", targetDocument=Documents\Phonebook::class) */
+    /**
+     * @ODM\EmbedMany(strategy="setArray", targetDocument=Documents\Phonebook::class)
+     *
+     * @var Collection<int, Phonebook>
+     */
     public $setArray;
 
-    /** @ODM\EmbedMany(strategy="pushAll", targetDocument=Documents\Phonebook::class) */
+    /**
+     * @ODM\EmbedMany(strategy="pushAll", targetDocument=Documents\Phonebook::class)
+     *
+     * @var Collection<int, Phonebook>
+     */
     public $pushAll;
 
-    /** @ODM\EmbedMany(strategy="addToSet", targetDocument=Documents\Phonebook::class) */
+    /**
+     * @ODM\EmbedMany(strategy="addToSet", targetDocument=Documents\Phonebook::class)
+     *
+     * @var Collection<int, Phonebook>
+     */
     public $addToSet;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
@@ -153,29 +153,33 @@ class Hierarchy
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     private $name;
 
-    /** @ODM\ReferenceMany(targetDocument=Hierarchy::class) */
+    /**
+     * @ODM\ReferenceMany(targetDocument=Hierarchy::class)
+     *
+     * @var Collection<int, Hierarchy>|array<Hierarchy>
+     */
     private $children = [];
 
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }
 
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
 
-    public function setName($name): void
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -218,25 +222,29 @@ class BaseCategory
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     protected $name;
 
-    /** @ODM\EmbedMany(targetDocument=ChildCategory::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=ChildCategory::class)
+     *
+     * @var Collection<int, ChildCategory>
+     */
     protected $children;
 
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name     = $name;
         $this->children = new ArrayCollection();
     }
 
-    public function setName($name): void
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -283,7 +291,7 @@ class Category extends BaseCategory
      */
     protected $id;
 
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
@@ -311,7 +319,11 @@ class Order
      */
     public $title;
 
-    /** @ODM\EmbedOne(targetDocument=ProductBackup::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=ProductBackup::class)
+     *
+     * @var ProductBackup|null
+     */
     public $product;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
@@ -310,16 +311,32 @@ class OrphanRemovalUser
      */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument=OrphanRemovalProfile::class, orphanRemoval=true) */
+    /**
+     * @ODM\ReferenceOne(targetDocument=OrphanRemovalProfile::class, orphanRemoval=true)
+     *
+     * @var OrphanRemovalProfile|null
+     */
     public $profile;
 
-    /** @ODM\ReferenceOne(targetDocument=OrphanRemovalProfile::class, orphanRemoval=false) */
+    /**
+     * @ODM\ReferenceOne(targetDocument=OrphanRemovalProfile::class, orphanRemoval=false)
+     *
+     * @var OrphanRemovalProfile|null
+     */
     public $profileNoOrphanRemoval;
 
-    /** @ODM\ReferenceMany(targetDocument=OrphanRemovalProfile::class, orphanRemoval=true) */
+    /**
+     * @ODM\ReferenceMany(targetDocument=OrphanRemovalProfile::class, orphanRemoval=true)
+     *
+     * @var Collection<int, OrphanRemovalProfile>|array<OrphanRemovalProfile>
+     */
     public $profileMany = [];
 
-    /** @ODM\ReferenceMany(targetDocument=OrphanRemovalProfile::class, orphanRemoval=false) */
+    /**
+     * @ODM\ReferenceMany(targetDocument=OrphanRemovalProfile::class, orphanRemoval=false)
+     *
+     * @var Collection<int, OrphanRemovalProfile>|array<OrphanRemovalProfile>
+     */
     public $profileManyNoOrphanRemoval = [];
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionCloneTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionCloneTest.php
@@ -12,7 +12,10 @@ use function get_class;
 
 class PersistentCollectionCloneTest extends BaseTest
 {
+    /** @var CmsUser|null */
     private $user1;
+
+    /** @var CmsUser|null */
     private $user2;
 
     public function setUp(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RawTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RawTypeTest.php
@@ -53,6 +53,10 @@ class RawType
      */
     public $id;
 
-    /** @ODM\Field(type="raw") */
+    /**
+     * @ODM\Field(type="raw")
+     *
+     * @var mixed
+     */
     public $raw;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
@@ -112,6 +112,10 @@ class ReadPreferenceTest extends BaseTest
  */
 class DocumentWithReadPreference
 {
-    /** @ODM\Id() */
+    /**
+     * @ODM\Id()
+     *
+     * @var string|null
+     */
     public $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
@@ -108,21 +108,21 @@ class Action
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     protected $type;
 
-    public function __construct($type)
+    public function __construct(string $type)
     {
         $this->type = $type;
     }
 
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
 
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
@@ -131,10 +131,14 @@ class Action
 /** @ODM\Document */
 class CommentableAction extends Action
 {
-    /** @ODM\Field(type="collection") **/
+    /**
+     * @ODM\Field(type="collection") *
+     *
+     * @var array
+     */
     protected $comments = [];
 
-    public function __construct($type, array $comments = [])
+    public function __construct(string $type, array $comments = [])
     {
         parent::__construct($type);
         $this->comments = $comments;
@@ -156,7 +160,11 @@ abstract class ActivityStreamItem
      */
     protected $id;
 
-    /** @ODM\ReferenceOne(targetDocument=Action::class) */
+    /**
+     * @ODM\ReferenceOne(targetDocument=Action::class)
+     *
+     * @var Action
+     */
     protected $action;
 
     public function __construct(Action $action)
@@ -164,7 +172,7 @@ abstract class ActivityStreamItem
         $this->action = $action;
     }
 
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
@@ -184,17 +192,17 @@ abstract class GroupActivityStreamItem extends ActivityStreamItem
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     protected $groupId;
 
-    public function __construct(Action $action, $groupId)
+    public function __construct(Action $action, string $groupId)
     {
         parent::__construct($action);
         $this->groupId = $groupId;
     }
 
-    public function getGroupId()
+    public function getGroupId(): string
     {
         return $this->groupId;
     }
@@ -219,17 +227,17 @@ abstract class UserActivityStreamItem extends ActivityStreamItem
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     protected $userId;
 
-    public function __construct(Action $action, $userId)
+    public function __construct(Action $action, string $userId)
     {
         parent::__construct($action);
         $this->userId = $userId;
     }
 
-    public function getUserId()
+    public function getUserId(): string
     {
         return $this->userId;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
@@ -22,6 +22,7 @@ use Documents\User;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectId;
 use ProxyManager\Proxy\GhostObjectInterface;
+use ProxyManager\Proxy\LazyLoadingInterface;
 
 use function assert;
 use function get_class;
@@ -388,6 +389,7 @@ class ReferencesTest extends BaseTest
         );
 
         $test = $this->dm->find(get_class($test), $test->id);
+        $this->assertInstanceOf(LazyLoadingInterface::class, $test->referenceOne);
         $this->expectException(DocumentNotFoundException::class);
         $this->expectExceptionMessage(
             'The "Doctrine\ODM\MongoDB\Tests\Functional\DocumentWithArrayId" document with identifier ' .
@@ -420,6 +422,7 @@ class ReferencesTest extends BaseTest
 
         $user    = $this->dm->find(get_class($user), $user->getId());
         $profile = $user->getProfile();
+        $this->assertInstanceOf(LazyLoadingInterface::class, $profile);
         $this->expectException(DocumentNotFoundException::class);
         $this->expectExceptionMessage(
             'The "Documents\Profile" document with identifier "abcdefabcdefabcdefabcdef" could not be found.'
@@ -450,6 +453,7 @@ class ReferencesTest extends BaseTest
         );
 
         $test = $this->dm->find(get_class($test), $test->id);
+        $this->assertInstanceOf(LazyLoadingInterface::class, $test->referenceOne);
         $this->expectException(DocumentNotFoundException::class);
         $this->expectExceptionMessage(
             'The "Doctrine\ODM\MongoDB\Tests\Functional\DocumentWithMongoBinDataId" document with identifier ' .
@@ -505,14 +509,22 @@ class DocumentWithArrayReference
      */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument=DocumentWithArrayId::class) */
+    /**
+     * @ODM\ReferenceOne(targetDocument=DocumentWithArrayId::class)
+     *
+     * @var DocumentWithArrayId|null
+     */
     public $referenceOne;
 }
 
 /** @ODM\Document */
 class DocumentWithArrayId
 {
-    /** @ODM\Id(strategy="none", options={"type"="hash"}) */
+    /**
+     * @ODM\Id(strategy="none", options={"type"="hash"})
+     *
+     * @var array<string, int>
+     */
     public $id;
 }
 
@@ -527,19 +539,28 @@ class DocumentWithMongoBinDataReference
      */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument=DocumentWithMongoBinDataId::class) */
+    /**
+     * @ODM\ReferenceOne(targetDocument=DocumentWithMongoBinDataId::class)
+     *
+     * @var DocumentWithMongoBinDataId|null
+     */
     public $referenceOne;
 }
 
 /** @ODM\Document */
 class DocumentWithMongoBinDataId
 {
-    /** @ODM\Id(strategy="none", options={"type"="bin"}) */
+    /**
+     * @ODM\Id(strategy="none", options={"type"="bin"})
+     *
+     * @var string|null
+     */
     public $id;
 }
 
 class DocumentNotFoundListener
 {
+    /** @var Closure */
     private $closure;
 
     public function __construct(Closure $closure)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
@@ -101,10 +102,18 @@ class SplColDoc
      */
     public $name;
 
-    /** @ODM\EmbedOne */
+    /**
+     * @ODM\EmbedOne
+     *
+     * @var object|null
+     */
     public $one;
 
-    /** @ODM\EmbedMany */
+    /**
+     * @ODM\EmbedMany
+     *
+     * @var Collection<int, object>|array<object>
+     */
     public $many = [];
 }
 
@@ -114,11 +123,11 @@ class SplColEmbed
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     public $name;
 
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TestTargetDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TestTargetDocument.php
@@ -29,7 +29,11 @@ class TargetDocumentTestDocument
      */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument=Doctrine\ODM\MongoDB\Tests\Functional\TargetDocumentTestReference::class) */
+    /**
+     * @ODM\ReferenceOne(targetDocument=Doctrine\ODM\MongoDB\Tests\Functional\TargetDocumentTestReference::class)
+     *
+     * @var TargetDocumentTestReference|null
+     */
     public $reference;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1017Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1017Test.php
@@ -61,7 +61,11 @@ class GH1017Document
      */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument=GH1017EmbeddedDocument::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=GH1017EmbeddedDocument::class)
+     *
+     * @var GH1017EmbeddedDocument|null
+     */
     public $embedded;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1107Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1107Test.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\ODM\MongoDB\Tests\Persisters;
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
@@ -25,7 +25,11 @@ class GH1107Test extends BaseTest
  */
 class GH1107ParentClass
 {
-    /** @ODM\Id(strategy="NONE") */
+    /**
+     * @ODM\Id(strategy="NONE")
+     *
+     * @var string|null
+     */
     public $id;
 
     /**
@@ -39,6 +43,10 @@ class GH1107ParentClass
 /** @ODM\Document */
 class GH1107ChildClass extends GH1107ParentClass
 {
-    /** @ODM\Id(strategy="AUTO") */
+    /**
+     * @ODM\Id(strategy="AUTO")
+     *
+     * @var string|null
+     */
     public $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
@@ -44,7 +45,11 @@ class GH1117Document
      */
     public $id;
 
-    /** @ODM\EmbedMany(strategy="set", targetDocument=GH1117EmbeddedDocument::class) */
+    /**
+     * @ODM\EmbedMany(strategy="set", targetDocument=GH1117EmbeddedDocument::class)
+     *
+     * @var Collection<int, GH1117EmbeddedDocument>
+     */
     public $embeds;
 
     public function __construct()
@@ -61,11 +66,11 @@ class GH1117EmbeddedDocument
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     public $value;
 
-    public function __construct($value)
+    public function __construct(string $value)
     {
         $this->value = $value;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1138Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1138Test.php
@@ -68,7 +68,10 @@ class GH1138Document
 
 class GH1138Listener
 {
+    /** @var int */
     public $inserts = 0;
+
+    /** @var int */
     public $updates = 0;
 
     public function onFlush(OnFlushEventArgs $args): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1152Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1152Test.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class GH1152Test extends BaseTest
@@ -46,13 +47,22 @@ class GH1152Parent
      */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument=GH1152Child::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=GH1152Child::class)
+     *
+     * @var GH1152Child|null
+     */
     public $child;
 }
 
-/** @ODM\EmbeddedDocument */
+/**
+ * @ODM\EmbeddedDocument
+ *
+ * @psalm-import-type FieldMapping from ClassMetadata
+ */
 class GH1152Child
 {
+    /** @psalm-var array{0: FieldMapping, 1: object|null, 2: string}|null */
     public $parentAssociation;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
@@ -45,7 +46,11 @@ class GH1225Document
      */
     public $id;
 
-    /** @ODM\EmbedMany(strategy="atomicSet", targetDocument=GH1225EmbeddedDocument::class) */
+    /**
+     * @ODM\EmbedMany(strategy="atomicSet", targetDocument=GH1225EmbeddedDocument::class)
+     *
+     * @var Collection<int, GH1225EmbeddedDocument>
+     */
     public $embeds;
 
     public function __construct()
@@ -69,11 +74,11 @@ class GH1225EmbeddedDocument
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     public $value;
 
-    public function __construct($value)
+    public function __construct(string $value)
     {
         $this->value = $value;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1294Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1294Test.php
@@ -40,7 +40,11 @@ class GH1294Test extends BaseTest
 /** @ODM\Document */
 class GH1294User
 {
-    /** @ODM\Id(strategy="UUID", type="string") */
+    /**
+     * @ODM\Id(strategy="UUID", type="string")
+     *
+     * @var string|null
+     */
     public $id;
 
     /**
@@ -50,7 +54,7 @@ class GH1294User
      */
     public $name = '';
 
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1344Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1344Test.php
@@ -56,10 +56,18 @@ class GH1344Main
      */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument=GH1344Embedded::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=GH1344Embedded::class)
+     *
+     * @var GH1344Embedded|null
+     */
     public $embedded1;
 
-    /** @ODM\EmbedOne(targetDocument=GH1344Embedded::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=GH1344Embedded::class)
+     *
+     * @var GH1344Embedded|null
+     */
     public $embedded2;
 }
 
@@ -69,10 +77,18 @@ class GH1344Main
  */
 class GH1344Embedded
 {
-    /** @ODM\Field */
+    /**
+     * @ODM\Field
+     *
+     * @var string|null
+     */
     public $property;
 
-    /** @ODM\EmbedOne(targetDocument=GH1344EmbeddedNested::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=GH1344EmbeddedNested::class)
+     *
+     * @var GH1344EmbeddedNested|null
+     */
     public $embedded;
 }
 
@@ -82,7 +98,11 @@ class GH1344Embedded
  */
 class GH1344EmbeddedNested
 {
-    /** @ODM\Field */
+    /**
+     * @ODM\Field
+     *
+     * @var string|null
+     */
     public $property;
 }
 
@@ -96,7 +116,11 @@ class GH1344LongIndexName
      */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument=GH1344LongIndexNameEmbedded::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=GH1344LongIndexNameEmbedded::class)
+     *
+     * @var GH1344LongIndexNameEmbedded|null
+     */
     public $embedded1;
 }
 
@@ -106,6 +130,10 @@ class GH1344LongIndexName
  */
 class GH1344LongIndexNameEmbedded
 {
-    /** @ODM\Field */
+    /**
+     * @ODM\Field
+     *
+     * @var string|null
+     */
     public $property;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1346Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1346Test.php
@@ -54,7 +54,11 @@ class GH1346Document
      */
     protected $id;
 
-    /** @ODM\ReferenceMany(targetDocument=GH1346ReferencedDocument::class) */
+    /**
+     * @ODM\ReferenceMany(targetDocument=GH1346ReferencedDocument::class)
+     *
+     * @var Collection<int, GH1346ReferencedDocument>
+     */
     protected $references;
 
     public function __construct()
@@ -62,16 +66,19 @@ class GH1346Document
         $this->references = new ArrayCollection();
     }
 
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
 
-    public function addReference($otherReference): void
+    public function addReference(GH1346ReferencedDocument $otherReference): void
     {
         $this->references->add($otherReference);
     }
 
+    /**
+     * @return Collection<int, GH1346ReferencedDocument>
+     */
     public function getReferences(): Collection
     {
         return $this->references;
@@ -86,7 +93,7 @@ class GH1346ReferencedDocument
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     public $test;
 
@@ -97,12 +104,12 @@ class GH1346ReferencedDocument
      */
     protected $id;
 
-    public function setTest($test): void
+    public function setTest(string $test): void
     {
         $this->test = $test;
     }
 
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
@@ -133,6 +133,8 @@ class GH1418Embedded
     /**
      * @ODM\Id(strategy="none", type="int")
      * @ODM\AlsoLoad("sourceId")
+     *
+     * @var int|null
      */
     public $id;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1435Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1435Test.php
@@ -72,10 +72,18 @@ class GH1435Test extends BaseTest
  */
 class GH1435Document
 {
-    /** @ODM\Id() */
+    /**
+     * @ODM\Id()
+     *
+     * @var string|null
+     */
     public $id;
 
-    /** @ODM\Field(type="string", nullable=true) */
+    /**
+     * @ODM\Field(type="string", nullable=true)
+     *
+     * @var string|null
+     */
     public $name;
 }
 
@@ -84,9 +92,17 @@ class GH1435Document
  */
 class GH1435DocumentIncrement
 {
-    /** @ODM\Id(strategy="increment") */
+    /**
+     * @ODM\Id(strategy="increment")
+     *
+     * @var int|null
+     */
     public $id;
 
-    /** @ODM\Field(type="string", nullable=true) */
+    /**
+     * @ODM\Field(type="string", nullable=true)
+     *
+     * @var string|null
+     */
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1525Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1525Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Id\UuidGenerator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
@@ -107,17 +108,25 @@ class GH1525Document
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     public $name;
 
-    /** @ODM\EmbedOne(targetDocument=GH1525Embedded::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=GH1525Embedded::class)
+     *
+     * @var GH1525Embedded|null
+     */
     public $embedded;
 
-    /** @ODM\EmbedMany(targetDocument=GH1525Embedded::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=GH1525Embedded::class)
+     *
+     * @var Collection<int, GH1525Embedded>
+     */
     public $embedMany;
 
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name      = $name;
         $this->embedMany = new ArrayCollection();
@@ -127,20 +136,28 @@ class GH1525Document
 /** @ODM\Document(collection="document_test_with_auto_ids") */
 class GH1525DocumentIdStrategyNone
 {
-    /** @ODM\Id(strategy="NONE") */
+    /**
+     * @ODM\Id(strategy="NONE")
+     *
+     * @var string
+     */
     public $id;
 
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     public $name;
 
-    /** @ODM\EmbedOne(targetDocument=GH1525Embedded::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=GH1525Embedded::class)
+     *
+     * @var GH1525Embedded|null
+     */
     public $embedded;
 
-    public function __construct($id, $name)
+    public function __construct(string $id, string $name)
     {
         $this->id   = $id;
         $this->name = $name;
@@ -153,11 +170,11 @@ class GH1525Embedded
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     public $name;
 
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1572Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1572Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
@@ -52,13 +53,25 @@ class GH1572Blog
      */
     public $id;
 
-    /** @ODM\ReferenceMany(targetDocument=GH1572Post::class, mappedBy="blog") */
+    /**
+     * @ODM\ReferenceMany(targetDocument=GH1572Post::class, mappedBy="blog")
+     *
+     * @var Collection<int, GH1572Post>|array<GH1572Post>
+     */
     public $allPosts = [];
 
-    /** @ODM\ReferenceMany(targetDocument=GH1572Post::class, mappedBy="blog", sort={"id"="asc"}, limit=2) */
+    /**
+     * @ODM\ReferenceMany(targetDocument=GH1572Post::class, mappedBy="blog", sort={"id"="asc"}, limit=2)
+     *
+     * @var Collection<int, GH1572Post>|array<GH1572Post>
+     */
     public $latestPosts = [];
 
-    /** @ODM\ReferenceMany(targetDocument=GH1572Post::class, repositoryMethod="getPostsForBlog") */
+    /**
+     * @ODM\ReferenceMany(targetDocument=GH1572Post::class, repositoryMethod="getPostsForBlog")
+     *
+     * @var Collection<int, GH1572Post>|array<GH1572Post>
+     */
     public $latestPostsRepositoryMethod = [];
 }
 
@@ -72,7 +85,11 @@ class GH1572Post
      */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument=GH1572Blog::class) */
+    /**
+     * @ODM\ReferenceOne(targetDocument=GH1572Blog::class)
+     *
+     * @var GH1572Blog
+     */
     public $blog;
 
     public function __construct(GH1572Blog $blog)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1775Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1775Test.php
@@ -99,19 +99,35 @@ class GH1775Blog
      */
     public $id;
 
-    /** @ODM\ReferenceMany(targetDocument=GH1775Post::class, inversedBy="blogs") */
+    /**
+     * @ODM\ReferenceMany(targetDocument=GH1775Post::class, inversedBy="blogs")
+     *
+     * @var Collection<int, GH1775Post>|array<GH1775Post>
+     */
     public $posts = [];
 }
 
 /** @ODM\Document */
 class GH1775Post extends GH1775MetaDocument
 {
-    /** @ODM\ReferenceMany(targetDocument=GH1775Image::class, storeAs=ClassMetadata::REFERENCE_STORE_AS_ID) */
+    /**
+     * @ODM\ReferenceMany(targetDocument=GH1775Image::class, storeAs=ClassMetadata::REFERENCE_STORE_AS_ID)
+     *
+     * @var Collection<int, GH1775Image>
+     */
     protected $images;
 
-    /** @ODM\ReferenceMany(targetDocument=GH1775Blog::class, mappedBy="posts") */
+    /**
+     * @ODM\ReferenceMany(targetDocument=GH1775Blog::class, mappedBy="posts")
+     *
+     * @var Collection<int, GH1775Blog>
+     */
     protected $blogs;
 
+    /**
+     * @param array<GH1775Blog>  $blogs
+     * @param array<GH1775Image> $images
+     */
     public function __construct(array $blogs, array $images)
     {
         $this->blogs  = new ArrayCollection($blogs);
@@ -130,7 +146,7 @@ class GH1775Post extends GH1775MetaDocument
     }
 
     /**
-     * @return Collection
+     * @return Collection<int, GH1775Image>
      */
     public function getImages()
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH232Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH232Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
@@ -54,10 +55,18 @@ class Product
      */
     public $name;
 
-    /** @ODM\EmbedMany(targetDocument=Price::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=Price::class)
+     *
+     * @var Collection<int, Price>|array<Price>
+     */
     public $prices = [];
 
-    /** @ODM\EmbedMany(targetDocument=SubProduct::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=SubProduct::class)
+     *
+     * @var Collection<int, SubProduct>|array<SubProduct>
+     */
     public $subproducts = [];
 
     public function __construct($name)
@@ -70,7 +79,11 @@ class Product
 /** @ODM\EmbeddedDocument */
 class SubProduct
 {
-    /** @ODM\EmbedMany(targetDocument=Price::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=Price::class)
+     *
+     * @var Collection<int, Price>|array<Price>
+     */
     public $prices = [];
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH453Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH453Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
@@ -307,37 +308,81 @@ class GH453Document
      */
     public $id;
 
-    /** @ODM\Field(type="hash") */
+    /**
+     * @ODM\Field(type="hash")
+     *
+     * @var array<string>
+     */
     public $hash;
 
-    /** @ODM\Field(type="collection") */
+    /**
+     * @ODM\Field(type="collection")
+     *
+     * @var string[]
+     */
     public $colPush;
 
-    /** @ODM\Field(type="collection") */
+    /**
+     * @ODM\Field(type="collection")
+     *
+     * @var string[]
+     */
     public $colSet;
 
-    /** @ODM\EmbedMany(strategy="pushAll")) */
+    /**
+     * @ODM\EmbedMany(strategy="pushAll"))
+     *
+     * @var Collection<int, GH453EmbeddedDocument>
+     */
     public $embedManyPush;
 
-    /** @ODM\EmbedMany(strategy="set") */
+    /**
+     * @ODM\EmbedMany(strategy="set")
+     *
+     * @var Collection<int, object>
+     */
     public $embedManySet;
 
-    /** @ODM\EmbedMany(strategy="setArray") */
+    /**
+     * @ODM\EmbedMany(strategy="setArray")
+     *
+     * @var Collection<int, object>
+     */
     public $embedManySetArray;
 
-    /** @ODM\EmbedMany(strategy="addToSet") */
+    /**
+     * @ODM\EmbedMany(strategy="addToSet")
+     *
+     * @var Collection<int, object>
+     */
     public $embedManyAddToSet;
 
-    /** @ODM\ReferenceMany(strategy="pushAll")) */
+    /**
+     * @ODM\ReferenceMany(strategy="pushAll"))
+     *
+     * @var Collection<int, GH453ReferencedDocument>
+     */
     public $referenceManyPush;
 
-    /** @ODM\ReferenceMany(strategy="set") */
+    /**
+     * @ODM\ReferenceMany(strategy="set")
+     *
+     * @var Collection<int, object>
+     */
     public $referenceManySet;
 
-    /** @ODM\ReferenceMany(strategy="setArray") */
+    /**
+     * @ODM\ReferenceMany(strategy="setArray")
+     *
+     * @var Collection<int, object>
+     */
     public $referenceManySetArray;
 
-    /** @ODM\ReferenceMany(strategy="addToSet") */
+    /**
+     * @ODM\ReferenceMany(strategy="addToSet")
+     *
+     * @var Collection<int, object>
+     */
     public $referenceManyAddToSet;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH467Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH467Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
@@ -38,13 +39,25 @@ class GH467Document
      */
     public $id;
 
-    /** @ODM\Field(type="collection") */
+    /**
+     * @ODM\Field(type="collection")
+     *
+     * @var mixed[]
+     */
     public $col;
 
-    /** @ODM\EmbedMany(targetDocument=GH467EmbeddedDocument::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=GH467EmbeddedDocument::class)
+     *
+     * @var Collection<int, GH467EmbeddedDocument>
+     */
     public $embedMany;
 
-    /** @ODM\ReferenceMany(targetDocument=GH467EmbeddedDocument::class) */
+    /**
+     * @ODM\ReferenceMany(targetDocument=GH467EmbeddedDocument::class)
+     *
+     * @var Collection<int, GH467EmbeddedDocument>
+     */
     public $refMany;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH499Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH499Test.php
@@ -46,10 +46,14 @@ class GH499Document
      */
     protected $id;
 
-    /** @ODM\ReferenceMany(targetDocument=GH499Document::class, storeAs="id", strategy="set") */
+    /**
+     * @ODM\ReferenceMany(targetDocument=GH499Document::class, storeAs="id", strategy="set")
+     *
+     * @var Collection<array-key, GH499Document>
+     */
     protected $refMany;
 
-    public function __construct($id = null)
+    public function __construct(?ObjectId $id = null)
     {
         $this->id      = (string) $id;
         $this->refMany = new ArrayCollection();
@@ -60,6 +64,9 @@ class GH499Document
         return $this->id;
     }
 
+    /**
+     * @return Collection<int, GH499Document>
+     */
     public function getRefMany(): Collection
     {
         return $this->refMany;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH520Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH520Test.php
@@ -73,6 +73,10 @@ class GH520Document
      */
     public $id;
 
-    /** @ODM\ReferenceOne(targetDocument=GH520Document::class, cascade={"persist"}) */
+    /**
+     * @ODM\ReferenceOne(targetDocument=GH520Document::class, cascade={"persist"})
+     *
+     * @var GH520Document|null
+     */
     public $ref;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH529Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH529Test.php
@@ -91,13 +91,21 @@ class GH529AutoIdDocument
 /** @ODM\Document */
 class GH529CustomIdDocument
 {
-    /** @ODM\Id(strategy="none", type="custom_id") */
+    /**
+     * @ODM\Id(strategy="none", type="custom_id")
+     *
+     * @var string|null
+     */
     public $id;
 }
 
 /** @ODM\Document */
 class GH529IntIdDocument
 {
-    /** @ODM\Id(strategy="none", type="int") */
+    /**
+     * @ODM\Id(strategy="none", type="int")
+     *
+     * @var float|int|null
+     */
     public $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH566Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH566Test.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 use function iterator_to_array;
@@ -38,6 +40,10 @@ class GH566Test extends BaseTest
         ]);
 
         $this->dm->flush();
+
+        $this->assertInstanceOf(PersistentCollectionInterface::class, $doc1->children);
+        $this->assertInstanceOf(PersistentCollectionInterface::class, $doc2->children);
+        $this->assertInstanceOf(PersistentCollectionInterface::class, $doc3->children);
 
         /* The inverse-side $children PersistentCollection on these documents
          * is already initialized by this point, so we need to either clear the
@@ -75,10 +81,18 @@ class GH566Document
      */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument=GH566EmbeddedDocument::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=GH566EmbeddedDocument::class)
+     *
+     * @var GH566EmbeddedDocument|null
+     */
     public $version;
 
-    /** @ODM\EmbedMany(targetDocument=GH566EmbeddedDocument::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=GH566EmbeddedDocument::class)
+     *
+     * @var Collection<int, GH566EmbeddedDocument>
+     */
     public $versions;
 
     /**
@@ -88,6 +102,8 @@ class GH566Document
      *      mappedBy="version.parent",
      *      sort={"version.sequence"="asc"}
      * )
+     *
+     * @var Collection<int, GH566Document>
      */
     public $children;
 
@@ -108,6 +124,10 @@ class GH566EmbeddedDocument
      */
     public $sequence = 0;
 
-    /** @ODM\ReferenceOne(targetDocument=GH566Document::class, cascade={"all"}, inversedBy="children") */
+    /**
+     * @ODM\ReferenceOne(targetDocument=GH566Document::class, cascade={"all"}, inversedBy="children")
+     *
+     * @var GH566Document|null
+     */
     public $parent;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
@@ -72,6 +72,11 @@ class GH580Document
      */
     public $id;
 
-    /** @ODM\Field(type="string") @ODM\Index(unique=true) */
+    /**
+     * @ODM\Field(type="string")
+     * @ODM\Index(unique=true)
+     *
+     * @var string|null
+     */
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH593Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH593Test.php
@@ -110,7 +110,11 @@ class GH593User
      */
     public $id;
 
-    /** @ODM\Field(name="d", type="bool") */
+    /**
+     * @ODM\Field(name="d", type="bool")
+     *
+     * @var bool
+     */
     public $deleted = false;
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
@@ -112,7 +112,11 @@ class GH602User
      */
     public $id;
 
-    /** @ODM\Field(name="user_deleted", type="bool") */
+    /**
+     * @ODM\Field(name="user_deleted", type="bool")
+     *
+     * @var bool
+     */
     public $deleted = false;
 
     /**
@@ -144,10 +148,18 @@ class GH602Thing
      */
     public $id;
 
-    /** @ODM\Field(name="thing_deleted", type="bool") */
+    /**
+     * @ODM\Field(name="thing_deleted", type="bool")
+     *
+     * @var bool
+     */
     public $deleted = false;
 
-    /** @ODM\ReferenceMany(targetDocument=GH602User::class, mappedBy="likes") */
+    /**
+     * @ODM\ReferenceMany(targetDocument=GH602User::class, mappedBy="likes")
+     *
+     * @var Collection<int, GH602User>
+     */
     public $likedBy;
 
     public function __construct()
@@ -156,7 +168,7 @@ class GH602Thing
     }
 
     /** Return the identifier without triggering Proxy initialization */
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH611Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH611Test.php
@@ -129,7 +129,11 @@ class GH611Document
      */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument=GH611EmbeddedDocument::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=GH611EmbeddedDocument::class)
+     *
+     * @var GH611EmbeddedDocument|null
+     */
     public $embedded;
 }
 
@@ -139,14 +143,18 @@ class GH611EmbeddedDocument
     /**
      * @ODM\Field(type="int")
      *
-     * @var int|null
+     * @var int
      */
     public $id;
 
-    /** @ODM\Field(name="n", type="string") */
+    /**
+     * @ODM\Field(name="n", type="string")
+     *
+     * @var string
+     */
     public $name;
 
-    public function __construct($id, $name)
+    public function __construct(int $id, string $name)
     {
         $this->id   = $id;
         $this->name = $name;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH850Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH850Test.php
@@ -34,6 +34,10 @@ class GH850Document
      */
     public $id;
 
-    /** @ODM\ReferenceOne */
+    /**
+     * @ODM\ReferenceOne
+     *
+     * @var object|string
+     */
     public $refs = '';
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
@@ -115,7 +115,11 @@ class GH852Test extends BaseTest
 /** @ODM\Document */
 class GH852Document
 {
-    /** @ODM\Id(strategy="NONE", type="custom_id") */
+    /**
+     * @ODM\Id(strategy="NONE", type="custom_id")
+     *
+     * @var Binary|array<string, mixed>
+     */
     public $id;
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH921Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH921Test.php
@@ -81,7 +81,11 @@ class GH921User
      */
     private $name;
 
-    /** @ODM\ReferenceMany(targetDocument=GH921Post::class) */
+    /**
+     * @ODM\ReferenceMany(targetDocument=GH921Post::class)
+     *
+     * @var Collection<int, GH921Post>
+     */
     private $posts;
 
     public function __construct()
@@ -89,17 +93,17 @@ class GH921User
         $this->posts = new ArrayCollection();
     }
 
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
 
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function setName($name): void
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
@@ -109,6 +113,9 @@ class GH921User
         $this->posts[] = $post;
     }
 
+    /**
+     * @return Collection<int, GH921Post>
+     */
     public function getPosts(): Collection
     {
         return $this->posts;
@@ -132,17 +139,17 @@ class GH921Post
      */
     private $name;
 
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
 
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function setName($name): void
+    public function setName(string $name): void
     {
         $this->name = $name;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
@@ -56,25 +56,29 @@ class MODM116Parent
      */
     private $name;
 
-    /** @ODM\ReferenceOne(targetDocument=MODM116Child::class) **/
+    /**
+     * @ODM\ReferenceOne(targetDocument=MODM116Child::class) *
+     *
+     * @var MODM116Child|null
+     */
     private $child;
 
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
 
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function setName($name): void
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    public function getChild()
+    public function getChild(): ?MODM116Child
     {
         return $this->child;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM140Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM140Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\Functional\EmbeddedTestLevel0;
@@ -138,7 +139,11 @@ class Category
      */
     public $name;
 
-    /** @ODM\EmbedMany(targetDocument=Post::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=Post::class)
+     *
+     * @var Collection<int, Post>
+     */
     public $posts;
 
     public function __construct()
@@ -150,10 +155,18 @@ class Category
 /** @ODM\EmbeddedDocument */
 class Post
 {
-    /** @ODM\EmbedMany(targetDocument=PostVersion::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=PostVersion::class)
+     *
+     * @var Collection<int, PostVersion>
+     */
     public $versions;
 
-    /** @ODM\ReferenceMany(targetDocument=Comment::class) */
+    /**
+     * @ODM\ReferenceMany(targetDocument=Comment::class)
+     *
+     * @var Collection<int, Comment>
+     */
     public $comments;
 
     public function __construct()
@@ -169,11 +182,11 @@ class PostVersion
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     public $name;
 
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM29Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM29Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
@@ -60,20 +61,30 @@ class MODM29Doc
      */
     protected $id;
 
-    /** @ODM\EmbedMany(targetDocument=MODM29Embedded::class, strategy="set") */
+    /**
+     * @ODM\EmbedMany(targetDocument=MODM29Embedded::class, strategy="set")
+     *
+     * @var Collection<int, MODM29Embedded>
+     */
     protected $collection;
 
-    public function __construct($c)
+    public function __construct(Collection $c)
     {
         $this->set($c);
     }
 
-    public function set($c): void
+    /**
+     * @param Collection<int, MODM29Embedded> $c
+     */
+    public function set(Collection $c): void
     {
         $this->collection = $c;
     }
 
-    public function get()
+    /**
+     * @return Collection<int, MODM29Embedded>
+     */
+    public function get(): Collection
     {
         return $this->collection;
     }
@@ -85,21 +96,21 @@ class MODM29Embedded
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     protected $val;
 
-    public function __construct($val)
+    public function __construct(string $val)
     {
         $this->set($val);
     }
 
-    public function get()
+    public function get(): string
     {
         return $this->val;
     }
 
-    public function set($val): void
+    public function set(string $val): void
     {
         $this->val = $val;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM48Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM48Test.php
@@ -40,7 +40,11 @@ class MODM48A
      */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument=MODM48B::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=MODM48B::class)
+     *
+     * @var MODM48B|null
+     */
     public $b;
 
     public function getId()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM52Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM52Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
@@ -47,10 +48,17 @@ class MODM52Container
      */
     public $value;
 
-    /** @ODM\EmbedMany(targetDocument=MODM52Embedded::class, strategy="set") */
+    /**
+     * @ODM\EmbedMany(targetDocument=MODM52Embedded::class, strategy="set")
+     *
+     * @var Collection<int, MODM52Embedded>|array<MODM52Embedded>
+     */
     public $items = [];
 
-    public function __construct($items = null, $value = null)
+    /**
+     * @param array<MODM52Embedded>|null $items
+     */
+    public function __construct(?array $items = null, ?string $value = null)
     {
         if ($items) {
             $this->items = $items;
@@ -59,17 +67,20 @@ class MODM52Container
         $this->value = $value;
     }
 
-    public function getItems()
+    /**
+     * @return Collection<int, MODM52Embedded>
+     */
+    public function getItems(): Collection
     {
         return $this->items;
     }
 
-    public function getItem($index)
+    public function getItem(int $index): MODM52Embedded
     {
         return $this->items[$index];
     }
 
-    public function removeItem($i): void
+    public function removeItem(int $i): void
     {
         unset($this->items[$i]);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM65Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM65Test.php
@@ -48,6 +48,8 @@ class MODM65User
      *  },
      *  name="snu"
      * )
+     *
+     * @var MODM65SocialNetworkUser|null
      */
     public $socialNetworkUser;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM66Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM66Test.php
@@ -72,14 +72,24 @@ class MODM52A
      */
     protected $id;
 
-    /** @ODM\ReferenceMany(targetDocument=MODM52B::class, cascade="all") */
+    /**
+     * @ODM\ReferenceMany(targetDocument=MODM52B::class, cascade="all")
+     *
+     * @var Collection<int, MODM52B>
+     */
     protected $b;
 
-    public function __construct($b)
+    /**
+     * @param array<MODM52B> $b
+     */
+    public function __construct(array $b)
     {
         $this->b = new ArrayCollection($b);
     }
 
+    /**
+     * @return Collection<int, MODM52B>
+     */
     public function getB(): Collection
     {
         return $this->b;
@@ -99,16 +109,16 @@ class MODM52B
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     protected $value;
 
-    public function __construct($v)
+    public function __construct(string $v)
     {
         $this->value = $v;
     }
 
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM67Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM67Test.php
@@ -59,6 +59,7 @@ class MODM67Test extends BaseTest
 
 class MODM67TestEventListener
 {
+    /** @var DocumentManager */
     public $documentManager;
 
     public function __construct(DocumentManager $documentManager)
@@ -119,7 +120,11 @@ class MODM67DerivedClass
      */
     public $id;
 
-    /** @ODM\EmbedOne(targetDocument=MODM67EmbeddedObject::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=MODM67EmbeddedObject::class)
+     *
+     * @var MODM67EmbeddedObject|null
+     */
     public $embedOne;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
@@ -119,17 +119,25 @@ class MODM81TestEmbeddedDocument
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     public $message;
 
-    /** @ODM\ReferenceOne(targetDocument=MODM81TestDocument::class) */
+    /**
+     * @ODM\ReferenceOne(targetDocument=MODM81TestDocument::class)
+     *
+     * @var MODM81TestDocument
+     */
     public $refTodocument1;
 
-    /** @ODM\ReferenceOne(targetDocument=MODM81TestDocument::class) */
+    /**
+     * @ODM\ReferenceOne(targetDocument=MODM81TestDocument::class)
+     *
+     * @var MODM81TestDocument
+     */
     public $refTodocument2;
 
-    public function __construct($document1, $document2, $message)
+    public function __construct(MODM81TestDocument $document1, MODM81TestDocument $document2, string $message)
     {
         $this->refTodocument1 = $document1;
         $this->refTodocument2 = $document2;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM83Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM83Test.php
@@ -60,6 +60,7 @@ class MODM83Test extends BaseTest
 
 class MODM83EventListener
 {
+    /** @var array<string, class-string[]> */
     public $called = [];
 
     public function __call($method, $args)
@@ -87,7 +88,11 @@ class MODM83TestDocument
      */
     public $name;
 
-    /** @ODM\EmbedOne(targetDocument=MODM83TestEmbeddedDocument::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=MODM83TestEmbeddedDocument::class)
+     *
+     * @var MODM83TestEmbeddedDocument|null
+     */
     public $embedded;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM90Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM90Test.php
@@ -76,6 +76,7 @@ class MODM90Test extends BaseTest
 
 class MODM90EventListener
 {
+    /** @var array<string, class-string[]> */
     public $called = [];
 
     public function __call($method, $args)
@@ -112,6 +113,8 @@ class MODM90TestDocument
      *     "test2"=MODM90Test2EmbeddedDocument::class
      *   }
      *  )
+     *
+     * @var MODM90TestEmbeddedDocument|MODM90Test2EmbeddedDocument|null
      */
     public $embedded;
 }
@@ -137,6 +140,10 @@ class MODM90Test2EmbeddedDocument
      */
     public $name;
 
-    /** @ODM\Field(type="string") The discriminator field is a real property */
+    /**
+     * @ODM\Field(type="string") The discriminator field is a real property
+     *
+     * @var string
+     */
     public $type;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM91Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM91Test.php
@@ -52,6 +52,7 @@ class MODM91Test extends BaseTest
 
 class MODM91EventListener
 {
+    /** @var array<string, class-string[]>  */
     public $called = [];
 
     public function __call($method, $args)
@@ -79,7 +80,11 @@ class MODM91TestDocument
      */
     public $name;
 
-    /** @ODM\EmbedOne(targetDocument=MODM91TestEmbeddedDocument::class) */
+    /**
+     * @ODM\EmbedOne(targetDocument=MODM91TestEmbeddedDocument::class)
+     *
+     * @var MODM91TestEmbeddedDocument|null
+     */
     public $embedded;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM92Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM92Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Traversable;
@@ -50,7 +51,11 @@ class MODM92TestDocument
     public $id;
 
     // Note: Test case fails with default "pushAll" strategy, but "set" works
-    /** @ODM\EmbedMany(targetDocument=MODM92TestEmbeddedDocument::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=MODM92TestEmbeddedDocument::class)
+     *
+     * @var Collection<int, MODM92TestEmbeddedDocument>
+     */
     public $embeddedDocuments;
 
     public function __construct()
@@ -67,7 +72,7 @@ class MODM92TestDocument
      * by mapping array indexes (size URL's are required, cropMetadata is not).
      * Any invalid elements will be ignored.
      *
-     * @param array|Traversable $embeddedDocuments
+     * @param array<MODM92TestEmbeddedDocument>|Traversable<MODM92TestEmbeddedDocument> $embeddedDocuments
      */
     public function setEmbeddedDocuments($embeddedDocuments): void
     {
@@ -89,11 +94,11 @@ class MODM92TestEmbeddedDocument
     /**
      * @ODM\Field(type="string")
      *
-     * @var string|null
+     * @var string
      */
     public $name;
 
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/UpsertTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/UpsertTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use MongoDB\BSON\ObjectId;
@@ -96,16 +97,32 @@ class UpsertTestUser
      */
     public $id;
 
-    /** @ODM\Field(nullable=true) */
+    /**
+     * @ODM\Field(nullable=true)
+     *
+     * @var string|null
+     */
     public $nullableField;
 
-    /** @ODM\EmbedOne(targetDocument=UpsertTestUserEmbedded::class, nullable=true) */
+    /**
+     * @ODM\EmbedOne(targetDocument=UpsertTestUserEmbedded::class, nullable=true)
+     *
+     * @var UpsertTestUserEmbedded|null
+     */
     public $nullableEmbedOne;
 
-    /** @ODM\ReferenceOne(targetDocument=UpsertTestUser::class, cascade="persist", nullable=true) */
+    /**
+     * @ODM\ReferenceOne(targetDocument=UpsertTestUser::class, cascade="persist", nullable=true)
+     *
+     * @var UpsertTestUser|null
+     */
     public $nullableReferenceOne;
 
-    /** @ODM\EmbedMany(targetDocument=UpsertTestUserEmbedded::class) */
+    /**
+     * @ODM\EmbedMany(targetDocument=UpsertTestUserEmbedded::class)
+     *
+     * @var Collection<int, UpsertTestUserEmbedded>
+     */
     public $embedMany;
 
     public function __construct()


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->

Follow-up of https://github.com/doctrine/mongodb-odm/pull/2363, with this one `tests/Doctrine/ODM/MongoDB/Tests/Functional` files are free of missing property type hints.