### PR TITLE
Avoid PHP 8.1 deprecations with ReturnTypeWillChange

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,6 +42,11 @@ jobs:
             mongodb-version: "4.4"
             driver-version: "stable"
             deps: "highest"
+          - topology: "server"
+            php-version: "8.1"
+            mongodb-version: "4.4"
+            driver-version: "alpha"
+            dependencies: "highest"
 
     steps:
       - name: "Checkout"
@@ -75,6 +80,11 @@ jobs:
 
       - name: "Show driver information"
         run: "php --ri mongodb"
+
+      # Remove this when laminas/laminas-code 4.5 is released
+      - name: "Use dev stability"
+        if: "${{ matrix.php-version == '8.1' }}"
+        run: composer config minimum-stability dev
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"

--- a/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Iterator;
 
 use Generator;
+use ReturnTypeWillChange;
 use RuntimeException;
 use Traversable;
 
@@ -68,20 +69,18 @@ final class CachingIterator implements Iterator
     }
 
     /**
-     * @see http://php.net/iterator.current
-     *
-     * @return mixed
+     * @return TValue|false
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->items);
     }
 
     /**
-     * @see http://php.net/iterator.mixed
-     *
-     * @return mixed
+     * @return TKey|null
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->items);

--- a/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
@@ -8,6 +8,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use Generator;
 use Iterator;
+use ReturnTypeWillChange;
 use RuntimeException;
 use Traversable;
 
@@ -59,20 +60,18 @@ final class HydratingIterator implements Iterator
     }
 
     /**
-     * @see http://php.net/iterator.current
-     *
-     * @return mixed
+     * @return TDocument|null
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->hydrate($this->getIterator()->current());
     }
 
     /**
-     * @see http://php.net/iterator.mixed
-     *
-     * @return mixed
+     * @return TKey|null
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->getIterator()->key();
@@ -116,6 +115,8 @@ final class HydratingIterator implements Iterator
 
     /**
      * @param array<string, mixed>|null $document
+     *
+     * @return TDocument|null
      */
     private function hydrate(?array $document): ?object
     {

--- a/lib/Doctrine/ODM/MongoDB/Iterator/PrimingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/PrimingIterator.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Query\ReferencePrimer;
 use Doctrine\ODM\MongoDB\UnitOfWork;
+use ReturnTypeWillChange;
 
 use function is_callable;
 use function iterator_to_array;
@@ -61,6 +62,10 @@ final class PrimingIterator implements Iterator
         return iterator_to_array($this);
     }
 
+    /**
+     * @return TValue|null
+     */
+    #[ReturnTypeWillChange]
     public function current()
     {
         $this->primeReferences();
@@ -73,6 +78,10 @@ final class PrimingIterator implements Iterator
         $this->iterator->next();
     }
 
+    /**
+     * @return TKey|null
+     */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->iterator->key();

--- a/lib/Doctrine/ODM/MongoDB/Iterator/UnrewindableIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/UnrewindableIterator.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Iterator;
 
 use Generator;
 use LogicException;
+use ReturnTypeWillChange;
 use RuntimeException;
 use Traversable;
 
@@ -60,20 +61,18 @@ final class UnrewindableIterator implements Iterator
     }
 
     /**
-     * @see http://php.net/iterator.current
-     *
-     * @return mixed
+     * @return TValue|null
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->getIterator()->current();
     }
 
     /**
-     * @see http://php.net/iterator.mixed
-     *
-     * @return mixed
+     * @return TKey|null
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         if ($this->iterator) {

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -11,6 +11,8 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
+use ReturnTypeWillChange;
+use Traversable;
 
 use function array_udiff;
 use function array_udiff_assoc;
@@ -461,8 +463,9 @@ trait PersistentCollectionTrait
     }
 
     /**
-     * {@inheritdoc}
+     * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         // Workaround around not being able to directly count inverse collections anymore
@@ -496,8 +499,9 @@ trait PersistentCollectionTrait
     }
 
     /**
-     * {@inheritdoc}
+     * @return Traversable
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         $this->initialize();
@@ -611,8 +615,11 @@ trait PersistentCollectionTrait
     /* ArrayAccess implementation */
 
     /**
-     * @see containsKey()
+     * @param mixed $offset
+     *
+     * @return bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $this->initialize();
@@ -621,8 +628,11 @@ trait PersistentCollectionTrait
     }
 
     /**
-     * @see get()
+     * @param mixed $offset
+     *
+     * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $this->initialize();
@@ -631,9 +641,12 @@ trait PersistentCollectionTrait
     }
 
     /**
-     * @see add()
-     * @see set()
+     * @param mixed $offset
+     * @param mixed $value
+     *
+     * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (! isset($offset)) {
@@ -646,8 +659,11 @@ trait PersistentCollectionTrait
     }
 
     /**
-     * @see remove()
+     * @param mixed $offset
+     *
+     * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->doRemove($offset, true);

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,6 +28,7 @@
     </groups>
 
     <php>
+        <ini name="error_reporting" value="-1"/>
         <const name="DOCTRINE_MONGODB_SERVER" value="mongodb://localhost:27017" />
         <const name="DOCTRINE_MONGODB_DATABASE" value="doctrine_odm_tests" />
     </php>

--- a/psalm.xml
+++ b/psalm.xml
@@ -29,5 +29,12 @@
                 <file name="tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php"/>
             </errorLevel>
         </UndefinedConstant>
+
+        <UndefinedAttributeClass>
+            <errorLevel type="suppress">
+                <!-- Remove it when using PHP 8.1 for running Psalm -->
+                <referencedClass name="ReturnTypeWillChange" />
+            </errorLevel>
+        </UndefinedAttributeClass>
     </issueHandlers>
 </psalm>

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
@@ -111,8 +111,9 @@ class PersistentCollectionTest extends BaseTest
 
     public function testSnapshotIsPreservedDuringSerialization(): void
     {
+        $obj        = new stdClass();
         $collection = new PersistentCollection(new ArrayCollection(), $this->dm, $this->uow);
-        $collection->add(new stdClass());
+        $collection->add($obj);
         $collection->takeSnapshot();
 
         $this->assertCount(1, $collection->getSnapshot());


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->

~We should probably add `#[\ReturnTypeWillChange]` in some methods, let's see what happens~

Added some `ReturnTypeWillChange`