### PR TITLE
Allow more recent symfony/deprecation-contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "mongodb/mongodb": "^1.2.0",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "symfony/console": "^3.4 || ^4.1 || ^5.0 || ^6.0",
-        "symfony/deprecation-contracts": "^2.2",
+        "symfony/deprecation-contracts": "^2.2 || ^3.0",
         "symfony/var-dumper": "^3.4 || ^4.1 || ^5.0 || ^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
To prevent conflicts with newer libraries.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

Trying to install recent libraries (eg. `doctrine/mongodb-odm-bundle` and `easycorp/easyadmin-bundle`) is not possible because of a `symfony/deprecation-contracts` conflict. This PR fixes that.

I understand that this could also be fixed by changing `easycorp/easyadmin-bundle`'s requirements and I will open a similar PR, too.
