### PR TITLE
Drop support of unsupported Symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,9 @@
         "jean85/pretty-package-versions": "^1.3.0 || ^2.0.1",
         "mongodb/mongodb": "^1.2.0",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
-        "symfony/console": "^3.4 || ^4.1 || ^5.0",
+        "symfony/console": "^4.4 || ^5.3",
         "symfony/deprecation-contracts": "^2.2",
-        "symfony/var-dumper": "^3.4 || ^4.1 || ^5.0"
+        "symfony/var-dumper": "^4.4 || ^5.3"
     },
     "require-dev": {
         "ext-bcmath": "*",
@@ -48,7 +48,7 @@
         "phpstan/phpstan-phpunit": "^0.12.19",
         "phpunit/phpunit": "^8.5 || ^9",
         "squizlabs/php_codesniffer": "^3.5",
-        "symfony/cache": "^4.4 || ^5.0",
+        "symfony/cache": "^4.4 || ^5.3",
         "vimeo/psalm": "^4.8.1"
     },
     "suggest": {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->

Ref: https://github.com/doctrine/mongodb-odm/pull/2375#discussion_r728641746

I've looked for: `method_exists`, `interface_exists`, `symfony 3.4` and I haven't found anything, so I guess there are no BC layers.
