### PR TITLE
Schema:create fails with single collection inheritance

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -305,10 +305,20 @@ final class SchemaManager
      */
     public function createCollections(?int $maxTimeMs = null, ?WriteConcern $writeConcern = null): void
     {
+        $singleInheritanceProcessed = [];
+
         foreach ($this->metadataFactory->getAllMetadata() as $class) {
             assert($class instanceof ClassMetadata);
             if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument) {
                 continue;
+            }
+
+            if ($class->inheritanceType === ClassMetadata::INHERITANCE_TYPE_SINGLE_COLLECTION) {
+                if (in_array($class->collection, $singleInheritanceProcessed)) {
+                    continue;
+                }
+
+                $singleInheritanceProcessed[] = $class->collection;
             }
 
             $this->createDocumentCollection($class->name, $maxTimeMs, $writeConcern);

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -18,6 +18,7 @@ use Documents\File;
 use Documents\Sharded\ShardedOne;
 use Documents\Sharded\ShardedOneWithDifferentKey;
 use Documents\SimpleReferenceUser;
+use Documents\Tournament\Tournament;
 use Documents\UserName;
 use MongoDB\Client;
 use MongoDB\Collection;
@@ -458,6 +459,9 @@ class SchemaManagerTest extends BaseTest
      */
     public function testCreateCollections(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern)
     {
+        $class = $this->dm->getClassMetadata(Tournament::class);
+        self::assertSame(ClassMetadata::INHERITANCE_TYPE_SINGLE_COLLECTION, $class->inheritanceType);
+
         $createdCollections = [];
         foreach ($this->documentDatabases as $database) {
             $database


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #2182 

#### Summary

Maintain in memory already processed collection in case of single collection inheritance and skip next procession of these collections.
