### PR TITLE
Fix deprecation notices in CommandLogger

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/APM/CommandLogger.php
+++ b/lib/Doctrine/ODM/MongoDB/APM/CommandLogger.php
@@ -44,12 +44,12 @@ final class CommandLogger implements Countable, CommandLoggerInterface
         $this->registered = false;
     }
 
-    public function commandStarted(CommandStartedEvent $event)
+    public function commandStarted(CommandStartedEvent $event): void
     {
         $this->startedCommands[$event->getRequestId()] = $event;
     }
 
-    public function commandSucceeded(CommandSucceededEvent $event)
+    public function commandSucceeded(CommandSucceededEvent $event): void
     {
         $commandStartedEvent = $this->findAndRemoveCommandStartedEvent($event->getRequestId());
         if (! $commandStartedEvent) {
@@ -59,7 +59,7 @@ final class CommandLogger implements Countable, CommandLoggerInterface
         $this->logCommand(Command::createForSucceededCommand($commandStartedEvent, $event));
     }
 
-    public function commandFailed(CommandFailedEvent $event)
+    public function commandFailed(CommandFailedEvent $event): void
     {
         $commandStartedEvent = $this->findAndRemoveCommandStartedEvent($event->getRequestId());
         if (! $commandStartedEvent) {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -37,7 +37,7 @@ use function ucfirst;
  *
  * @internal
  *
- * @method ClassMetadata[] getAllMetadata()
+ * @method list<ClassMetadata> getAllMetadata()
  * @method ClassMetadata[] getLoadedMetadata()
  * @method ClassMetadata getMetadataFor($className)
  */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -137,12 +137,6 @@ parameters:
             count: 1
             path: tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
 
-        # 'strategy' offset is defined as nullable, but here there is no check here
-        -
-            message: "#^Offset 'strategy' does not exist on array\\{\\}\\|array\\{type\\?\\: string, fieldName\\: string, name\\: string, isCascadeRemove\\: bool, isCascadePersist\\: bool, isCascadeRefresh\\: bool, isCascadeMerge\\: bool, isCascadeDetach\\: bool, \\.\\.\\.\\}\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/UnitOfWork.php
-
         # When iterating over SimpleXMLElement, we cannot know the key values
         -
             message: "#^Parameter \\#2 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\Driver\\\\XmlDriver\\:\\:addFieldMapping\\(\\) expects array#"
@@ -177,7 +171,7 @@ parameters:
         # compatibility layer for doctrine/persistence ^2.4 || ^3.0
         -
             message: "#.*#"
-            count: 3
+            count: 1
             path: lib/Doctrine/ODM/MongoDB/Event/OnClearEventArgs
 
         -


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

#### Summary

When using `ext-mongodb` [v1.15](https://github.com/mongodb/mongo-php-driver/releases/tag/1.15.0), following deprecation notices are shown:

>Deprecated: Return type of Doctrine\ODM\MongoDB\APM\CommandLogger::commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event) should either be compatible with MongoDB\Driver\Monitoring\CommandSubscriber::commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /.../mongodb-odm/lib/Doctrine/ODM/MongoDB/APM/CommandLogger.php on line 47

This PR fixes it by adding `ReturnTypeWillChange` attribute.

See `ext-mongodb` release notes: https://github.com/mongodb/mongo-php-driver/releases/tag/1.15.0
