### PR TITLE
Remove deprecated "boolean" mapping type in docs

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -146,7 +146,7 @@ Here is a quick overview of the built-in mapping types:
 -  ``bin_func``
 -  ``bin_md5``
 -  ``bin_uuid``
--  ``boolean``
+-  ``bool``
 -  ``collection``
 -  ``custom_id``
 -  ``date``


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | docs
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->
User Deprecated: Since doctrine/mongodb-odm 2.1: The "boolean" mapping type is deprecated. Use "bool" instead