### PR TITLE
Make Iterator covariant

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Iterator/Iterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/Iterator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Iterator;
 
 /**
- * @template TValue
+ * @template-covariant TValue
  * @template-extends \Iterator<mixed, TValue>
  */
 interface Iterator extends \Iterator


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Since \Iterator is covariant, the mongo Iterator could be too.

This allows to write
```
/**
 * @template-covariant T of object
 */
interface MyCustomClass 
{
     /** @return Iterator<T> */
     public function getIrator(): Iterator
}
```
or to pass an Iterator<Cat> to a method which works on Iterator<Animal>