### PR TITLE
Skip non-mapped typed properties with default values when using Proxies

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Proxy/Factory/StaticProxyFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Factory/StaticProxyFactory.php
@@ -14,9 +14,11 @@ use Doctrine\ODM\MongoDB\Utility\LifecycleEventManager;
 use Doctrine\Persistence\NotifyPropertyChanged;
 use ProxyManager\Factory\LazyLoadingGhostFactory;
 use ProxyManager\Proxy\GhostObjectInterface;
+use ReflectionClass;
 use ReflectionProperty;
 
 use function array_filter;
+use function array_merge;
 use function count;
 
 /**
@@ -131,6 +133,19 @@ final class StaticProxyFactory implements ProxyFactory
      */
     private function skippedFieldsFqns(ClassMetadata $metadata): array
     {
+        $skippedIdFieldsFqns        = $this->getIdFieldsFqns($metadata);
+        $skippedNonMappedFieldsFqns = $this->getUnmappedPropertyFqns($metadata);
+
+        return array_merge($skippedIdFieldsFqns, $skippedNonMappedFieldsFqns);
+    }
+
+    /**
+     * @param ClassMetadata<object> $metadata
+     *
+     * @return array<int, string>
+     */
+    private function getIdFieldsFqns(ClassMetadata $metadata): array
+    {
         $idFieldFqcns = [];
 
         foreach ($metadata->getIdentifierFieldNames() as $idField) {
@@ -138,6 +153,30 @@ final class StaticProxyFactory implements ProxyFactory
         }
 
         return $idFieldFqcns;
+    }
+
+    /**
+     * @param ClassMetadata<object> $metadata
+     *
+     * @return array<int, string>
+     */
+    private function getUnmappedPropertyFqns(ClassMetadata $metadata): array
+    {
+        $nonMappedFieldFqcns = [];
+
+        $reflectionClass = new ReflectionClass($metadata->getName());
+
+        foreach ($reflectionClass->getProperties() as $property) {
+            $propertyName = $property->getName();
+
+            if ($metadata->hasField($propertyName)) {
+                continue;
+            }
+
+            $nonMappedFieldFqcns[] = $this->propertyFqcn($property);
+        }
+
+        return $nonMappedFieldFqcns;
     }
 
     private function propertyFqcn(ReflectionProperty $property): string

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2349Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2349Test.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents74\GH2349Customer;
+use Documents74\GH2349Order;
+
+/** @requires PHP 7.4 */
+class GH2349Test extends BaseTestCase
+{
+    public function testAccessingUnitializedProperties(): void
+    {
+        $customer = new GH2349Customer('Some Place');
+        $order    = new GH2349Order($customer);
+
+        $this->dm->persist($customer);
+        $this->dm->persist($order);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $orderId = GH2349Order::ID;
+
+        $order = $this->dm->getRepository(GH2349Order::class)->find($orderId);
+
+        // Fetch a list of Customers from the DB. Any customer object that was referenced in the above order is still
+        // a proxy object, however it will not have the defaults set for the un-managed $domainEvents property.
+        $customers = $this->dm->getRepository(GH2349Customer::class)->findAll();
+
+        foreach ($customers as $customer) {
+            self::assertSame([], $customer->getEvents()); // This would trigger an error if unmapped properties are unset
+        }
+    }
+}

--- a/tests/Documents74/GH2349Customer.php
+++ b/tests/Documents74/GH2349Customer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents74;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/** @ODM\Document() */
+class GH2349Customer
+{
+    public const ID = '610419a277d50f7609139542';
+
+    /** @ODM\Id() */
+    private string $id;
+
+    /** @ODM\Field() */
+    private string $name;
+
+    private array $domainEvents = [];
+
+    public function __construct(string $name)
+    {
+        $this->id   = self::ID;
+        $this->name = $name;
+    }
+
+    public function doSomeUpdate(): void
+    {
+        $this->domainEvents[] = 'a new event!';
+    }
+
+    public function getEvents(): array
+    {
+        return $this->domainEvents;
+    }
+}

--- a/tests/Documents74/GH2349Order.php
+++ b/tests/Documents74/GH2349Order.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents74;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use MongoDB\BSON\ObjectId;
+
+/** @ODM\Document() */
+class GH2349Order
+{
+    public const ID = '610419a277d50f7609139543';
+
+    /** @ODM\Id() */
+    private string $id;
+
+    /** @ODM\ReferenceOne(targetDocument=GH2349Customer::class, storeAs="ref") */
+    private GH2349Customer $customer;
+
+    public function __construct(GH2349Customer $customer)
+    {
+        $this->id       = (string) new ObjectId(self::ID);
+        $this->customer = $customer;
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | #2349

#### Summary

Taking a look at #2349 seems like the problem is that the proxy is not initialized when it's managed. 

~Looking at the code, if the document is an instance of `GhostObjectInterface` and it not initialized, it calls to `$document->setProxyInitializer(null);` which removes the initialization.~

To be honest I'm not sure if it's the right fix, maybe that code was there for some reason.

The test is from https://github.com/andythorne/doctrine-odm-example-error

**Update**: I was taking a look again to this issue, apparently one way to solve it is to skip those properties when using a proxy.