### PR TITLE
Use array_diff_key to get diff for new or deleted documents

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -256,10 +256,10 @@ trait PersistentCollectionTrait
     public function getDeletedDocuments()
     {
         $coll = $this->coll->toArray();
-        $loadedObjectsByOid = \array_combine(\array_map('spl_object_hash', $this->snapshot), $this->snapshot);
-        $newObjectsByOid = \array_combine(\array_map('spl_object_hash', $coll), $coll);
+        $loadedObjectsByOid = array_combine(array_map('spl_object_hash', $this->snapshot), $this->snapshot);
+        $newObjectsByOid = array_combine(array_map('spl_object_hash', $coll), $coll);
 
-        return array_values(\array_diff_key($loadedObjectsByOid, $newObjectsByOid));
+        return array_values(array_diff_key($loadedObjectsByOid, $newObjectsByOid));
     }
 
     /** {@inheritdoc} */
@@ -278,10 +278,10 @@ trait PersistentCollectionTrait
     public function getInsertedDocuments()
     {
         $coll = $this->coll->toArray();
-        $loadedObjectsByOid = \array_combine(\array_map('spl_object_hash', $this->snapshot), $this->snapshot);
-        $newObjectsByOid = \array_combine(\array_map('spl_object_hash', $coll), $coll);
+        $loadedObjectsByOid = array_combine(array_map('spl_object_hash', $this->snapshot), $this->snapshot);
+        $newObjectsByOid = array_combine(array_map('spl_object_hash', $coll), $coll);
 
-        return array_values(\array_diff_key($newObjectsByOid, $loadedObjectsByOid));
+        return array_values(array_diff_key($newObjectsByOid, $loadedObjectsByOid));
     }
 
     /** {@inheritdoc} */

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -11,13 +11,14 @@ use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 
-use function array_udiff;
+use function array_combine;
+use function array_diff_key;
+use function array_map;
 use function array_udiff_assoc;
 use function array_values;
 use function count;
 use function get_class;
 use function is_object;
-use function spl_object_hash;
 
 /**
  * Trait with methods needed to implement PersistentCollectionInterface.
@@ -255,9 +256,9 @@ trait PersistentCollectionTrait
     /** {@inheritdoc} */
     public function getDeletedDocuments()
     {
-        $coll = $this->coll->toArray();
+        $coll               = $this->coll->toArray();
         $loadedObjectsByOid = array_combine(array_map('spl_object_hash', $this->snapshot), $this->snapshot);
-        $newObjectsByOid = array_combine(array_map('spl_object_hash', $coll), $coll);
+        $newObjectsByOid    = array_combine(array_map('spl_object_hash', $coll), $coll);
 
         return array_values(array_diff_key($loadedObjectsByOid, $newObjectsByOid));
     }
@@ -277,9 +278,9 @@ trait PersistentCollectionTrait
     /** {@inheritdoc} */
     public function getInsertedDocuments()
     {
-        $coll = $this->coll->toArray();
+        $coll               = $this->coll->toArray();
         $loadedObjectsByOid = array_combine(array_map('spl_object_hash', $this->snapshot), $this->snapshot);
-        $newObjectsByOid = array_combine(array_map('spl_object_hash', $coll), $coll);
+        $newObjectsByOid    = array_combine(array_map('spl_object_hash', $coll), $coll);
 
         return array_values(array_diff_key($newObjectsByOid, $loadedObjectsByOid));
     }

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -255,18 +255,11 @@ trait PersistentCollectionTrait
     /** {@inheritdoc} */
     public function getDeletedDocuments()
     {
-        $compare = static function ($a, $b) {
-            $compareA = is_object($a) ? spl_object_hash($a) : $a;
-            $compareb = is_object($b) ? spl_object_hash($b) : $b;
+        $coll = $this->coll->toArray();
+        $loadedObjectsByOid = \array_combine(\array_map('spl_object_hash', $this->snapshot), $this->snapshot);
+        $newObjectsByOid = \array_combine(\array_map('spl_object_hash', $coll), $coll);
 
-            return $compareA === $compareb ? 0 : ($compareA > $compareb ? 1 : -1);
-        };
-
-        return array_values(array_udiff(
-            $this->snapshot,
-            $this->coll->toArray(),
-            $compare
-        ));
+        return array_values(\array_diff_key($loadedObjectsByOid, $newObjectsByOid));
     }
 
     /** {@inheritdoc} */
