### PR TITLE
Address changes from doctrine/collections 1.8.0

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -359,6 +359,9 @@ trait PersistentCollectionTrait
         return $this->coll->containsKey($key);
     }
 
+    /**
+     * @template TMaybeContained
+     */
     public function contains($element)
     {
         $this->initialize();
@@ -373,6 +376,11 @@ trait PersistentCollectionTrait
         return $this->coll->exists($p);
     }
 
+    /**
+     * @psalm-return (TMaybeContained is T ? TKey|false : false)
+     *
+     * @template TMaybeContained
+     */
     public function indexOf($element)
     {
         $this->initialize();


### PR DESCRIPTION
`Collection::contains()` and `Collection::indexOf()` use templating to infer if they are going to return false or null respectively, in case `$element` does not even match the type of the collection.
