### PR TITLE
Make use of PHP 7.4 syntax

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -277,9 +277,7 @@ class Builder
         }
 
         $pipeline = array_map(
-            static function (Stage $stage) {
-                return $stage->getExpression();
-            },
+            static fn (Stage $stage) => $stage->getExpression(),
             $this->stages
         );
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
@@ -318,9 +318,7 @@ class Expr
     public static function convertExpression($expression)
     {
         if (is_array($expression)) {
-            return array_map(static function ($expression) {
-                return static::convertExpression($expression);
-            }, $expression);
+            return array_map(static fn ($expression) => static::convertExpression($expression), $expression);
         }
 
         if ($expression instanceof self) {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Facet.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Facet.php
@@ -25,9 +25,7 @@ class Facet extends Stage
     public function getExpression(): array
     {
         return [
-            '$facet' => array_map(static function (Builder $builder) {
-                return $builder->getPipeline(false);
-            }, $this->pipelines),
+            '$facet' => array_map(static fn (Builder $builder) => $builder->getPipeline(false), $this->pipelines),
         ];
     }
 

--- a/lib/Doctrine/ODM/MongoDB/DocumentNotFoundException.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentNotFoundException.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB;
 
+use JsonException;
+
 use function json_encode;
 use function sprintf;
 
@@ -20,10 +22,15 @@ final class DocumentNotFoundException extends MongoDBException
      */
     public static function documentNotFound(string $className, $identifier): self
     {
+        try {
+            $id = json_encode($identifier, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+        }
+
         return new self(sprintf(
             'The "%s" document with identifier %s could not be found.',
             $className,
-            json_encode($identifier, JSON_THROW_ON_ERROR)
-        ));
+            $id ?? false,
+        ), 0, $e ?? null);
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/DocumentNotFoundException.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentNotFoundException.php
@@ -7,6 +7,8 @@ namespace Doctrine\ODM\MongoDB;
 use function json_encode;
 use function sprintf;
 
+use const JSON_THROW_ON_ERROR;
+
 /**
  * Class for exception when encountering proxy object that has
  * an identifier that does not exist in the database.
@@ -21,7 +23,7 @@ final class DocumentNotFoundException extends MongoDBException
         return new self(sprintf(
             'The "%s" document with identifier %s could not be found.',
             $className,
-            json_encode($identifier)
+            json_encode($identifier, JSON_THROW_ON_ERROR)
         ));
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -8,6 +8,7 @@ use BackedEnum;
 use BadMethodCallException;
 use DateTime;
 use DateTimeImmutable;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Instantiator\Instantiator;
 use Doctrine\Instantiator\InstantiatorInterface;
 use Doctrine\ODM\MongoDB\Id\IdGenerator;
@@ -1851,9 +1852,7 @@ use const PHP_VERSION_ID;
     {
         return array_filter(
             $this->associationMappings,
-            static function ($assoc) {
-                return ! empty($assoc['embedded']);
-            }
+            static fn ($assoc) => ! empty($assoc['embedded'])
         );
     }
 
@@ -2206,7 +2205,7 @@ use const PHP_VERSION_ID;
 
         if (! empty($mapping['collectionClass'])) {
             $rColl = new ReflectionClass($mapping['collectionClass']);
-            if (! $rColl->implementsInterface('Doctrine\\Common\\Collections\\Collection')) {
+            if (! $rColl->implementsInterface(Collection::class)) {
                 throw MappingException::collectionClassDoesNotImplementCommonInterface($this->name, $mapping['fieldName'], $mapping['collectionClass']);
             }
         }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -738,9 +738,7 @@ class XmlDriver extends FileDriver
      */
     private function formatErrors(array $xmlErrors): string
     {
-        return implode("\n", array_map(static function (LibXMLError $error): string {
-            return sprintf('Line %d:%d: %s', $error->line, $error->column, $error->message);
-        }, $xmlErrors));
+        return implode("\n", array_map(static fn (LibXMLError $error): string => sprintf('Line %d:%d: %s', $error->line, $error->column, $error->message), $xmlErrors));
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/DefaultPersistentCollectionGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/DefaultPersistentCollectionGenerator.php
@@ -154,7 +154,7 @@ class $class extends \\$for implements \\Doctrine\\ODM\\MongoDB\\PersistentColle
 
 CODE;
         $rc        = new ReflectionClass($for);
-        $rt        = new ReflectionClass('Doctrine\\ODM\\MongoDB\\PersistentCollection\\PersistentCollectionTrait');
+        $rt        = new ReflectionClass(PersistentCollectionTrait::class);
         foreach ($rc->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
             if (
                 $rt->hasMethod($method->name) ||
@@ -302,18 +302,14 @@ CODE;
     ): string {
         if ($type instanceof ReflectionUnionType) {
             return implode('|', array_map(
-                function (ReflectionType $unionedType) use ($method, $parameter) {
-                    return $this->formatType($unionedType, $method, $parameter);
-                },
+                fn (ReflectionType $unionedType) => $this->formatType($unionedType, $method, $parameter),
                 $type->getTypes()
             ));
         }
 
         if ($type instanceof ReflectionIntersectionType) {
             return implode('&', array_map(
-                function (ReflectionType $intersectedType) use ($method, $parameter) {
-                    return $this->formatType($intersectedType, $method, $parameter);
-                },
+                fn (ReflectionType $intersectedType) => $this->formatType($intersectedType, $method, $parameter),
                 $type->getTypes()
             ));
         }

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -247,9 +247,7 @@ trait PersistentCollectionTrait
         return array_udiff_assoc(
             $this->snapshot,
             $this->coll->toArray(),
-            static function ($a, $b) {
-                return $a === $b ? 0 : 1;
-            }
+            static fn ($a, $b) => $a === $b ? 0 : 1
         );
     }
 
@@ -267,9 +265,7 @@ trait PersistentCollectionTrait
         return array_udiff_assoc(
             $this->coll->toArray(),
             $this->snapshot,
-            static function ($a, $b) {
-                return $a === $b ? 0 : 1;
-            }
+            static fn ($a, $b) => $a === $b ? 0 : 1
         );
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -396,14 +396,10 @@ final class CollectionPersister
     {
         $mapping = $coll->getMapping();
         if (isset($mapping['embedded'])) {
-            return function ($v) use ($mapping) {
-                return $this->pb->prepareEmbeddedDocumentValue($mapping, $v);
-            };
+            return fn ($v) => $this->pb->prepareEmbeddedDocumentValue($mapping, $v);
         }
 
-        return function ($v) use ($mapping) {
-            return $this->pb->prepareReferencedDocumentValue($mapping, $v);
-        };
+        return fn ($v) => $this->pb->prepareReferencedDocumentValue($mapping, $v);
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1176,7 +1176,7 @@ final class DocumentPersister
      */
     private function prepareQueryElement(string $fieldName, $value = null, ?ClassMetadata $class = null, bool $prepareValue = true, bool $inNewObj = false): array
     {
-        $class = $class ?? $this->class;
+        $class ??= $this->class;
 
         // @todo Consider inlining calls to ClassMetadata methods
 
@@ -1662,9 +1662,7 @@ final class DocumentPersister
         }
 
         return array_map(
-            static function ($key) use ($reference, $fieldName) {
-                return [$fieldName . '.' . $key, $reference[$key]];
-            },
+            static fn ($key) => [$fieldName . '.' . $key, $reference[$key]],
             array_keys($keys)
         );
     }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
@@ -498,12 +498,8 @@ final class PersistenceBuilder
         $mapping  = $coll->getMapping();
         $pb       = $this;
         $callback = isset($mapping['embedded'])
-            ? static function ($v) use ($pb, $mapping, $includeNestedCollections) {
-                return $pb->prepareEmbeddedDocumentValue($mapping, $v, $includeNestedCollections);
-            }
-            : static function ($v) use ($pb, $mapping) {
-                return $pb->prepareReferencedDocumentValue($mapping, $v);
-            };
+            ? static fn ($v) => $pb->prepareEmbeddedDocumentValue($mapping, $v, $includeNestedCollections)
+            : static fn ($v) => $pb->prepareReferencedDocumentValue($mapping, $v);
 
         $setData = $coll->map($callback)->toArray();
         if (CollectionHelper::isList($mapping['strategy'])) {

--- a/lib/Doctrine/ODM/MongoDB/Proxy/Factory/StaticProxyFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Factory/StaticProxyFactory.php
@@ -61,19 +61,14 @@ final class StaticProxyFactory implements ProxyFactory
 
     public function generateProxyClasses(array $classes): int
     {
-        $concreteClasses = array_filter($classes, static function (ClassMetadata $metadata): bool {
-            return ! ($metadata->isMappedSuperclass || $metadata->isQueryResultDocument || $metadata->getReflectionClass()->isAbstract());
-        });
+        $concreteClasses = array_filter($classes, static fn (ClassMetadata $metadata): bool => ! ($metadata->isMappedSuperclass || $metadata->isQueryResultDocument || $metadata->getReflectionClass()->isAbstract()));
 
         foreach ($concreteClasses as $metadata) {
             $this
                 ->proxyFactory
                 ->createProxy(
                     $metadata->getName(),
-                    static function (): bool {
-                        // empty closure, serves its purpose, for now
-                        return true;
-                    },
+                    static fn (): bool => true, // empty closure, serves its purpose, for now
                     [
                         'skippedProperties' => $this->skippedFieldsFqns($metadata),
                     ]

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -704,9 +704,7 @@ class Builder
                 $this->hydrate && $this->class->inheritanceType === ClassMetadata::INHERITANCE_TYPE_SINGLE_COLLECTION
                 && ! isset($query['select'][$this->class->discriminatorField])
             ) {
-                $includeMode = 0 < count(array_filter($query['select'], static function ($mode) {
-                    return $mode === 1;
-                }));
+                $includeMode = 0 < count(array_filter($query['select'], static fn ($mode) => $mode === 1));
                 if ($includeMode) {
                     $query['select'][$this->class->discriminatorField] = 1;
                 }

--- a/lib/Doctrine/ODM/MongoDB/Query/CriteriaMerger.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/CriteriaMerger.php
@@ -26,9 +26,7 @@ final class CriteriaMerger
      */
     public function merge(...$criterias): array
     {
-        $nonEmptyCriterias = array_values(array_filter($criterias, static function (array $criteria) {
-            return ! empty($criteria);
-        }));
+        $nonEmptyCriterias = array_values(array_filter($criterias, static fn (array $criteria) => ! empty($criteria)));
 
         switch (count($nonEmptyCriterias)) {
             case 0:

--- a/lib/Doctrine/ODM/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Expr.php
@@ -1254,9 +1254,7 @@ class Expr
     {
         $fields = is_array($fieldName) ? $fieldName : [$fieldName => $order];
 
-        return $this->operator('$sort', array_map(function ($order) {
-            return $this->normalizeSortOrder($order);
-        }, $fields));
+        return $this->operator('$sort', array_map(fn ($order) => $this->normalizeSortOrder($order), $fields));
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Query/FilterCollection.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/FilterCollection.php
@@ -157,9 +157,7 @@ final class FilterCollection
 
         return $this->cm->merge(
             ...array_map(
-                static function ($filter) use ($class) {
-                    return $filter->addFilterCriteria($class);
-                },
+                static fn ($filter) => $filter->addFilterCriteria($class),
                 array_values($this->enabledFilters)
             )
         );

--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -30,6 +30,7 @@ use function array_combine;
 use function array_filter;
 use function array_flip;
 use function array_intersect_key;
+use function array_key_first;
 use function array_keys;
 use function array_map;
 use function array_merge;
@@ -37,8 +38,6 @@ use function array_values;
 use function is_array;
 use function is_callable;
 use function is_string;
-use function key;
-use function reset;
 
 /**
  * ODM Query wraps the raw Doctrine MongoDB queries to add additional functionality
@@ -385,9 +384,7 @@ final class Query implements IteratorAggregate
     {
         return array_filter(
             array_intersect_key($this->query, array_flip($keys)),
-            static function ($value) {
-                return $value !== null;
-            }
+            static fn ($value) => $value !== null
         );
     }
 
@@ -433,9 +430,7 @@ final class Query implements IteratorAggregate
 
         $options = array_combine(
             array_map(
-                static function ($key) use ($rename) {
-                    return $rename[$key] ?? $key;
-                },
+                static fn ($key) => $rename[$key] ?? $key,
                 array_keys($options)
             ),
             array_values($options)
@@ -552,8 +547,7 @@ final class Query implements IteratorAggregate
 
     private function isFirstKeyUpdateOperator(): bool
     {
-        reset($this->query['newObj']);
-        $firstKey = key($this->query['newObj']);
+        $firstKey = array_key_first($this->query['newObj']);
 
         return is_string($firstKey) && $firstKey[0] === '$';
     }

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -576,9 +576,7 @@ final class SchemaManager
         if (isset($mongoIndexKeys['_fts']) && $mongoIndexKeys['_fts'] === 'text') {
             unset($mongoIndexKeys['_fts'], $mongoIndexKeys['_ftsx']);
 
-            $documentIndexKeys = array_filter($documentIndexKeys, static function ($type) {
-                return $type !== 'text';
-            });
+            $documentIndexKeys = array_filter($documentIndexKeys, static fn ($type) => $type !== 'text');
         }
 
         /* Avoid a strict equality check of the arrays here. The numeric type returned

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
@@ -66,9 +66,7 @@ EOT
         $dm = $this->getHelper('documentManager')->getDocumentManager();
         assert($dm instanceof DocumentManager);
 
-        $metadatas = array_filter($dm->getMetadataFactory()->getAllMetadata(), static function (ClassMetadata $classMetadata): bool {
-            return ! $classMetadata->isEmbeddedDocument && ! $classMetadata->isMappedSuperclass && ! $classMetadata->isQueryResultDocument;
-        });
+        $metadatas = array_filter($dm->getMetadataFactory()->getAllMetadata(), static fn (ClassMetadata $classMetadata): bool => ! $classMetadata->isEmbeddedDocument && ! $classMetadata->isMappedSuperclass && ! $classMetadata->isQueryResultDocument);
         $metadatas = MetadataFilter::filter($metadatas, $filter);
         $destPath  = $dm->getConfiguration()->getProxyDir();
 

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
@@ -16,6 +16,8 @@ use function is_numeric;
 use function is_string;
 use function json_decode;
 
+use const JSON_THROW_ON_ERROR;
+
 /**
  * Command to query mongodb and inspect the outputted results from your document classes.
  */
@@ -77,7 +79,7 @@ EOT
 
         $dm = $this->getHelper('documentManager')->getDocumentManager();
         $qb = $dm->getRepository($input->getArgument('class'))->createQueryBuilder();
-        $qb->setQueryArray((array) json_decode($query));
+        $qb->setQueryArray((array) json_decode($query, null, 512, JSON_THROW_ON_ERROR));
         $qb->hydrate((bool) $input->getOption('hydrate'));
 
         $skip = $input->getOption('skip');

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
@@ -45,9 +45,7 @@ class CreateCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $create = array_filter($this->createOrder, static function (string $option) use ($input): bool {
-            return (bool) $input->getOption($option);
-        });
+        $create = array_filter($this->createOrder, static fn (string $option): bool => (bool) $input->getOption($option));
 
         // Default to the full creation order if no options were specified
         $create = empty($create) ? $this->createOrder : $create;

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
@@ -42,9 +42,7 @@ class DropCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $drop = array_filter($this->dropOrder, static function (string $option) use ($input): bool {
-            return (bool) $input->getOption($option);
-        });
+        $drop = array_filter($this->dropOrder, static fn (string $option): bool => (bool) $input->getOption($option));
 
         // Default to the full drop order if no options were specified
         $drop = empty($drop) ? $this->dropOrder : $drop;

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -854,9 +854,7 @@ final class UnitOfWork implements PropertyChangedListener
         // Look for changes in associations of the document
         $associationMappings = array_filter(
             $class->associationMappings,
-            static function ($assoc) {
-                return empty($assoc['notSaved']);
-            }
+            static fn ($assoc) => empty($assoc['notSaved'])
         );
 
         foreach ($associationMappings as $mapping) {
@@ -2184,9 +2182,7 @@ final class UnitOfWork implements PropertyChangedListener
 
         $associationMappings = array_filter(
             $class->associationMappings,
-            static function ($assoc) {
-                return $assoc['isCascadeRefresh'];
-            }
+            static fn ($assoc) => $assoc['isCascadeRefresh']
         );
 
         foreach ($associationMappings as $mapping) {
@@ -2246,9 +2242,7 @@ final class UnitOfWork implements PropertyChangedListener
 
         $associationMappings = array_filter(
             $class->associationMappings,
-            static function ($assoc) {
-                return $assoc['isCascadeMerge'];
-            }
+            static fn ($assoc) => $assoc['isCascadeMerge']
         );
 
         foreach ($associationMappings as $assoc) {
@@ -2280,9 +2274,7 @@ final class UnitOfWork implements PropertyChangedListener
 
         $associationMappings = array_filter(
             $class->associationMappings,
-            static function ($assoc) {
-                return $assoc['isCascadePersist'];
-            }
+            static fn ($assoc) => $assoc['isCascadePersist']
         );
 
         foreach ($associationMappings as $fieldName => $mapping) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationOperatorsProviderTrait.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationOperatorsProviderTrait.php
@@ -151,13 +151,11 @@ trait AggregationOperatorsProviderTrait
             'cond' => [
                 'expected' => ['$cond' => ['if' => ['$gte' => ['$field', 5]], 'then' => '$field', 'else' => '$otherField']],
                 'operator' => 'cond',
-                'args' => static function (Expr $expr) {
-                    return [
-                        $expr->gte('$field', 5),
-                        '$field',
-                        '$otherField',
-                    ];
-                },
+                'args' => static fn (Expr $expr) => [
+                    $expr->gte('$field', 5),
+                    '$field',
+                    '$otherField',
+                ],
             ],
             'dateToString' => [
                 'expected' => ['$dateToString' => ['format' => '%Y-%m-%d', 'date' => '$dateField']],
@@ -320,17 +318,15 @@ trait AggregationOperatorsProviderTrait
                     ],
                 ],
                 'operator' => 'let',
-                'args' => static function (Expr $expr) {
-                    return [
-                        $expr->expr()
-                            ->field('total')
-                            ->add('$price', '$tax')
-                            ->field('discounted')
-                            ->cond('$applyDiscount', 0.9, 1),
-                        $expr->expr()
-                            ->multiply('$$total', '$$discounted'),
-                    ];
-                },
+                'args' => static fn (Expr $expr) => [
+                    $expr->expr()
+                        ->field('total')
+                        ->add('$price', '$tax')
+                        ->field('discounted')
+                        ->cond('$applyDiscount', 0.9, 1),
+                    $expr->expr()
+                        ->multiply('$$total', '$$discounted'),
+                ],
             ],
             'literal' => [
                 'expected' => ['$literal' => '$field'],
@@ -365,13 +361,11 @@ trait AggregationOperatorsProviderTrait
             'map' => [
                 'expected' => ['$map' => ['input' => '$quizzes', 'as' => 'grade', 'in' => ['$add' => ['$$grade', 2]]]],
                 'operator' => 'map',
-                'args' => static function (Expr $expr) {
-                    return [
-                        '$quizzes',
-                        'grade',
-                        $expr->add('$$grade', 2),
-                    ];
-                },
+                'args' => static fn (Expr $expr) => [
+                    '$quizzes',
+                    'grade',
+                    $expr->add('$$grade', 2),
+                ],
             ],
             'meta' => [
                 'expected' => ['$meta' => '$field'],
@@ -440,15 +434,13 @@ trait AggregationOperatorsProviderTrait
                     ],
                 ],
                 'operator' => 'reduce',
-                'args' => static function (Expr $expr) {
-                    return [
-                        '$array',
-                        ['sum' => 0, 'product' => 1],
-                        $expr
-                            ->add('$$value.sum', '$$this')
-                            ->multiply('$$value.product', '$$this'),
-                    ];
-                },
+                'args' => static fn (Expr $expr) => [
+                    '$array',
+                    ['sum' => 0, 'product' => 1],
+                    $expr
+                        ->add('$$value.sum', '$$this')
+                        ->multiply('$$value.product', '$$this'),
+                ],
             ],
             'reverseArray' => [
                 'expected' => ['$reverseArray' => '$array'],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationTestTrait.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationTestTrait.php
@@ -22,9 +22,7 @@ trait AggregationTestTrait
      */
     protected function getMockAggregationExpr()
     {
-        return $this->getMockBuilder(AggregationExpr::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(AggregationExpr::class);
     }
 
     /**
@@ -32,8 +30,6 @@ trait AggregationTestTrait
      */
     protected function getMockQueryExpr()
     {
-        return $this->getMockBuilder(QueryExpr::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(QueryExpr::class);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
@@ -123,8 +123,6 @@ class MatchStageTest extends BaseTest
      */
     private function getMockGeometry()
     {
-        return $this->getMockBuilder(Geometry::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(Geometry::class);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
@@ -58,9 +58,7 @@ class ProjectTest extends BaseTest
     {
         $operators = ['avg', 'max', 'min', 'stdDevPop', 'stdDevSamp', 'sum'];
 
-        return array_combine($operators, array_map(static function ($operator) {
-            return [$operator];
-        }, $operators));
+        return array_combine($operators, array_map(static fn ($operator) => [$operator], $operators));
     }
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
@@ -49,9 +49,7 @@ abstract class BaseTest extends TestCase
         // returned
         $client        = $this->dm->getClient();
         $databases     = iterator_to_array($client->listDatabases());
-        $databaseNames = array_map(static function (DatabaseInfo $database) {
-            return $database->getName();
-        }, $databases);
+        $databaseNames = array_map(static fn (DatabaseInfo $database) => $database->getName(), $databases);
         if (! in_array(DOCTRINE_MONGODB_DATABASE, $databaseNames)) {
             return;
         }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/PreUpdateEventArgsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/PreUpdateEventArgsTest.php
@@ -32,6 +32,9 @@ class PreUpdateEventArgsTest extends BaseTest
         $this->assertEquals('Changed', $a->getBody());
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testCollectionsAreInChangeSet(): void
     {
         $listener = new CollectionsAreInChangeSetListener($this);
@@ -74,14 +77,13 @@ class ChangeSetIsUpdatedListener
 class CollectionsAreInChangeSetListener
 {
     /** @var list<class-string> */
-    private $allowed;
+    private $allowed = [Book::class, Chapter::class];
 
     /** @var PreUpdateEventArgsTest */
     private $phpunit;
 
     public function __construct(PreUpdateEventArgsTest $phpunit)
     {
-        $this->allowed = [Book::class, Chapter::class];
         $this->phpunit = $phpunit;
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php
@@ -288,9 +288,7 @@ class MyEmbedsCollection extends ArrayCollection
      */
     public function getByName(string $name): MyEmbedsCollection
     {
-        return $this->filter(static function ($item) use ($name) {
-            return $item->name === $name;
-        });
+        return $this->filter(static fn ($item) => $item->name === $name);
     }
 
     /**
@@ -298,9 +296,7 @@ class MyEmbedsCollection extends ArrayCollection
      */
     public function getEnabled(): MyEmbedsCollection
     {
-        return $this->filter(static function ($item) {
-            return $item->enabled;
-        });
+        return $this->filter(static fn ($item) => $item->enabled);
     }
 
     public function move(int $i, int $j): void
@@ -327,8 +323,6 @@ class MyDocumentsCollection extends ArrayCollection
      */
     public function havingEmbeds(): MyDocumentsCollection
     {
-        return $this->filter(static function ($item) {
-            return $item->coll->count();
-        });
+        return $this->filter(static fn ($item) => $item->coll->count());
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
@@ -67,9 +67,7 @@ class DateCollectionType extends Type
 
         $converter = Type::getType('date');
 
-        $value = array_map(static function ($date) use ($converter) {
-            return $converter->convertToDatabaseValue($date);
-        }, array_values($value));
+        $value = array_map(static fn ($date) => $converter->convertToDatabaseValue($date), array_values($value));
 
         return $value;
     }
@@ -86,9 +84,7 @@ class DateCollectionType extends Type
 
         $converter = Type::getType('date');
 
-        $value = array_map(static function ($date) use ($converter) {
-            return $converter->convertToPHPValue($date);
-        }, array_values($value));
+        $value = array_map(static fn ($date) => $converter->convertToPHPValue($date), array_values($value));
 
         return $value;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/MemoryUsageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/MemoryUsageTest.php
@@ -14,7 +14,6 @@ use function floor;
 use function gc_collect_cycles;
 use function log;
 use function memory_get_usage;
-use function pow;
 use function round;
 use function sprintf;
 
@@ -25,6 +24,8 @@ class MemoryUsageTest extends BaseTest
 {
     /**
      * Output for jwage "Memory increased by 14.09 kb"
+     *
+     * @doesNotPerformAssertions
      */
     public function testMemoryUsage(): void
     {
@@ -64,6 +65,6 @@ class MemoryUsageTest extends BaseTest
     {
         $unit = ['b', 'kb', 'mb', 'gb', 'tb', 'pb'];
 
-        return round($size / pow(1024, ($i = (int) floor(log($size, 1024)))), 2) . ' ' . $unit[$i];
+        return round($size / 1024 ** ($i = (int) floor(log($size, 1024))), 2) . ' ' . $unit[$i];
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TestTargetDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TestTargetDocument.php
@@ -9,6 +9,9 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 
 class TargetDocumentTest extends BaseTest
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testMappedSuperClassAsTargetDocument(): void
     {
         $test            = new TargetDocumentTestDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
@@ -17,9 +17,7 @@ class GH1275Test extends BaseTest
 {
     public function testResortAtomicCollectionsFlipItems(): void
     {
-        $getNameCallback = static function (Item $item) {
-            return $item->name;
-        };
+        $getNameCallback = static fn (Item $item) => $item->name;
 
         $container = new Container();
         $this->dm->persist($container);
@@ -58,9 +56,7 @@ class GH1275Test extends BaseTest
 
     public function testResortAtomicCollections(): void
     {
-        $getNameCallback = static function (Item $item) {
-            return $item->name;
-        };
+        $getNameCallback = static fn (Item $item) => $item->name;
 
         $container = new Container();
         $this->dm->persist($container);
@@ -154,9 +150,7 @@ class GH1275Test extends BaseTest
      */
     public function testResortEmbedManyCollection(string $strategy): void
     {
-        $getNameCallback = static function (Element $element) {
-            return $element->name;
-        };
+        $getNameCallback = static fn (Element $element) => $element->name;
 
         $container = new Container();
         $container->$strategy->add(new Element('one'));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH453Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH453Test.php
@@ -120,15 +120,9 @@ class GH453Test extends BaseTest
             new GH453EmbeddedDocument(),
             new GH453EmbeddedDocument(),
         ]);
-        $colSet      = $colPush->map(static function ($v) {
-            return clone $v;
-        });
-        $colSetArray = $colPush->map(static function ($v) {
-            return clone $v;
-        });
-        $colAddToSet = $colPush->map(static function ($v) {
-            return clone $v;
-        });
+        $colSet      = $colPush->map(static fn ($v) => clone $v);
+        $colSetArray = $colPush->map(static fn ($v) => clone $v);
+        $colAddToSet = $colPush->map(static fn ($v) => clone $v);
 
         $doc                    = new GH453Document();
         $doc->embedManyPush     = $colPush;
@@ -170,15 +164,9 @@ class GH453Test extends BaseTest
             new GH453ReferencedDocument(),
             new GH453ReferencedDocument(),
         ]);
-        $colSet      = $colPush->map(static function ($v) {
-            return clone $v;
-        });
-        $colSetArray = $colPush->map(static function ($v) {
-            return clone $v;
-        });
-        $colAddToSet = $colPush->map(static function ($v) {
-            return clone $v;
-        });
+        $colSet      = $colPush->map(static fn ($v) => clone $v);
+        $colSetArray = $colPush->map(static fn ($v) => clone $v);
+        $colAddToSet = $colPush->map(static fn ($v) => clone $v);
 
         $dm = $this->dm;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
@@ -98,14 +98,13 @@ class GH560Test extends BaseTest
 class GH560EventSubscriber implements EventSubscriber
 {
     /** @var array<array{string, class-string}> */
-    public $called;
+    public $called = [];
 
     /** @var string[] */
     public $events;
 
     public function __construct(array $events)
     {
-        $this->called = [];
         $this->events = $events;
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
@@ -104,14 +104,10 @@ class GH852Test extends BaseTest
 
         return [
             [
-                static function ($id) {
-                    return ['foo' => $id];
-                },
+                static fn ($id) => ['foo' => $id],
             ],
             [
-                static function ($id) use ($binDataType) {
-                    return new Binary($id, $binDataType);
-                },
+                static fn ($id) => new Binary($id, $binDataType),
             ],
         ];
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM92Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM92Test.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Traversable;
 
-use function is_array;
+use function is_iterable;
 
 class MODM92Test extends BaseTest
 {
@@ -78,7 +78,7 @@ class MODM92TestDocument
     {
         $this->embeddedDocuments->clear();
 
-        if (! (is_array($embeddedDocuments) || $embeddedDocuments instanceof Traversable)) {
+        if (! is_iterable($embeddedDocuments)) {
             return;
         }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM95Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM95Test.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Traversable;
 
-use function is_array;
+use function is_iterable;
 
 class MODM95Test extends BaseTest
 {
@@ -84,7 +84,7 @@ class MODM95TestDocument
     {
         $this->embeddedDocuments->clear();
 
-        if (! (is_array($embeddedDocuments) || $embeddedDocuments instanceof Traversable)) {
+        if (! is_iterable($embeddedDocuments)) {
             return;
         }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTest.php
@@ -419,9 +419,7 @@ abstract class AbstractMappingDriverTest extends BaseTest
         /* Sort indexes by their first fieldname. This is necessary since the
          * index registration order may differ among drivers.
          */
-        $this->assertTrue(usort($indexes, static function (array $a, array $b) {
-            return strcmp(key($a['keys']), key($b['keys']));
-        }));
+        $this->assertTrue(usort($indexes, static fn (array $a, array $b) => strcmp(key($a['keys']), key($b['keys']))));
 
         $this->assertTrue(isset($indexes[0]['keys']['createdAt']));
         $this->assertEquals(1, $indexes[0]['keys']['createdAt']);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/User.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/User.php
@@ -37,7 +37,7 @@ class User
     protected $phonenumbers;
 
     /** @var Collection<int, Group>|Group[] */
-    protected $groups;
+    protected $groups = [];
 
     /** @var Account|null */
     protected $account;
@@ -51,7 +51,6 @@ class User
     public function __construct()
     {
         $this->phonenumbers = new ArrayCollection();
-        $this->groups       = [];
         $this->createdAt    = new DateTime();
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/HydrationPerformanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/HydrationPerformanceTest.php
@@ -20,6 +20,8 @@ class HydrationPerformanceTest extends BaseTest
 {
     /**
      * [jwage: 10000 objects in ~6 seconds]
+     *
+     * @doesNotPerformAssertions
      */
     public function testHydrationPerformance(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/InsertPerformanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/InsertPerformanceTest.php
@@ -20,6 +20,8 @@ class InsertPerformanceTest extends BaseTest
 {
     /**
      * [jwage: 10000 objects in ~4 seconds]
+     *
+     * @doesNotPerformAssertions
      */
     public function testInsertPerformance(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/MemoryUsageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/MemoryUsageTest.php
@@ -14,7 +14,6 @@ use function floor;
 use function gc_collect_cycles;
 use function log;
 use function memory_get_usage;
-use function pow;
 use function round;
 use function sprintf;
 
@@ -27,6 +26,8 @@ class MemoryUsageTest extends BaseTest
 {
     /**
      * [jwage: Memory increased by 14.09 kb]
+     *
+     * @doesNotPerformAssertions
      */
     public function testMemoryUsage(): void
     {
@@ -63,6 +64,6 @@ class MemoryUsageTest extends BaseTest
     {
         $unit = ['b', 'kb', 'mb', 'gb', 'tb', 'pb'];
 
-        return round($size / pow(1024, ($i = (int) floor(log($size, 1024)))), 2) . ' ' . $unit[$i];
+        return round($size / 1024 ** ($i = (int) floor(log($size, 1024))), 2) . ' ' . $unit[$i];
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/UnitOfWorkPerformanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/UnitOfWorkPerformanceTest.php
@@ -19,6 +19,8 @@ class UnitOfWorkPerformanceTest extends BaseTest
 {
     /**
      * [jwage: compute changesets for 10000 objects in ~10 seconds]
+     *
+     * @doesNotPerformAssertions
      */
     public function testComputeChanges(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -863,9 +863,7 @@ class BuilderTest extends BaseTest
      */
     private function getMockExpr()
     {
-        return $this->getMockBuilder(Expr::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(Expr::class);
     }
 
     /**
@@ -873,9 +871,7 @@ class BuilderTest extends BaseTest
      */
     private function getMockGeometry()
     {
-        return $this->getMockBuilder(Geometry::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(Geometry::class);
     }
 
     /**
@@ -883,9 +879,7 @@ class BuilderTest extends BaseTest
      */
     private function getMockPoint(array $json)
     {
-        $point = $this->getMockBuilder(Point::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $point = $this->createMock(Point::class);
 
         $point->expects($this->once())
             ->method('jsonSerialize')

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -704,9 +704,7 @@ class ExprTest extends BaseTest
      */
     private function getMockPoint(array $json)
     {
-        $point = $this->getMockBuilder(Point::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $point = $this->createMock(Point::class);
 
         $point->expects($this->once())
             ->method('jsonSerialize')
@@ -720,9 +718,7 @@ class ExprTest extends BaseTest
      */
     private function getMockPolygon(array $json)
     {
-        $point = $this->getMockBuilder(Polygon::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $point = $this->createMock(Polygon::class);
 
         $point->expects($this->once())
             ->method('jsonSerialize')

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -583,9 +583,7 @@ class QueryTest extends BaseTest
      */
     private function getMockCollection()
     {
-        return $this->getMockBuilder(Collection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(Collection::class);
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -104,9 +104,7 @@ class SchemaManagerTest extends BaseTest
             $this->documentDatabases[$db] = $this->getMockDatabase();
         }
 
-        $client->method('selectDatabase')->willReturnCallback(function (string $db) {
-            return $this->documentDatabases[$db];
-        });
+        $client->method('selectDatabase')->willReturnCallback(fn (string $db) => $this->documentDatabases[$db]);
 
         $this->schemaManager = $this->dm->getSchemaManager();
     }
@@ -168,9 +166,7 @@ class SchemaManagerTest extends BaseTest
     public function testEnsureIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false): void
     {
         $indexedCollections = array_map(
-            function (string $fqcn) {
-                return $this->dm->getClassMetadata($fqcn)->getCollection();
-            },
+            fn (string $fqcn) => $this->dm->getClassMetadata($fqcn)->getCollection(),
             $this->indexedClasses
         );
         foreach ($this->documentCollections as $collectionName => $collection) {
@@ -348,9 +344,7 @@ class SchemaManagerTest extends BaseTest
     public function testDeleteIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $views = array_map(
-            function (string $fqcn) {
-                return $this->dm->getClassMetadata($fqcn)->getCollection();
-            },
+            fn (string $fqcn) => $this->dm->getClassMetadata($fqcn)->getCollection(),
             $this->views
         );
 
@@ -388,6 +382,9 @@ class SchemaManagerTest extends BaseTest
         $this->schemaManager->deleteDocumentIndexes(CmsArticle::class, $maxTimeMs, $writeConcern);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testUpdateValidators(): void
     {
         $dbCommands = [];
@@ -1120,7 +1117,7 @@ EOT;
      */
     private function getDatabaseName(ClassMetadata $cm): string
     {
-        return $cm->getDatabase() ?: $this->dm->getConfiguration()->getDefaultDB() ?: 'doctrine';
+        return ($cm->getDatabase() ?: $this->dm->getConfiguration()->getDefaultDB()) ?: 'doctrine';
     }
 
     /** @return Bucket&MockObject */
@@ -1137,9 +1134,7 @@ EOT;
     private function getMockCollection(?string $name = null)
     {
         $collection = $this->createMock(Collection::class);
-        $collection->method('getCollectionName')->willReturnCallback(static function () use ($name) {
-            return $name;
-        });
+        $collection->method('getCollectionName')->willReturnCallback(static fn () => $name);
 
         return $collection;
     }
@@ -1148,12 +1143,8 @@ EOT;
     private function getMockDatabase()
     {
         $db = $this->createMock(Database::class);
-        $db->method('selectCollection')->willReturnCallback(function (string $collection) {
-            return $this->documentCollections[$collection];
-        });
-        $db->method('selectGridFSBucket')->willReturnCallback(function (array $options) {
-            return $this->documentBuckets[$options['bucketName']];
-        });
+        $db->method('selectCollection')->willReturnCallback(fn (string $collection) => $this->documentCollections[$collection]);
+        $db->method('selectGridFSBucket')->willReturnCallback(fn (array $options) => $this->documentBuckets[$options['bucketName']]);
         $db->method('listCollections')->willReturnCallback(function () {
             $collections = [];
             foreach ($this->documentCollections as $collectionName => $collection) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -537,10 +537,8 @@ class UnitOfWorkTest extends BaseTest
         try {
             $this->dm->flush();
         } catch (Throwable $exception) {
-            $getCommitsInProgress = Closure::bind(function (UnitOfWork $unitOfWork) {
-                /** @psalm-suppress InaccessibleProperty */
-                return $unitOfWork->commitsInProgress;
-            }, $this->dm->getUnitOfWork(), UnitOfWork::class);
+            $getCommitsInProgress = Closure::bind(fn (UnitOfWork $unitOfWork) => /** @psalm-suppress InaccessibleProperty */
+$unitOfWork->commitsInProgress, $this->dm->getUnitOfWork(), UnitOfWork::class);
 
             $this->assertSame(0, $getCommitsInProgress($this->dm->getUnitOfWork()));
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

Migrates some of the old syntax to PHP 7.4 where applicable:
- Arrow functions
- Null-coalesce assignment operator
- `array_key_first` and `is_iterable`

Migrates usage of PHPUnit API:
- Adds `@doesNotPerformAssertions` where no assertions are performed
- Uses `$this->createMock()` shorthand

Linked to #2464 