### PR TITLE
Normalize assert calls in tests

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleListenersTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleListenersTest.php
@@ -12,7 +12,7 @@ use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 use function get_class;
 
@@ -196,7 +196,7 @@ class LifecycleListenersTest extends BaseTest
     public function testPostCollectionLoad(): void
     {
         $evm = $this->dm->getEventManager();
-        $evm->addEventListener([Events::postCollectionLoad], new PostCollectionLoadEventListener($this));
+        $evm->addEventListener([Events::postCollectionLoad], new PostCollectionLoadEventListener());
 
         $document       = new TestDocument();
         $document->name = 'Maciej';
@@ -242,14 +242,6 @@ class PostCollectionLoadEventListener
     /** @var int */
     private $at = 0;
 
-    /** @var TestCase */
-    private $phpunit;
-
-    public function __construct(TestCase $phpunit)
-    {
-        $this->phpunit = $phpunit;
-    }
-
     /**
      * @param PostCollectionLoadEventArgs<int, TestEmbeddedDocument> $e
      */
@@ -257,11 +249,11 @@ class PostCollectionLoadEventListener
     {
         switch ($this->at++) {
             case 0:
-                $this->phpunit->assertCount(0, $e->getCollection());
+                Assert::assertCount(0, $e->getCollection());
                 break;
             case 1:
-                $this->phpunit->assertCount(1, $e->getCollection());
-                $this->phpunit->assertEquals(new TestEmbeddedDocument('For mock at 1'), $e->getCollection()[0]);
+                Assert::assertCount(1, $e->getCollection());
+                Assert::assertEquals(new TestEmbeddedDocument('For mock at 1'), $e->getCollection()[0]);
                 break;
             default:
                 throw new BadMethodCallException('This was not expected');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/PreUpdateEventArgsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/PreUpdateEventArgsTest.php
@@ -11,6 +11,7 @@ use Documents\Article;
 use Documents\Book;
 use Documents\Chapter;
 use Documents\Page;
+use PHPUnit\Framework\Assert;
 
 use function get_class;
 use function in_array;
@@ -34,7 +35,7 @@ class PreUpdateEventArgsTest extends BaseTest
 
     public function testCollectionsAreInChangeSet(): void
     {
-        $listener = new CollectionsAreInChangeSetListener($this);
+        $listener = new CollectionsAreInChangeSetListener();
         $this->dm->getEventManager()->addEventListener(Events::preUpdate, $listener);
 
         $book = new Book();
@@ -74,16 +75,7 @@ class ChangeSetIsUpdatedListener
 class CollectionsAreInChangeSetListener
 {
     /** @var list<class-string> */
-    private $allowed;
-
-    /** @var PreUpdateEventArgsTest */
-    private $phpunit;
-
-    public function __construct(PreUpdateEventArgsTest $phpunit)
-    {
-        $this->allowed = [Book::class, Chapter::class];
-        $this->phpunit = $phpunit;
-    }
+    private $allowed = [Book::class, Chapter::class];
 
     public function checkOnly(array $allowed): void
     {
@@ -95,13 +87,13 @@ class CollectionsAreInChangeSetListener
         switch (get_class($e->getDocument())) {
             case Book::class:
                 if (in_array(Book::class, $this->allowed)) {
-                    $this->phpunit->assertTrue($e->hasChangedField('chapters'));
+                    Assert::assertTrue($e->hasChangedField('chapters'));
                 }
 
                 break;
             case Chapter::class:
                 if (in_array(Chapter::class, $this->allowed)) {
-                    $this->phpunit->assertTrue($e->hasChangedField('pages'));
+                    Assert::assertTrue($e->hasChangedField('pages'));
                 }
 
                 break;


### PR DESCRIPTION
Some unusual calls were forgotten in [the preview PR](https://github.com/doctrine/mongodb-odm/pull/2475)

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #2441 

#### Summary

Normalizes assert*() calls in tests
