### PR TITLE
Allow `doctrine/instantiator` 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.5 || ^2.0",
         "doctrine/event-manager": "^1.0 || ^2.0",
-        "doctrine/instantiator": "^1.1",
+        "doctrine/instantiator": "^1.1 || ^2",
         "doctrine/persistence": "^2.4 || ^3.0",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "jean85/pretty-package-versions": "^1.3.0 || ^2.0.1",


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->
There shouldn't be any BC break since the changes involved are only about modernizing the code: https://github.com/doctrine/instantiator/releases/tag/2.0.0

Update: for example, in https://github.com/doctrine/mongodb-odm/actions/runs/3959728289/jobs/6782933801#step:8:39 version 2 is installed.