### PR TITLE
add BackedEnum support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
             "Doctrine\\ODM\\MongoDB\\Tests\\": "tests/Doctrine/ODM/MongoDB/Tests",
             "Documents\\": "tests/Documents",
             "Documents74\\": "tests/Documents74",
+            "Documents81\\": "tests/Documents81",
             "Stubs\\": "tests/Stubs",
             "TestDocuments\\" :"tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures"
         }

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -361,6 +361,10 @@ Optional attributes:
    :ref:`doctrine_mapping_types` for a list of types. Defaults to "string" or
    :ref:`Type from PHP property type <reference-php-mapping-types>`.
 -
+   ``enumType`` - A |FQCN| of an ``enum``. ODM will automatically handle conversion
+   from the backing value stored in the database to an ``enum``. Can be auto-detected
+   by :ref:`type from PHP property type <reference-php-mapping-types>`.
+-
    ``name`` - By default, the property name is used for the field name in
    MongoDB; however, this option may be used to specify a database field name.
 -

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -215,6 +215,10 @@ follows:
 - ``int``: ``int``
 - ``string``: ``string``
 
+Doctrine will also autoconfigure any backed ``enum`` it encounters: ``type``
+will be set to ``string`` or ``int``, depending on the enum's backing type,
+and ``enumType`` to the enum's |FQCN|.
+
 Please note that at this time, due to backward compatibility reasons, nullable type does not imply `nullable` mapping.
 
 Property Mapping

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -138,6 +138,7 @@
     <xs:attribute name="not-saved" type="xs:boolean" />
     <xs:attribute name="nullable" type="xs:boolean" />
     <xs:attribute name="also-load" type="xs:string" />
+    <xs:attribute name="enum-type" type="xs:string" />
 
     <!-- index options -->
     <xs:attribute name="background" type="xs:boolean" />

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Field.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Field.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
 
 use Attribute;
+use BackedEnum;
 use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
