### PR TITLE
Add PHPStan check for iterable types

### DIFF
--- a/benchmark/Document/HydrateDocumentBench.php
+++ b/benchmark/Document/HydrateDocumentBench.php
@@ -17,19 +17,19 @@ use PhpBench\Benchmark\Metadata\Annotations\Warmup;
  */
 final class HydrateDocumentBench extends BaseBench
 {
-    /** @var array */
+    /** @var array<string, mixed> */
     private static $data;
 
-    /** @var array */
+    /** @var array<string, mixed> */
     private static $embedOneData;
 
-    /** @var array */
+    /** @var array<string, mixed[]> */
     private static $embedManyData;
 
-    /** @var array */
+    /** @var array<string, mixed[]> */
     private static $referenceOneData;
 
-    /** @var array */
+    /** @var array<string, mixed[]> */
     private static $referenceManyData;
 
     /** @var HydratorInterface */

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
@@ -31,8 +31,10 @@ class Lookup extends Stage
 
     private ?string $as = null;
 
+    /** @var array<string, string>|null */
     private ?array $let = null;
 
+    /** @var array<array<string, mixed>>|null */
     private ?array $pipeline = null;
 
     private bool $excludeLocalAndForeignField = false;
@@ -155,6 +157,8 @@ class Lookup extends Stage
      *
      * Use the variable expressions to access the fields from
      * the joined collection's documents that are input to the pipeline.
+     *
+     * @param array<string, string> $let
      */
     public function let(array $let): self
     {
@@ -172,6 +176,8 @@ class Lookup extends Stage
      * The pipeline cannot directly access the joined document fields.
      * Instead, define variables for the joined document fields using the let option
      * and then reference the variables in the pipeline stages.
+     *
+     * @param array<array<string, mixed>> $pipeline
      */
     public function pipeline(array $pipeline): self
     {

--- a/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
@@ -19,13 +19,12 @@ use Traversable;
  *
  * @psalm-import-type Hints from UnitOfWork
  *
- * @template TValue
  * @template TDocument of object
- * @template-implements Iterator<TValue>
+ * @template-implements Iterator<TDocument>
  */
 final class HydratingIterator implements Iterator
 {
-    /** @var Generator<mixed, TValue>|null */
+    /** @var Generator<mixed, array<string, mixed>>|null */
     private $iterator;
 
     private UnitOfWork $unitOfWork;
@@ -40,8 +39,8 @@ final class HydratingIterator implements Iterator
     private array $unitOfWorkHints;
 
     /**
-     * @param Traversable<mixed, TValue> $traversable
-     * @param ClassMetadata<TDocument>   $class
+     * @param Traversable<mixed, array<string, mixed>> $traversable
+     * @param ClassMetadata<TDocument>                 $class
      * @psalm-param Hints $unitOfWorkHints
      */
     public function __construct(Traversable $traversable, UnitOfWork $unitOfWork, ClassMetadata $class, array $unitOfWorkHints = [])
@@ -100,7 +99,7 @@ final class HydratingIterator implements Iterator
     }
 
     /**
-     * @return Generator<mixed, TValue>
+     * @return Generator<mixed, array<string, mixed>>
      */
     private function getIterator(): Generator
     {
@@ -122,9 +121,9 @@ final class HydratingIterator implements Iterator
     }
 
     /**
-     * @param Traversable<mixed, TValue> $traversable
+     * @param Traversable<mixed, array<string, mixed>> $traversable
      *
-     * @return Generator<mixed, TValue>
+     * @return Generator<mixed, array<string, mixed>>
      */
     private function wrapTraversable(Traversable $traversable): Generator
     {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -198,7 +198,15 @@ use const PHP_VERSION_ID;
  *      alsoLoadFields?: list<string>,
  * }
  * @psalm-type IndexKeys = array<string, mixed>
- * @psalm-type IndexOptions = array<string, mixed>
+ * @psalm-type IndexOptions = array{
+ *      background?: bool,
+ *      unique?: bool,
+ *      name?: string,
+ *      partialFilterExpression?: mixed[],
+ *      sparse?: bool,
+ *      expireAfterSeconds?: int,
+ *      storageEngine?: mixed[],
+ * }
  * @psalm-type IndexMapping = array{
  *      keys: IndexKeys,
  *      options: IndexOptions

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -237,3 +237,8 @@ parameters:
             message: "#^Call to an undefined method ReflectionEnum\\:\\:getBackingType\\(\\)\\.$#"
             count: 1
             path: lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+
+        -
+            message: "#has parameter \\$[^\\s]+ with no value type specified in iterable type array\\.$#"
+            count: 6
+            path: tests/*

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -58,11 +58,6 @@ parameters:
             count: 1
             path: tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
 
-        -
-            message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\SchemaManagerTest\\:\\:writeOptions\\(\\) should return PHPUnit\\\\Framework\\\\Constraint\\\\Constraint but returns PHPUnit\\\\Framework\\\\Constraint\\\\ArraySubset\\.$#"
-            count: 1
-            path: tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
-
         # Support for doctrine/collections v1
         -
             message: '#^Method Doctrine\\ODM\\MongoDB\\PersistentCollection\:\:add\(\) with return type void returns true but should not return anything\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -143,12 +143,6 @@ parameters:
             count: 1
             path: tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
 
-        # 'strategy' offset is defined as nullable, but here there is no check here
-        -
-            message: "#^Offset 'strategy' does not exist on array\\{\\}\\|array\\{type\\?\\: string, fieldName\\: string, name\\: string, isCascadeRemove\\: bool, isCascadePersist\\: bool, isCascadeRefresh\\: bool, isCascadeMerge\\: bool, isCascadeDetach\\: bool, \\.\\.\\.\\}\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/UnitOfWork.php
-
         # When iterating over SimpleXMLElement, we cannot know the key values
         -
             message: "#^Parameter \\#2 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\Driver\\\\XmlDriver\\:\\:addFieldMapping\\(\\) expects array#"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,9 +16,13 @@ parameters:
     - tests/PersistentCollections/
     - tests/Proxies/
   treatPhpDocTypesAsCertain: false
+  ignoreErrors:
+      # Ignore typing providers in tests
+      - '#^Method Doctrine\\ODM\\MongoDB\\Tests\\[^:]+(Test)::(get\w+|data\w+|provide\w+)\(\) return type has no value type specified in iterable type (array|iterable)\.#'
   # To be removed when reaching phpstan level 6
   checkMissingVarTagTypehint: true
   checkMissingTypehints: true
+  checkMissingIterableValueType: true
 
 # To be removed when reaching phpstan level 6
 rules:

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.22.0@fc2c6ab4d5fa5d644d8617089f012f3bb84b8703">
+<files psalm-version="4.29.0@7ec5ffbd5f68ae03782d7fd33fff0c45a69f95b3">
   <file src="lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php">
     <InvalidArgument occurrences="1">
       <code>$fields</code>
@@ -23,11 +23,6 @@
       <code>TValue|false</code>
     </ImplementedReturnTypeMismatch>
   </file>
-  <file src="lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>TDocument|null</code>
-    </ImplementedReturnTypeMismatch>
-  </file>
   <file src="lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php">
     <ImplementedReturnTypeMismatch occurrences="2">
       <code>array&lt;string|null&gt;</code>
@@ -36,8 +31,7 @@
     <InvalidArrayOffset occurrences="1">
       <code>[$this-&gt;identifier =&gt; $this-&gt;getIdentifierValue($object)]</code>
     </InvalidArrayOffset>
-    <LessSpecificImplementedReturnType occurrences="2">
-      <code>?string</code>
+    <LessSpecificImplementedReturnType occurrences="1">
       <code>array</code>
     </LessSpecificImplementedReturnType>
   </file>
@@ -80,12 +74,6 @@
       <code>$p</code>
       <code>$p</code>
     </InvalidArgument>
-    <InvalidNullableReturnType occurrences="1">
-      <code>getMapping</code>
-    </InvalidNullableReturnType>
-    <InvalidReturnType occurrences="1">
-      <code>getTypeClass</code>
-    </InvalidReturnType>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php">
     <RedundantFunctionCall occurrences="1">
@@ -122,10 +110,6 @@
     </RedundantCondition>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/UnitOfWork.php">
-    <InvalidPropertyAssignmentValue occurrences="2">
-      <code>$this-&gt;identityMap</code>
-      <code>$this-&gt;originalDocumentData</code>
-    </InvalidPropertyAssignmentValue>
     <NullableReturnStatement occurrences="1">
       <code>$mapping['targetDocument']</code>
     </NullableReturnStatement>
@@ -181,11 +165,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>1</code>
     </InvalidScalarArgument>
-  </file>
-  <file src="tests/Doctrine/ODM/MongoDB/Tests/Query/QueryExpressionVisitorTest.php">
-    <TooManyArguments occurrences="1">
-      <code>andX</code>
-    </TooManyArguments>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php">
     <InvalidArgument occurrences="1">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -36,9 +36,10 @@
     </LessSpecificImplementedReturnType>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php">
-    <InvalidArgument occurrences="2">
+    <InvalidArgument occurrences="3">
       <code>$mapping</code>
       <code>$mapping</code>
+      <code>$options</code>
     </InvalidArgument>
     <RedundantCondition occurrences="15">
       <code>assert($attributes instanceof SimpleXMLElement)</code>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationOperatorsProviderTrait.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationOperatorsProviderTrait.php
@@ -606,7 +606,9 @@ trait AggregationOperatorsProviderTrait
     }
 
     /**
-     * @param mixed $args
+     * @param Closure(Expr): mixed[]|mixed[] $args
+     *
+     * @return mixed[]
      */
     protected function resolveArgs($args): array
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/ExprTest.php
@@ -15,7 +15,8 @@ class ExprTest extends BaseTest
     use AggregationOperatorsProviderTrait;
 
     /**
-     * @param array|Closure $args
+     * @param array<string, string>          $expected
+     * @param Closure(Expr): mixed[]|mixed[] $args
      *
      * @dataProvider provideAllOperators
      */
@@ -29,7 +30,8 @@ class ExprTest extends BaseTest
     }
 
     /**
-     * @param array|Closure $args
+     * @param array<string, string>          $expected
+     * @param Closure(Expr): mixed[]|mixed[] $args
      *
      * @dataProvider provideAllOperators
      */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
@@ -148,6 +148,9 @@ class GraphLookupTest extends BaseTest
     }
 
     /**
+     * @param Closure(Builder): GraphLookup $addGraphLookupStage
+     * @param array<string, string>         $expectedFields
+     *
      * @dataProvider provideEmployeeAggregations
      */
     public function testGraphLookupWithEmployees(Closure $addGraphLookupStage, array $expectedFields): void
@@ -218,6 +221,9 @@ class GraphLookupTest extends BaseTest
     }
 
     /**
+     * @param Closure(Builder): GraphLookup $addGraphLookupStage
+     * @param array<string, string>         $expectedFields
+     *
      * @dataProvider provideTravellerAggregations
      */
     public function testGraphLookupWithTraveller(Closure $addGraphLookupStage, array $expectedFields): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GroupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GroupTest.php
@@ -17,7 +17,7 @@ class GroupTest extends BaseTest
     use AggregationOperatorsProviderTrait;
 
     /**
-     * @param Closure|array $args
+     * @param Closure(Expr): Expr[]|mixed[] $args
      *
      * @dataProvider provideProxiedExprMethods
      */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
@@ -40,6 +40,8 @@ class MatchStageTest extends BaseTest
     }
 
     /**
+     * @param mixed[] $args
+     *
      * @dataProvider provideProxiedExprMethods
      */
     public function testProxiedExprMethods(string $method, array $args = []): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
