### PR TITLE
Allow ^6.0 for symfony/*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
         "jean85/pretty-package-versions": "^1.3.0 || ^2.0.1",
         "mongodb/mongodb": "^1.2.0",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
-        "symfony/console": "^3.4 || ^4.1 || ^5.0",
+        "symfony/console": "^3.4 || ^4.1 || ^5.0 || ^6.0",
         "symfony/deprecation-contracts": "^2.2",
-        "symfony/var-dumper": "^3.4 || ^4.1 || ^5.0"
+        "symfony/var-dumper": "^3.4 || ^4.1 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "ext-bcmath": "*",
@@ -47,7 +47,7 @@
         "phpstan/phpstan-phpunit": "^0.12.19",
         "phpunit/phpunit": "^8.5 || ^9",
         "squizlabs/php_codesniffer": "^3.5",
-        "symfony/cache": "^4.4 || ^5.0",
+        "symfony/cache": "^4.4 || ^5.0 || ^6.0",
         "vimeo/psalm": "^4.8.1"
     },
     "suggest": {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | n/a

#### Summary

This PR allows installation of upcoming 6.0 version of Symfony's components. Can't really make a test for them as phpbench/phpbench and psalm are in conflict, so let's home the community will let us know if anything is wrong. FWIW I tried running Symfony's `./vendor/bin/patch-type-declarations` (https://wouterj.nl/2021/09/symfony-6-native-typing) for 5.4 and we're looking A-OK.
