### PR TITLE
Use typed properties for default metadata

### DIFF
--- a/UPGRADE-2.4.md
+++ b/UPGRADE-2.4.md
@@ -1,0 +1,15 @@
+# UPGRADE FROM 2.3 to 2.4
+
+## Typed properties as default mapping metadata
+
+When using typed properties on Document classes, Doctrine will use these types to set defaults mapping types.
+
+If you have defined some properties like:
+
+```php
+#[Field]
+private int $myProp;
+```
+
+This property will be stored in DB as `string` but casted back to `int`. Please note that at this
+time, due to backward compatibility reasons, nullable type does not imply `nullable` mapping.

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -210,7 +210,8 @@ Optional attributes:
     information.
 -
     ``collectionClass`` - A |FQCN| of class that implements ``Collection``
-    interface and is used to hold documents. Doctrine's ``ArrayCollection`` is
+    interface and is used to hold documents. When typed properties
+    are used it is inherited from PHP type, otherwise Doctrine's ``ArrayCollection`` is
     used by default.
 -
     ``notSaved`` - The property is loaded if it exists in the database; however,
@@ -257,7 +258,8 @@ following excerpt from the MongoDB documentation:
 Optional attributes:
 
 -
-    ``targetDocument`` - A |FQCN| of the target document.
+    ``targetDocument`` - A |FQCN| of the target document. When typed properties
+    are used it is inherited from PHP type.
 -
     ``discriminatorField`` - The database field name to store the discriminator
     value within the embedded document.
@@ -356,7 +358,8 @@ Optional attributes:
 -
    ``type`` - Name of the ODM type, which will determine the value's
    representation in PHP and BSON (i.e. MongoDB). See
-   :ref:`doctrine_mapping_types` for a list of types. Defaults to "string".
+   :ref:`doctrine_mapping_types` for a list of types. Defaults to "string" or
+   :ref:`Type from PHP property type <reference-php-mapping-types>`.
 -
    ``name`` - By default, the property name is used for the field name in
    MongoDB; however, this option may be used to specify a database field name.
@@ -961,7 +964,8 @@ Optional attributes:
     information.
 -
     ``collectionClass`` - A |FQCN| of class that implements ``Collection``
-    interface and is used to hold documents. Doctrine's ``ArrayCollection`` is
+    interface and is used to hold documents. When typed properties
+    are used it is inherited from PHP type, otherwise Doctrine's ``ArrayCollection`` is
     used by default
 -
     ``prime`` - A list of references contained in the target document that will
@@ -1002,7 +1006,8 @@ Optional attributes:
 
 -
     ``targetDocument`` - A |FQCN| of the target document. A ``targetDocument``
-    is required when using ``storeAs: id``.
+    is required when using ``storeAs: id``. When typed properties are used
+    it is inherited from PHP type.
 -
     ``storeAs`` - Indicates how to store the reference. ``id`` stores the
     identifier, ``ref`` an embedded object containing the ``id`` field and

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -198,6 +198,25 @@ This list explains some of the less obvious mapping types:
     suitable you should either use an embedded document or use formats provided
     by the MongoDB driver (e.g. ``\MongoDB\BSON\UTCDateTime`` instead of ``\DateTime``).
 
