### PR TITLE
Remove occurrences of "$this" in data providers

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
@@ -12,7 +12,6 @@ use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\User;
 use GeoJson\Geometry\Geometry;
 use MongoDB\BSON\UTCDateTime;
-use PHPUnit\Framework\MockObject\MockObject;
 
 class MatchStageTest extends BaseTestCase
 {
@@ -77,19 +76,19 @@ class MatchStageTest extends BaseTestCase
             'type()' => ['type', [7]],
             'all()' => ['all', [['value1', 'value2']]],
             'mod()' => ['mod', [2, 0]],
-            'geoIntersects()' => ['geoIntersects', [$this->getMockGeometry()]],
-            'geoWithin()' => ['geoWithin', [$this->getMockGeometry()]],
+            'geoIntersects()' => ['geoIntersects', [self::createGeometry()]],
+            'geoWithin()' => ['geoWithin', [self::createGeometry()]],
             'geoWithinBox()' => ['geoWithinBox', [1, 2, 3, 4]],
             'geoWithinCenter()' => ['geoWithinCenter', [1, 2, 3]],
             'geoWithinCenterSphere()' => ['geoWithinCenterSphere', [1, 2, 3]],
             'geoWithinPolygon()' => ['geoWithinPolygon', [[0, 0], [1, 1], [1, 0]]],
             'addAnd() array' => ['addAnd', [[]]],
-            'addAnd() Expr' => ['addAnd', [$this->getMockQueryExpr()]],
+            'addAnd() Expr' => ['addAnd', [self::createExpr()]],
             'addOr() array' => ['addOr', [[]]],
-            'addOr() Expr' => ['addOr', [$this->getMockQueryExpr()]],
+            'addOr() Expr' => ['addOr', [self::createExpr()]],
             'addNor() array' => ['addNor', [[]]],
-            'addNor() Expr' => ['addNor', [$this->getMockQueryExpr()]],
-            'not()' => ['not', [$this->getMockQueryExpr()]],
+            'addNor() Expr' => ['addNor', [self::createExpr()]],
+            'not()' => ['not', [self::createExpr()]],
             'language()' => ['language', ['en']],
             'text()' => ['text', ['foo']],
         ];
@@ -116,9 +115,14 @@ class MatchStageTest extends BaseTestCase
         );
     }
 
-    /** @return MockObject&Geometry */
-    private function getMockGeometry()
+    private static function createGeometry(): Geometry
     {
-        return $this->createMock(Geometry::class);
+        return new class extends Geometry {
+        };
+    }
+
+    private static function createExpr(): Expr
+    {
+        return new Expr(static::createTestDocumentManager());
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
@@ -32,7 +32,7 @@ abstract class BaseTestCase extends TestCase
 
     public function setUp(): void
     {
-        $this->dm  = $this->createTestDocumentManager();
+        $this->dm  = static::createTestDocumentManager();
         $this->uow = $this->dm->getUnitOfWork();
     }
 
@@ -64,7 +64,7 @@ abstract class BaseTestCase extends TestCase
         }
     }
 
-    protected function getConfiguration(): Configuration
+    protected static function getConfiguration(): Configuration
     {
         $config = new Configuration();
 
@@ -75,7 +75,7 @@ abstract class BaseTestCase extends TestCase
         $config->setPersistentCollectionDir(__DIR__ . '/../../../../PersistentCollections');
         $config->setPersistentCollectionNamespace('PersistentCollections');
         $config->setDefaultDB(DOCTRINE_MONGODB_DATABASE);
-        $config->setMetadataDriverImpl($this->createMetadataDriverImpl());
+        $config->setMetadataDriverImpl(static::createMetadataDriverImpl());
 
         $config->addFilter('testFilter', Filter::class);
         $config->addFilter('testFilter2', Filter::class);
@@ -100,14 +100,14 @@ abstract class BaseTestCase extends TestCase
         }
     }
 
-    protected function createMetadataDriverImpl(): MappingDriver
+    protected static function createMetadataDriverImpl(): MappingDriver
     {
         return AnnotationDriver::create(__DIR__ . '/../../../../Documents');
     }
 
-    protected function createTestDocumentManager(): DocumentManager
+    protected static function createTestDocumentManager(): DocumentManager
     {
-        $config = $this->getConfiguration();
+        $config = static::getConfiguration();
         $client = new Client(getenv('DOCTRINE_MONGODB_SERVER') ?: DOCTRINE_MONGODB_SERVER, [], ['typeMap' => ['root' => 'array', 'document' => 'array']]);
 
         return DocumentManager::create($client, $config);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DatabasesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DatabasesTest.php
@@ -20,7 +20,7 @@ class DatabasesTest extends BaseTestCase
         self::assertEquals('test_default', $this->dm->getDocumentDatabase(DefaultDatabaseTest::class)->getDatabaseName());
     }
 