@@ -40,8 +40,6 @@ class MatchStageTest extends BaseTest
     }
 
     /**
-     * @param mixed[] $args
-     *
      * @dataProvider provideProxiedExprMethods
      */
     public function testProxiedExprMethods(string $method, array $args = []): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OperatorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OperatorTest.php
@@ -18,7 +18,8 @@ class OperatorTest extends BaseTest
     use AggregationOperatorsProviderTrait;
 
     /**
-     * @param Closure|array $args
+     * @param array<string, mixed>           $expected
+     * @param Closure(Expr): mixed[]|mixed[] $args
      *
      * @dataProvider provideExpressionOperators
      */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
@@ -62,6 +62,8 @@ class ProjectTest extends BaseTest
     }
 
     /**
+     * @param string[] $args
+     *
      * @dataProvider provideProxiedExprMethods
      */
     public function testProxiedExprMethods(string $method, array $args = []): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortTest.php
@@ -8,12 +8,16 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
+/**
+ * @psalm-import-type SortShape from Sort
+ */
 class SortTest extends BaseTest
 {
     use AggregationTestTrait;
 
     /**
      * @param string|array<string, string> $field
+     * @psalm-param SortShape $expectedSort
      *
      * @dataProvider provideSortOptions
      */
@@ -26,6 +30,7 @@ class SortTest extends BaseTest
 
     /**
      * @param string|array<string, string> $field
+     * @psalm-param SortShape $expectedSort
      *
      * @dataProvider provideSortOptions
      */

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -88,6 +88,9 @@ abstract class BaseTest extends TestCase
      * the original assertion checked.
      *
      * @deprecated
+     *
+     * @param mixed[] $subset
+     * @param mixed[] $array
      */
     public static function assertArraySubset(array $subset, array $array, bool $checkForObjectIdentity = false, string $message = ''): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -88,9 +88,6 @@ abstract class BaseTest extends TestCase
      * the original assertion checked.
      *
      * @deprecated
-     *
-     * @param mixed[] $subset
-     * @param mixed[] $array
      */
     public static function assertArraySubset(array $subset, array $array, bool $checkForObjectIdentity = false, string $message = ''): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleListenersTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleListenersTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Events;
 use BadMethodCallException;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Event\PostCollectionLoadEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -224,6 +225,9 @@ class MyEventListener
     /** @psalm-var array<string, list<class-string>> */
     public array $called = [];
 
+    /**
+     * @param array{LifecycleEventArgs} $args
+     */
     public function __call(string $method, array $args): void
     {
         $document                = $args[0]->getDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/PreUpdateEventArgsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/PreUpdateEventArgsTest.php
@@ -83,6 +83,7 @@ class CollectionsAreInChangeSetListener
         $this->phpunit = $phpunit;
     }
 
+    /** @param list<class-string> $allowed */
     public function checkOnly(array $allowed): void
     {
         $this->allowed = $allowed;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\APM\CommandLogger;
+use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\LockException;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
@@ -160,6 +161,9 @@ class PhonenumberMachine implements EventSubscriber
         ];
     }
 
