### PR TITLE
Deprecate document namespace short aliases

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -22,3 +22,13 @@ This does not apply to `@Indexes` which is deprecated and can't be used as
 Attribute. Use `@Index` and `@UniqueIndex` instead.
 
 `@Inheritance` annotation has been removed as it was never used.
+
+## Deprecated: Document Namespace Aliases
+
+Document namespace aliases are deprecated, use the magic ::class constant to abbreviate full class names
+in DocumentManager and DocumentRepository.
+
+```diff
+-  $documentManager->find('MyBundle:User', $id);
++  $documentManager->find(User::class, $id);
+```

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "doctrine/annotations": "^1.6",
         "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.5",
+        "doctrine/deprecations": "^0.5.3",
         "doctrine/event-manager": "^1.0",
         "doctrine/instantiator": "^1.1",
         "doctrine/persistence": "^2.2",

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\MongoDB\PersistentCollection\DefaultPersistentCollectionFactory;
@@ -140,6 +141,13 @@ class Configuration
      */
     public function getDocumentNamespace(string $documentNamespaceAlias): string
     {
+        Deprecation::trigger(
+            'doctrine/mongodb-odm',
+            'https://github.com/doctrine/mongodb-odm/pull/2374',
+            'Document short namespace aliases such as "%s" are deprecated, use ::class constant instead.',
+            $documentNamespaceAlias
+        );
+
         if (! isset($this->attributes['documentNamespaces'][$documentNamespaceAlias])) {
             throw MongoDBException::unknownDocumentNamespace($documentNamespaceAlias);
         }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | deprecations
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->
This PR deprecates the usage of document namespace short aliases as in https://github.com/doctrine/orm/issues/8818

I haven't found any usage in docs.