### PR TITLE
Remove targetDocument autocompletion

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -1551,10 +1551,6 @@ use const PHP_VERSION_ID;
         $mapping['embedded'] = true;
         $mapping['type']     = self::ONE;
 
-        if ($this->isTypedProperty($mapping['fieldName'])) {
-            $mapping = $this->validateAndCompleteTypedAssociationMapping($mapping);
-        }
-
         $this->mapField($mapping);
     }
 
@@ -1579,10 +1575,6 @@ use const PHP_VERSION_ID;
     {
         $mapping['reference'] = true;
         $mapping['type']      = self::ONE;
-
-        if ($this->isTypedProperty($mapping['fieldName'])) {
-            $mapping = $this->validateAndCompleteTypedAssociationMapping($mapping);
-        }
 
         $this->mapField($mapping);
     }
@@ -2667,10 +2659,6 @@ use const PHP_VERSION_ID;
 
         if (! $type instanceof ReflectionNamedType) {
             return $mapping;
-        }
-
-        if (! isset($mapping['targetDocument']) && $mapping['type'] === self::ONE) {
-            $mapping['targetDocument'] = $type->getName();
         }
 
         if (

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -19,7 +19,6 @@ use Doctrine\ODM\MongoDB\Types\Type;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Reflection\EnumReflectionProperty;
 use Documents74\CustomCollection;
-use Documents74\TypedEmbeddedDocument;
 use Documents74\UserTyped;
 use Documents81\Card;
 use Documents81\Suit;
@@ -215,9 +214,6 @@ abstract class AbstractMappingDriverTest extends BaseTest
         $this->assertSame(Type::HASH, $class->getTypeOfField('array'));
         $this->assertSame(Type::BOOL, $class->getTypeOfField('boolean'));
         $this->assertSame(Type::FLOAT, $class->getTypeOfField('float'));
-
-        $this->assertSame(TypedEmbeddedDocument::class, $class->getAssociationTargetClass('embedOne'));
-        $this->assertSame(UserTyped::class, $class->getAssociationTargetClass('referenceOne'));
 
         $this->assertSame(CustomCollection::class, $class->getAssociationCollectionClass('embedMany'));
         $this->assertSame(CustomCollection::class, $class->getAssociationCollectionClass('referenceMany'));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -27,7 +27,6 @@ use Documents\User;
 use Documents\UserName;
 use Documents\UserRepository;
 use Documents74\CustomCollection;
-use Documents74\TypedEmbeddedDocument;
 use Documents74\UserTyped;
 use Documents81\Card;
 use Documents81\Suit;
@@ -177,12 +176,6 @@ class ClassMetadataTest extends BaseTest
         // int
         $cm->mapField(['fieldName' => 'int']);
         self::assertEquals(Type::INT, $cm->getTypeOfField('int'));
-
-        $cm->mapOneEmbedded(['fieldName' => 'embedOne']);
-        self::assertEquals(TypedEmbeddedDocument::class, $cm->getAssociationTargetClass('embedOne'));
-
-        $cm->mapOneReference(['fieldName' => 'referenceOne']);
-        self::assertEquals(UserTyped::class, $cm->getAssociationTargetClass('referenceOne'));
 
         $cm->mapManyEmbedded(['fieldName' => 'embedMany']);
         self::assertEquals(CustomCollection::class, $cm->getAssociationCollectionClass('embedMany'));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Documents74.UserTyped.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Documents74.UserTyped.dcm.xml
@@ -16,9 +16,6 @@
         <field name="float"/>
         <field name="int"/>
 
-        <embed-one field="embedOne" />
-        <reference-one field="referenceOne" />
-
         <embed-many field="embedMany" />
         <reference-many field="referenceMany" />
     </document>

--- a/tests/Documents74/UserTyped.php
+++ b/tests/Documents74/UserTyped.php
@@ -46,14 +46,6 @@ class UserTyped
     #[ODM\Field]
     public int $int;
 
-    /** @ODM\EmbedOne */
-    #[ODM\EmbedOne]
-    public TypedEmbeddedDocument $embedOne;
-
-    /** @ODM\ReferenceOne */
-    #[ODM\ReferenceOne]
-    public UserTyped $referenceOne;
-
     /** @ODM\EmbedMany  */
     #[ODM\EmbedMany]
     public CustomCollection $embedMany;


### PR DESCRIPTION
This dodges a BC break, probably not impacting a lot of users but still a BC break. I use single reference as an example but same goes for `EmbedOne`. Currently

```
    /** @ODM\ReferenceOne() */
    private BaseDocument $referenceToAnywhere;
```

is a perfectly fine mapping that allows user to have a reference to any document (from ODM's perspective) as long as it extends `BaseDocument` (from PHP's perspective). With #2411 due to autocompletion for typed properties this would become (implicitly):

```
    /** @ODM\ReferenceOne(targetDocument=BaseDocument::class) */
    private BaseDocument $referenceToAnywhere;
```

which is wrong. This could be worked around by an explicit `targetDocument=false` in the mapping but that would then require us to widen `targetDocument` to allow `|false`. As we want to get 2.4.0 out of the door let's defer the decision and work to future us.

If we ever get to implementing this feature there's a number of edge cases we'll need to consider as well. All I've found so far involve having typed properties and discriminators (be it maps or anything else hinting discriminators may be in use). Hopefully these will be easier to spot with my next PR which will move autocompleting types before some mapping sanity checks.