### PR TITLE
Fix typo in method name

### DIFF
--- a/docs/en/reference/aggregation-builder.rst
+++ b/docs/en/reference/aggregation-builder.rst
@@ -207,7 +207,7 @@ can tell the query builder to not return a caching iterator:
     <?php
 
     $builder = $dm->createAggregationBuilder(\Documents\Orders::class);
-    $builder->setRewindable(false);
+    $builder->rewindable(false);
 
 When setting this option to ``false``, attempting a second iteration will result
 in an exception. Note that calling ``getAggregation()`` will always yield a


### PR DESCRIPTION
`Doctrine/ODM/MongoDB/Aggregation/Builder` has a method `rewindable`, not `setRewindable`.

Possible mixup with `setRewindable` in `Doctrine/ODM/MongoDB/Query/Builder`

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | documentation
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Just a typo in method name