-    protected function getConfiguration(): Configuration
+    protected static function getConfiguration(): Configuration
     {
         $config = parent::getConfiguration();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnumTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnumTest.php
@@ -96,7 +96,7 @@ class EnumTest extends BaseTestCase
         self::assertSame(['_id' => 'C'], $qb->getQuery()->debug('query'));
     }
 
-    protected function createMetadataDriverImpl(): MappingDriver
+    protected static function createMetadataDriverImpl(): MappingDriver
     {
         return AttributeDriver::create(__DIR__ . '/../../../Documents');
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH774Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH774Test.php
@@ -30,7 +30,7 @@ class GH774Test extends BaseTestCase
         self::assertEquals('test', $thread->permalink);
     }
 
-    protected function createMetadataDriverImpl(): MappingDriver
+    protected static function createMetadataDriverImpl(): MappingDriver
     {
         return new XmlDriver(__DIR__ . '/GH774');
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
@@ -31,11 +31,11 @@ use function usort;
 
 abstract class AbstractMappingDriverTestCase extends BaseTestCase
 {
-    abstract protected function loadDriver(): MappingDriver;
+    abstract protected static function loadDriver(): MappingDriver;
 
-    protected function createMetadataDriverImpl(): MappingDriver
+    protected static function createMetadataDriverImpl(): MappingDriver
     {
-        return $this->loadDriver();
+        return static::loadDriver();
     }
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
@@ -10,7 +10,7 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 
 class AnnotationDriverTest extends AbstractAnnotationDriverTestCase
 {
-    protected function loadDriver(): MappingDriver
+    protected static function loadDriver(): MappingDriver
     {
         $reader = new AnnotationReader();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AttributeDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AttributeDriverTest.php
@@ -10,7 +10,7 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 /** @requires PHP >= 8.0 */
 class AttributeDriverTest extends AbstractAnnotationDriverTestCase
 {
-    protected function loadDriver(): MappingDriver
+    protected static function loadDriver(): MappingDriver
     {
         return new AttributeDriver();
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
@@ -18,7 +18,7 @@ use const DIRECTORY_SEPARATOR;
 
 class XmlMappingDriverTest extends AbstractMappingDriverTestCase
 {
-    protected function loadDriver(): MappingDriver
+    protected static function loadDriver(): MappingDriver
     {
         return new XmlDriver(__DIR__ . DIRECTORY_SEPARATOR . 'xml');
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -511,8 +511,8 @@ class BuilderTest extends BaseTestCase
             'mod()' => ['mod', [2, 0]],
             'near()' => ['near', [1, 2]],
             'nearSphere()' => ['nearSphere', [1, 2]],
-            'geoIntersects()' => ['geoIntersects', [$this->getMockGeometry()]],
-            'geoWithin()' => ['geoWithin', [$this->getMockGeometry()]],
+            'geoIntersects()' => ['geoIntersects', [self::createGeometry()]],
+            'geoWithin()' => ['geoWithin', [self::createGeometry()]],
             'geoWithinBox()' => ['geoWithinBox', [1, 2, 3, 4]],
             'geoWithinCenter()' => ['geoWithinCenter', [1, 2, 3]],
             'geoWithinCenterSphere()' => ['geoWithinCenterSphere', [1, 2, 3]],
@@ -522,22 +522,22 @@ class BuilderTest extends BaseTestCase
             'unsetField()' => ['unsetField'],
             'setOnInsert()' => ['setOnInsert', [1]],
             'push() with value' => ['push', ['value']],
-            'push() with Expr' => ['push', [$this->getMockExpr()]],
+            'push() with Expr' => ['push', [self::createExpr()]],
             'addToSet() with value' => ['addToSet', ['value']],
-            'addToSet() with Expr' => ['addToSet', [$this->getMockExpr()]],
+            'addToSet() with Expr' => ['addToSet', [self::createExpr()]],
             'popFirst()' => ['popFirst'],
             'popLast()' => ['popLast'],
             'pull()' => ['pull', ['value']],
             'pullAll()' => ['pullAll', [['value1', 'value2']]],
             'addAnd() array' => ['addAnd', [[]]],
-            'addAnd() Expr' => ['addAnd', [$this->getMockExpr()]],
+            'addAnd() Expr' => ['addAnd', [self::createExpr()]],
             'addOr() array' => ['addOr', [[]]],
-            'addOr() Expr' => ['addOr', [$this->getMockExpr()]],
+            'addOr() Expr' => ['addOr', [self::createExpr()]],
             'addNor() array' => ['addNor', [[]]],
-            'addNor() Expr' => ['addNor', [$this->getMockExpr()]],
+            'addNor() Expr' => ['addNor', [self::createExpr()]],
             'elemMatch() array' => ['elemMatch', [[]]],
-            'elemMatch() Expr' => ['elemMatch', [$this->getMockExpr()]],
-            'not()' => ['not', [$this->getMockExpr()]],
+            'elemMatch() Expr' => ['elemMatch', [self::createExpr()]],
+            'not()' => ['not', [self::createExpr()]],
             'language()' => ['language', ['en']],
             'caseSensitive()' => ['caseSensitive', [true]],
             'diacriticSensitive()' => ['diacriticSensitive', [true]],
@@ -560,7 +560,7 @@ class BuilderTest extends BaseTestCase
         return [
             'legacy array' => [$coordinates, $coordinates, false],
             'GeoJSON array' => [$json, $json, true],
-            'GeoJSON object' => [$this->getMockPoint($json), $json, true],
+            'GeoJSON object' => [new Point($coordinates), $json, true],
         ];
     }
 
@@ -864,26 +864,15 @@ class BuilderTest extends BaseTestCase
         return $this->createMock(Expr::class);
     }
 
-    /** @return MockObject&Geometry */
-    private function getMockGeometry()
+    private static function createExpr(): Expr
     {
-        return $this->createMock(Geometry::class);
+        return new Expr(static::createTestDocumentManager());
     }
 
-    /**
-     * @param array<string, mixed> $json
-     *
-     * @return MockObject&Point
-     */
-    private function getMockPoint(array $json)
+    private static function createGeometry(): Geometry
     {
-        $point = $this->createMock(Point::class);
-
-        $point->expects($this->once())
-            ->method('jsonSerialize')
-            ->willReturn($json);
-
-        return $point;
+        return new class extends Geometry {
+        };
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -12,7 +12,6 @@ use Documents\User;
 use GeoJson\Geometry\Point;
 use GeoJson\Geometry\Polygon;
 use MongoDB\BSON\ObjectId;
-use PHPUnit\Framework\MockObject\MockObject;
 
 class ExprTest extends BaseTestCase
 {
@@ -399,12 +398,13 @@ class ExprTest extends BaseTestCase
 
     public function provideGeoJsonPoint(): array
     {
-        $json     = ['type' => 'Point', 'coordinates' => [1, 2]];
-        $expected = ['$geometry' => $json];
+        $coordinates = [1, 2];
+        $json        = ['type' => 'Point', 'coordinates' => $coordinates];
+        $expected    = ['$geometry' => $json];
 
         return [
             'array' => [$json, $expected],
-            'object' => [$this->getMockPoint($json), $expected],
+            'object' => [new Point($coordinates), $expected],
         ];
     }
 
@@ -561,16 +561,18 @@ class ExprTest extends BaseTestCase
 
     public function provideGeoJsonPolygon(): array
     {
+        $coordinates = [[[0, 0], [1, 1], [1, 0], [0, 0]]];
+
         $json = [
             'type' => 'Polygon',
-            'coordinates' => [[[0, 0], [1, 1], [1, 0], [0, 0]]],
+            'coordinates' => $coordinates,
         ];
 
         $expected = ['$geometry' => $json];
 
         return [
             'array' => [$json, $expected],
-            'object' => [$this->getMockPolygon($json), $expected],
+            'object' => [new Polygon($coordinates), $expected],
         ];
     }
 
@@ -701,37 +703,5 @@ class ExprTest extends BaseTestCase
         $expr->setClassMetadata($this->dm->getClassMetadata(User::class));
 
         return $expr;
-    }
-
-    /**
-     * @param array<string, mixed> $json
-     *
-     * @return MockObject&Point
-     */
-    private function getMockPoint(array $json)
-    {
-        $point = $this->createMock(Point::class);
-
-        $point->expects($this->once())
-            ->method('jsonSerialize')
-            ->willReturn($json);
-
-        return $point;
-    }
-
-    /**
-     * @param array<string, mixed> $json
-     *
-     * @return MockObject&Polygon
-     */
-    private function getMockPolygon(array $json)
-    {
-        $point = $this->createMock(Polygon::class);
-
-        $point->expects($this->once())
-            ->method('jsonSerialize')
-            ->willReturn($json);
-
-        return $point;
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/RepositoryFactoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/RepositoryFactoryTest.php
@@ -18,7 +18,7 @@ class RepositoryFactoryTest extends BaseTestCase
         $factory = $this->createMock(RepositoryFactory::class);
         $factory->expects($this->once())->method('getRepository');
 
-        $conf = $this->getConfiguration();
+        $conf = static::getConfiguration();
         $conf->setRepositoryFactory($factory);
         $dm = DocumentManager::create(null, $conf);
 
@@ -36,7 +36,7 @@ class RepositoryFactoryTest extends BaseTestCase
 
     public function testRepositoriesAreDifferentForDifferentDms(): void
     {
-        $conf = $this->getConfiguration();
+        $conf = static::getConfiguration();
         $conf->setRepositoryFactory(new DefaultRepositoryFactory());
 
         $dm1 = DocumentManager::create(null, $conf);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | task
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->
To make data providers static we need to remove "$this" from data providers, I've modified some method to make them static, not sure if there is another way for these cases.

Related to https://github.com/doctrine/mongodb-odm/issues/2509