### PR TITLE
Fix EnumReflectionProperty ClassMetadata deserialization

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -2533,6 +2533,11 @@ use const PHP_VERSION_ID;
         foreach ($this->fieldMappings as $field => $mapping) {
             $prop = $this->reflectionService->getAccessibleProperty($mapping['declared'] ?? $this->name, $field);
             assert($prop instanceof ReflectionProperty);
+
+            if (isset($mapping['enumType'])) {
+                $prop = new EnumReflectionProperty($prop, $mapping['enumType']);
+            }
+
             $this->reflFields[$field] = $prop;
         }
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -13,6 +13,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Doctrine\ODM\MongoDB\Tests\ClassMetadataTestUtil;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
+use Doctrine\Persistence\Reflection\EnumReflectionProperty;
 use DoctrineGlobal_Article;
 use DoctrineGlobal_User;
 use Documents\Account;
@@ -212,6 +213,22 @@ class ClassMetadataTest extends BaseTest
         self::assertEquals(Type::STRING, $cm->getTypeOfField('nullableSuit'));
         self::assertSame(Suit::class, $cm->fieldMappings['nullableSuit']['enumType']);
         self::assertFalse($cm->isNullable('nullableSuit'));
+    }
+
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function testEnumReflectionPropertySerialization(): void
+    {
+        $cm = new ClassMetadata(Card::class);
+
+        $cm->mapField(['fieldName' => 'suit']);
+        self::assertInstanceOf(EnumReflectionProperty::class, $cm->reflFields['suit']);
+
+        $serialized = serialize($cm);
+        $cm         = unserialize($serialized);
+
+        self::assertInstanceOf(EnumReflectionProperty::class, $cm->reflFields['suit']);
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

#### Summary

When deserializing `ClassMetadata`, `reflProperty` is recreated using `ReflectionService` but the `EnumReflectionProperty` is not handled there and since it does not have access to the mapping, it has been fixed in `ClassMetadata::__wakeup()` instead.
