### PR TITLE
Added --disable-validators option to odm:schema:update command

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/Console/Command/Schema/UpdateCommandTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/Console/Command/Schema/UpdateCommandTest.php
@@ -53,6 +53,18 @@ class UpdateCommandTest extends AbstractCommandTest
         $this->assertStringContainsString('Updated validation for Documents\SchemaValidated', $output);
     }
 
+    public function testDisabledValidatorProcessing(): void
+    {
+        $this->commandTester->execute(
+            [
+                '--class' => SchemaValidated::class,
+                '--disable-validators' => true,
+            ]
+        );
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringNotContainsString('Updated validation for Documents\SchemaValidated', $output);
+    }
+
     public function testProcessValidators(): void
     {
         // Only load a subset of documents with legit annotations
@@ -61,5 +73,15 @@ class UpdateCommandTest extends AbstractCommandTest
         $this->commandTester->execute([]);
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('Updated validation for all classes', $output);
+    }
+
+    public function testDisabledValidatorsProcessing(): void
+    {
+        // Only load a subset of documents with legit annotations
+        $annotationDriver = AnnotationDriver::create(__DIR__ . '/../../../../../../../../Documents/Ecommerce');
+        $this->dm->getConfiguration()->setMetadataDriverImpl($annotationDriver);
+        $this->commandTester->execute(['--disable-validators' => true]);
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringNotContainsString('Updated validation for all classes', $output);
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | #2405 

#### Summary

This PR adds `--disable-validators` option to the `odm:schema:update` command. Once the option is enabled, the command will not try to update database-level validation rules. 