### PR TITLE
Remove key template for iterators

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
@@ -23,16 +23,15 @@ use function reset;
  *
  * @internal
  *
- * @template TKey
  * @template TValue
- * @template-implements Iterator<TKey, TValue>
+ * @template-implements Iterator<TValue>
  */
 final class CachingIterator implements Iterator
 {
-    /** @var array<TKey, TValue> */
+    /** @var array<mixed, TValue> */
     private $items = [];
 
-    /** @var Generator<TKey, TValue>|null */
+    /** @var Generator<mixed, TValue>|null */
     private $iterator;
 
     /** @var bool */
@@ -48,7 +47,7 @@ final class CachingIterator implements Iterator
      * behavior of the SPL iterators and allows users to omit an explicit call
      * to rewind() before using the other methods.
      *
-     * @param Traversable<TKey, TValue> $iterator
+     * @param Traversable<mixed, TValue> $iterator
      */
     public function __construct(Traversable $iterator)
     {
@@ -78,7 +77,7 @@ final class CachingIterator implements Iterator
     }
 
     /**
-     * @return TKey|null
+     * @return mixed
      */
     #[ReturnTypeWillChange]
     public function key()
@@ -135,7 +134,7 @@ final class CachingIterator implements Iterator
     }
 
     /**
-     * @return Generator<TKey, TValue>
+     * @return Generator<mixed, TValue>
      */
     private function getIterator(): Generator
     {
@@ -161,9 +160,9 @@ final class CachingIterator implements Iterator
     }
 
     /**
-     * @param Traversable<TKey, TValue> $traversable
+     * @param Traversable<mixed, TValue> $traversable
      *
-     * @return Generator<TKey, TValue>
+     * @return Generator<mixed, TValue>
      */
     private function wrapTraversable(Traversable $traversable): Generator
     {

--- a/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
@@ -19,14 +19,13 @@ use Traversable;
  *
  * @psalm-import-type Hints from UnitOfWork
  *
- * @template TKey
  * @template TValue
  * @template TDocument of object
- * @template-implements Iterator<TKey, TDocument>
+ * @template-implements Iterator<TValue>
  */
 final class HydratingIterator implements Iterator
 {
-    /** @var Generator<TKey, TValue>|null */
+    /** @var Generator<mixed, TValue>|null */
     private $iterator;
 
     /** @var UnitOfWork */
@@ -42,8 +41,8 @@ final class HydratingIterator implements Iterator
     private $unitOfWorkHints;
 
     /**
-     * @param Traversable<TKey, TValue> $traversable
-     * @param ClassMetadata<TDocument>  $class
+     * @param Traversable<mixed, TValue> $traversable
+     * @param ClassMetadata<TDocument>   $class
      * @psalm-param Hints $unitOfWorkHints
      */
     public function __construct(Traversable $traversable, UnitOfWork $unitOfWork, ClassMetadata $class, array $unitOfWorkHints = [])
@@ -69,7 +68,7 @@ final class HydratingIterator implements Iterator
     }
 
     /**
-     * @return TKey|null
+     * @return mixed
      */
     #[ReturnTypeWillChange]
     public function key()
@@ -102,7 +101,7 @@ final class HydratingIterator implements Iterator
     }
 
     /**
-     * @return Generator<TKey, TValue>
+     * @return Generator<mixed, TValue>
      */
     private function getIterator(): Generator
     {
@@ -124,9 +123,9 @@ final class HydratingIterator implements Iterator
     }
 
     /**
-     * @param Traversable<TKey, TValue> $traversable
+     * @param Traversable<mixed, TValue> $traversable
      *
-     * @return Generator<TKey, TValue>
+     * @return Generator<mixed, TValue>
      */
     private function wrapTraversable(Traversable $traversable): Generator
     {

--- a/lib/Doctrine/ODM/MongoDB/Iterator/Iterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/Iterator.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Iterator;
 
 /**
- * @template TKey
  * @template TValue
- * @template-extends \Iterator<TKey, TValue>
+ * @template-extends \Iterator<mixed, TValue>
  */
 interface Iterator extends \Iterator
 {
     /**
-     * @psalm-return array<TKey, TValue>
+     * @psalm-return array<mixed, TValue>
      */
     public function toArray(): array;
 }

--- a/lib/Doctrine/ODM/MongoDB/Iterator/PrimingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/PrimingIterator.php
@@ -14,14 +14,13 @@ use function iterator_to_array;
 
 /**
  * @psalm-import-type Hints from UnitOfWork
- * @template TKey
  * @template TValue
  * @template TDocument of object
- * @template-implements Iterator<TKey, TValue>
+ * @template-implements Iterator<TValue>
  */
 final class PrimingIterator implements Iterator
 {
-    /** @var \Iterator<TKey, TValue> */
+    /** @var \Iterator<mixed, TValue> */
     private $iterator;
 
     /** @var ClassMetadata<TDocument> */
@@ -43,7 +42,7 @@ final class PrimingIterator implements Iterator
     private $referencesPrimed = false;
 
     /**
-     * @param \Iterator<TKey, TValue>      $iterator
+     * @param \Iterator<mixed, TValue>     $iterator
      * @param ClassMetadata<TDocument>     $class
      * @param array<string, callable|null> $primers
      * @psalm-param Hints $unitOfWorkHints
@@ -79,7 +78,7 @@ final class PrimingIterator implements Iterator
     }
 
     /**
-     * @return TKey|null
+     * @return mixed
      */
     #[ReturnTypeWillChange]
     public function key()

--- a/lib/Doctrine/ODM/MongoDB/Iterator/UnrewindableIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/UnrewindableIterator.php
@@ -18,13 +18,12 @@ use function sprintf;
  *
  * @internal
  *
- * @template TKey
  * @template TValue
- * @template-implements Iterator<TKey, TValue>
+ * @template-implements Iterator<TValue>
  */
 final class UnrewindableIterator implements Iterator
 {
-    /** @var Generator<TKey, TValue>|null */
+    /** @var Generator<mixed, TValue>|null */
     private $iterator;
 
     /** @var bool */
@@ -36,7 +35,7 @@ final class UnrewindableIterator implements Iterator
      * Additionally, this mimics behavior of the SPL iterators and allows users
      * to omit an explicit call to rewind() before using the other methods.
      *
-     * @param Traversable<TKey, TValue> $iterator
+     * @param Traversable<mixed, TValue> $iterator
      */
     public function __construct(Traversable $iterator)
     {
@@ -70,7 +69,7 @@ final class UnrewindableIterator implements Iterator
     }
 
     /**
-     * @return TKey|null
+     * @return mixed
      */
     #[ReturnTypeWillChange]
     public function key()
@@ -121,7 +120,7 @@ final class UnrewindableIterator implements Iterator
     }
 
     /**
-     * @return Generator<TKey, TValue>
+     * @return Generator<mixed, TValue>
      */
     private function getIterator(): Generator
     {
@@ -133,9 +132,9 @@ final class UnrewindableIterator implements Iterator
     }
 
     /**
-     * @param Traversable<TKey, TValue> $traversable
+     * @param Traversable<mixed, TValue> $traversable
      *
-     * @return Generator<TKey, TValue>
+     * @return Generator<mixed, TValue>
      */
     private function wrapTraversable(Traversable $traversable): Generator
     {

--- a/lib/Doctrine/ODM/MongoDB/Repository/DocumentRepository.php
+++ b/lib/Doctrine/ODM/MongoDB/Repository/DocumentRepository.php
@@ -218,7 +218,7 @@ class DocumentRepository implements ObjectRepository, Selectable
      * Selects all elements from a selectable that match the expression and
      * returns a new collection containing these elements.
      *
-     * @return ArrayCollection<int, T>
+     * @return ArrayCollection<array-key, T>
      */
     public function matching(Criteria $criteria): ArrayCollection
     {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

I think there is no need for specifying the key as template when using iterators, otherwise we (and users) always have to use: `Iterator<key, User>` instead of `Iterator<User>`.

I've used `mixed` as key because of [`Iterator::key` definition](https://www.php.net/manual/en/iterator.key.php). In the tests directory, all the occurrences I've found are using `int`.