### PR TITLE
Remove PHP <7.4 version checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "phpbench/phpbench": "^1.0.0",
         "phpstan/phpstan": "^1.4.6",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/cache": "^4.4 || ^5.0 || ^6.0",
         "vimeo/psalm": "^4.20.0"

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -2597,8 +2597,7 @@ use const PHP_VERSION_ID;
 
     private function isTypedProperty(string $name): bool
     {
-        return PHP_VERSION_ID >= 70400
-            && $this->reflClass->hasProperty($name)
+        return $this->reflClass->hasProperty($name)
             && $this->reflClass->getProperty($name)->hasType();
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -52,28 +52,16 @@ use MongoDB\BSON\ObjectId;
 
 use function assert;
 use function bcscale;
-use function bcsqrt;
-use function min;
-use function strlen;
-use function version_compare;
-
-use const PHP_VERSION;
 
 class FunctionalTest extends BaseTest
 {
-    /** @var int */
-    private $initialScale;
+    private int $initialScale;
 
     public function setUp(): void
     {
         parent::setUp();
 
-        if (version_compare('7.3.0', PHP_VERSION, '<=')) {
-            $this->initialScale = bcscale(2);
-        } else {
-            $this->initialScale = min(0, strlen(bcsqrt('2')) - 2);
-            bcscale(2);
-        }
+        $this->initialScale = bcscale(2);
     }
 
     public function tearDown(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2310Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2310Test.php
@@ -9,9 +9,6 @@ use Documents74\GH2310Container;
 use Documents74\GH2310Embedded;
 use MongoDB\BSON\ObjectId;
 
-/**
- * @requires PHP 7.4
- */
 class GH2310Test extends BaseTest
 {
     public function testFindWithNullableEmbeddedAfterUpsert(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TypedPropertiesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TypedPropertiesTest.php
@@ -11,9 +11,6 @@ use MongoDB\BSON\ObjectId;
 
 use function assert;
 
-/**
- * @requires PHP 7.4
- */
 class TypedPropertiesTest extends BaseTest
 {
     public function testPersistNew(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -200,9 +200,6 @@ abstract class AbstractMappingDriverTest extends BaseTest
         return $class;
     }
 
-    /**
-     * @requires PHP >= 7.4
-     */
     public function testFieldTypeFromReflection(): void
     {
         $class = $this->dm->getClassMetadata(UserTyped::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -143,9 +143,6 @@ class ClassMetadataTest extends BaseTest
         $this->assertFalse($cm->isNullable('name'), 'By default a field should not be nullable.');
     }
 
-    /**
-     * @requires PHP >= 7.4
-     */
     public function testFieldTypeFromReflection(): void
     {
         $cm = new ClassMetadata(UserTyped::class);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

Removes remaining PHP version checks after bumping it to 7.4.
Linked to #2464 