+    /**
+     * @param array{LifecycleEventArgs} $args
+     */
     public function __call(string $eventName, array $args): void
     {
         $document = $args[0]->getDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -224,6 +224,9 @@ class DocumentPersisterTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $expected
+     * @param array<string, mixed> $query
+     *
      * @dataProvider queryProviderForCustomTypeId
      */
     public function testPrepareQueryOrNewObjWithCustomTypedId(array $expected, array $query): void
@@ -503,6 +506,9 @@ class DocumentPersisterTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $expected
+     * @param array<string, mixed> $query
+     *
      * @dataProvider queryProviderForComplexRefWithObjectValue
      */
     public function testPrepareQueryOrNewObjWithComplexRefToTargetDocumentFieldWithObjectValue(array $expected, array $query): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/CachingIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/CachingIteratorTest.php
@@ -175,6 +175,13 @@ class CachingIteratorTest extends TestCase
         $this->assertCount(1, $iterator);
     }
 
+    /**
+     * @param T[] $items
+     *
+     * @return Generator<T>
+     *
+     * @template T
+     */
     private function getTraversable(array $items): Generator
     {
         foreach ($items as $item) {
@@ -182,6 +189,11 @@ class CachingIteratorTest extends TestCase
         }
     }
 
+    /**
+     * @param array<mixed|Exception> $items
+     *
+     * @return Generator<mixed>
+     */
     private function getTraversableThatThrows(array $items): Generator
     {
         foreach ($items as $item) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/HydratingIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/HydratingIteratorTest.php
@@ -48,6 +48,11 @@ final class HydratingIteratorTest extends BaseTest
         self::assertFalse($iterator->valid());
     }
 
