### PR TITLE
Avoid triggering deprecation when calling `UnitOfWork::clear()`

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2395,6 +2395,8 @@ final class UnitOfWork implements PropertyChangedListener
             $this->embeddedDocumentsRegistry   =
             $this->orphanRemovals              =
             $this->hasScheduledCollections     = [];
+
+            $event = new Event\OnClearEventArgs($this->dm);
         } else {
             $visited = [];
             foreach ($this->identityMap as $className => $documents) {
@@ -2406,9 +2408,11 @@ final class UnitOfWork implements PropertyChangedListener
                     $this->doDetach($document, $visited);
                 }
             }
+
+            $event = new Event\OnClearEventArgs($this->dm, $documentName);
         }
 
-        $this->evm->dispatchEvent(Events::onClear, new Event\OnClearEventArgs($this->dm, $documentName));
+        $this->evm->dispatchEvent(Events::onClear, $event);
     }
 
     /**


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | task
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->

When calling `UnitOfWork::clear()` without argument it always triggers a deprecation (using `doctrine/persistence` 3) because it's passing a value to `OnClearEventArgs::__construct()`:

https://github.com/doctrine/mongodb-odm/blob/5ea5b1dc632d008f58ee20eaf6b9f07e9178be1f/lib/Doctrine/ODM/MongoDB/Event/OnClearEventArgs.php#L28-L48

The deprecation can be seen in https://github.com/doctrine/DoctrineMongoDBBundle/actions/runs/4363102968/jobs/7628786971#step:10:30