@@ -16,4 +17,24 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class Field extends AbstractField
 {
+    /** @var class-string<BackedEnum>|null */
+    public $enumType;
+
+    /**
+     * @param mixed[]                       $options
+     * @param class-string<BackedEnum>|null $enumType
+     */
+    public function __construct(
+        ?string $name = null,
+        ?string $type = null,
+        bool $nullable = false,
+        array $options = [],
+        ?string $strategy = null,
+        bool $notSaved = false,
+        ?string $enumType = null
+    ) {
+        parent::__construct($name, $type, $nullable, $options, $strategy, $notSaved);
+
+        $this->enumType = $enumType;
+    }
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Mapping;
 
+use BackedEnum;
 use BadMethodCallException;
 use DateTime;
 use DateTimeImmutable;
@@ -18,10 +19,12 @@ use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 use Doctrine\Persistence\Mapping\ClassMetadata as BaseClassMetadata;
 use Doctrine\Persistence\Mapping\ReflectionService;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
+use Doctrine\Persistence\Reflection\EnumReflectionProperty;
 use InvalidArgumentException;
 use LogicException;
 use ProxyManager\Proxy\GhostObjectInterface;
 use ReflectionClass;
+use ReflectionEnum;
 use ReflectionNamedType;
 use ReflectionProperty;
 
@@ -34,6 +37,7 @@ use function assert;
 use function class_exists;
 use function constant;
 use function count;
+use function enum_exists;
 use function extension_loaded;
 use function get_class;
 use function in_array;
@@ -100,7 +104,8 @@ use const PHP_VERSION_ID;
  *      criteria?: array<string, string>,
  *      alsoLoadFields?: list<string>,
  *      order?: int|string,
- *      background?: bool
+ *      background?: bool,
+ *      enumType?: class-string<BackedEnum>,
  * }
  * @psalm-type FieldMapping = array{
  *      type: string,
@@ -145,6 +150,7 @@ use const PHP_VERSION_ID;
  *      index?: bool,
  *      criteria?: array<string, string>,
  *      alsoLoadFields?: list<string>,
+ *      enumType?: class-string<BackedEnum>,
  * }
  * @psalm-type AssociationFieldMapping = array{
  *      type?: string,
@@ -2377,6 +2383,19 @@ use const PHP_VERSION_ID;
 
         $reflProp = $this->reflectionService->getAccessibleProperty($this->name, $mapping['fieldName']);
         assert($reflProp instanceof ReflectionProperty);
+
+        if (isset($mapping['enumType'])) {
+            if (PHP_VERSION_ID < 80100) {
+                throw MappingException::enumsRequirePhp81($this->name, $mapping['fieldName']);
+            }
+
+            if (! enum_exists($mapping['enumType'])) {
+                throw MappingException::nonEnumTypeMapped($this->name, $mapping['fieldName'], $mapping['enumType']);
+            }
+
+            $reflProp = new EnumReflectionProperty($reflProp, $mapping['enumType']);
+        }
+
         $this->reflFields[$mapping['fieldName']] = $reflProp;
 
         return $mapping;
@@ -2583,6 +2602,15 @@ use const PHP_VERSION_ID;
 
         if (! $type instanceof ReflectionNamedType || isset($mapping['type'])) {
             return $mapping;
+        }
+
+        if (PHP_VERSION_ID >= 80100 && ! $type->isBuiltin() && enum_exists($type->getName())) {
+            $mapping['enumType'] = $type->getName();
+
+            $reflection = new ReflectionEnum($type->getName());
+            $type       = $reflection->getBackingType();
+
+            assert($type instanceof ReflectionNamedType);
         }
 
         switch ($type->getName()) {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -2393,6 +2393,11 @@ use const PHP_VERSION_ID;
                 throw MappingException::nonEnumTypeMapped($this->name, $mapping['fieldName'], $mapping['enumType']);
             }
 
+            $reflectionEnum = new ReflectionEnum($mapping['enumType']);
+            if (! $reflectionEnum->isBacked()) {
+                throw MappingException::nonBackedEnumMapped($this->name, $mapping['fieldName'], $mapping['enumType']);
+            }
+
             $reflProp = new EnumReflectionProperty($reflProp, $mapping['enumType']);
         }
 
@@ -2609,6 +2614,10 @@ use const PHP_VERSION_ID;
 
             $reflection = new ReflectionEnum($type->getName());
             $type       = $reflection->getBackingType();
+
+            if ($type === null) {
+                throw MappingException::nonBackedEnumMapped($this->name, $mapping['fieldName'], $mapping['enumType']);
+            }
 
             assert($type instanceof ReflectionNamedType);
         }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -278,6 +278,10 @@ class XmlDriver extends FileDriver
                     $mapping['notSaved'] = ((string) $attributes['not-saved'] === 'true');
                 }
 
+                if (isset($attributes['enum-type'])) {
+                    $mapping['enumType'] = (string) $attributes['enum-type'];
+                }
+
                 if (isset($attributes['field-name'])) {
                     $mapping['fieldName'] = (string) $attributes['field-name'];
                 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -276,4 +276,19 @@ final class MappingException extends BaseMappingException
     {
         return new self(sprintf('The following schema validation error occurred while parsing the "%s" property of the "%s" class: "%s" (code %s).', $property, $className, $errorMessage, $errorCode));
     }
+
+    public static function enumsRequirePhp81(string $className, string $fieldName): self
+    {
+        return new self(sprintf('Enum types require PHP 8.1 in %s::%s', $className, $fieldName));
+    }
+
+    public static function nonEnumTypeMapped(string $className, string $fieldName, string $enumType): self
+    {
+        return new self(sprintf(
+            'Attempting to map a non-enum type %s as an enum: %s::%s',
+            $enumType,
+            $className,
+            $fieldName
+        ));
+    }
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -291,4 +291,14 @@ final class MappingException extends BaseMappingException
             $fieldName
         ));
     }
