### PR TITLE
Add more iterable types

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation;
 
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
@@ -26,6 +27,8 @@ use function trigger_deprecation;
 
 /**
  * Fluent interface for building aggregation pipelines.
+ *
+ * @psalm-import-type SortShape from Sort
  */
 class Builder
 {
@@ -533,8 +536,9 @@ class Builder
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sort/
      *
-     * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
-     * @param int|string                       $order     Field order (if one field is specified)
+     * @param array<string, int|string|array<string, string>>|string $fieldName Field name or array of field/order pairs
+     * @param int|string|null                                        $order     Field order (if one field is specified)
+     * @psalm-param SortShape|string $fieldName Field name or array of field/order pairs
      */
     public function sort($fieldName, $order = null): Stage\Sort
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Sort.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Sort.php
@@ -14,15 +14,19 @@ use function strtolower;
 
 /**
  * Fluent interface for adding a $sort stage to an aggregation pipeline.
+ *
+ * @psalm-type SortMeta = array{"$meta": 'textScore'}
+ * @psalm-type SortShape = array<string, int|SortMeta|string>
  */
 class Sort extends Stage
 {
-    /** @var array<string, -1|1|array{"$meta": string}> */
+    /** @var array<string, -1|1|SortMeta> */
     private $sort = [];
 
     /**
-     * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
-     * @param int|string                       $order     Field order (if one field is specified)
+     * @param array<string, int|string|array<string, string>>|string $fieldName Field name or array of field/order pairs
+     * @param int|string                                             $order     Field order (if one field is specified)
+     * @psalm-param SortShape|string                       $fieldName
      */
     public function __construct(Builder $builder, $fieldName, $order = null)
     {
@@ -34,7 +38,7 @@ class Sort extends Stage
 
         foreach ($fields as $fieldName => $order) {
             if (is_string($order)) {
-                if (in_array($order, $allowedMetaSort)) {
+                if (in_array($order, $allowedMetaSort, true)) {
                     $order = ['$meta' => $order];
                 } else {
                     $order = strtolower($order) === 'asc' ? 1 : -1;

--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -50,6 +50,7 @@ use function trigger_deprecation;
  *     $dm = DocumentManager::create(new Connection(), $config);
  *
  * @psalm-import-type CommitOptions from UnitOfWork
+ * @psalm-import-type FieldMapping from ClassMetadata
  */
 class DocumentManager implements ObjectManager
 {
@@ -760,6 +761,8 @@ class DocumentManager implements ObjectManager
     /**
      * Returns a reference to the supplied document.
      *
+     * @psalm-param FieldMapping $referenceMapping
+     *
      * @return mixed The reference for the document in question, according to the desired mapping
      *
      * @throws MappingException
@@ -816,8 +819,10 @@ class DocumentManager implements ObjectManager
      *
      * @param array         $referenceMapping Mappings of reference for which discriminator data is created.
      * @param ClassMetadata $class            Metadata of reference document class.
+     * @psalm-param FieldMapping $referenceMapping
      *
      * @return array with next structure [{discriminator field} => {discriminator value}]
+     * @psalm-return array<string, class-string>
      *
      * @throws MappingException When discriminator map is present and reference class in not registered in it.
      */

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -591,7 +591,8 @@ use const PHP_VERSION_ID;
      *
      * @see discriminatorField
      *
-     * @var mixed
+     * @var string|null
+     * @psalm-var class-string|null
      */
     public $discriminatorValue;
 

--- a/lib/Doctrine/ODM/MongoDB/MongoDBException.php
+++ b/lib/Doctrine/ODM/MongoDB/MongoDBException.php
@@ -62,8 +62,8 @@ class MongoDBException extends Exception
     }
 
     /**
-     * @param string|array $expected
-     * @param mixed        $got
+     * @param string|string[] $expected
+     * @param mixed           $got
      *
      * @return MongoDBException
      */

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionFactory.php
@@ -6,14 +6,19 @@ namespace Doctrine\ODM\MongoDB\PersistentCollection;
 
 use Doctrine\Common\Collections\Collection as BaseCollection;
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 
 /**
  * Interface for persistent collection classes factory.
+ *
+ * @psalm-import-type FieldMapping from ClassMetadata
  */
 interface PersistentCollectionFactory
 {
     /**
      * Creates specified persistent collection to work with given collection class.
+     *
+     * @psalm-param FieldMapping $mapping
      */
     public function create(DocumentManager $dm, array $mapping, ?BaseCollection $coll = null): PersistentCollectionInterface;
 }

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionInterface.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionInterface.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\PersistentCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\MongoDBException;
+use Doctrine\ODM\MongoDB\UnitOfWork;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 
 /**
@@ -15,6 +16,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
  * @internal
  *
  * @psalm-import-type FieldMapping from \Doctrine\ODM\MongoDB\Mapping\ClassMetadata
+ * @psalm-import-type Hints from UnitOfWork
  *
  * @template TKey of array-key
  * @template T of object
@@ -32,7 +34,7 @@ interface PersistentCollectionInterface extends Collection
     /**
      * Sets the array of raw mongo data that will be used to initialize this collection.
      *
-     * @param array $mongoData
+     * @param mixed[] $mongoData
      *
      * @return void
      */
@@ -41,14 +43,14 @@ interface PersistentCollectionInterface extends Collection
     /**
      * Gets the array of raw mongo data that will be used to initialize this collection.
      *
-     * @return array $mongoData
+     * @return mixed[] $mongoData
      */
     public function getMongoData();
 
     /**
      * Set hints to account for during reconstitution/lookup of the documents.
      *
-     * @param array $hints
+     * @param Hints $hints
      *
      * @return void
      */
@@ -57,7 +59,7 @@ interface PersistentCollectionInterface extends Collection
     /**
      * Get hints to account for during reconstitution/lookup of the documents.
      *
-     * @return array $hints
+     * @return Hints $hints
      */
     public function getHints();
 
@@ -117,31 +119,31 @@ interface PersistentCollectionInterface extends Collection
     /**
      * Returns the last snapshot of the elements in the collection.
      *
-     * @return array The last snapshot of the elements.
+     * @return object[] The last snapshot of the elements.
      */
     public function getSnapshot();
 
     /**
-     * @return array
+     * @return array<string, object>
      */
     public function getDeleteDiff();
 
     /**
      * Get objects that were removed, unlike getDeleteDiff this doesn't care about indices.
      *
-     * @return array
+     * @return list<object>
      */
     public function getDeletedDocuments();
 
     /**
-     * @return array
+     * @return array<string, object>
      */
     public function getInsertDiff();
 
     /**
      * Get objects that were added, unlike getInsertDiff this doesn't care about indices.
      *
-     * @return array
+     * @return list<object>
      */
     public function getInsertedDocuments();
 

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -26,6 +26,7 @@ use function is_object;
 /**
  * Trait with methods needed to implement PersistentCollectionInterface.
  *
+ * @psalm-import-type Hints from UnitOfWork
  * @psalm-import-type FieldMapping from ClassMetadata
  * @template TKey of array-key
  * @template T of object
@@ -92,7 +93,7 @@ trait PersistentCollectionTrait
     /**
      * The raw mongo data that will be used to initialize this collection.
      *
-     * @var array
+     * @var mixed[]
      */
     private $mongoData = [];
 
@@ -100,6 +101,7 @@ trait PersistentCollectionTrait
      * Any hints to account for during reconstitution/lookup of the documents.
      *
      * @var array
+     * @psalm-var Hints
      */
     private $hints = [];
 

--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -64,7 +64,7 @@ final class CollectionPersister
      * Deletes a PersistentCollection instances completely from a document using $unset.
      *
      * @param PersistentCollectionInterface[] $collections
-     * @param array                           $options
+     * @param array<string, mixed>            $options
      */
     public function delete(object $parent, array $collections, array $options): void
     {
@@ -100,7 +100,7 @@ final class CollectionPersister
      * Updates a list PersistentCollection instances deleting removed rows and inserting new rows.
      *
      * @param PersistentCollectionInterface[] $collections
-     * @param array                           $options
+     * @param array<string, mixed>            $options
      */
     public function update(object $parent, array $collections, array $options): void
     {
@@ -155,7 +155,7 @@ final class CollectionPersister
      * reindexed numerically before storage.
      *
      * @param PersistentCollectionInterface[] $collections
-     * @param array                           $options
+     * @param array<string, mixed>            $options
      */
     private function setCollections(object $parent, array $collections, array $options): void
     {
@@ -195,7 +195,7 @@ final class CollectionPersister
      * This method is intended to be used with the "pushAll" and "addToSet" strategies.
      *
      * @param PersistentCollectionInterface[] $collections
-     * @param array                           $options
+     * @param array<string, mixed>            $options
      */
     private function deleteElements(object $parent, array $collections, array $options): void
     {
@@ -258,7 +258,7 @@ final class CollectionPersister
      * This method is intended to be used with the "pushAll" and "addToSet" strategies.
      *
      * @param PersistentCollectionInterface[] $collections
-     * @param array                           $options
+     * @param array<string, mixed>            $options
      */
     private function insertElements(object $parent, array $collections, array $options): void
     {
@@ -328,11 +328,11 @@ final class CollectionPersister
     /**
      * Perform collections update for 'pushAll' strategy.
      *
-     * @param object $parent       Parent object to which passed collections is belong.
-     * @param array  $collsPaths   Paths of collections that is passed.
-     * @param array  $pathCollsMap List of collections indexed by their paths.
-     * @param array  $diffsMap     List of collection diffs indexed by collections paths.
-     * @param array  $options
+     * @param object                                                          $parent       Parent object to which passed collections is belong.
+     * @param string[]                                                        $collsPaths   Paths of collections that is passed.
+     * @param array<string, PersistentCollectionInterface<array-key, object>> $pathCollsMap List of collections indexed by their paths.
+     * @param array<string, mixed[]>                                          $diffsMap     List of collection diffs indexed by collections paths.
+     * @param array<string, mixed>                                            $options
      */
     private function pushAllCollections(object $parent, array $collsPaths, array $pathCollsMap, array $diffsMap, array $options): void
     {
@@ -362,11 +362,11 @@ final class CollectionPersister
     /**
      * Perform collections update by 'addToSet' strategy.
      *
-     * @param object $parent       Parent object to which passed collections is belong.
-     * @param array  $collsPaths   Paths of collections that is passed.
-     * @param array  $pathCollsMap List of collections indexed by their paths.
-     * @param array  $diffsMap     List of collection diffs indexed by collections paths.
-     * @param array  $options
+     * @param object                                                          $parent       Parent object to which passed collections is belong.
+     * @param string[]                                                        $collsPaths   Paths of collections that is passed.
+     * @param array<string, PersistentCollectionInterface<array-key, object>> $pathCollsMap List of collections indexed by their paths.
+     * @param array<string, mixed[]>                                          $diffsMap     List of collection diffs indexed by collections paths.
+     * @param array<string, mixed>                                            $options
      */
     private function addToSetCollections(object $parent, array $collsPaths, array $pathCollsMap, array $diffsMap, array $options): void
     {
@@ -416,6 +416,8 @@ final class CollectionPersister
      *     <code>
      *     list($path, $parent) = $this->getPathAndParent($coll)
      *     </code>
+     *
+     * @return array{string, object|null}
      */
     private function getPathAndParent(PersistentCollectionInterface $coll): array
     {
@@ -443,6 +445,9 @@ final class CollectionPersister
 
     /**
      * Executes a query updating the given document.
+     *
+     * @param array<string, mixed> $newObj
+     * @param array<string, mixed> $options
      */
     private function executeQuery(object $document, array $newObj, array $options): void
     {

--- a/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
@@ -26,6 +26,8 @@ use function get_class;
  * UnitOfWork to build queries using atomic operators like $set, $unset, etc.
  *
  * @internal
+ *
+ * @psalm-import-type FieldMapping from ClassMetadata
  */
 final class PersistenceBuilder
 {
@@ -57,7 +59,7 @@ final class PersistenceBuilder
      *
      * @param object $document
      *
-     * @return array $insertData
+     * @return array<string, mixed> $insertData
      */
     public function prepareInsertData($document)
     {
@@ -122,7 +124,7 @@ final class PersistenceBuilder
      *
      * @param object $document
      *
-     * @return array $updateData
+     * @return array<string, mixed> $updateData
      */
     public function prepareUpdateData($document)
     {
@@ -232,7 +234,7 @@ final class PersistenceBuilder
      *
      * @param object $document
      *
-     * @return array $updateData
+     * @return array<string, mixed> $updateData
      */
     public function prepareUpsertData($document)
     {
@@ -323,10 +325,10 @@ final class PersistenceBuilder
      * If the document does not have an identifier and the mapping calls for a
      * simple reference, null may be returned.
      *
-     * @param array  $referenceMapping
      * @param object $document
+     * @psalm-param FieldMapping $referenceMapping
      *
-     * @return array|null
+     * @return array<string, mixed>|null
      */
     public function prepareReferencedDocumentValue(array $referenceMapping, $document)
     {
@@ -347,11 +349,11 @@ final class PersistenceBuilder
      * within this value were previously scheduled for deletion or update, they
      * will also be unscheduled.
      *
-     * @param array  $embeddedMapping
      * @param object $embeddedDocument
      * @param bool   $includeNestedCollections
+     * @psalm-param FieldMapping  $embeddedMapping
      *
-     * @return array|object
+     * @return array<string, mixed>|object
      *
      * @throws UnexpectedValueException If an unsupported associating mapping is found.
      */
@@ -462,11 +464,11 @@ final class PersistenceBuilder
     /**
      * Returns the embedded document or reference representation to be stored.
      *
-     * @param array  $mapping
      * @param object $document
      * @param bool   $includeNestedCollections
+     * @psalm-param FieldMapping  $mapping
      *
-     * @return array|object|null
+     * @return mixed[]|object|null
      *
      * @throws InvalidArgumentException If the mapping is neither embedded nor reference.
      */
@@ -488,7 +490,7 @@ final class PersistenceBuilder
      *
      * @param bool $includeNestedCollections
      *
-     * @return array
+     * @return mixed[]
      */
     public function prepareAssociatedCollectionValue(PersistentCollectionInterface $coll, $includeNestedCollections = false)
     {

--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Query;
 
 use BadMethodCallException;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Iterator\CachingIterator;
 use Doctrine\ODM\MongoDB\Iterator\HydratingIterator;
@@ -54,11 +55,12 @@ use function reset;
  *     readPreference?: ReadPreference,
  *     select?: array<string, 0|1|array<string, mixed>>,
  *     skip?: int,
- *     sort?: array<string, int|array{"$meta": string}>,
+ *     sort?: array<string, -1|1|SortMeta>,
  *     type?: Query::TYPE_*,
  *     upsert?: bool,
  * }
  * @psalm-import-type Hints from UnitOfWork
+ * @psalm-import-type SortMeta from Sort
  */
 final class Query implements IteratorAggregate
 {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -185,3 +185,32 @@ parameters:
             message: "#^Parameter \\#4 \\$query of class Doctrine\\\\ODM\\\\MongoDB\\\\Query\\\\Query constructor expects array\\{distinct\\?\\: string, hint\\?\\: array\\<string, \\-1\\|1\\>\\|string, limit\\?\\: int, multiple\\?\\: bool, new\\?\\: bool, newObj\\?\\: array\\<string, mixed\\>, query\\?\\: array\\<string, mixed\\>, readPreference\\?\\: MongoDB\\\\Driver\\\\ReadPreference, \\.\\.\\.\\}, array\\{type\\: \\-1\\} given\\.$#"
             count: 1
             path: tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+
+        -
+            message: "#^Parameter \\#2 \\$referenceMapping of method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:createReference\\(\\) expects array\\{type\\: string, fieldName\\: string, name\\: string, isCascadeRemove\\: bool, isCascadePersist\\: bool, isCascadeRefresh\\: bool, isCascadeMerge\\: bool, isCascadeDetach\\: bool, \\.\\.\\.\\}, array\\{storeAs\\: 'dbRef'\\} given\\.$#"
+            count: 1
+            path: tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+
+        # import type in PHPStan does not work, see https://github.com/phpstan/phpstan/issues/5091
+        -
+            message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:\\$hints \\(Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints\\) does not accept default value of type array\\.$#"
+            count: 1
+            path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+
+        # import type in PHPStan does not work, see https://github.com/phpstan/phpstan/issues/5091
+        -
+            message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:\\$hints has unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints as its type\\.$#"
+            count: 1
+            path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+
+        # import type in PHPStan does not work, see https://github.com/phpstan/phpstan/issues/5091
+        -
+            message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\<TKey of \\(int\\|string\\),T of object\\>\\:\\:\\$hints \\(Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints\\) does not accept array\\<int, mixed\\>\\.$#"
+            count: 1
+            path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+
+        # import type in PHPStan does not work, see https://github.com/phpstan/phpstan/issues/5091
+        -
+            message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:getHints\\(\\) should return array\\<int, mixed\\> but returns Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints\\.$#"
+            count: 1
+            path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.22.0@fc2c6ab4d5fa5d644d8617089f012f3bb84b8703">
+  <file src="lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php">
+    <InvalidArgument occurrences="1">
+      <code>$fields</code>
+    </InvalidArgument>
+  </file>
   <file src="lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GeoNear.php">
     <InvalidReturnStatement occurrences="1">
       <code>$this-&gt;num($limit)</code>
@@ -93,6 +98,9 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Query/Builder.php">
+    <InvalidArgument occurrences="1">
+      <code>$query</code>
+    </InvalidArgument>
     <InvalidPropertyAssignmentValue occurrences="2">
       <code>$this-&gt;query</code>
       <code>$this-&gt;query</code>
@@ -121,6 +129,11 @@
     <NullableReturnStatement occurrences="1">
       <code>$mapping['targetDocument']</code>
     </NullableReturnStatement>
+  </file>
+  <file src="tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php">
+    <InvalidArgument occurrences="1">
+      <code>['storeAs' =&gt; ClassMetadata::REFERENCE_STORE_AS_DB_REF]</code>
+    </InvalidArgument>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php">
     <InvalidArgument occurrences="1">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -201,12 +201,12 @@
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Types/DateImmutableTypeTest.php">
     <TypeDoesNotContainType occurrences="1">
-      <code>assert($return instanceof DateTimeImmutable)</code>
+      <code>assertInstanceOf</code>
     </TypeDoesNotContainType>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php">
     <TypeDoesNotContainType occurrences="1">
-      <code>assert($return instanceof DateTime)</code>
+      <code>assertInstanceOf</code>
     </TypeDoesNotContainType>
   </file>
   <file src="tests/Documents/CommentRepository.php">

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -184,7 +184,10 @@ class DocumentManagerTest extends BaseTest
         $phonenumber->phonenumber = 0;
         $this->dm->persist($phonenumber);
 
-        $dbRef = $this->dm->createReference($phonenumber, ['storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF, 'targetDocument' => CmsPhonenumber::class]);
+        $dbRef = $this->dm->createReference($phonenumber, ClassMetadataTestUtil::getFieldMapping([
+            'storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF,
+            'targetDocument' => CmsPhonenumber::class,
+        ]));
 
         $this->assertSame(['$ref' => 'CmsPhonenumber', '$id' => 0], $dbRef);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php
@@ -13,6 +13,7 @@ use Doctrine\ODM\MongoDB\PersistentCollection;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Repository\GridFSRepository;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\ClassMetadataTestUtil;
 use Documents\File;
 use Documents\ProfileNotify;
 use stdClass;
@@ -58,7 +59,7 @@ class CustomCollectionsTest extends BaseTest
         $coll  = new MyEmbedsCollection();
         $pcoll = $this->dm->getConfiguration()->getPersistentCollectionFactory()->create(
             $this->dm,
-            ['collectionClass' => MyEmbedsCollection::class],
+            ClassMetadataTestUtil::getFieldMapping(['collectionClass' => MyEmbedsCollection::class]),
             $coll
         );
         $this->assertInstanceOf(PersistentCollectionInterface::class, $pcoll);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
@@ -9,6 +9,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Query\Query;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\ClassMetadataTestUtil;
 use Documents\Account;
 use Documents\Agent;
 use Documents\BlogPost;
@@ -416,7 +417,10 @@ class ReferencePrimerTest extends BaseTest
         $this->dm->persist($group);
         $this->dm->flush();
 
-        $groupDBRef = $this->dm->createReference($group, ['storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF, 'targetDocument' => Group::class]);
+        $groupDBRef = $this->dm->createReference($group, ClassMetadataTestUtil::getFieldMapping([
+            'storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF,
+            'targetDocument' => Group::class,
+        ]));
 
         $this->dm->clear();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/DateImmutableTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/DateImmutableTypeTest.php
@@ -136,8 +136,6 @@ class DateImmutableTypeTest extends TestCase
         })($input);
 
         // @phpstan-ignore-next-line
-        assert($return instanceof DateTimeImmutable);
-
         $this->assertInstanceOf(DateTimeImmutable::class, $return);
         $this->assertTimestampEquals($output, $return);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
@@ -136,8 +136,6 @@ class DateTypeTest extends TestCase
         })($input);
 
         // @phpstan-ignore-next-line
-        assert($return instanceof DateTime);
-
         $this->assertInstanceOf(DateTime::class, $return);
         $this->assertTimestampEquals($output, $return);
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Follow-up of https://github.com/doctrine/mongodb-odm/pull/2433

With this finishes adding iterable types in `lib` directory, next PR will add iterable types in `tests` and will add the PHPStan check.

The ignored issues in PHPStan are expected, one is because the type is incorrect and that's what the test is checking (same for Psalm) and the other issues are because PHPStan doesn't yet understand importing custom types in traits.
