### PR TITLE
Ignore SA issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,12 +43,12 @@
         "doctrine/coding-standard": "^10.0",
         "jmikola/geojson": "^1.0",
         "phpbench/phpbench": "^1.0.0",
-        "phpstan/phpstan": "^1.9.2",
+        "phpstan/phpstan": "^1.9.4",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.5.5",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/cache": "^4.4 || ^5.0 || ^6.0",
-        "vimeo/psalm": "^4.20.0"
+        "vimeo/psalm": "^4.30.0"
     },
     "suggest": {
         "ext-bcmath": "Decimal128 type support"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -227,18 +227,13 @@ parameters:
             count: 2
             path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
 
-        # it loads an empty class ReflectionEnum of ReflectionEnumPolyfill.php file from laminas/laminas-code, see https://github.com/phpstan/phpstan/issues/7290
-        -
-            message: "#^Call to an undefined method ReflectionEnum\\:\\:isBacked\\(\\)\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
-
-        -
-            message: "#^Call to an undefined method ReflectionEnum\\:\\:getBackingType\\(\\)\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
-
         -
             message: "#has parameter \\$[^\\s]+ with no value type specified in iterable type array\\.$#"
             count: 6
             path: tests/*
+
+        # cannot know that Command::getHelper('documentManager') returns a DocumentManagerHelper
+        -
+            message: "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Helper\\\\HelperInterface\\:\\:getDocumentManager\\(\\)\\.$#"
+            count: 7
+            path: lib/Doctrine/ODM/MongoDB/Tools/Console/Command/*

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.29.0@7ec5ffbd5f68ae03782d7fd33fff0c45a69f95b3">
+<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
   <file src="lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php">
     <InvalidArgument occurrences="1">
       <code>$fields</code>
@@ -104,6 +104,41 @@
     <LessSpecificImplementedReturnType occurrences="1">
       <code>array</code>
     </LessSpecificImplementedReturnType>
+  </file>
+  <file src="lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php">
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getDocumentManager</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php">
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getDocumentManager</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GeneratePersistentCollectionsCommand.php">
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getDocumentManager</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php">
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getDocumentManager</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php">
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getDocumentManager</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/AbstractCommand.php">
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getDocumentManager</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ValidateCommand.php">
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getDocumentManager</code>
+    </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Types/DateImmutableType.php">
     <RedundantCondition occurrences="1">


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | task
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

These new issues appeared because Symfony `Command::getHelper()` changed the return type from `mixed` to `HelperInterface`.

We can ignore these issues and I'll see if I can make something similar to https://github.com/doctrine/orm/pull/8524 to remove the use of the helper.
