### PR TITLE
support wildcard index mapping

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -449,7 +449,7 @@
       <xs:element name="partial-filter-expression" type="odm:partial-filter-expression" minOccurs="0" />
     </xs:choice>
 
-    <xs:attribute name="name" type="xs:NMTOKEN" />
+    <xs:attribute name="name" type="xs:string" />
     <xs:attribute name="drop-dups" type="xs:boolean" />
     <xs:attribute name="background" type="xs:boolean" />
     <xs:attribute name="unique" type="xs:boolean" />

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -389,7 +389,7 @@ class XmlDriver extends FileDriver
         }
 
         if (isset($attributes['also-load'])) {
-            $mapping['alsoLoadFields'] = explode(',', $attributes['also-load']);
+            $mapping['alsoLoadFields'] = explode(',', (string) $attributes['also-load']);
         }
 
         $this->addFieldMapping($class, $mapping);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
@@ -12,6 +12,7 @@ use TestDocuments\CustomIdGenerator;
 use TestDocuments\InvalidPartialFilterDocument;
 use TestDocuments\UserCustomIdGenerator;
 use TestDocuments\UserNonStringOptions;
+use TestDocuments\WildcardIndexDocument;
 
 class XmlDriverTest extends AbstractDriverTest
 {
@@ -69,6 +70,19 @@ class XmlDriverTest extends AbstractDriverTest
         $this->expectExceptionMessageMatches('#The mapping file .+ is invalid#');
 
         $this->driver->loadMetadataForClass(InvalidPartialFilterDocument::class, $classMetadata);
+    }
+
+    public function testWildcardIndexName(): void
+    {
+        $classMetadata = new ClassMetadata(WildcardIndexDocument::class);
+        $this->driver->loadMetadataForClass(WildcardIndexDocument::class, $classMetadata);
+
+        $this->assertSame([
+            [
+                'keys' => ['fieldA.$**' => 1],
+                'options' => ['name' => 'fieldA.$**_1'],
+            ],
+        ], $classMetadata->getIndexes());
     }
 
     public function testAlsoLoadFieldMapping()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/WildcardIndexDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/WildcardIndexDocument.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestDocuments;
+
+class WildcardIndexDocument
+{
+    protected $id;
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.WildcardIndexDocument.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.WildcardIndexDocument.dcm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="TestDocuments\WildcardIndexDocument" db="documents" collection="wildcardIndexDocument">
+        <id />
+        <indexes>
+            <index name="fieldA.$**_1">
+                <key name="fieldA.$**" />
+            </index>
+        </indexes>
+    </document>
+</doctrine-mongo-mapping>


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fix #2371 

#### Summary

This enables us to map indexes with `field.$**` name.