+
+    public static function nonBackedEnumMapped(string $className, string $fieldName, string $enumType): self
+    {
+        return new self(sprintf(
+            'Attempting to map a non-backed enum %s: %s::%s',
+            $enumType,
+            $className,
+            $fieldName
+        ));
+    }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -81,10 +81,10 @@
     </rule>
     <rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect">
         <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/3474 -->
-        <exclude-pattern>tests/Documents81/Suit.php</exclude-pattern>
+        <exclude-pattern>tests/Documents81/Suit*</exclude-pattern>
     </rule>
     <rule ref="Generic.WhiteSpace.ScopeIndent.IncorrectExact">
         <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/3474 -->
-        <exclude-pattern>tests/Documents81/Suit.php</exclude-pattern>
+        <exclude-pattern>tests/Documents81/Suit*</exclude-pattern>
     </rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -79,4 +79,12 @@
         <!-- We do want to test generating collections without return types -->
         <exclude-pattern>*/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/Coll*</exclude-pattern>
     </rule>
+    <rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect">
+        <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/3474 -->
+        <exclude-pattern>tests/Documents81/Suit.php</exclude-pattern>
+    </rule>
+    <rule ref="Generic.WhiteSpace.ScopeIndent.IncorrectExact">
+        <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/3474 -->
+        <exclude-pattern>tests/Documents81/Suit.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -214,3 +214,9 @@ parameters:
             message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:getHints\\(\\) should return array\\<int, mixed\\> but returns Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints\\.$#"
             count: 1
             path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+
+        # breaking types expected by static analysis to check exceptions
+        -
+            message: "#.+mapField\\(\\) expects.+enumType\\: 'Documents81#"
+            count: 2
+            path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -174,6 +174,9 @@
       <code>$this-&gt;dm</code>
     </NullableReturnStatement>
   </file>
+  <file src="tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php">
+    <InvalidArgument occurrences="2"/>
+  </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php">
     <InvalidScalarArgument occurrences="1">
       <code>1</code>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnumTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnumTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Documents81\Card;
