### PR TITLE
feat: use IteratorAggregate interface instead of final class

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -10,6 +10,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use Doctrine\ODM\MongoDB\Query\Expr as QueryExpr;
 use GeoJson\Geometry\Point;
+use IteratorAggregate;
 use MongoDB\Collection;
 use OutOfRangeException;
 use TypeError;
@@ -226,7 +227,7 @@ class Builder
     /**
      * Returns an aggregation object for the current pipeline
      */
-    public function getAggregation(array $options = []): Aggregation
+    public function getAggregation(array $options = []): IteratorAggregate
     {
         $class = $this->hydrationClass ? $this->dm->getClassMetadata($this->hydrationClass) : null;
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         |improvement
| BC Break     | no

Hi, I have unit tests which are mocking the Builder and as `Aggregation` is a final class (even instantiating it in a test is hard, and even if I do so the `getIterator` method uses an `assert($cursor instanceof Cursor)` where Cursor is a final class that we can not instantiate. Using an interface here seems more appropriate, thoughts? 