### PR TITLE
Rename abstract test classes to *TestCase

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -28,7 +28,7 @@ parameters:
         -
             message: "#DOCTRINE_MONGODB_DATABASE not found\\.$#"
             paths:
-                - tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+                - tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
                 - tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
                 - tests/Doctrine/ODM/MongoDB/Tests/Id/IncrementGeneratorTest.php
                 - tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -36,7 +36,7 @@ parameters:
         -
             message: "#DOCTRINE_MONGODB_SERVER not found\\.$#"
             paths:
-                - tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+                - tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
 
         -
             message: "#^Parameter \\#1 \\$builder of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Facet\\:\\:pipeline\\(\\) expects Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Builder\\|Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage, stdClass given\\.$#"

--- a/psalm.xml
+++ b/psalm.xml
@@ -29,7 +29,7 @@
         <UndefinedConstant>
             <!-- DOCTRINE_MONGODB_DATABASE constant defined in phpunit.xml.dist -->
             <errorLevel type="suppress">
-                <file name="tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php"/>
+                <file name="tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php"/>
                 <file name="tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php"/>
                 <file name="tests/Doctrine/ODM/MongoDB/Tests/Id/IncrementGeneratorTest.php"/>
                 <file name="tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php"/>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Aggregation;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Iterator\UnrewindableIterator;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Article;
 use Documents\BlogPost;
 use Documents\BlogTagAggregation;
@@ -21,7 +21,7 @@ use MongoDB\BSON\UTCDateTime;
 
 use function array_keys;
 