+use Documents81\Suit;
+use MongoDB\BSON\ObjectId;
+use ValueError;
+
+use function sprintf;
+
+/**
+ * @requires PHP 8.1
+ */
+class EnumTest extends BaseTest
+{
+    public function testPersistNew(): void
+    {
+        $doc       = new Card();
+        $doc->suit = Suit::Clubs;
+
+        $this->dm->persist($doc);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $saved = $this->dm->find(Card::class, $doc->id);
+        $this->assertInstanceOf(Card::class, $saved);
+        $this->assertSame($doc->id, $saved->id);
+        $this->assertSame(Suit::Clubs, $saved->suit);
+        $this->assertNull($saved->nullableSuit);
+    }
+
+    public function testLoadingInvalidBackingValueThrowsError(): void
+    {
+        $document = [
+            '_id' => new ObjectId(),
+            'suit' => 'ABC',
+        ];
+
+        $this->dm->getDocumentCollection(Card::class)->insertOne($document);
+
+        $this->expectException(ValueError::class);
+        $this->expectExceptionMessage(sprintf('"ABC" is not a valid backing value for enum "%s"', Suit::class));
+        $this->dm->getRepository(Card::class)->findOneBy([]);
+    }
+
+    protected function createMetadataDriverImpl(): MappingDriver
+    {
+        return AttributeDriver::create(__DIR__ . '/../../../Documents');
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -17,9 +17,12 @@ use Doctrine\ODM\MongoDB\Repository\ViewRepository;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Persistence\Reflection\EnumReflectionProperty;
 use Documents74\CustomCollection;
 use Documents74\TypedEmbeddedDocument;
 use Documents74\UserTyped;
+use Documents81\Card;
+use Documents81\Suit;
 use InvalidArgumentException;
 
 use function key;
@@ -636,6 +639,21 @@ abstract class AbstractMappingDriverTest extends BaseTest
             'nullable' => false,
             'strategy' => ClassMetadata::STORAGE_STRATEGY_SET,
         ], $metadata->fieldMappings['name']);
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testEnumType(): void
+    {
+        $metadata = $this->dm->getClassMetadata(Card::class);
+
+        self::assertSame(Suit::class, $metadata->fieldMappings['suit']['enumType']);
+        self::assertSame('string', $metadata->fieldMappings['suit']['type']);
+        self::assertInstanceOf(EnumReflectionProperty::class, $metadata->reflFields['suit']);
+        self::assertSame(Suit::class, $metadata->fieldMappings['nullableSuit']['enumType']);
+        self::assertSame('string', $metadata->fieldMappings['suit']['type']);
+        self::assertInstanceOf(EnumReflectionProperty::class, $metadata->reflFields['nullableSuit']);
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -650,9 +650,12 @@ abstract class AbstractMappingDriverTest extends BaseTest
 
         self::assertSame(Suit::class, $metadata->fieldMappings['suit']['enumType']);
         self::assertSame('string', $metadata->fieldMappings['suit']['type']);
+        self::assertFalse($metadata->fieldMappings['suit']['nullable']);
         self::assertInstanceOf(EnumReflectionProperty::class, $metadata->reflFields['suit']);
+
         self::assertSame(Suit::class, $metadata->fieldMappings['nullableSuit']['enumType']);
-        self::assertSame('string', $metadata->fieldMappings['suit']['type']);
+        self::assertSame('string', $metadata->fieldMappings['nullableSuit']['type']);
+        self::assertTrue($metadata->fieldMappings['nullableSuit']['nullable']);
         self::assertInstanceOf(EnumReflectionProperty::class, $metadata->reflFields['nullableSuit']);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Documents81.Card.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Documents81.Card.dcm.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping
+    xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+    http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd"
+>
+    <document name="Documents81\Card">
+        <id />
+        <field name="suit" />
+        <field name="nullableSuit" type="string" enum-type="Documents81\Suit" nullable="true" />
+    </document>
+</doctrine-mongo-mapping>

--- a/tests/Documents81/Card.php
+++ b/tests/Documents81/Card.php
@@ -20,7 +20,13 @@ class Card
     #[ODM\Field()]
     public Suit $suit;
 
+    /** @ODM\Field() */
+    #[ODM\Field()]
+    public ?SuitInt $suitInt;
+
     /** @ODM\Field(type="string", enumType=Suit::class, nullable=true) */
     #[ODM\Field(type: 'string', enumType: Suit::class, nullable: true)]
     public ?Suit $nullableSuit;
+
+    public ?SuitNonBacked $suitNonBacked;
 }

--- a/tests/Documents81/Card.php
+++ b/tests/Documents81/Card.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents81;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document
+ */
+#[ODM\Document]
+class Card
+{
+    /** @ODM\Id */
+    #[ODM\Id]
+    public string $id;
+
+    /** @ODM\Field() */
+    #[ODM\Field()]
+    public Suit $suit;
+
+    /** @ODM\Field(type="string", enumType=Suit::class, nullable=true) */
+    #[ODM\Field(type: 'string', enumType: Suit::class, nullable: true)]
+    public ?Suit $nullableSuit;
+}

--- a/tests/Documents81/Suit.php
+++ b/tests/Documents81/Suit.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents81;
+
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}

--- a/tests/Documents81/SuitInt.php
+++ b/tests/Documents81/SuitInt.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents81;
+
+enum SuitInt: int
+{
+    case Hearts = 1;
+    case Diamonds = 2;
+    case Clubs = 3;
+    case Spades = 4;
+}

--- a/tests/Documents81/SuitNonBacked.php
+++ b/tests/Documents81/SuitNonBacked.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents81;
+
+enum SuitNonBacked
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}


### PR DESCRIPTION
Finishing touches for #2412

Things changed contrary to original PR:
- PHPStan is no longer locked
- added exception when non-backed enum is being used
- added tests for class metadata creation
- added docs