### PR TITLE
Updated phpunit.xml.dist to be compatible with PHPUnit 9.5

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,11 +15,11 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">./lib/Doctrine/ODM/MongoDB</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 
     <groups>
         <exclude>


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

A simple change to make `phpunit.xml.dist` compatible with the latest PHPUnit version to get rid of the below message:

```
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```