### PR TITLE
Use PHP 8.1 to run CS

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -10,4 +10,6 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.4.0"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.4.1"
+    with:
+      php-version: "8.1"


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

Bumps `coding-standards` pipeline to newest version and runs it using PHP 8.1 to support latest features like enums.
Cherry-picked from #2412 as per @malarzm suggestion.
