### PR TITLE
Expected UUID length should be 16 bytes 

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Id/UuidGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Id/UuidGenerator.php
@@ -125,7 +125,7 @@ final class UuidGenerator extends AbstractIdGenerator
         // Calculate hash value
         $hash = sha1($nstr . $salt);
 
-        return sprintf(
+        return hexdec(sprintf(
             '%08s%04s%04x%04x%12s',
             // 32 bits for "time_low"
             substr($hash, 0, 8),
@@ -140,6 +140,6 @@ final class UuidGenerator extends AbstractIdGenerator
             (hexdec(substr($hash, 16, 4)) & 0x3fff) | 0x8000,
             // 48 bits for "node"
             substr($hash, 20, 12)
-        );
+        ));
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Id/UuidGeneratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Id/UuidGeneratorTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Id;
+
+use Doctrine\ODM\MongoDB\Id\UuidGenerator;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\User;
+
+use const DOCTRINE_MONGODB_DATABASE;
+
+class UuidGeneratorTest extends BaseTest
+{
+    public function testUuidGeneratorCreates16ByteUuid(): void
+    {
+        $generator = new UuidGenerator();
+        $generator->setSalt(date('now'));
+
+        $this->assertSame(16, strlen($generator->generate($this->dm, new User())));
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2149 

#### Summary

Quick and dirty attempt to fix length of UUID returned by the auto UUID generator.
