### PR TITLE
Add implementation of Countable for CachingIterator

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Iterator;
 
+use Countable;
 use Generator;
 use ReturnTypeWillChange;
 use RuntimeException;
 use Traversable;
 
+use function count;
 use function current;
 use function key;
 use function next;
@@ -26,7 +28,7 @@ use function reset;
  * @template TValue
  * @template-implements Iterator<TValue>
  */
-final class CachingIterator implements Iterator
+final class CachingIterator implements Countable, Iterator
 {
     /** @var array<mixed, TValue> */
     private $items = [];
@@ -53,6 +55,16 @@ final class CachingIterator implements Iterator
     {
         $this->iterator = $this->wrapTraversable($iterator);
         $this->storeCurrentItem();
+    }
+
+    /**
+     * @see https://php.net/countable.count
+     */
+    public function count(): int
+    {
+        $this->exhaustIterator();
+
+        return count($this->items);
     }
 
     public function __destruct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/CachingIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/CachingIteratorTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Iterator;
 use Doctrine\ODM\MongoDB\Iterator\CachingIterator;
 use Exception;
 use Generator;
+use Iterator;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
@@ -108,6 +109,71 @@ class CachingIteratorTest extends TestCase
 
         $iterator->next();
         $this->assertSame([1, 2, 3], $iterator->toArray());
+    }
+
+    public function testCount(): void
+    {
+        $iterator = new CachingIterator($this->getTraversable([1, 2, 3]));
+        $this->assertCount(3, $iterator);
+    }
+
+    public function testCountAfterPartialIteration(): void
+    {
+        $iterator = new CachingIterator($this->getTraversable([1, 2, 3]));
+
+        $iterator->rewind();
+        $this->assertTrue($iterator->valid());
+        $this->assertSame(0, $iterator->key());
+        $this->assertSame(1, $iterator->current());
+
+        $iterator->next();
+        $this->assertCount(3, $iterator);
+    }
+
+    public function testCountWithEmptySet(): void
+    {
+        $iterator = new CachingIterator($this->getTraversable([]));
+        $this->assertCount(0, $iterator);
+    }
+
+    /**
+     * This protects against iterators that return valid keys on invalid
+     * positions, which was the case in ext-mongodb until PHPC-1748 was fixed.
+     */
+    public function testWithWrongIterator(): void
+    {
+        $nestedIterator = new class implements Iterator {
+            /** @var int */
+            private $i = 0;
+
+            public function current(): int
+            {
+                return $this->i;
+            }
+
+            public function next(): void
+            {
+                $this->i++;
+            }
+
+            public function key(): int
+            {
+                return $this->i;
+            }
+
+            public function valid(): bool
+            {
+                return $this->i === 0;
+            }
+
+            public function rewind(): void
+            {
+                $this->i = 0;
+            }
+        };
+
+        $iterator = new CachingIterator($nestedIterator);
+        $this->assertCount(1, $iterator);
     }
 
     private function getTraversable(array $items): Generator


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Hi,

I currently use MongoDB with Doctrine, as well as ElasticSearch through FOSElascitaBundle.
When trying to use EnqueueBundle to speed up the populate command [https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/master/doc/cookbook/speed-up-populate-command.md](https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/master/doc/cookbook/speed-up-populate-command.md), I encountered an error.

The enqueue command for elastica makes a count of getCurrentPageResults:
[https://github.com/php-enqueue/enqueue-elastica-bundle/blob/master/Queue/PopulateProcessor.php#L61](https://github.com/php-enqueue/enqueue-elastica-bundle/blob/master/Queue/PopulateProcessor.php#L61)

Unfortunately, Doctrine's CachingIterator does not implement countable unlike Mongo's [https://github.com/mongodb/mongo-php-library/blob/master/src/Model/CachingIterator.php](https://github.com/mongodb/mongo-php-library/blob/master/src/Model/CachingIterator.php) which generates an error.

So I added the implementation of countable in CachingIterator in order to be able to use Enqueue with FOSElastica and MongoDB via Doctrine.


Thank you very much for the library :wink: 

<!-- Provide a summary your change. -->