+    /**
+     * @param array<string, mixed>|null $items
+     *
+     * @return Generator<array<string, mixed>>
+     */
     private function getTraversable(?array $items = null): Generator
     {
         if (! is_array($items)) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/UnrewindableIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/UnrewindableIteratorTest.php
@@ -120,6 +120,11 @@ class UnrewindableIteratorTest extends TestCase
         $iterator->toArray();
     }
 
+    /**
+     * @param list<mixed> $items
+     *
+     * @return Generator<mixed>
+     */
     private function getTraversable(array $items): Generator
     {
         foreach ($items as $item) {
@@ -127,6 +132,11 @@ class UnrewindableIteratorTest extends TestCase
         }
     }
 
+    /**
+     * @param array<mixed|Exception> $items
+     *
+     * @return Generator<mixed>
+     */
     private function getTraversableThatThrows(array $items): Generator
     {
         foreach ($items as $item) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
@@ -13,6 +13,9 @@ use Documents\User;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 
+/**
+ * @psalm-type ReadPreferenceTagShape = array{dc?: string, usage?: string}
+ */
 class ReadPreferenceTest extends BaseTest
 {
     public function setUp(): void
@@ -43,6 +46,8 @@ class ReadPreferenceTest extends BaseTest
     }
 
     /**
+     * @psalm-param ReadPreferenceTagShape[] $tags
+     *
      * @dataProvider provideReadPreferenceHints
      */
     public function testHintIsSetOnQuery(int $readPreference, array $tags = []): void
@@ -100,6 +105,9 @@ class ReadPreferenceTest extends BaseTest
         $this->assertReadPreferenceHint(ReadPreference::RP_SECONDARY, $query->getQuery()['readPreference']);
     }
 
