### PR TITLE
fix ClassMetadata generic docblock type for filters

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Filter/BsonFilter.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Filter/BsonFilter.php
@@ -66,6 +66,8 @@ abstract class BsonFilter
      * Gets the criteria array to add to a query.
      *
      * If there is no criteria for the class, an empty array should be returned.
+     *
+     * @param ClassMetadata<object> $class Target document metadata.
      */
     abstract public function addFilterCriteria(ClassMetadata $class): array;
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #2358 

#### Summary

This fixes missing `<T>` type for `BsonFilter`.
