### PR TITLE
Allow using enums directly in queries

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Persisters;
 
+use BackedEnum;
 use BadMethodCallException;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
 use Doctrine\ODM\MongoDB\DocumentManager;
@@ -1128,6 +1129,10 @@ final class DocumentPersister
         }
 
         if (! $this->class->hasField($fieldName)) {
+            if ($value instanceof BackedEnum) {
+                $value = $value->value;
+            }
+
             return Type::convertPHPToDatabaseValue($value);
         }
 
@@ -1142,6 +1147,10 @@ final class DocumentPersister
             throw new InvalidArgumentException(
                 sprintf('Mapping type "%s" does not exist', $typeName)
             );
+        }
+
+        if ($value instanceof BackedEnum && isset($mapping['enumType'])) {
+            $value = $value->value;
         }
 
         if (in_array($typeName, ['collection', 'hash'])) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug/improvement
| BC Break     | no

#### Summary

This change allows using `BackedEnum`s directly in the query builder instead of using `->value`:
```php
// Before:
$this->createQueryBuilder()->field('status')->equals(Status::APPROVED->value)->getQuery();

// Now
$this->createQueryBuilder()->field('status')->equals(Status::APPROVED)->getQuery();
```

This supports arrays too. Please do note that if `enumType` is not set, the value is passed directly to the `Type` without any changes to allow developers to customize the behaviour in their custom types if needed (see `testQueryWithMappedNonEnumFieldIsPassedToTypeDirectly()` where value is passed directly to `StringType` and producing an error).

I've added the tests in `EnumTest` instead of `DocumentPersisterTest` to avoid conditional mapping loading there (this feature requires PHP 8.1+).

Not sure if this should be treated as bugfix or improvement so feel free to assign to correct milestone.