@@ -284,18 +277,11 @@ trait PersistentCollectionTrait
     /** {@inheritdoc} */
     public function getInsertedDocuments()
     {
-        $compare = static function ($a, $b) {
-            $compareA = is_object($a) ? spl_object_hash($a) : $a;
-            $compareb = is_object($b) ? spl_object_hash($b) : $b;
+        $coll = $this->coll->toArray();
+        $loadedObjectsByOid = \array_combine(\array_map('spl_object_hash', $this->snapshot), $this->snapshot);
+        $newObjectsByOid = \array_combine(\array_map('spl_object_hash', $coll), $coll);
 
-            return $compareA === $compareb ? 0 : ($compareA > $compareb ? 1 : -1);
-        };
-
-        return array_values(array_udiff(
-            $this->coll->toArray(),
-            $this->snapshot,
-            $compare
-        ));
+        return array_values(\array_diff_key($newObjectsByOid, $loadedObjectsByOid));
     }
 
     /** {@inheritdoc} */

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -19,7 +19,6 @@ use function array_values;
 use function count;
 use function get_class;
 use function is_object;
-use function spl_object_hash;
 
 /**
  * Trait with methods needed to implement PersistentCollectionInterface.
@@ -257,13 +256,9 @@ trait PersistentCollectionTrait
     /** {@inheritdoc} */
     public function getDeletedDocuments()
     {
-        $callback = static function ($val) {
-            return is_object($val) ? spl_object_hash($val) : $val;
-        };
-
         $coll               = $this->coll->toArray();
-        $loadedObjectsByOid = array_combine(array_map($callback, $this->snapshot), $this->snapshot);
-        $newObjectsByOid    = array_combine(array_map($callback, $coll), $coll);
+        $loadedObjectsByOid = array_combine(array_map('spl_object_id', $this->snapshot), $this->snapshot);
+        $newObjectsByOid    = array_combine(array_map('spl_object_id', $coll), $coll);
 
         return array_values(array_diff_key($loadedObjectsByOid, $newObjectsByOid));
     }
@@ -283,13 +278,9 @@ trait PersistentCollectionTrait
     /** {@inheritdoc} */
     public function getInsertedDocuments()
     {
-        $callback = static function ($val) {
-            return is_object($val) ? spl_object_hash($val) : $val;
-        };
-
         $coll               = $this->coll->toArray();
-        $newObjectsByOid    = array_combine(array_map($callback, $coll), $coll);
-        $loadedObjectsByOid = array_combine(array_map($callback, $this->snapshot), $this->snapshot);
+        $newObjectsByOid    = array_combine(array_map('spl_object_id', $coll), $coll);
+        $loadedObjectsByOid = array_combine(array_map('spl_object_id', $this->snapshot), $this->snapshot);
 
         return array_values(array_diff_key($newObjectsByOid, $loadedObjectsByOid));
     }

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -19,6 +19,7 @@ use function array_values;
 use function count;
 use function get_class;
 use function is_object;
+use function spl_object_hash;
 
 /**
  * Trait with methods needed to implement PersistentCollectionInterface.
@@ -256,9 +257,13 @@ trait PersistentCollectionTrait
     /** {@inheritdoc} */
     public function getDeletedDocuments()
     {
+        $callback = static function ($val) {
+            return is_object($val) ? spl_object_hash($val) : $val;
+        };
+
         $coll               = $this->coll->toArray();
-        $loadedObjectsByOid = array_combine(array_map('spl_object_hash', $this->snapshot), $this->snapshot);
-        $newObjectsByOid    = array_combine(array_map('spl_object_hash', $coll), $coll);
+        $loadedObjectsByOid = array_combine(array_map($callback, $this->snapshot), $this->snapshot);
+        $newObjectsByOid    = array_combine(array_map($callback, $coll), $coll);
 
         return array_values(array_diff_key($loadedObjectsByOid, $newObjectsByOid));
     }
@@ -278,9 +283,13 @@ trait PersistentCollectionTrait
     /** {@inheritdoc} */
     public function getInsertedDocuments()
     {
+        $callback = static function ($val) {
+            return is_object($val) ? spl_object_hash($val) : $val;
+        };
+
         $coll               = $this->coll->toArray();
-        $loadedObjectsByOid = array_combine(array_map('spl_object_hash', $this->snapshot), $this->snapshot);
-        $newObjectsByOid    = array_combine(array_map('spl_object_hash', $coll), $coll);
+        $newObjectsByOid    = array_combine(array_map($callback, $coll), $coll);
+        $loadedObjectsByOid = array_combine(array_map($callback, $this->snapshot), $this->snapshot);
 
         return array_values(array_diff_key($newObjectsByOid, $loadedObjectsByOid));
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | fixes #2387

#### Summary

Avoid of array_udiff usage for getDeletedDocuments and getInsertedDocuments functions