+.. _reference-php-mapping-types:
+
+PHP Types Mapping
+_________________
+
+Since version 2.4 Doctrine can determine usable defaults from property types
+on document classes. Doctrine will map PHP types to ``type`` attribute as
+follows:
+
+- ``DateTime``: ``date``
+- ``DateTimeImmutable``: ``date_immutable``
+- ``array``: ``hash``
+- ``bool``: ``bool``
+- ``float``: ``float``
+- ``int``: ``int``
+- ``string``: ``string``
+
+Please note that at this time, due to backward compatibility reasons, nullable type does not imply `nullable` mapping.
+
 Property Mapping
 ----------------
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractField.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractField.php
@@ -29,7 +29,7 @@ abstract class AbstractField implements Annotation
      */
     public function __construct(
         ?string $name = null,
-        ?string $type = 'string',
+        ?string $type = null,
         bool $nullable = false,
         array $options = [],
         ?string $strategy = null,

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -15,7 +15,11 @@ use Doctrine\ODM\MongoDB\Repository\DefaultGridFSRepository;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\ODM\MongoDB\Repository\ViewRepository;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Documents74\CustomCollection;
+use Documents74\TypedEmbeddedDocument;
+use Documents74\UserTyped;
 use InvalidArgumentException;
 
 use function key;
@@ -192,6 +196,28 @@ abstract class AbstractMappingDriverTest extends BaseTest
         $this->assertEquals('identifier', $class->identifier);
 
         return $class;
+    }
+
+    /**
+     * @requires PHP >= 7.4
+     */
+    public function testFieldTypeFromReflection(): void
+    {
+        $class = $this->dm->getClassMetadata(UserTyped::class);
+
+        $this->assertSame(Type::ID, $class->getTypeOfField('id'));
+        $this->assertSame(Type::STRING, $class->getTypeOfField('username'));
+        $this->assertSame(Type::DATE, $class->getTypeOfField('dateTime'));
+        $this->assertSame(Type::DATE_IMMUTABLE, $class->getTypeOfField('dateTimeImmutable'));
+        $this->assertSame(Type::HASH, $class->getTypeOfField('array'));
+        $this->assertSame(Type::BOOL, $class->getTypeOfField('boolean'));
+        $this->assertSame(Type::FLOAT, $class->getTypeOfField('float'));
+
+        $this->assertSame(TypedEmbeddedDocument::class, $class->getAssociationTargetClass('embedOne'));
+        $this->assertSame(UserTyped::class, $class->getAssociationTargetClass('referenceOne'));
+
+        $this->assertSame(CustomCollection::class, $class->getAssociationCollectionClass('embedMany'));
+        $this->assertSame(CustomCollection::class, $class->getAssociationCollectionClass('referenceMany'));
     }
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -26,6 +26,9 @@ use Documents\SpecialUser;
 use Documents\User;
 use Documents\UserName;
 use Documents\UserRepository;
+use Documents74\CustomCollection;
+use Documents74\TypedEmbeddedDocument;
+use Documents74\UserTyped;
 use Generator;
 use InvalidArgumentException;
 use ProxyManager\Proxy\GhostObjectInterface;
@@ -134,6 +137,54 @@ class ClassMetadataTest extends BaseTest
         // Implicit Not Nullable
         $cm->mapField(['fieldName' => 'name', 'type' => 'string', 'length' => 50]);
         $this->assertFalse($cm->isNullable('name'), 'By default a field should not be nullable.');
