### PR TITLE
Deprecate DocumentManager::clear with an argument

### DIFF
--- a/UPGRADE-2.4.md
+++ b/UPGRADE-2.4.md
@@ -23,3 +23,9 @@ in `doctrine/persistence`, and no longer do.
 
 That method was inherited from the abstract `AnnotationDriver` class of
 `doctrine/persistence`, and does not seem to serve any purpose.
+
+## Deprecate `DocumentManager::clear()` with an argument
+
+Detaching all documents of a given class has been deprecated. We deem the process fragile and suggest
+detaching your documents one-by-one using `DocumentManager::detach()`. This effectively deprecates
+`OnClearEventArgs::getDocumentClass` and `OnClearEventArgs::clearsAllDocuments`.

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -34,3 +34,12 @@ for the class and read the class using `$metadata->getName()`. The metadata
 layer is aware of these proxy namespace changes and how to resolve them, so
 users should always go through the metadata layer to retrieve mapped class
 names.
+
+## Clearing all documents of a specific class
+
+Clearing all documents of a given class with `DocumentManager::clear(Document::class)`
+has been removed. Use `DocumentManager::detach` passing documents to be detached
+to retain the functionality.
+
+`Doctrine\ODM\MongoDB\Event\OnClearEventArgs`' methods `getDocumentClass` and 
+`clearsAllDocuments` have been removed.

--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -38,6 +38,7 @@ use function gettype;
 use function is_object;
 use function ltrim;
 use function sprintf;
+use function trigger_deprecation;
 
 /**
  * The DocumentManager class is the central access point for managing the
@@ -703,6 +704,15 @@ class DocumentManager implements ObjectManager
      */
     public function clear($objectName = null)
     {
+        if ($objectName !== null) {
+            trigger_deprecation(
+                'doctrine/mongodb-odm',
+                '2.4',
+                'Calling %s() with any arguments to clear specific documents is deprecated and will not be supported in Doctrine ODM 3.0.',
+                __METHOD__
+            );
+        }
+
         $this->unitOfWork->clear($objectName);
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/OnClearEventArgs.php
@@ -8,12 +8,43 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\Persistence\Event\OnClearEventArgs as BaseOnClearEventArgs;
 
 use function assert;
+use function func_num_args;
+use function method_exists;
+use function trigger_deprecation;
 
 /**
  * Provides event arguments for the onClear event.
  */
 final class OnClearEventArgs extends BaseOnClearEventArgs
 {
+    /**
+     * @deprecated
+     *
+     * @var class-string|null
+     */
+    private $entityClass;
+
+    public function __construct($objectManager, $entityClass = null)
+    {
+        if (method_exists(parent::class, 'getEntityClass') && $entityClass !== null) {
+            parent::__construct($objectManager, $entityClass);
+        } else {
+            if (func_num_args() > 1) {
+                trigger_deprecation(
+                    'doctrine/mongodb-odm',
+                    '2.4',
+                    'Passing $entityClass argument to %s::%s() is deprecated and will not be supported in Doctrine ODM 3.0.',
+                    self::class,
+                    __METHOD__
+                );
+            }
+
+            parent::__construct($objectManager);
+        }
+
+        $this->entityClass = $entityClass;
+    }
+
     public function getDocumentManager(): DocumentManager
     {
         $dm = $this->getObjectManager();
@@ -22,16 +53,77 @@ final class OnClearEventArgs extends BaseOnClearEventArgs
         return $dm;
     }
 
+    /**
+     * @deprecated no replacement planned
+     *
+     * @return class-string|null
+     */
     public function getDocumentClass(): ?string
     {
-        return $this->getEntityClass();
+        trigger_deprecation(
+            'doctrine/mongodb-odm',
+            '2.4',
+            'Calling %s() is deprecated and will not be supported in Doctrine ODM 3.0.',
+            __METHOD__
+        );
+
+        return $this->entityClass;
     }
 
     /**
      * Returns whether this event clears all documents.
+     *
+     * @deprecated no replacement planned
      */
     public function clearsAllDocuments(): bool
     {
-        return $this->clearsAllEntities();
+        trigger_deprecation(
+            'doctrine/mongodb-odm',
+            '2.4',
+            'Calling %s() is deprecated and will not be supported in Doctrine ODM 3.0.',
+            __METHOD__
+        );
+
+        return $this->entityClass !== null;
+    }
+
+    /**
+     * @deprecated no replacement planned
+     */
+    public function clearsAllEntities()
+    {
+        if (method_exists(parent::class, 'clearsAllEntities')) {
+            return parent::clearsAllEntities();
+        }
+
+        trigger_deprecation(
+            'doctrine/mongodb-odm',
+            '2.4',
+            'Calling %s() is deprecated and will not be supported in Doctrine ODM 3.0.',
+            __METHOD__
+        );
+
+        return $this->entityClass !== null;
+    }
+
+    /**
+     * @deprecated no replacement planned
+     *
+     * @return class-string|null
+     */
+    public function getEntityClass()
+    {
+        if (method_exists(parent::class, 'getEntityClass')) {
+            return parent::getEntityClass();
+        }
+
+        trigger_deprecation(
+            'doctrine/mongodb-odm',
+            '2.4',
+            'Calling %s() is deprecated and will not be supported in Doctrine ODM 3.0.',
+            __METHOD__
+        );
+
+        return $this->entityClass;
     }
 }


### PR DESCRIPTION
`doctrine/persistence` deprecated using `clear` with an argument (finally) so let's bring ODM on par. I fully agree that clearing documents blindly may be a footgun and as it's still possible to use `detach` I have no second thoughts about the deprecation.

|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | no
| Fixed issues | part of https://github.com/doctrine/mongodb-odm/issues/2419

#### Summary

This PR deprecates clearing documents of a specified class and provides a forward compatibility layer for `doctrine/persistence` 3.0 which will have methods removed.
