### PR TITLE
Describe better types in phpdoc for Iterators

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
@@ -21,13 +21,17 @@ use function reset;
  * those operations (e.g. MongoDB\Driver\Cursor).
  *
  * @internal
+ *
+ * @template TKey
+ * @template TValue
+ * @template-implements Iterator<TKey, TValue>
  */
 final class CachingIterator implements Iterator
 {
-    /** @var array */
+    /** @var array<TKey, TValue> */
     private $items = [];
 
-    /** @var Generator|null */
+    /** @var Generator<TKey, TValue>|null */
     private $iterator;
 
     /** @var bool */
@@ -42,6 +46,8 @@ final class CachingIterator implements Iterator
      * will execute up to its first yield statement. Additionally, this mimics
      * behavior of the SPL iterators and allows users to omit an explicit call
      * to rewind() before using the other methods.
+     *
+     * @param Traversable<TKey, TValue> $iterator
      */
     public function __construct(Traversable $iterator)
     {
@@ -129,6 +135,9 @@ final class CachingIterator implements Iterator
         $this->iterator = null;
     }
 
+    /**
+     * @return Generator<TKey, TValue>
+     */
     private function getIterator(): Generator
     {
         if ($this->iterator === null) {
@@ -152,6 +161,11 @@ final class CachingIterator implements Iterator
         $this->items[$key] = $this->getIterator()->current();
     }
 
+    /**
+     * @param Traversable<TKey, TValue> $traversable
+     *
+     * @return Generator<TKey, TValue>
+     */
     private function wrapTraversable(Traversable $traversable): Generator
     {
         foreach ($traversable as $key => $value) {

--- a/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
@@ -15,21 +15,36 @@ use Traversable;
  * Iterator that wraps a traversable and hydrates results into objects
  *
  * @internal
+ *
+ * @psalm-import-type Hints from UnitOfWork
+ *
+ * @template TKey
+ * @template TValue
+ * @template TDocument of object
+ * @template-implements Iterator<TKey, TDocument>
  */
 final class HydratingIterator implements Iterator
 {
-    /** @var Generator|null */
+    /** @var Generator<TKey, TValue>|null */
     private $iterator;
 
     /** @var UnitOfWork */
     private $unitOfWork;
 
-    /** @var ClassMetadata */
+    /** @var ClassMetadata<TDocument> */
     private $class;
 
-    /** @var array */
+    /**
+     * @var array<int, mixed>
+     * @psalm-var Hints
+     */
     private $unitOfWorkHints;
 
+    /**
+     * @param Traversable<TKey, TValue> $traversable
+     * @param ClassMetadata<TDocument>  $class
+     * @psalm-param Hints $unitOfWorkHints
+     */
     public function __construct(Traversable $traversable, UnitOfWork $unitOfWork, ClassMetadata $class, array $unitOfWorkHints = [])
     {
         $this->iterator        = $this->wrapTraversable($traversable);
@@ -87,6 +102,9 @@ final class HydratingIterator implements Iterator
         return $this->key() !== null;
     }
 
+    /**
+     * @return Generator<TKey, TValue>
+     */
     private function getIterator(): Generator
     {
         if ($this->iterator === null) {
@@ -96,11 +114,19 @@ final class HydratingIterator implements Iterator
         return $this->iterator;
     }
 
-    private function hydrate($document): ?object
+    /**
+     * @param array<string, mixed>|null $document
+     */
+    private function hydrate(?array $document): ?object
     {
         return $document !== null ? $this->unitOfWork->getOrCreateDocument($this->class->name, $document, $this->unitOfWorkHints) : null;
     }
 
+    /**
+     * @param Traversable<TKey, TValue> $traversable
+     *
+     * @return Generator<TKey, TValue>
+     */
     private function wrapTraversable(Traversable $traversable): Generator
     {
         foreach ($traversable as $key => $value) {

--- a/lib/Doctrine/ODM/MongoDB/Iterator/PrimingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/PrimingIterator.php
@@ -6,30 +6,47 @@ namespace Doctrine\ODM\MongoDB\Iterator;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Query\ReferencePrimer;
+use Doctrine\ODM\MongoDB\UnitOfWork;
 
 use function is_callable;
 use function iterator_to_array;
 
+/**
+ * @psalm-import-type Hints from UnitOfWork
+ * @template TKey
+ * @template TValue
+ * @template TDocument of object
+ * @template-implements Iterator<TKey, TValue>
+ */
 final class PrimingIterator implements Iterator
 {
-    /** @var \Iterator */
+    /** @var \Iterator<TKey, TValue> */
     private $iterator;
 
-    /** @var ClassMetadata */
+    /** @var ClassMetadata<TDocument> */
     private $class;
 
     /** @var ReferencePrimer */
     private $referencePrimer;
 
-    /** @var array */
+    /** @var array<string, callable|null> */
     private $primers;
 
-    /** @var array */
+    /**
+     * @var array<int, mixed>
+     * @psalm-var Hints
+     */
     private $unitOfWorkHints;
 
     /** @var bool */
     private $referencesPrimed = false;
 
+    /**
+     * @param \Iterator<TKey, TValue>      $iterator
+     * @param ClassMetadata<TDocument>     $class
+     * @param array<string, callable|null> $primers
+     * @psalm-param Hints $unitOfWorkHints
+     */
     public function __construct(\Iterator $iterator, ClassMetadata $class, ReferencePrimer $referencePrimer, array $primers, array $unitOfWorkHints = [])
     {
         $this->iterator        = $iterator;

--- a/lib/Doctrine/ODM/MongoDB/Iterator/UnrewindableIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/UnrewindableIterator.php
@@ -16,10 +16,14 @@ use function sprintf;
  * Iterator for wrapping a Traversable/Cursor.
  *
  * @internal
+ *
+ * @template TKey
+ * @template TValue
+ * @template-implements Iterator<TKey, TValue>
  */
 final class UnrewindableIterator implements Iterator
 {
-    /** @var Generator|null */
+    /** @var Generator<TKey, TValue>|null */
     private $iterator;
 
     /** @var bool */
@@ -30,6 +34,8 @@ final class UnrewindableIterator implements Iterator
      * the wrapping Generator, which will execute up to its first yield statement.
      * Additionally, this mimics behavior of the SPL iterators and allows users
      * to omit an explicit call to rewind() before using the other methods.
+     *
+     * @param Traversable<TKey, TValue> $iterator
      */
     public function __construct(Traversable $iterator)
     {
@@ -115,6 +121,9 @@ final class UnrewindableIterator implements Iterator
         }
     }
 
+    /**
+     * @return Generator<TKey, TValue>
+     */
     private function getIterator(): Generator
     {
         if ($this->iterator === null) {
@@ -124,6 +133,11 @@ final class UnrewindableIterator implements Iterator
         return $this->iterator;
     }
 
+    /**
+     * @param Traversable<TKey, TValue> $traversable
+     *
+     * @return Generator<TKey, TValue>
+     */
     private function wrapTraversable(Traversable $traversable): Generator
     {
         foreach ($traversable as $key => $value) {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

In this case I went through `Iterator` directory fixing issues with phpstan level 6, I'll try to keep small PR to be easier to review.

I've been using `T` as generic template name, but I think it's better if we give it a more meaningful name, so in this case I've started using `TDocument` when it is supposed to be a document.
