### PR TITLE
Lift sharding restrictions from $lookup and $graphLookup

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup.php
@@ -136,9 +136,6 @@ class GraphLookup extends Stage
      * Target collection for the $graphLookup operation to search, recursively
      * matching the connectFromField to the connectToField.
      *
-     * The from collection cannot be sharded and must be in the same database as
-     * any other collections used in the operation.
-     *
      * @psalm-param class-string|string $from
      */
     public function from(string $from): self
@@ -159,10 +156,6 @@ class GraphLookup extends Stage
             $this->from = $from;
 
             return $this;
-        }
-
-        if ($this->targetClass->isSharded()) {
-            throw MappingException::cannotUseShardedCollectionInLookupStages($this->targetClass->name);
         }
 
         $this->from = $this->targetClass->getCollection();
@@ -239,9 +232,6 @@ class GraphLookup extends Stage
 
         $referenceMapping  = $this->class->getFieldMapping($fieldName);
         $this->targetClass = $this->dm->getClassMetadata($referenceMapping['targetDocument']);
-        if ($this->targetClass->isSharded()) {
-            throw MappingException::cannotUseShardedCollectionInLookupStages($this->targetClass->name);
-        }
 
         $this->from = $this->targetClass->getCollection();
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
@@ -65,8 +65,6 @@ class Lookup extends Stage
 
     /**
      * Specifies the collection or field name in the same database to perform the join with.
-     *
-     * Starting in MongoDB 5.1, the from collection can be sharded.
      */
     public function from(string $from): self
     {
@@ -86,10 +84,6 @@ class Lookup extends Stage
             $this->from = $from;
 
             return $this;
-        }
-
-        if ($this->targetClass->isSharded()) {
-            throw MappingException::cannotUseShardedCollectionInLookupStages($this->targetClass->name);
         }
 
         $this->from = $this->targetClass->getCollection();
@@ -214,9 +208,6 @@ class Lookup extends Stage
 
         $referenceMapping  = $this->class->getFieldMapping($fieldName);
         $this->targetClass = $this->dm->getClassMetadata($referenceMapping['targetDocument']);
-        if ($this->targetClass->isSharded()) {
-            throw MappingException::cannotUseShardedCollectionInLookupStages($this->targetClass->name);
-        }
 
         $this->from = $this->targetClass->getCollection();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
@@ -15,7 +15,6 @@ use Documents\GraphLookup\Airport;
 use Documents\GraphLookup\Employee;
 use Documents\GraphLookup\ReportingHierarchy;
 use Documents\GraphLookup\Traveller;
-use Documents\Sharded\ShardedOne;
 use Documents\User;
 
 use function array_merge;
@@ -250,15 +249,6 @@ class GraphLookupTest extends BaseTest
         $result = $builder->execute()->toArray();
 
         self::assertCount(3, $result);
-    }
-
-    public function testGraphLookupToShardedCollectionThrowsException(): void
-    {
-        $builder = $this->dm->createAggregationBuilder(User::class);
-
-        $this->expectException(MappingException::class);
-        $builder
-            ->graphLookup(ShardedOne::class);
     }
 
     public function testGraphLookupWithUnmappedFields(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LookupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LookupTest.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\CmsComment;
 use Documents\ReferenceUser;
-use Documents\Sharded\ShardedOne;
 use Documents\SimpleReferenceUser;
 use Documents\User;
 
@@ -404,26 +402,6 @@ class LookupTest extends BaseTest
 
         self::assertCount(1, $result);
         self::assertCount(1, $result[0]['embeddedReferenceManyInverse']);
-    }
-
-    public function testLookupToShardedCollectionThrowsException(): void
-    {
-        $builder = $this->dm->createAggregationBuilder(User::class);
-
-        $this->expectException(MappingException::class);
-        $builder
-            ->lookup(ShardedOne::class)
-                ->localField('id')
-                ->foreignField('id');
-    }
-
-    public function testLookupToShardedReferenceThrowsException(): void
-    {
-        $builder = $this->dm->createAggregationBuilder(ShardedOne::class);
-
-        $this->expectException(MappingException::class);
-        $builder
-            ->lookup('user');
     }
 
     private function insertTestData(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | fixes #2479

MongoDB allows sharded collections since 5.1. We're not going to proactively warn user using older versions that they can't use the feature, we'll let the db tell them :)