+    }
+
+    /**
+     * @requires PHP >= 7.4
+     */
+    public function testFieldTypeFromReflection(): void
+    {
+        $cm = new ClassMetadata(UserTyped::class);
+
+        // String
+        $cm->mapField(['fieldName' => 'username', 'length' => 50]);
+        self::assertEquals(Type::STRING, $cm->getTypeOfField('username'));
+
+        // DateTime object
+        $cm->mapField(['fieldName' => 'dateTime']);
+        self::assertEquals(Type::DATE, $cm->getTypeOfField('dateTime'));
+
+        // DateTimeImmutable object
+        $cm->mapField(['fieldName' => 'dateTimeImmutable']);
+        self::assertEquals(Type::DATE_IMMUTABLE, $cm->getTypeOfField('dateTimeImmutable'));
+
+        // array as hash
+        $cm->mapField(['fieldName' => 'array']);
+        self::assertEquals(Type::HASH, $cm->getTypeOfField('array'));
+
+        // bool
+        $cm->mapField(['fieldName' => 'boolean']);
+        self::assertEquals(Type::BOOL, $cm->getTypeOfField('boolean'));
+
+        // float
+        $cm->mapField(['fieldName' => 'float']);
+        self::assertEquals(Type::FLOAT, $cm->getTypeOfField('float'));
+
+        // int
+        $cm->mapField(['fieldName' => 'int']);
+        self::assertEquals(Type::INT, $cm->getTypeOfField('int'));
+
+        $cm->mapOneEmbedded(['fieldName' => 'embedOne']);
+        self::assertEquals(TypedEmbeddedDocument::class, $cm->getAssociationTargetClass('embedOne'));
+
+        $cm->mapOneReference(['fieldName' => 'referenceOne']);
+        self::assertEquals(UserTyped::class, $cm->getAssociationTargetClass('referenceOne'));
+
+        $cm->mapManyEmbedded(['fieldName' => 'embedMany']);
+        self::assertEquals(CustomCollection::class, $cm->getAssociationCollectionClass('embedMany'));
+
+        $cm->mapManyReference(['fieldName' => 'referenceMany']);
+        self::assertEquals(CustomCollection::class, $cm->getAssociationCollectionClass('referenceMany'));
     }
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Documents74.UserTyped.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Documents74.UserTyped.dcm.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="Documents74\UserTyped">
+        <id field-name="id" />
+
+        <field name="username"/>
+        <field name="dateTime"/>
+        <field name="dateTimeImmutable"/>
+        <field name="array"/>
+        <field name="boolean"/>
+        <field name="float"/>
+        <field name="int"/>
+
+        <embed-one field="embedOne" />
+        <reference-one field="referenceOne" />
+
+        <embed-many field="embedMany" />
+        <reference-many field="referenceMany" />
+    </document>
+</doctrine-mongo-mapping>

--- a/tests/Documents74/CustomCollection.php
+++ b/tests/Documents74/CustomCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents74;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @template TKey of array-key
+ * @template TElement
+ * @template-extends ArrayCollection<TKey, TElement>
+ */
+class CustomCollection extends ArrayCollection
+{
+}

--- a/tests/Documents74/UserTyped.php
+++ b/tests/Documents74/UserTyped.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents74;
+
+use DateTime;
+use DateTimeImmutable;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document()
+ */
+#[ODM\Document]
+class UserTyped
+{
+    /** @ODM\Id */
+    #[ODM\Id]
+    public string $id;
+
+    /** @ODM\Field */
+    #[ODM\Field]
+    public string $username;
+
+    /** @ODM\Field */
+    #[ODM\Field]
+    public DateTime $dateTime;
+
+    /** @ODM\Field */
+    #[ODM\Field]
+    public DateTimeImmutable $dateTimeImmutable;
+
+    /** @ODM\Field */
+    #[ODM\Field]
+    public array $array;
+
+    /** @ODM\Field */
+    #[ODM\Field]
+    public bool $boolean;
+
+    /** @ODM\Field */
+    #[ODM\Field]
+    public float $float;
+
+    /** @ODM\Field */
+    #[ODM\Field]
+    public int $int;
+
+    /** @ODM\EmbedOne */
+    #[ODM\EmbedOne]
+    public TypedEmbeddedDocument $embedOne;
+
+    /** @ODM\ReferenceOne */
+    #[ODM\ReferenceOne]
+    public UserTyped $referenceOne;
+
+    /** @ODM\EmbedMany  */
+    #[ODM\EmbedMany]
+    public CustomCollection $embedMany;
+
+    /** @ODM\ReferenceMany  */
+    #[ODM\ReferenceMany]
+    public CustomCollection $referenceMany;
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

~I'll retarget to `2.4.x` once is created.~

This is kind of based on https://github.com/doctrine/orm/pull/8439 and https://github.com/doctrine/orm/pull/8589.

The idea is that if you use typed properties, it gets the type from that properties. For `array`, I've chosen `hash`, I thought it was more right.