+    /**
+     * @psalm-param ReadPreferenceTagShape[] $tags
+     */
     private function assertReadPreferenceHint(int $mode, ReadPreference $readPreference, array $tags = []): void
     {
         self::assertInstanceOf(ReadPreference::class, $readPreference);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
@@ -134,16 +134,22 @@ class CommentableAction extends Action
     /**
      * @ODM\Field(type="collection") *
      *
-     * @var array
+     * @var string[]
      */
     protected $comments = [];
 
+    /**
+     * @param string[] $comments
+     */
     public function __construct(string $type, array $comments = [])
     {
         parent::__construct($type);
         $this->comments = $comments;
     }
 
+    /**
+     * @return string[]
+     */
     public function getComments(): array
     {
         return $this->comments;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
@@ -6,9 +6,12 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+use function assert;
 
 class GH1232Test extends BaseTest
 {
@@ -93,16 +96,20 @@ class GH1232Comment
 class GH1232CommentRepository extends DocumentRepository
 {
     /**
-     * @return array|int|object|null
+     * @return Iterator<GH1232Comment>
      */
     public function getLongComments(GH1232Post $post)
     {
-        return $this
+        $comments = $this
             ->createQueryBuilder()
             ->field('post')
             ->references($post)
             ->sort('_id', 'asc')
             ->getQuery()
             ->execute();
+
+        assert($comments instanceof Iterator);
+
+        return $comments;
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2002Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2002Test.php
@@ -14,6 +14,8 @@ use function sprintf;
 class GH2002Test extends BaseTest
 {
     /**
+     * @param array<string, mixed> $expectedReference
+     *
      * @dataProvider getValidReferenceData
      */
     public function testBuildingReferenceCreatesCorrectStructure(array $expectedReference, object $document): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\EventSubscriber;
+use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
@@ -103,6 +104,9 @@ class GH560EventSubscriber implements EventSubscriber
     /** @var string[] */
     public $events;
 
+    /**
+     * @param string[] $events
+     */
     public function __construct(array $events)
     {
         $this->events = $events;
@@ -113,6 +117,9 @@ class GH560EventSubscriber implements EventSubscriber
         return $this->events;
     }
 
+    /**
+     * @param array{LifecycleEventArgs} $args
+     */
     public function __call(string $eventName, array $args): void
     {
         $this->called[] = [$eventName, get_class($args[0]->getDocument())];

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH597Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH597Test.php
@@ -110,7 +110,7 @@ class GH597Test extends BaseTest
     /**
      * Asserts that raw document matches expected document.
      *
-     * @param array $expected
+     * @param array<string, mixed> $expected
      */
     private function assertPostDocument(array $expected, GH597Post $post): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM62Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM62Test.php
@@ -42,6 +42,9 @@ class MODM62Document
      */
     public $b = ['ok'];
 
+    /**
+     * @param string[] $b
+     */
     public function setB(array $b): void
     {
         $this->b = $b;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
@@ -108,7 +108,7 @@ class MODM81TestDocument
     }
 
     /**
-     * @param array $documents
+     * @param MODM81TestEmbeddedDocument[] $documents
      */
     public function setEmbeddedDocuments(array $documents): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM83Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM83Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
@@ -62,6 +63,9 @@ class MODM83EventListener
     /** @var array<string, class-string[]> */
     public $called = [];
 
+    /**
+     * @param array{LifecycleEventArgs} $args
+     */
     public function __call(string $method, array $args): void
     {
         $document                = $args[0]->getDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM90Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM90Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
@@ -79,6 +80,9 @@ class MODM90EventListener
     /** @var array<string, class-string[]> */
     public $called = [];
 
+    /**
+     * @param array{LifecycleEventArgs} $args
+     */
     public function __call(string $method, array $args): void
     {
         $document                = $args[0]->getDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM91Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM91Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
@@ -54,6 +55,9 @@ class MODM91EventListener
     /** @var array<string, class-string[]>  */
     public $called = [];
 
+    /**
+     * @param array{LifecycleEventArgs} $args
+     */
     public function __call(string $method, array $args): void
     {
         $document                = $args[0]->getDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM95Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM95Test.php
@@ -8,9 +8,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
-use Traversable;
-
-use function is_iterable;
 
 class MODM95Test extends BaseTest
 {
@@ -70,23 +67,11 @@ class MODM95TestDocument
     }
 
     /**
-     * Sets children
-     *
-     * If $images is not an array or Traversable object, this method will simply
-     * clear the images collection property.  If any elements in the parameter
-     * are not an Image object, this method will attempt to convert them to one
-     * by mapping array indexes (size URL's are required, cropMetadata is not).
-     * Any invalid elements will be ignored.
-     *
-     * @param array|Traversable $embeddedDocuments
+     * @param iterable<MODM95TestEmbeddedDocument> $embeddedDocuments
      */
-    public function setEmbeddedDocuments($embeddedDocuments): void
+    public function setEmbeddedDocuments(iterable $embeddedDocuments): void
     {
         $this->embeddedDocuments->clear();
-
-        if (! is_iterable($embeddedDocuments)) {
-            return;
-        }
 
         foreach ($embeddedDocuments as $embeddedDocument) {
             $this->embeddedDocuments->add($embeddedDocument);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -761,6 +761,8 @@ class ClassMetadataTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $config
+     *
      * @dataProvider provideOwningAndInversedRefsNeedTargetDocument
      */
     public function testOwningAndInversedRefsNeedTargetDocument(array $config): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/AbstractDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/AbstractDriverTest.php
@@ -92,6 +92,8 @@ abstract class AbstractDriverTest extends TestCase
     abstract protected function getFileExtension(): string;
 
     /**
+     * @param string[] $paths
+     *
      * @return FileDriver
      */
     abstract protected function getDriver(array $paths = []);

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
@@ -133,8 +133,8 @@ class PersistentCollectionTest extends BaseTest
     }
 
     /**
-     * @param array $expected
-     * @param array $snapshot
+     * @param stdClass[] $expected
+     * @param stdClass[] $snapshot
      *
      * @dataProvider dataGetDeletedDocuments
      */
@@ -207,8 +207,8 @@ class PersistentCollectionTest extends BaseTest
     }
 
     /**
-     * @param array $expected
-     * @param array $snapshot
+     * @param stdClass[] $expected
+     * @param stdClass[] $snapshot
      *
      * @dataProvider dataGetInsertedDocuments
      */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php
@@ -205,6 +205,8 @@ class PersistenceBuilderTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $expectedData
+     *
      * @dataProvider getDocumentsAndExpectedData
      */
     public function testPrepareInsertData(object $document, array $expectedData): void
@@ -228,7 +230,11 @@ class PersistenceBuilderTest extends BaseTest
         ];
     }
 
-    private function assertDocumentInsertData(array $expectedData, ?array $preparedData = null): void
+    /**
+     * @param array<string, mixed> $expectedData
+     * @param array<string, mixed> $preparedData
+     */
+    private function assertDocumentInsertData(array $expectedData, array $preparedData): void
     {
         foreach ($preparedData as $key => $value) {
             if ($key === '_id') {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -474,6 +474,8 @@ class BuilderTest extends BaseTest
     }
 
     /**
+     * @param mixed[] $args
+     *
      * @dataProvider provideProxiedExprMethods
      */
     public function testProxiedExprMethods(string $method, array $args = []): void
@@ -567,6 +569,9 @@ class BuilderTest extends BaseTest
     }
 
     /**
+     * @param string[]         $args
+     * @param array<string, 1> $expected
+     *
      * @dataProvider provideSelectProjections
      */
     public function testSelect(array $args, array $expected): void
@@ -583,6 +588,9 @@ class BuilderTest extends BaseTest
     }
 
     /**
+     * @param string[]         $args
+     * @param array<string, 0> $expected
+     *
      * @dataProvider provideExcludeProjections
      */
     public function testExclude(array $args, array $expected): void
@@ -875,6 +883,8 @@ class BuilderTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $json
+     *
      * @return MockObject&Point
      */
     private function getMockPoint(array $json)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -474,8 +474,6 @@ class BuilderTest extends BaseTest
     }
 
     /**
-     * @param mixed[] $args
-     *
      * @dataProvider provideProxiedExprMethods
      */
     public function testProxiedExprMethods(string $method, array $args = []): void
@@ -569,8 +567,7 @@ class BuilderTest extends BaseTest
     }
 
     /**
-     * @param string[]         $args
-     * @param array<string, 1> $expected
+     * @param string[] $args
      *
      * @dataProvider provideSelectProjections
      */
@@ -588,8 +585,7 @@ class BuilderTest extends BaseTest
     }
 
     /**
-     * @param string[]         $args
-     * @param array<string, 0> $expected
+     * @param string[] $args
      *
      * @dataProvider provideExcludeProjections
      */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/CriteriaMergerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/CriteriaMergerTest.php
@@ -12,6 +12,9 @@ use function call_user_func_array;
 class CriteriaMergerTest extends TestCase
 {
     /**
+     * @param array<array<string, mixed>> $args
+     * @param array<string, mixed>        $merged
+     *
      * @dataProvider provideMerge
      */
     public function testMerge(array $args, array $merged): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -409,7 +409,8 @@ class ExprTest extends BaseTest
     }
 
     /**
-     * @param mixed $point
+     * @param Point|array<string, mixed> $point
+     * @param array<string, mixed>       $expected
      *
      * @dataProvider provideGeoJsonPoint
      */
@@ -430,7 +431,8 @@ class ExprTest extends BaseTest
     }
 
     /**
-     * @param mixed $point
+     * @param Point|array<string, mixed> $point
+     * @param array<string, mixed>       $expected
      *
      * @dataProvider provideGeoJsonPoint
      */
@@ -544,7 +546,8 @@ class ExprTest extends BaseTest
     }
 
     /**
-     * @param mixed $geometry
+     * @param Polygon|array<string, array<string, mixed>> $geometry
+     * @param array<string, mixed>                        $expected
      *
      * @dataProvider provideGeoJsonPolygon
      */
@@ -572,7 +575,8 @@ class ExprTest extends BaseTest
     }
 
     /**
-     * @param mixed $geometry
+     * @param Polygon|array<string, array<string, mixed>> $geometry
+     * @param array<string, mixed>                        $expected
      *
      * @dataProvider provideGeoJsonPolygon
      */
@@ -700,6 +704,8 @@ class ExprTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $json
+     *
      * @return MockObject&Point
      */
     private function getMockPoint(array $json)
@@ -714,6 +720,8 @@ class ExprTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $json
+     *
      * @return MockObject&Polygon
      */
     private function getMockPolygon(array $json)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/QueryExpressionVisitorTest.php
@@ -30,6 +30,8 @@ class QueryExpressionVisitorTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $expectedQuery
+     *
      * @dataProvider provideComparisons
      */
     public function testWalkComparison(Comparison $comparison, array $expectedQuery): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -46,6 +46,9 @@ use function in_array;
 use function MongoDB\BSON\fromJSON;
 use function MongoDB\BSON\toPHP;
 
+/**
+ * @psalm-import-type IndexMapping from ClassMetadata
+ */
 class SchemaManagerTest extends BaseTest
 {
     /** @psalm-var list<class-string> */
@@ -160,6 +163,8 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getIndexCreationWriteOptions
      */
     public function testEnsureIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false): void
@@ -207,6 +212,8 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getIndexCreationWriteOptions
      */
     public function testEnsureDocumentIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false): void
@@ -227,6 +234,8 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getIndexCreationWriteOptions
      */
     public function testEnsureDocumentIndexesForGridFSFile(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false): void
@@ -269,6 +278,8 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getIndexCreationWriteOptions
      */
     public function testEnsureDocumentIndexesWithTwoLevelInheritance(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false): void
@@ -284,6 +295,8 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testUpdateDocumentIndexesShouldCreateMappedIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -307,6 +320,8 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testUpdateDocumentIndexesShouldDeleteUnmappedIndexesBeforeCreatingMappedIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -338,6 +353,8 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testDeleteIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -362,6 +379,8 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testDeleteDocumentIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -404,6 +423,8 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testUpdateDocumentValidator(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -453,6 +474,8 @@ EOT;
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testUpdateDocumentValidatorReset(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -475,6 +498,8 @@ EOT;
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testCreateDocumentCollection(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -502,6 +527,8 @@ EOT;
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testCreateDocumentCollectionForFile(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -519,6 +546,8 @@ EOT;
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testCreateDocumentCollectionWithValidator(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -562,6 +591,8 @@ EOT;
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testCreateView(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -599,6 +630,8 @@ EOT;
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testCreateCollections(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -627,6 +660,8 @@ EOT;
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testDropCollections(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -641,6 +676,8 @@ EOT;
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testDropDocumentCollection(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -660,6 +697,8 @@ EOT;
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testDropDocumentCollectionForGridFSFile(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -695,6 +734,8 @@ EOT;
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testDropView(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -714,6 +755,8 @@ EOT;
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testDropDocumentDatabase(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -734,6 +777,8 @@ EOT;
     }
 
     /**
+     * @param array<string, mixed> $expectedWriteOptions
+     *
      * @dataProvider getWriteOptions
      */
     public function testDropDatabases(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
@@ -749,6 +794,9 @@ EOT;
     }
 
     /**
+     * @param array<string, mixed> $mongoIndex
+     * @psalm-param IndexMapping $documentIndex
+     *
      * @dataProvider dataIsMongoIndexEquivalentToDocumentIndex
      */
     public function testIsMongoIndexEquivalentToDocumentIndex(bool $expected, array $mongoIndex, array $documentIndex): void
@@ -959,6 +1007,9 @@ EOT;
     }
 
     /**
+     * @param array<string, mixed> $mongoIndex
+     * @psalm-param IndexMapping $documentIndex
+     *
      * @dataProvider dataIsMongoTextIndexEquivalentToDocumentIndex
      */
     public function testIsMongoIndexEquivalentToDocumentIndexWithTextIndexes(bool $expected, array $mongoIndex, array $documentIndex): void
@@ -1153,13 +1204,16 @@ EOT;
         return $db;
     }
 
+    /**
+     * @param array<string, mixed> $expectedWriteOptions
+     */
     private function writeOptions(array $expectedWriteOptions): Constraint
     {
         if (class_exists(ArraySubset::class)) {
             return new ArraySubset($expectedWriteOptions);
         }
 
-        return new Callback(static function ($value) use ($expectedWriteOptions) {
+        return new Callback(static function (array $value) use ($expectedWriteOptions) {
             foreach ($expectedWriteOptions as $writeOption => $expectedValue) {
                 if (! (new ArrayHasKey($writeOption))->evaluate($value, '', true)) {
                     return false;

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -32,7 +32,6 @@ use MongoDB\Model\CollectionInfo;
 use MongoDB\Model\IndexInfo;
 use MongoDB\Model\IndexInfoIteratorIterator;
 use PHPUnit\Framework\Constraint\ArrayHasKey;
-use PHPUnit\Framework\Constraint\ArraySubset;
 use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\IsEqual;
@@ -41,7 +40,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use function array_count_values;
 use function array_map;
 use function assert;
-use function class_exists;
 use function in_array;
 use function MongoDB\BSON\fromJSON;
 use function MongoDB\BSON\toPHP;
@@ -1209,10 +1207,6 @@ EOT;
      */
     private function writeOptions(array $expectedWriteOptions): Constraint
     {
-        if (class_exists(ArraySubset::class)) {
-            return new ArraySubset($expectedWriteOptions);
-        }
-
         return new Callback(static function (array $value) use ($expectedWriteOptions) {
             foreach ($expectedWriteOptions as $writeOption => $expectedValue) {
                 if (! (new ArrayHasKey($writeOption))->evaluate($value, '', true)) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -46,6 +46,7 @@ use function MongoDB\BSON\toPHP;
 
 /**
  * @psalm-import-type IndexMapping from ClassMetadata
+ * @psalm-import-type IndexOptions from ClassMetadata
  */
 class SchemaManagerTest extends BaseTest
 {
@@ -161,7 +162,7 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getIndexCreationWriteOptions
      */
@@ -210,7 +211,7 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getIndexCreationWriteOptions
      */
@@ -232,7 +233,7 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getIndexCreationWriteOptions
      */
@@ -276,7 +277,7 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getIndexCreationWriteOptions
      */
@@ -293,7 +294,7 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -318,7 +319,7 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -351,7 +352,7 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -377,7 +378,7 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -421,7 +422,7 @@ class SchemaManagerTest extends BaseTest
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -472,7 +473,7 @@ EOT;
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -496,7 +497,7 @@ EOT;
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -525,7 +526,7 @@ EOT;
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -544,7 +545,7 @@ EOT;
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -589,7 +590,7 @@ EOT;
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -628,7 +629,7 @@ EOT;
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -658,7 +659,7 @@ EOT;
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -674,7 +675,7 @@ EOT;
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -695,7 +696,7 @@ EOT;
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -732,7 +733,7 @@ EOT;
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -753,7 +754,7 @@ EOT;
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -775,7 +776,7 @@ EOT;
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      *
      * @dataProvider getWriteOptions
      */
@@ -1203,7 +1204,7 @@ EOT;
     }
 
     /**
-     * @param array<string, mixed> $expectedWriteOptions
+     * @psalm-param IndexOptions $expectedWriteOptions
      */
     private function writeOptions(array $expectedWriteOptions): Constraint
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -249,6 +249,9 @@ class UnitOfWorkTest extends BaseTest
     }
 
     /**
+     * @param array<string, mixed>|null $origData
+     * @param array<string, mixed>|null $updateData
+     *
      * @dataProvider getScheduleForUpdateWithArraysTests
      */
     public function testScheduleForUpdateWithArrays(?array $origData, ?array $updateData, bool $shouldInUpdate): void
@@ -712,10 +715,13 @@ class ArrayTest
     /**
      * @ODM\Field(type="hash")
      *
-     * @var array<array-key, mixed>|null
+     * @var array<string, mixed>|null
      */
     public $data;
 
+    /**
+     * @param array<string, mixed>|null $data
+     */
     public function __construct(?array $data)
     {
         $this->data = $data;

--- a/tests/Documents/Article.php
+++ b/tests/Documents/Article.php
@@ -106,6 +106,9 @@ class Article
         unset($this->tags[array_search($tag, $this->tags)]);
     }
 
+    /**
+     * @return int[]
+     */
     public function getTags(): array
     {
         return $this->tags;

--- a/tests/Documents/BaseEmployee.php
+++ b/tests/Documents/BaseEmployee.php
@@ -90,6 +90,9 @@ abstract class BaseEmployee
         return $this;
     }
 
+    /**
+     * @return string[]
+     */
     public function getNotes(): array
     {
         return $this->notes;

--- a/tests/Documents/SpecialUser.php
+++ b/tests/Documents/SpecialUser.php
@@ -16,11 +16,17 @@ class SpecialUser extends User
      */
     private $rules = [];
 
+    /**
+     * @param string[] $rules
+     */
     public function setRules(array $rules): void
     {
         $this->rules = $rules;
     }
 
+    /**
+     * @return string[]
+     */
     public function getRules(): array
     {
         return $this->rules;

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -250,6 +250,9 @@ class User extends BaseDocument
         $this->id = $id;
     }
 
+    /**
+     * @return string[]
+     */
     public function getLogs(): array
     {
         return $this->logs;

--- a/tests/Documents74/UserTyped.php
+++ b/tests/Documents74/UserTyped.php
@@ -30,7 +30,11 @@ class UserTyped
     #[ODM\Field]
     public DateTimeImmutable $dateTimeImmutable;
 
-    /** @ODM\Field */
+    /**
+     * @ODM\Field
+     *
+     * @var mixed[]
+     */
     #[ODM\Field]
     public array $array;
 
@@ -46,11 +50,19 @@ class UserTyped
     #[ODM\Field]
     public int $int;
 
-    /** @ODM\EmbedMany  */
+    /**
+     * @ODM\EmbedMany
+     *
+     * @var CustomCollection<array-key, object>
+     */
     #[ODM\EmbedMany]
     public CustomCollection $embedMany;
 
-    /** @ODM\ReferenceMany  */
+    /**
+     * @ODM\ReferenceMany
+     *
+     * @var CustomCollection<array-key, object>
+     */
     #[ODM\ReferenceMany]
     public CustomCollection $referenceMany;
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Last PR to add the PHPStan check for iterable types, the remaining ones where the ones in `tests`.