-class BuilderTest extends BaseTest
+class BuilderTest extends BaseTestCase
 {
     public function testGetPipeline(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/ExprTest.php
@@ -7,10 +7,10 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation;
 use BadMethodCallException;
 use Closure;
 use Doctrine\ODM\MongoDB\Aggregation\Expr;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use LogicException;
 
-class ExprTest extends BaseTest
+class ExprTest extends BaseTestCase
 {
     use AggregationOperatorsProviderTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/AddFieldsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/AddFieldsTest.php
@@ -6,9 +6,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\AddFields;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class AddFieldsTest extends BaseTest
+class AddFieldsTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketAutoTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketAutoTest.php
@@ -7,11 +7,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\BucketAuto;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsComment;
 use Documents\User;
 
-class BucketAutoTest extends BaseTest
+class BucketAutoTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketTest.php
@@ -7,11 +7,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Bucket;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsComment;
 use Documents\User;
 
-class BucketTest extends BaseTest
+class BucketTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/CollStatsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/CollStatsTest.php
@@ -6,9 +6,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\CollStats;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class CollStatsTest extends BaseTest
+class CollStatsTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/CountTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/CountTest.php
@@ -6,9 +6,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Count;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class CountTest extends BaseTest
+class CountTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FacetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FacetTest.php
@@ -6,12 +6,12 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Facet;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use InvalidArgumentException;
 use LogicException;
 use stdClass;
 
-class FacetTest extends BaseTest
+class FacetTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GeoNearTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GeoNearTest.php
@@ -6,9 +6,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\GeoNear;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GeoNearTest extends BaseTest
+class GeoNearTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\GraphLookup;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\GraphLookup\Airport;
 use Documents\GraphLookup\Employee;
 use Documents\GraphLookup\ReportingHierarchy;
@@ -20,7 +20,7 @@ use Documents\User;
 use function array_merge;
 use function count;
 
-class GraphLookupTest extends BaseTest
+class GraphLookupTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GroupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GroupTest.php
@@ -9,9 +9,9 @@ use Doctrine\ODM\MongoDB\Aggregation\Expr;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Group;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationOperatorsProviderTrait;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GroupTest extends BaseTest
+class GroupTest extends BaseTestCase
 {
     use AggregationTestTrait;
     use AggregationOperatorsProviderTrait;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/IndexStatsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/IndexStatsTest.php
@@ -6,10 +6,10 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\IndexStats;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use stdClass;
 
-class IndexStatsTest extends BaseTest
+class IndexStatsTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LimitTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LimitTest.php
@@ -6,9 +6,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Limit;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class LimitTest extends BaseTest
+class LimitTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LookupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LookupTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsComment;
 use Documents\ReferenceUser;
 use Documents\SimpleReferenceUser;
 use Documents\User;
 use InvalidArgumentException;
 
-class LookupTest extends BaseTest
+class LookupTest extends BaseTestCase
 {
     public function setUp(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
@@ -8,13 +8,13 @@ use DateTime;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\MatchStage;
 use Doctrine\ODM\MongoDB\Query\Expr;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\User;
 use GeoJson\Geometry\Geometry;
 use MongoDB\BSON\UTCDateTime;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class MatchStageTest extends BaseTest
+class MatchStageTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OperatorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OperatorTest.php
@@ -10,9 +10,9 @@ use Doctrine\ODM\MongoDB\Aggregation\Expr;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Operator;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationOperatorsProviderTrait;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class OperatorTest extends BaseTest
+class OperatorTest extends BaseTestCase
 {
     use AggregationTestTrait;
     use AggregationOperatorsProviderTrait;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OutTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OutTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Sharded\ShardedUser;
 use Documents\SimpleReferenceUser;
 use Documents\User;
 
-class OutTest extends BaseTest
+class OutTest extends BaseTestCase
 {
     public function testOutStageWithClassName(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
@@ -7,12 +7,12 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Aggregation\Expr;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Project;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function array_combine;
 use function array_map;
 
-class ProjectTest extends BaseTest
+class ProjectTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/RedactTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/RedactTest.php
@@ -6,9 +6,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Redact;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class RedactTest extends BaseTest
+class RedactTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use DateTimeImmutable;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsComment;
 use Documents\User;
 use MongoDB\BSON\UTCDateTime;
 
-class ReplaceRootTest extends BaseTest
+class ReplaceRootTest extends BaseTestCase
 {
     public function testTypeConversion(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SampleTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SampleTest.php
@@ -6,9 +6,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Sample;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class SampleTest extends BaseTest
+class SampleTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SkipTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SkipTest.php
@@ -6,9 +6,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Skip;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class SkipTest extends BaseTest
+class SkipTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortByCountTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortByCountTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsComment;
 
-class SortByCountTest extends BaseTest
+class SortByCountTest extends BaseTestCase
 {
     public function testFieldNameConversion(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortTest.php
@@ -6,10 +6,10 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 /** @psalm-import-type SortShape from Sort */
-class SortTest extends BaseTest
+class SortTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnwindTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnwindTest.php
@@ -6,9 +6,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Unwind;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class UnwindTest extends BaseTest
+class UnwindTest extends BaseTestCase
 {
     use AggregationTestTrait;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
@@ -25,7 +25,7 @@ use function version_compare;
 use const DOCTRINE_MONGODB_DATABASE;
 use const DOCTRINE_MONGODB_SERVER;
 
-abstract class BaseTest extends TestCase
+abstract class BaseTestCase extends TestCase
 {
     protected ?DocumentManager $dm;
     protected UnitOfWork $uow;

--- a/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
@@ -8,7 +8,7 @@ use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionFactory;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionGenerator;
 
-class ConfigurationTest extends BaseTest
+class ConfigurationTest extends BaseTestCase
 {
     public function testDefaultPersistentCollectionFactory(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -37,7 +37,7 @@ use stdClass;
 
 use function get_class;
 
-class DocumentManagerTest extends BaseTest
+class DocumentManagerTest extends BaseTestCase
 {
     public function testCustomRepository(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
@@ -18,7 +18,7 @@ use MongoDB\BSON\ObjectId;
 
 use const DOCTRINE_MONGODB_DATABASE;
 
-class DocumentRepositoryTest extends BaseTest
+class DocumentRepositoryTest extends BaseTestCase
 {
     public function testMatchingAcceptsCriteriaWithNullWhereExpression(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleCallbacksTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleCallbacksTest.php
@@ -8,10 +8,10 @@ use DateTime;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Event;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 
-class LifecycleCallbacksTest extends BaseTest
+class LifecycleCallbacksTest extends BaseTestCase
 {
     private function createUser(string $name = 'jon', string $fullName = 'Jonathan H. Wage'): User
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleListenersTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleListenersTest.php
@@ -12,12 +12,12 @@ use Doctrine\ODM\MongoDB\Event\PostCollectionLoadEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use PHPUnit\Framework\Assert;
 
 use function get_class;
 
-class LifecycleListenersTest extends BaseTest
+class LifecycleListenersTest extends BaseTestCase
 {
     private MyEventListener $listener;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/PreLoadEventArgsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/PreLoadEventArgsTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Events;
 
 use Doctrine\ODM\MongoDB\Event\PreLoadEventArgs;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Group;
 
-class PreLoadEventArgsTest extends BaseTest
+class PreLoadEventArgsTest extends BaseTestCase
 {
     public function testGetData(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/PreUpdateEventArgsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/PreUpdateEventArgsTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Events;
 
 use Doctrine\ODM\MongoDB\Event\PreUpdateEventArgs;
 use Doctrine\ODM\MongoDB\Events;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Article;
 use Documents\Book;
 use Documents\Chapter;
@@ -16,7 +16,7 @@ use PHPUnit\Framework\Assert;
 use function get_class;
 use function in_array;
 
-class PreUpdateEventArgsTest extends BaseTest
+class PreUpdateEventArgsTest extends BaseTestCase
 {
     public function testChangeSetIsUpdated(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AlsoLoadTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AlsoLoadTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function explode;
 
-class AlsoLoadTest extends BaseTest
+class AlsoLoadTest extends BaseTestCase
 {
     public function testPropertyAlsoLoadDoesNotInterfereWithBasicHydration(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
@@ -8,7 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\APM\CommandLogger;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Book;
 use Documents\Chapter;
 use Documents\IdentifiedChapter;
@@ -24,7 +24,7 @@ use function get_class;
  * or atomicSetArray should be handled by it. If no exception was thrown it
  * means that collection update was handled by DocumentPersister.
  */
-class AtomicSetTest extends BaseTest
+class AtomicSetTest extends BaseTestCase
 {
     private CommandLogger $logger;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/BidirectionalInheritanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/BidirectionalInheritanceTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Tournament\ParticipantTeam;
 use Documents\Tournament\TournamentFootball;
 
-class BidirectionalInheritanceTest extends BaseTest
+class BidirectionalInheritanceTest extends BaseTestCase
 {
     /**
      * Test bi-directional reference "one to many", both owning sides and with inheritance maps.

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\Binary;
 
 use function get_class;
 
-class BinDataTest extends BaseTest
+class BinDataTest extends BaseTestCase
 {
     /** @dataProvider provideData */
     public function testBinData(string $field, string $data, int $type): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -11,11 +11,11 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Persisters\CollectionPersister;
 use Doctrine\ODM\MongoDB\Persisters\PersistenceBuilder;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function get_class;
 
-class CollectionPersisterTest extends BaseTest
+class CollectionPersisterTest extends BaseTestCase
 {
     private CommandLogger $logger;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionsTest.php
@@ -6,11 +6,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Bars\Bar;
 use Documents\Bars\Location;
 
-class CollectionsTest extends BaseTest
+class CollectionsTest extends BaseTestCase
 {
     public function testCollections(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\LockException;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Phonebook;
 use Documents\Phonenumber;
 use Documents\User;
@@ -18,7 +18,7 @@ use Documents\VersionedUser;
 
 use function get_class;
 
-class CommitImprovementTest extends BaseTest
+class CommitImprovementTest extends BaseTestCase
 {
     private CommandLogger $logger;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php
@@ -12,7 +12,7 @@ use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\PersistentCollection;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Repository\GridFSRepository;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\Tests\ClassMetadataTestUtil;
 use Documents\File;
 use Documents\ProfileNotify;
@@ -21,7 +21,7 @@ use stdClass;
 use function assert;
 use function get_class;
 
-class CustomCollectionsTest extends BaseTest
+class CustomCollectionsTest extends BaseTestCase
 {
     public function testMappingNamespaceIsAdded(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomFieldNameTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomFieldNameTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class CustomFieldNameTest extends BaseTest
+class CustomFieldNameTest extends BaseTestCase
 {
     public function testInsertSetsLoginInsteadOfUsername(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomIdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomIdTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Account;
 use Documents\CustomUser;
 use Documents\User;
 
-class CustomIdTest extends BaseTest
+class CustomIdTest extends BaseTestCase
 {
     public function testSetId(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use DateTime;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Exception;
@@ -15,7 +15,7 @@ use function array_map;
 use function array_values;
 use function is_array;
 
-class CustomTypeTest extends BaseTest
+class CustomTypeTest extends BaseTestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DatabasesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DatabasesTest.php
@@ -6,9 +6,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class DatabasesTest extends BaseTest
+class DatabasesTest extends BaseTestCase
 {
     public function testCustomDatabase(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use DateTime;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\User;
 use InvalidArgumentException;
 use MongoDB\BSON\UTCDateTime;
@@ -15,7 +15,7 @@ use function time;
 
 use const PHP_INT_SIZE;
 
-class DateTest extends BaseTest
+class DateTest extends BaseTestCase
 {
     public function testDates(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DetachedDocumentTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DetachedDocumentTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsArticle;
 use Documents\CmsPhonenumber;
 use Documents\CmsUser;
@@ -14,7 +14,7 @@ use function assert;
 use function serialize;
 use function unserialize;
 
-class DetachedDocumentTest extends BaseTest
+class DetachedDocumentTest extends BaseTestCase
 {
     public function testSimpleDetachMerge(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
@@ -6,9 +6,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class DiscriminatorsDefaultValueTest extends BaseTest
+class DiscriminatorsDefaultValueTest extends BaseTestCase
 {
     public function setUp(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\LockException;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Documents\Article;
@@ -27,7 +27,7 @@ use function gettype;
 use function is_object;
 use function sprintf;
 
-class DocumentPersisterTest extends BaseTest
+class DocumentPersisterTest extends BaseTestCase
 {
     /** @var class-string<DocumentPersisterTestDocument> */
     private string $class;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EcommerceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EcommerceTest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Ecommerce\ConfigurableProduct;
 use Documents\Ecommerce\Currency;
 use Documents\Ecommerce\Money;
 use Documents\Ecommerce\Option;
 use Documents\Ecommerce\StockItem;
 
-class EcommerceTest extends BaseTest
+class EcommerceTest extends BaseTestCase
 {
     public function setUp(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedIdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedIdTest.php
@@ -6,11 +6,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use InvalidArgumentException;
 use MongoDB\BSON\ObjectId;
 
-class EmbeddedIdTest extends BaseTest
+class EmbeddedIdTest extends BaseTestCase
 {
     public function testEmbeddedIdsAreGenerated(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedReferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedReferenceTest.php
@@ -7,9 +7,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class EmbeddedReferenceTest extends BaseTest
+class EmbeddedReferenceTest extends BaseTestCase
 {
     public function testReferencedDocumentInsideEmbeddedDocument(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
@@ -8,7 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Address;
 use Documents\Functional\EmbeddedTestLevel0;
 use Documents\Functional\EmbeddedTestLevel0b;
@@ -25,7 +25,7 @@ use MongoDB\BSON\ObjectId;
 use function assert;
 use function get_class;
 
-class EmbeddedTest extends BaseTest
+class EmbeddedTest extends BaseTestCase
 {
     public function testSetEmbeddedToNull(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\MongoDBException;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Sharded\ShardedByUser;
 use Documents\Sharded\ShardedOne;
 use Documents\Sharded\ShardedOneWithDifferentKey;
@@ -13,7 +13,7 @@ use Documents\Sharded\ShardedOneWithDifferentKey;
 use function iterator_to_array;
 
 /** @group sharding */
-class EnsureShardingTest extends BaseTest
+class EnsureShardingTest extends BaseTestCase
 {
     public function setUp(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnumTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnumTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Documents81\Card;
 use Documents81\Suit;
@@ -17,7 +17,7 @@ use function preg_quote;
 use function sprintf;
 
 /** @requires PHP >= 8.1 */
-class EnumTest extends BaseTest
+class EnumTest extends BaseTestCase
 {
     public function testPersistNew(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilterTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\DocumentNotFoundException;
 use Doctrine\ODM\MongoDB\Query\FilterCollection;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Group;
 use Documents\Profile;
 use Documents\User;
@@ -14,7 +14,7 @@ use MongoDB\BSON\ObjectId;
 
 use function sort;
 
-class FilterTest extends BaseTest
+class FilterTest extends BaseTestCase
 {
     /** @var array<string, ObjectId|string|null> */
     private array $ids;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FindAndModifyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FindAndModifyTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\User;
 
-class FindAndModifyTest extends BaseTest
+class FindAndModifyTest extends BaseTestCase
 {
     public function testFindAndModify(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FlushTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FlushTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\FriendUser;
 
 use function get_class;
 
-class FlushTest extends BaseTest
+class FlushTest extends BaseTestCase
 {
     /**
      * Given 3 users, userA userB userC

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -11,7 +11,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\PersistentCollection;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Account;
 use Documents\Address;
 use Documents\Agent;
@@ -53,7 +53,7 @@ use MongoDB\BSON\ObjectId;
 use function assert;
 use function bcscale;
 
-class FunctionalTest extends BaseTest
+class FunctionalTest extends BaseTestCase
 {
     private int $initialScale;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/HasLifecycleCallbacksTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/HasLifecycleCallbacksTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class HasLifecycleCallbacksTest extends BaseTest
+class HasLifecycleCallbacksTest extends BaseTestCase
 {
     public function testHasLifecycleCallbacksSubExtendsSuper(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Id\UuidGenerator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use InvalidArgumentException;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectId;
@@ -26,7 +26,7 @@ use function sprintf;
 use function ucfirst;
 use function unserialize;
 
-class IdTest extends BaseTest
+class IdTest extends BaseTestCase
 {
     public function testUuidId(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdentifiersTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdentifiersTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Event;
 use Documents\User;
 use ProxyManager\Proxy\LazyLoadingInterface;
@@ -12,7 +12,7 @@ use ProxyManager\Proxy\LazyLoadingInterface;
 use function assert;
 use function get_class;
 
-class IdentifiersTest extends BaseTest
+class IdentifiersTest extends BaseTestCase
 {
     public function testGetIdentifierValue(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
@@ -6,10 +6,10 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\Driver\Exception\BulkWriteException;
 
-class IndexesTest extends BaseTest
+class IndexesTest extends BaseTestCase
 {
     /** @param class-string $class */
     private function uniqueTest(string $class): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/InheritanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/InheritanceTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Developer;
 use Documents\OtherSubProject;
 use Documents\Profile;
@@ -13,7 +13,7 @@ use Documents\SpecialUser;
 use Documents\SubProject;
 use Documents\User;
 
-class InheritanceTest extends BaseTest
+class InheritanceTest extends BaseTestCase
 {
     public function testCollectionPerClassInheritance(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/HydratingIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/HydratingIteratorTest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Iterator;
 
 use Doctrine\ODM\MongoDB\Iterator\HydratingIterator;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\User;
 use Generator;
 use MongoDB\BSON\ObjectId;
 
 use function is_array;
 
-final class HydratingIteratorTest extends BaseTest
+final class HydratingIteratorTest extends BaseTestCase
 {
     public function testConstructorRewinds(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/PrimingIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/PrimingIteratorTest.php
@@ -10,14 +10,14 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Iterator\PrimingIterator;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Query\ReferencePrimer;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Profile;
 use Documents\ProfileNotify;
 use Documents\User;
 use Iterator;
 use MongoDB\BSON\ObjectId;
 
-final class PrimingIteratorTest extends BaseTest
+final class PrimingIteratorTest extends BaseTestCase
 {
     /** @var class-string[] */
     private array $callbackCalls = [];

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LifecycleTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LifecycleTest.php
@@ -6,9 +6,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class LifecycleTest extends BaseTest
+class LifecycleTest extends BaseTestCase
 {
     public function testEventOnDoubleFlush(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
@@ -13,7 +13,7 @@ use Doctrine\ODM\MongoDB\LockMode;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Issue;
 use Documents\User;
 use InvalidArgumentException;
@@ -24,7 +24,7 @@ use MongoDB\BSON\UTCDateTime;
 use function get_class;
 use function time;
 
-class LockTest extends BaseTest
+class LockTest extends BaseTestCase
 {
     public function testOptimisticLockIntSetInitialVersion(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/MappedSuperclassTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/MappedSuperclassTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class MappedSuperclassTest extends BaseTest
+class MappedSuperclassTest extends BaseTestCase
 {
     public function testCRUD(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/MemoryUsageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/MemoryUsageTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsPhonenumber;
 use Documents\CmsUser;
 
@@ -18,7 +18,7 @@ use function round;
 use function sprintf;
 
 /** @group performance */
-class MemoryUsageTest extends BaseTest
+class MemoryUsageTest extends BaseTestCase
 {
     /**
      * Output for jwage "Memory increased by 14.09 kb"

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedCollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedCollectionsTest.php
@@ -7,13 +7,13 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Phonebook;
 use Documents\Phonenumber;
 
 use function get_class;
 
-class NestedCollectionsTest extends BaseTest
+class NestedCollectionsTest extends BaseTestCase
 {
     /** @dataProvider provideStrategy */
     public function testStrategy(string $field): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
@@ -7,13 +7,13 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\ObjectId;
 
 use function is_numeric;
 use function is_string;
 
-class NestedDocumentsTest extends BaseTest
+class NestedDocumentsTest extends BaseTestCase
 {
     public function testSimple(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalEmbedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalEmbedTest.php
@@ -7,14 +7,14 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function assert;
 
 /**
  * Test the orphan removal on embedded documents that contain references with cascade operations.
  */
-class OrphanRemovalEmbedTest extends BaseTest
+class OrphanRemovalEmbedTest extends BaseTestCase
 {
     /**
      * Test unsetting an embedOne relationship

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
@@ -7,11 +7,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function assert;
 
-class OrphanRemovalTest extends BaseTest
+class OrphanRemovalTest extends BaseTestCase
 {
     public function testOrphanRemoval(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OwningAndInverseReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OwningAndInverseReferencesTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use DateTime;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\BlogPost;
 use Documents\BrowseNode;
 use Documents\Cart;
@@ -20,7 +20,7 @@ use function assert;
 use function get_class;
 use function strtotime;
 
-class OwningAndInverseReferencesTest extends BaseTest
+class OwningAndInverseReferencesTest extends BaseTestCase
 {
     public function testOneToOne(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionCloneTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistentCollectionCloneTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsGroup;
 use Documents\CmsUser;
 
 use function get_class;
 
-class PersistentCollectionCloneTest extends BaseTest
+class PersistentCollectionCloneTest extends BaseTestCase
 {
     private ?CmsUser $user1 = null;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PersistingTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Account;
 use Documents\User;
 
-class PersistingTest extends BaseTest
+class PersistingTest extends BaseTestCase
 {
     public function testCascadeInsertUpdateAndRemove(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PrePersistTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PrePersistTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class PrePersistTest extends BaseTest
+class PrePersistTest extends BaseTestCase
 {
     public function testPrePersist(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Article;
 use Documents\CmsComment;
 use Documents\Group;
@@ -25,7 +25,7 @@ use function get_class;
 use function iterator_to_array;
 use function strtotime;
 
-class QueryTest extends BaseTest
+class QueryTest extends BaseTestCase
 {
     private User $user;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RawTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RawTypeTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
 
 use function get_class;
 
-class RawTypeTest extends BaseTest
+class RawTypeTest extends BaseTestCase
 {
     /**
      * @param mixed $value

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadOnlyDocumentTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadOnlyDocumentTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\ObjectId;
 
-class ReadOnlyDocumentTest extends BaseTest
+class ReadOnlyDocumentTest extends BaseTestCase
 {
     public function testCanBeInserted(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
@@ -7,14 +7,14 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Query\Query;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Group;
 use Documents\User;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 
 /** @psalm-type ReadPreferenceTagShape = array{dc?: string, usage?: string} */
-class ReadPreferenceTest extends BaseTest
+class ReadPreferenceTest extends BaseTestCase
 {
     public function setUp(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class ReferenceDiscriminatorsTest extends BaseTest
+class ReferenceDiscriminatorsTest extends BaseTestCase
 {
     public function setUp(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceEmbeddedDocumentsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceEmbeddedDocumentsTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Issue;
 use Documents\Project;
 use Documents\SubProject;
 
-class ReferenceEmbeddedDocumentsTest extends BaseTest
+class ReferenceEmbeddedDocumentsTest extends BaseTestCase
 {
     public function testSavesEmbeddedDocumentsInReferencedDocument(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
@@ -8,7 +8,7 @@ use DateTime;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Query\Query;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\Tests\ClassMetadataTestUtil;
 use Documents\Account;
 use Documents\Agent;
@@ -37,7 +37,7 @@ use ProxyManager\Proxy\GhostObjectInterface;
 use function assert;
 use function func_get_args;
 
-class ReferencePrimerTest extends BaseTest
+class ReferencePrimerTest extends BaseTestCase
 {
     public function testPrimeReferencesShouldRequireReferenceMapping(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceRepositoryMethodTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceRepositoryMethodTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use DateTime;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\BlogPost;
 use Documents\Comment;
 use Documents\User;
@@ -13,7 +13,7 @@ use Documents\User;
 use function assert;
 use function strtotime;
 
-class ReferenceRepositoryMethodTest extends BaseTest
+class ReferenceRepositoryMethodTest extends BaseTestCase
 {
     public function testOneToOne(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
@@ -12,7 +12,7 @@ use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Account;
 use Documents\Address;
 use Documents\Group;
@@ -28,7 +28,7 @@ use ProxyManager\Proxy\LazyLoadingInterface;
 use function assert;
 use function get_class;
 
-class ReferencesTest extends BaseTest
+class ReferencesTest extends BaseTestCase
 {
     public function testManyDeleteReference(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RemoveTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RemoveTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use DateTime;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Account;
 use Documents\BlogPost;
 use Documents\CmsArticle;
@@ -16,7 +16,7 @@ use Documents\Group;
 use Documents\Project;
 use Documents\User;
 
-class RemoveTest extends BaseTest
+class RemoveTest extends BaseTestCase
 {
     public function testRemove(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RepositoriesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RepositoriesTest.php
@@ -6,10 +6,10 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\User;
 
-class RepositoriesTest extends BaseTest
+class RepositoriesTest extends BaseTestCase
 {
     private User $user;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\APM\CommandLogger;
 use Doctrine\ODM\MongoDB\MongoDBException;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Sharded\ShardedOne;
 use MongoDB\BSON\ObjectId;
 
@@ -15,7 +15,7 @@ use function end;
 use function get_class;
 
 /** @group sharding */
-class ShardKeyTest extends BaseTest
+class ShardKeyTest extends BaseTestCase
 {
     private CommandLogger $logger;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SimpleReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SimpleReferencesTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\SimpleReferenceUser;
 use Documents\User;
 use MongoDB\BSON\ObjectId;
@@ -15,7 +15,7 @@ use function assert;
 use function current;
 use function end;
 
-class SimpleReferencesTest extends BaseTest
+class SimpleReferencesTest extends BaseTestCase
 {
     private User $user;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SimpleTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SimpleTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Bars\Bar;
 use Documents\Bars\Location;
 
-class SimpleTest extends BaseTest
+class SimpleTest extends BaseTestCase
 {
     public function testSimple(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
@@ -7,12 +7,12 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use ReflectionObject;
 
 use function get_class;
 
-class SplObjectHashCollisionsTest extends BaseTest
+class SplObjectHashCollisionsTest extends BaseTestCase
 {
     /**
      * @param callable(DocumentManager, object=): void $f

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TestTargetDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TestTargetDocument.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class TargetDocumentTest extends BaseTest
+class TargetDocumentTest extends BaseTestCase
 {
     /** @doesNotPerformAssertions */
     public function testMappedSuperClassAsTargetDocument(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php
@@ -8,9 +8,9 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH1011Test extends BaseTest
+class GH1011Test extends BaseTestCase
 {
     public function testClearCollection(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1017Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1017Test.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 
 use function in_array;
 use function spl_object_hash;
 
-class GH1017Test extends BaseTest
+class GH1017Test extends BaseTestCase
 {
     public function testSPLObjectHashCollisionOnReplacingEmbeddedDoc(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
@@ -7,14 +7,14 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Exception;
 use MongoDB\BSON\ObjectId;
 
 use function array_merge;
 use function get_class;
 
-class GH1058Test extends BaseTest
+class GH1058Test extends BaseTestCase
 {
     /** @doesNotPerformAssertions */
     public function testModifyingDuringOnFlushEventNewDocument(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1107Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1107Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH1107Test extends BaseTest
+class GH1107Test extends BaseTestCase
 {
     public function testOverrideIdStrategy(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php
@@ -7,11 +7,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function get_class;
 
-class GH1117Test extends BaseTest
+class GH1117Test extends BaseTestCase
 {
     public function testAddOnUninitializedCollection(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1132Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1132Test.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Phonenumber;
 use Documents\User;
 
 use function get_class;
 
-class GH1132Test extends BaseTest
+class GH1132Test extends BaseTestCase
 {
     public function testClonedPersistentCollectionCanBeClearedAndUsedInNewDocument(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1138Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1138Test.php
@@ -8,9 +8,9 @@ use Doctrine\ODM\MongoDB\APM\CommandLogger;
 use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH1138Test extends BaseTest
+class GH1138Test extends BaseTestCase
 {
     private CommandLogger $logger;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1152Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1152Test.php
@@ -8,9 +8,9 @@ use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH1152Test extends BaseTest
+class GH1152Test extends BaseTestCase
 {
     public function testParentAssociationsInPostLoad(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
@@ -7,11 +7,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function get_class;
 
-class GH1225Test extends BaseTest
+class GH1225Test extends BaseTestCase
 {
     public function testRemoveAddEmbeddedDocToExistingDocumentWithPreUpdateHook(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
@@ -7,13 +7,13 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function assert;
 use function count;
 use function end;
 
-class GH1229Test extends BaseTest
+class GH1229Test extends BaseTestCase
 {
     /** @var string */
     protected $firstParentId;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
@@ -9,11 +9,11 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function assert;
 
-class GH1232Test extends BaseTest
+class GH1232Test extends BaseTestCase
 {
     /** @doesNotPerformAssertions */
     public function testRemoveDoesNotCauseErrors(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
@@ -8,12 +8,12 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use InvalidArgumentException;
 
 use function array_map;
 
-class GH1275Test extends BaseTest
+class GH1275Test extends BaseTestCase
 {
     public function testResortAtomicCollectionsFlipItems(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1294Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1294Test.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\Regex;
 
-class GH1294Test extends BaseTest
+class GH1294Test extends BaseTestCase
 {
     public function testRegexSearchOnIdentifierWithUuidStrategy(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1344Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1344Test.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\Driver\Exception\CommandException;
 
-class GH1344Test extends BaseTest
+class GH1344Test extends BaseTestCase
 {
     public function testGeneratingIndexesDoesNotThrowException(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1346Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1346Test.php
@@ -7,9 +7,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH1346Test extends BaseTest
+class GH1346Test extends BaseTestCase
 {
     /** @group GH1346Test */
     public function testPublicProperty(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
@@ -7,11 +7,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Query\Query;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function assert;
 
-class GH1418Test extends BaseTest
+class GH1418Test extends BaseTestCase
 {
     public function testManualHydrateAndMerge(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1428Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1428Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH1428Test extends BaseTest
+class GH1428Test extends BaseTestCase
 {
     /** @doesNotPerformAssertions */
     public function testShortNameLossOnReplacingMiddleEmbeddedDocOfNestedEmbedding(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1435Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1435Test.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\ObjectId;
 
-class GH1435Test extends BaseTest
+class GH1435Test extends BaseTestCase
 {
     public function testUpsert(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1525Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1525Test.php
@@ -8,9 +8,9 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Id\UuidGenerator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH1525Test extends BaseTest
+class GH1525Test extends BaseTestCase
 {
     public function testEmbedCloneTwoFlushesPerDocument(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1572Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1572Test.php
@@ -9,9 +9,9 @@ use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH1572Test extends BaseTest
+class GH1572Test extends BaseTestCase
 {
     public function testPersistentCollectionCount(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1674Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1674Test.php
@@ -7,10 +7,10 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\ObjectId;
 
-class GH1674Test extends BaseTest
+class GH1674Test extends BaseTestCase
 {
     public function testElemMatchUsesCorrectMapping(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1775Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1775Test.php
@@ -8,9 +8,9 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH1775Test extends BaseTest
+class GH1775Test extends BaseTestCase
 {
     public function testProxyInitializationDoesNotLoseData(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1962Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1962Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH1962Test extends BaseTest
+class GH1962Test extends BaseTestCase
 {
     public function testDiscriminatorMaps(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1964Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1964Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH1964Test extends BaseTest
+class GH1964Test extends BaseTestCase
 {
     public function testSortMetaShouldReturnCorrectQuery(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1990Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1990Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH1990Test extends BaseTest
+class GH1990Test extends BaseTestCase
 {
     public function testInitialisationOfInverseProxy(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2002Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2002Test.php
@@ -6,12 +6,12 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function get_class;
 use function sprintf;
 
-class GH2002Test extends BaseTest
+class GH2002Test extends BaseTestCase
 {
     /**
      * @param array<string, mixed> $expectedReference

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2157Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2157Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\ODM\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH2157Test extends BaseTest
+class GH2157Test extends BaseTestCase
 {
     public function testFacetDiscriminatorMapCreation(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2251Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2251Test.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\User;
 use MongoDB\BSON\ObjectId;
 
-class GH2251Test extends BaseTest
+class GH2251Test extends BaseTestCase
 {
     /**
      * @testWith ["groups"]

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2310Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2310Test.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents74\GH2310Container;
 use Documents74\GH2310Embedded;
 use MongoDB\BSON\ObjectId;
 
-class GH2310Test extends BaseTest
+class GH2310Test extends BaseTestCase
 {
     public function testFindWithNullableEmbeddedAfterUpsert(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH232Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH232Test.php
@@ -7,9 +7,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH232Test extends BaseTest
+class GH232Test extends BaseTestCase
 {
     public function testReferencedDocumentInsideEmbeddedDocument(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH245Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH245Test.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function get_class;
 
-class GH245Test extends BaseTest
+class GH245Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
@@ -7,9 +7,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH267Test extends BaseTest
+class GH267Test extends BaseTestCase
 {
     public function testNestedReferences(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH385Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH385Test.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\User;
 use MongoDB\BSON\ObjectId;
 
-class GH385Test extends BaseTest
+class GH385Test extends BaseTestCase
 {
     public function testQueryBuilderShouldPrepareUnmappedFields(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH389Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH389Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH389Test extends BaseTest
+class GH389Test extends BaseTestCase
 {
     public function testDiscriminatorEmptyEmbeddedDocument(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH426Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH426Test.php
@@ -6,9 +6,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH426Test extends BaseTest
+class GH426Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH435Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH435Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH435Test extends BaseTest
+class GH435Test extends BaseTestCase
 {
     public function testOverridingFieldsType(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH453Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH453Test.php
@@ -7,13 +7,13 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function array_values;
 use function get_class;
 use function sprintf;
 
-class GH453Test extends BaseTest
+class GH453Test extends BaseTestCase
 {
     public function testHashWithStringKeys(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH467Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH467Test.php
@@ -7,9 +7,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH467Test extends BaseTest
+class GH467Test extends BaseTestCase
 {
     public function testMergeDocumentWithUnsetCollectionFields(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH499Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH499Test.php
@@ -7,10 +7,10 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\ObjectId;
 
-class GH499Test extends BaseTest
+class GH499Test extends BaseTestCase
 {
     public function testSetRefMany(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH520Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH520Test.php
@@ -7,10 +7,10 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use ProxyManager\Proxy\GhostObjectInterface;
 
-class GH520Test extends BaseTest
+class GH520Test extends BaseTestCase
 {
     public function testPrimeWithGetSingleResult(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH529Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH529Test.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\ObjectId;
 
 use function get_class;
 
-class GH529Test extends BaseTest
+class GH529Test extends BaseTestCase
 {
     public function testAutoIdWithConsistentValues(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
@@ -8,11 +8,11 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function get_class;
 
-class GH560Test extends BaseTest
+class GH560Test extends BaseTestCase
 {
     /**
      * @param int|string $id

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH561Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH561Test.php
@@ -7,9 +7,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH561Test extends BaseTest
+class GH561Test extends BaseTestCase
 {
     public function testPersistMainDocument(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH566Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH566Test.php
@@ -8,11 +8,11 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function iterator_to_array;
 
-class GH566Test extends BaseTest
+class GH566Test extends BaseTestCase
 {
     public function testFoo(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\Driver\Exception\BulkWriteException;
 
-class GH580Test extends BaseTest
+class GH580Test extends BaseTestCase
 {
     public function testDocumentPersisterShouldClearQueuedInsertsOnMongoException(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH593Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH593Test.php
@@ -8,12 +8,12 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\DocumentNotFoundException;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use ProxyManager\Proxy\GhostObjectInterface;
 
 use function iterator_to_array;
 
-class GH593Test extends BaseTest
+class GH593Test extends BaseTestCase
 {
     public function setUp(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH596Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH596Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH596Test extends BaseTest
+class GH596Test extends BaseTestCase
 {
     public function setUp(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH597Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH597Test.php
@@ -7,10 +7,10 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\ObjectId;
 
-class GH597Test extends BaseTest
+class GH597Test extends BaseTestCase
 {
     public function testEmbedManyGetsUnset(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
@@ -8,12 +8,12 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\DocumentNotFoundException;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use ProxyManager\Proxy\GhostObjectInterface;
 
 use function iterator_to_array;
 
-class GH602Test extends BaseTest
+class GH602Test extends BaseTestCase
 {
     public function testReferenceManyOwningSidePreparesFilterCriteriaForDifferentClass(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH611Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH611Test.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\ObjectId;
 
-class GH611Test extends BaseTest
+class GH611Test extends BaseTestCase
 {
     public function testPreparationofEmbeddedDocumentValues(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH628Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH628Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH628Test extends BaseTest
+class GH628Test extends BaseTestCase
 {
     public function testQueryBuilderShouldOnlyPrepareFirstPartOfRawFields(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH665Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH665Test.php
@@ -7,9 +7,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH665Test extends BaseTest
+class GH665Test extends BaseTestCase
 {
     public function testUseAddToSetStrategyOnEmbeddedDocument(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH683Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH683Test.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Functional\Ticket\GH683\EmbeddedSubDocument1;
 use Documents\Functional\Ticket\GH683\EmbeddedSubDocument2;
 use Documents\Functional\Ticket\GH683\ParentDocument;
 
 use function get_class;
 
-class GH683Test extends BaseTest
+class GH683Test extends BaseTestCase
 {
     public function testEmbedOne(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH774Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH774Test.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use MongoDB\BSON\ObjectId;
 
 use function get_class;
 
-class GH774Test extends BaseTest
+class GH774Test extends BaseTestCase
 {
     public function testUpsert(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH788Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH788Test.php
@@ -8,11 +8,11 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function get_class;
 
-class GH788Test extends BaseTest
+class GH788Test extends BaseTestCase
 {
     public function testDocumentWithDiscriminatorMap(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH816Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH816Test.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\ObjectId;
 
-class GH816Test extends BaseTest
+class GH816Test extends BaseTestCase
 {
     public function testPersistAfterDetachWithIdSet(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH850Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH850Test.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use InvalidArgumentException;
 
-class GH850Test extends BaseTest
+class GH850Test extends BaseTestCase
 {
     public function testPersistWrongReference(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
@@ -10,13 +10,13 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\Binary;
 use ProxyManager\Proxy\GhostObjectInterface;
 
 use function get_class;
 
-class GH852Test extends BaseTest
+class GH852Test extends BaseTestCase
 {
     /** @dataProvider provideIdGenerators */
     public function testA(Closure $idGenerator): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH878Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH878Test.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 
-class GH878Test extends BaseTest
+class GH878Test extends BaseTestCase
 {
     public function testSPLObjectHashCollisionOnDoubleMerge(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH880Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH880Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH880Test extends BaseTest
+class GH880Test extends BaseTestCase
 {
     public function test880(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH897Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH897Test.php
@@ -6,11 +6,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function get_class;
 
-class GH897Test extends BaseTest
+class GH897Test extends BaseTestCase
 {
     public function testRecomputeSingleDocumentChangesetForManagedDocumentWithoutChangeset(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH909Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH909Test.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Group;
 use Documents\Phonenumber;
 use Documents\User;
 
-class GH909Test extends BaseTest
+class GH909Test extends BaseTestCase
 {
     public function testManyReferenceAddAndPersist(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH921Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH921Test.php
@@ -8,9 +8,9 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH921Test extends BaseTest
+class GH921Test extends BaseTestCase
 {
     public function testPersistentCollectionCountAndIterationShouldBeConsistent(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH927Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH927Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH927Test extends BaseTest
+class GH927Test extends BaseTestCase
 {
     public function testInheritedClassHasAssociationMapping(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH928Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH928Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class GH928Test extends BaseTest
+class GH928Test extends BaseTestCase
 {
     public function testNullIdCriteriaShouldNotRemoveEverything(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH936Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH936Test.php
@@ -7,10 +7,10 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use ProxyManager\Proxy\GhostObjectInterface;
 
-class GH936Test extends BaseTest
+class GH936Test extends BaseTestCase
 {
     public function testRemoveCascadesThroughProxyDocuments(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH942Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH942Test.php
@@ -6,10 +6,10 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\ObjectId;
 
-class GH942Test extends BaseTest
+class GH942Test extends BaseTestCase
 {
     public function testDiscriminatorValueUsesClassNameIfMapIsNotDefined(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH944Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH944Test.php
@@ -7,11 +7,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function get_class;
 
-class GH944Test extends BaseTest
+class GH944Test extends BaseTestCase
 {
     public function testIssue(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
@@ -6,10 +6,10 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use InvalidArgumentException;
 
-class GH971Test extends BaseTest
+class GH971Test extends BaseTestCase
 {
     public function testUpdateOfInheritedDocumentUsingFindAndUpdate(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH977Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH977Test.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function get_class;
 
-class GH977Test extends BaseTest
+class GH977Test extends BaseTestCase
 {
     public function testAutoRecompute(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH978Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH978Test.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Ecommerce\ConfigurableProduct;
 use Documents\Ecommerce\Currency;
 use Documents\Ecommerce\Money;
@@ -14,7 +14,7 @@ use Documents\Ecommerce\StockItem;
 /**
  * Test for UnitOfWork::detach()
  */
-class GH978Test extends BaseTest
+class GH978Test extends BaseTestCase
 {
     public function testDetach(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH999Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH999Test.php
@@ -7,12 +7,12 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Exception;
 
 use function get_class;
 
-class GH999Test extends BaseTest
+class GH999Test extends BaseTestCase
 {
     public function testModifyingInFlushHandler(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function array_values;
 use function get_class;
 
-class MODM116Test extends BaseTest
+class MODM116Test extends BaseTestCase
 {
     public function testIssue(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM140Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM140Test.php
@@ -7,12 +7,12 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Functional\EmbeddedTestLevel0;
 use Documents\Functional\EmbeddedTestLevel1;
 use Documents\Functional\EmbeddedTestLevel2;
 
-class MODM140Test extends BaseTest
+class MODM140Test extends BaseTestCase
 {
     public function testInsertingNestedEmbeddedCollections(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM160Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM160Test.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Functional\Ticket\MODM160;
 
-class MODM160Test extends BaseTest
+class MODM160Test extends BaseTestCase
 {
     /** @doesNotPerformAssertions */
     public function testEmbedManyInArrayMergeNew(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM166Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM166Test.php
@@ -6,14 +6,14 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
 use Doctrine\ODM\MongoDB\Events;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Phonenumber;
 use Documents\User;
 
 use function get_class;
 use function sort;
 
-class MODM166Test extends BaseTest
+class MODM166Test extends BaseTestCase
 {
     private MODM166EventListener $listener;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM167Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM167Test.php
@@ -6,12 +6,12 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
 use Doctrine\ODM\MongoDB\Events;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\User;
 
 use function get_class;
 
-class MODM167Test extends BaseTest
+class MODM167Test extends BaseTestCase
 {
     private MODM167EventListener $listener;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM29Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM29Test.php
@@ -7,11 +7,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function assert;
 
-class MODM29Test extends BaseTest
+class MODM29Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM43Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM43Test.php
@@ -6,12 +6,12 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Event\PreLoadEventArgs;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\ObjectId;
 
 use function explode;
 
-class MODM43Test extends BaseTest
+class MODM43Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM45Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM45Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class MODM45Test extends BaseTest
+class MODM45Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM46Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM46Test.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\ObjectId;
 
-class MODM46Test extends BaseTest
+class MODM46Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM47Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM47Test.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\ObjectId;
 
-class MODM47Test extends BaseTest
+class MODM47Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM48Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM48Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class MODM48Test extends BaseTest
+class MODM48Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM52Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM52Test.php
@@ -6,11 +6,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function count;
 
-class MODM52Test extends BaseTest
+class MODM52Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM56Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM56Test.php
@@ -7,10 +7,10 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use DateTime;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\UTCDateTime;
 
-class MODM56Test extends BaseTest
+class MODM56Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM62Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM62Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class MODM62Test extends BaseTest
+class MODM62Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM65Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM65Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class MODM65Test extends BaseTest
+class MODM65Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM66Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM66Test.php
@@ -7,9 +7,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class MODM66Test extends BaseTest
+class MODM66Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM67Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM67Test.php
@@ -8,9 +8,9 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class MODM67Test extends BaseTest
+class MODM67Test extends BaseTestCase
 {
     private MODM67TestEventListener $listener;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
@@ -6,11 +6,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function array_search;
 
-class MODM70Test extends BaseTest
+class MODM70Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM72Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM72Test.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class MODM72Test extends BaseTest
+class MODM72Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM76Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM76Test.php
@@ -7,9 +7,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class MODM76Test extends BaseTest
+class MODM76Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
@@ -8,9 +8,9 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class MODM81Test extends BaseTest
+class MODM81Test extends BaseTestCase
 {
     private function getDocumentManager(): DocumentManager
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM83Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM83Test.php
@@ -8,11 +8,11 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function get_class;
 
-class MODM83Test extends BaseTest
+class MODM83Test extends BaseTestCase
 {
     private MODM83EventListener $listener;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM88Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM88Test.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Article;
 
-class MODM88Test extends BaseTest
+class MODM88Test extends BaseTestCase
 {
     public function testTest(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM90Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM90Test.php
@@ -8,11 +8,11 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function get_class;
 
-class MODM90Test extends BaseTest
+class MODM90Test extends BaseTestCase
 {
     private MODM90EventListener $listener;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM91Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM91Test.php
@@ -8,11 +8,11 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function get_class;
 
-class MODM91Test extends BaseTest
+class MODM91Test extends BaseTestCase
 {
     private MODM91EventListener $listener;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM92Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM92Test.php
@@ -7,12 +7,12 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Traversable;
 
 use function is_iterable;
 
-class MODM92Test extends BaseTest
+class MODM92Test extends BaseTestCase
 {
     public function testDocumentWithEmbeddedDocuments(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM95Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM95Test.php
@@ -7,9 +7,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class MODM95Test extends BaseTest
+class MODM95Test extends BaseTestCase
 {
     public function testDocumentWithEmbeddedDocuments(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TypedPropertiesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TypedPropertiesTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents74\TypedDocument;
 use Documents74\TypedEmbeddedDocument;
 use MongoDB\BSON\ObjectId;
 
 use function assert;
 
-class TypedPropertiesTest extends BaseTest
+class TypedPropertiesTest extends BaseTestCase
 {
     public function testPersistNew(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/UpsertTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/UpsertTest.php
@@ -6,12 +6,12 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\ObjectId;
 
 use function assert;
 
-class UpsertTest extends BaseTest
+class UpsertTest extends BaseTestCase
 {
     /**
      * Tests for "MongoCursorException: Cannot apply $push/$pushAll modifier to non-array" error.

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ValidationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ValidationTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\SchemaValidated;
 
 use function MongoDB\BSON\fromJSON;
@@ -14,7 +14,7 @@ use function MongoDB\BSON\fromPHP;
 use function MongoDB\BSON\toCanonicalExtendedJSON;
 use function MongoDB\BSON\toPHP;
 
-class ValidationTest extends BaseTest
+class ValidationTest extends BaseTestCase
 {
     public function testCreateUpdateValidatedDocument(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
@@ -7,9 +7,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class VersionTest extends BaseTest
+class VersionTest extends BaseTestCase
 {
     public function testVersioningWhenManipulatingEmbedMany(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ViewTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ViewTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Repository\ViewRepository;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use Documents\CmsUser;
 use Documents\UserName;
@@ -14,7 +14,7 @@ use ProxyManager\Proxy\GhostObjectInterface;
 
 use function assert;
 
-class ViewTest extends BaseTest
+class ViewTest extends BaseTestCase
 {
     public function setUp(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
@@ -13,7 +13,7 @@ use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Query\Query;
 use ProxyManager\Proxy\GhostObjectInterface;
 
-class HydratorTest extends BaseTest
+class HydratorTest extends BaseTestCase
 {
     public function testHydrator(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Id/IncrementGeneratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Id/IncrementGeneratorTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Id;
 
 use Doctrine\ODM\MongoDB\Id\IncrementGenerator;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\User;
 
 use const DOCTRINE_MONGODB_DATABASE;
 
-class IncrementGeneratorTest extends BaseTest
+class IncrementGeneratorTest extends BaseTestCase
 {
     public function testIdGeneratorWithStartingValue(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractAnnotationDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractAnnotationDriverTestCase.php
@@ -15,7 +15,7 @@ use stdClass;
 
 use function get_class;
 
-abstract class AbstractAnnotationDriverTest extends AbstractMappingDriverTest
+abstract class AbstractAnnotationDriverTestCase extends AbstractMappingDriverTestCase
 {
     public function testFieldInheritance(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
@@ -14,7 +14,7 @@ use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Repository\DefaultGridFSRepository;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\ODM\MongoDB\Repository\ViewRepository;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Reflection\EnumReflectionProperty;
@@ -29,7 +29,7 @@ use function sprintf;
 use function strcmp;
 use function usort;
 
-abstract class AbstractMappingDriverTest extends BaseTest
+abstract class AbstractMappingDriverTestCase extends BaseTestCase
 {
     abstract protected function loadDriver(): MappingDriver;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
@@ -8,7 +8,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 
-class AnnotationDriverTest extends AbstractAnnotationDriverTest
+class AnnotationDriverTest extends AbstractAnnotationDriverTestCase
 {
     protected function loadDriver(): MappingDriver
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AttributeDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AttributeDriverTest.php
@@ -8,7 +8,7 @@ use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 
 /** @requires PHP >= 8.0 */
-class AttributeDriverTest extends AbstractAnnotationDriverTest
+class AttributeDriverTest extends AbstractAnnotationDriverTestCase
 {
     protected function loadDriver(): MappingDriver
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
@@ -7,13 +7,13 @@ namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\Tests\Functional\MappedSuperclassRelated1;
 
 use function serialize;
 use function unserialize;
 
-class BasicInheritanceMappingTest extends BaseTest
+class BasicInheritanceMappingTest extends BaseTestCase
 {
     private ClassMetadataFactory $factory;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
@@ -8,11 +8,11 @@ use Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 use function assert;
 
-class ClassMetadataLoadEventTest extends BaseTest
+class ClassMetadataLoadEventTest extends BaseTestCase
 {
     public function testEvent(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\Tests\ClassMetadataTestUtil;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
@@ -47,7 +47,7 @@ use function MongoDB\BSON\toPHP;
 use function serialize;
 use function unserialize;
 
-class ClassMetadataTest extends BaseTest
+class ClassMetadataTest extends BaseTestCase
 {
     public function testClassMetadataInstanceSerialization(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTestCase.php
@@ -19,7 +19,7 @@ use TestDocuments\PrimedCollectionDocument;
 use TestDocuments\QueryResultDocument;
 use TestDocuments\User;
 
-abstract class AbstractDriverTest extends TestCase
+abstract class AbstractDriverTestCase extends TestCase
 {
     /** @var MappingDriver|null */
     protected $driver;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
@@ -19,7 +19,7 @@ use TestDocuments\WildcardIndexDocument;
 use function MongoDB\BSON\fromJSON;
 use function MongoDB\BSON\toPHP;
 
-class XmlDriverTest extends AbstractDriverTest
+class XmlDriverTest extends AbstractDriverTestCase
 {
     public function setUp(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php
@@ -7,9 +7,9 @@ namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
-class ShardKeyInheritanceMappingTest extends BaseTest
+class ShardKeyInheritanceMappingTest extends BaseTestCase
 {
     private ClassMetadataFactory $factory;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/AbstractDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/AbstractDriverTestCase.php
@@ -17,7 +17,7 @@ use function touch;
 use function unlink;
 
 /** @group DDC-1418 */
-abstract class AbstractDriverTest extends TestCase
+abstract class AbstractDriverTestCase extends TestCase
 {
     protected string $dir;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/XmlDriverTest.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Mapping\Driver\SimplifiedXmlDriver;
 use function array_flip;
 
 /** @group DDC-1418 */
-class XmlDriverTest extends AbstractDriverTest
+class XmlDriverTest extends AbstractDriverTestCase
 {
     protected function getFileExtension(): string
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
@@ -16,7 +16,7 @@ use function get_class;
 
 use const DIRECTORY_SEPARATOR;
 
-class XmlMappingDriverTest extends AbstractMappingDriverTest
+class XmlMappingDriverTest extends AbstractMappingDriverTestCase
 {
     protected function loadDriver(): MappingDriver
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/MongoCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/MongoCollectionTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests;
 
 use Documents\File;
 
-class MongoCollectionTest extends BaseTest
+class MongoCollectionTest extends BaseTestCase
 {
     public function testGridFSEmptyResult(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/HydrationPerformanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/HydrationPerformanceTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ODM\MongoDB\Performance;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsUser;
 
 use function gc_collect_cycles;
@@ -14,7 +14,7 @@ use function microtime;
 use const PHP_EOL;
 
 /** @group performance */
-class HydrationPerformanceTest extends BaseTest
+class HydrationPerformanceTest extends BaseTestCase
 {
     /**
      * [jwage: 10000 objects in ~6 seconds]

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/InsertPerformanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/InsertPerformanceTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ODM\MongoDB\Performance;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsUser;
 
 use function gc_collect_cycles;
@@ -14,7 +14,7 @@ use function microtime;
 use const PHP_EOL;
 
 /** @group performance */
-class InsertPerformanceTest extends BaseTest
+class InsertPerformanceTest extends BaseTestCase
 {
     /**
      * [jwage: 10000 objects in ~4 seconds]

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/MemoryUsageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/MemoryUsageTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Performance;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsPhonenumber;
 use Documents\CmsUser;
 
@@ -20,7 +20,7 @@ use function sprintf;
 use const PHP_EOL;
 
 /** @group performance */
-class MemoryUsageTest extends BaseTest
+class MemoryUsageTest extends BaseTestCase
 {
     /**
      * [jwage: Memory increased by 14.09 kb]

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/UnitOfWorkPerformanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/UnitOfWorkPerformanceTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ODM\MongoDB\Performance;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsUser;
 
 use function microtime;
@@ -13,7 +13,7 @@ use function str_replace;
 use const PHP_EOL;
 
 /** @group performance */
-class UnitOfWorkPerformanceTest extends BaseTest
+class UnitOfWorkPerformanceTest extends BaseTestCase
 {
     /**
      * [jwage: compute changesets for 10000 objects in ~10 seconds]

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/DefaultPersistentCollectionGeneratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/DefaultPersistentCollectionGeneratorTest.php
@@ -6,12 +6,12 @@ namespace Doctrine\ODM\MongoDB\Tests\PersistentCollection;
 
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\PersistentCollection\DefaultPersistentCollectionGenerator;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 /**
  * Tests aims to check if classes generated for various PHP versions are correct (i.e. parses).
  */
-class DefaultPersistentCollectionGeneratorTest extends BaseTest
+class DefaultPersistentCollectionGeneratorTest extends BaseTestCase
 {
     private DefaultPersistentCollectionGenerator $generator;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
@@ -19,7 +19,7 @@ use function assert;
 use function serialize;
 use function unserialize;
 
-class PersistentCollectionTest extends BaseTest
+class PersistentCollectionTest extends BaseTestCase
 {
     public function testSlice(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterFilterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterFilterTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Persisters;
 
 use DateTime;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\BlogPost;
 use Documents\Comment;
 use Documents\User;
 
-class DocumentPersisterFilterTest extends BaseTest
+class DocumentPersisterFilterTest extends BaseTestCase
 {
     public function testAddFilterToPreparedQuery(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Persisters;
 
 use DateTime;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\User;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectId;
@@ -15,7 +15,7 @@ use ReflectionMethod;
 
 use function get_class;
 
-class DocumentPersisterGetShardKeyQueryTest extends BaseTest
+class DocumentPersisterGetShardKeyQueryTest extends BaseTestCase
 {
     public function testGetShardKeyQueryScalars(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Persisters;
 
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Persisters\PersistenceBuilder;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsArticle;
 use Documents\CmsComment;
 use Documents\Ecommerce\ConfigurableProduct;
@@ -18,7 +18,7 @@ use MongoDB\BSON\ObjectId;
 use function array_keys;
 use function get_class;
 
-class PersistenceBuilderTest extends BaseTest
+class PersistenceBuilderTest extends BaseTestCase
 {
     private PersistenceBuilder $pb;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -11,7 +11,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use Doctrine\ODM\MongoDB\Query\Expr;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Documents\Feature;
 use Documents\User;
@@ -26,7 +26,7 @@ use MongoDB\Driver\ReadPreference;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionProperty;
 
-class BuilderTest extends BaseTest
+class BuilderTest extends BaseTestCase
 {
     public function testPrimeRequiresBooleanOrCallable(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Query;
 
 use BadMethodCallException;
 use Doctrine\ODM\MongoDB\Query\Expr;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Profile;
 use Documents\User;
 use GeoJson\Geometry\Point;
@@ -14,7 +14,7 @@ use GeoJson\Geometry\Polygon;
 use MongoDB\BSON\ObjectId;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class ExprTest extends BaseTest
+class ExprTest extends BaseTestCase
 {
     public function testSelectIsPrepared(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/BsonFilterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/Filter/BsonFilterTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Query\Filter;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use InvalidArgumentException;
 
-class BsonFilterTest extends BaseTest
+class BsonFilterTest extends BaseTestCase
 {
     public function testGetParameterInvalidArgument(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/FilterCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/FilterCollectionTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Query;
 
 use Doctrine\ODM\MongoDB\Query\Filter\BsonFilter;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\User;
 use InvalidArgumentException;
 
-class FilterCollectionTest extends BaseTest
+class FilterCollectionTest extends BaseTestCase
 {
     public function testEnable(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/QueryExpressionVisitorTest.php
@@ -11,12 +11,12 @@ use Doctrine\Common\Collections\ExpressionBuilder;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use Doctrine\ODM\MongoDB\Query\Expr;
 use Doctrine\ODM\MongoDB\Query\QueryExpressionVisitor;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Bars\Bar;
 use MongoDB\BSON\Regex;
 use RuntimeException;
 
-class QueryExpressionVisitorTest extends BaseTest
+class QueryExpressionVisitorTest extends BaseTestCase
 {
     private Builder $queryBuilder;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -29,7 +29,7 @@ use function iterator_to_array;
 
 use const DOCTRINE_MONGODB_DATABASE;
 
-class QueryTest extends BaseTest
+class QueryTest extends BaseTestCase
 {
     public function testSelectAndSelectSliceOnSameField(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Repository/DefaultGridFSRepositoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Repository/DefaultGridFSRepositoryTest.php
@@ -8,7 +8,7 @@ use DateTime;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Repository\GridFSRepository;
 use Doctrine\ODM\MongoDB\Repository\UploadOptions;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\File;
 use Documents\FileMetadata;
 use Documents\FileWithoutChunkSize;
@@ -26,7 +26,7 @@ use function fwrite;
 use function sprintf;
 use function tmpfile;
 
-class DefaultGridFSRepositoryTest extends BaseTest
+class DefaultGridFSRepositoryTest extends BaseTestCase
 {
     public function testOpenUploadStreamReturnsWritableResource(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/RepositoryFactoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/RepositoryFactoryTest.php
@@ -11,7 +11,7 @@ use Documents\User;
 
 use function get_class;
 
-class RepositoryFactoryTest extends BaseTest
+class RepositoryFactoryTest extends BaseTestCase
 {
     public function testRepositoryFactoryCanBeReplaced(): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -48,7 +48,7 @@ use function MongoDB\BSON\toPHP;
  * @psalm-import-type IndexMapping from ClassMetadata
  * @psalm-import-type IndexOptions from ClassMetadata
  */
-class SchemaManagerTest extends BaseTest
+class SchemaManagerTest extends BaseTestCase
 {
     /** @psalm-var list<class-string> */
     private array $indexedClasses = [

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/Console/Command/AbstractCommandTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/Console/Command/AbstractCommandTestCase.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Tools\Console\Command;
 
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\Tools\Console\Helper\DocumentManagerHelper;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
 
-abstract class AbstractCommandTest extends BaseTest
+abstract class AbstractCommandTestCase extends BaseTestCase
 {
     /** @var Application */
     protected $application;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/Console/Command/Schema/UpdateCommandTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/Console/Command/Schema/UpdateCommandTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Tools\Console\Command\Schema;
 
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
-use Doctrine\ODM\MongoDB\Tests\Tools\Console\Command\AbstractCommandTest;
+use Doctrine\ODM\MongoDB\Tests\Tools\Console\Command\AbstractCommandTestCase;
 use Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\UpdateCommand;
 use Documents\SchemaValidated;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class UpdateCommandTest extends AbstractCommandTest
+class UpdateCommandTest extends AbstractCommandTestCase
 {
     /** @var Command */
     protected $command;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
@@ -8,10 +8,10 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\Tools\ResolveTargetDocumentListener;
 
-class ResolveTargetDocumentListenerTest extends BaseTest
+class ResolveTargetDocumentListenerTest extends BaseTestCase
 {
     protected ResolveTargetDocumentListener $listener;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Types;
 
 use DateTime;
 use DateTimeImmutable;
-use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
@@ -21,7 +21,7 @@ use function time;
 
 use const STR_PAD_LEFT;
 
-class TypeTest extends BaseTest
+class TypeTest extends BaseTestCase
 {
     /**
      * @param mixed $test

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -31,7 +31,7 @@ use function get_class;
 use function spl_object_hash;
 use function sprintf;
 
-class UnitOfWorkTest extends BaseTest
+class UnitOfWorkTest extends BaseTestCase
 {
     public function testIsDocumentScheduled(): void
     {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | task
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->

[Abstract test case classes with "Test" suffix are deprecated in PHPUnit 10](https://github.com/sebastianbergmann/phpunit/issues/5132)
