### PR TITLE
Allow `doctrine/annotations` 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-mongodb": "^1.5",
-        "doctrine/annotations": "^1.12",
+        "doctrine/annotations": "^1.12 || ^2.0",
         "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.5 || ^2.0",
         "doctrine/event-manager": "^1.0 || ^2.0",
@@ -41,7 +41,7 @@
         "ext-bcmath": "*",
         "doctrine/coding-standard": "^10.0",
         "jmikola/geojson": "^1.0",
-        "phpbench/phpbench": "^1.0.0",
+        "phpbench/phpbench": "^1.0.0@dev",
         "phpstan/phpstan": "^1.9.4",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.5.5",

--- a/docs/en/reference/introduction.rst
+++ b/docs/en/reference/introduction.rst
@@ -427,15 +427,11 @@ more paths) and register the annotations for the driver:
 
     <?php
 
-    use Doctrine\Common\Annotations\AnnotationRegistry;
-
     // ...
 
     $config->setMetadataDriverImpl(AnnotationDriver::create(__DIR__ . '/Documents'));
 
-    $loader = require_once('path/to/vendor/autoload.php');
-
-    AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+    require_once('path/to/vendor/autoload.php');
 
 At this point, we have everything necessary to construct a ``DocumentManager``:
 
@@ -453,7 +449,6 @@ The final ``bootstrap.php`` file should look like this:
 
     <?php
 
-    use Doctrine\Common\Annotations\AnnotationRegistry;
     use Doctrine\ODM\MongoDB\Configuration;
     use Doctrine\ODM\MongoDB\DocumentManager;
     use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
@@ -462,10 +457,7 @@ The final ``bootstrap.php`` file should look like this:
         throw new RuntimeException('Install dependencies to run this script.');
     }
 
-    $loader = require_once $file;
-    $loader->add('Documents', __DIR__);
-
-    AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+    require_once $file;
 
     $config = new Configuration();
     $config->setProxyDir(__DIR__ . '/Proxies');

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -147,14 +147,10 @@ instance. Read more about setting up the Doctrine MongoDB ODM in the
 
     <?php
 
-    use Doctrine\Common\Annotations\AnnotationRegistry;
     use Doctrine\ODM\MongoDB\Configuration;
     use Doctrine\ODM\MongoDB\DocumentManager;
-    use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 
-    $loader = require_once('path/to/vendor/autoload.php');
-
-    AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+    require_once('path/to/vendor/autoload.php');
 
     $config = new Configuration();
     $config->setProxyDir('/path/to/generate/proxies');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,14 +2,10 @@
 
 declare(strict_types=1);
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
-
 $file = __DIR__ . '/../vendor/autoload.php';
 
 if (! file_exists($file)) {
     throw new RuntimeException('Install dependencies to run test suite.');
 }
 
-$loader = require $file;
-
-AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+require $file;

--- a/tools/sandbox/config.php
+++ b/tools/sandbox/config.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
@@ -14,9 +13,7 @@ if (! file_exists($file)) {
     throw new RuntimeException('Install dependencies to run this script.');
 }
 
-$loader = require_once $file;
-$loader->add('Documents', __DIR__);
-AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+require_once $file;
 
 $config = new Configuration();
 $config->setProxyDir(__DIR__ . '/Proxies');


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | yes
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->

Allow to install `doctrine/annotations` 2, apart from this, I think we should [make it optional](https://github.com/doctrine/orm/pull/8787) and [deprecate](https://github.com/doctrine/orm/pull/10098) [`AnnotationDriver`](https://github.com/doctrine/orm/pull/10161) in another PRs. 