### PR TITLE
Use static data providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ phpunit.xml
 composer.lock
 vendor/
 .phpcs-cache
+.phpunit.cache
 .phpunit.result.cache
 phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "phpbench/phpbench": "^1.0.0@dev",
         "phpstan/phpstan": "^1.9.4",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5.5",
+        "phpunit/phpunit": "^9.5.5 || ^10.0.15",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/cache": "^4.4 || ^5.0 || ^6.0",
         "vimeo/psalm": "^5.7.7"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,33 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         failOnRisky="true"
-         stopOnFailure="false"
-         bootstrap="tests/bootstrap.php"
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        backupGlobals="false"
+        backupStaticProperties="false"
+        colors="false"
+        failOnRisky="true"
+        stopOnFailure="false"
+        bootstrap="tests/bootstrap.php"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+        cacheDirectory=".phpunit.cache"
 >
     <testsuites>
         <testsuite name="Doctrine ODM MongoDB Test Suite">
             <directory>./tests/Doctrine/</directory>
         </testsuite>
     </testsuites>
-
     <coverage>
         <include>
             <directory suffix=".php">./lib/Doctrine/ODM/MongoDB</directory>
         </include>
     </coverage>
-
     <groups>
         <exclude>
             <group>performance</group>
         </exclude>
     </groups>
-
     <php>
         <ini name="error_reporting" value="-1"/>
         <const name="DOCTRINE_MONGODB_SERVER" value="mongodb://localhost:27017" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
         failOnRisky="true"
         stopOnFailure="false"
         bootstrap="tests/bootstrap.php"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
         cacheDirectory=".phpunit.cache"
 >
     <testsuites>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
@@ -107,7 +107,7 @@ class GraphLookupTest extends BaseTestCase
         );
     }
 
-    public function provideEmployeeAggregations(): array
+    public static function provideEmployeeAggregations(): array
     {
         return [
             'owningSide' => [
@@ -185,7 +185,7 @@ class GraphLookupTest extends BaseTestCase
         }
     }
 
-    public function provideTravellerAggregations(): array
+    public static function provideTravellerAggregations(): array
     {
         return [
             'owningSide' => [

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GroupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GroupTest.php
@@ -42,7 +42,7 @@ class GroupTest extends BaseTestCase
         self::assertSame($stage, $stage->$method(...$args));
     }
 
-    public function provideProxiedExprMethods(): array
+    public static function provideProxiedExprMethods(): array
     {
         return [
             'addToSet()' => ['addToSet', ['$field']],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
@@ -58,7 +58,7 @@ class MatchStageTest extends BaseTestCase
         self::assertSame($stage, $stage->$method(...$args));
     }
 
-    public function provideProxiedExprMethods(): array
+    public static function provideProxiedExprMethods(): array
     {
         return [
             'field()' => ['field', ['fieldName']],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
@@ -52,7 +52,7 @@ class ProjectTest extends BaseTestCase
         self::assertSame(['$project' => ['something' => ['$' . $operator => ['$expression1', '$expression2']]]], $projectStage->getExpression());
     }
 
-    public function provideAccumulators(): array
+    public static function provideAccumulators(): array
     {
         $operators = ['avg', 'max', 'min', 'stdDevPop', 'stdDevSamp', 'sum'];
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -120,7 +120,7 @@ class DocumentManagerTest extends BaseTestCase
         self::assertFalse($this->dm->isOpen());
     }
 
-    public function dataMethodsAffectedByNoObjectArguments(): array
+    public static function dataMethodsAffectedByNoObjectArguments(): array
     {
         return [
             ['persist'],
@@ -138,7 +138,7 @@ class DocumentManagerTest extends BaseTestCase
         $this->dm->$methodName(null);
     }
 
-    public function dataAffectedByErrorIfClosedException(): array
+    public static function dataAffectedByErrorIfClosedException(): array
     {
         return [
             ['flush'],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
@@ -120,7 +120,7 @@ class AtomicSetTest extends BaseTestCase
         self::assertEmpty($user->phonenumbers);
     }
 
-    public function provideAtomicCollectionUnset(): array
+    public static function provideAtomicCollectionUnset(): array
     {
         return [
             [null],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
@@ -26,7 +26,7 @@ class BinDataTest extends BaseTestCase
         self::assertEquals($data, $check[$field]->getData());
     }
 
-    public function provideData(): array
+    public static function provideData(): array
     {
         return [
             ['bin', 'test', Binary::TYPE_GENERIC],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
@@ -58,7 +58,7 @@ class DateTest extends BaseTestCase
         self::assertEmpty($changeset);
     }
 
-    public function provideEquivalentDates(): array
+    public static function provideEquivalentDates(): array
     {
         return [
             [new DateTime('1985-09-01 00:00:00'), new DateTime('1985-09-01 00:00:00')],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -126,7 +126,7 @@ class DocumentPersisterTest extends BaseTestCase
         self::assertEquals($expected, $this->documentPersister->prepareFieldName($fieldName));
     }
 
-    public function getTestPrepareFieldNameData(): array
+    public static function getTestPrepareFieldNameData(): array
     {
         return [
             ['name', 'dbName'],
@@ -256,7 +256,7 @@ class DocumentPersisterTest extends BaseTestCase
         );
     }
 
-    public function provideHashIdentifiers(): array
+    public static function provideHashIdentifiers(): array
     {
         return [
             [['key' => 'value']],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -71,7 +71,7 @@ class FunctionalTest extends BaseTestCase
         bcscale($this->initialScale);
     }
 
-    public function provideUpsertObjects(): array
+    public static function provideUpsertObjects(): array
     {
         return [
             [UserUpsert::class, new ObjectId('4f18f593acee41d724000005'), 'user'],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
@@ -193,7 +193,7 @@ class IdTest extends BaseTestCase
         self::assertSame($user2->id, $user2Id);
     }
 
-    public function provideEqualButNotIdenticalIds(): array
+    public static function provideEqualButNotIdenticalIds(): array
     {
         /* MongoDB allows comparisons between different numeric types, so we
          * cannot test integer and floating point values (e.g. 123 and 123.0).
@@ -251,7 +251,7 @@ class IdTest extends BaseTestCase
         self::assertEquals('changed', $object->test);
     }
 
-    public function getTestIdTypesAndStrategiesData(): array
+    public static function getTestIdTypesAndStrategiesData(): array
     {
         $identifier = new ObjectId();
 
@@ -326,7 +326,7 @@ class IdTest extends BaseTestCase
         self::assertEquals($expectedMongoBinDataType, $check['_id']->getType());
     }
 
-    public function getTestBinIdsData(): array
+    public static function getTestBinIdsData(): array
     {
         return [
             ['bin', 0, 'test-data'],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedCollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedCollectionsTest.php
@@ -65,7 +65,7 @@ class NestedCollectionsTest extends BaseTestCase
         self::assertEquals('10203040', $publicBook->getPhonenumbers()->get(0)->getPhonenumber());
     }
 
-    public function provideStrategy(): array
+    public static function provideStrategy(): array
     {
         return [
             [ClassMetadata::STORAGE_STRATEGY_ATOMIC_SET],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RawTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RawTypeTest.php
@@ -30,7 +30,7 @@ class RawTypeTest extends BaseTestCase
         self::assertEquals($value, $result['raw']);
     }
 
-    public function getTestRawTypeData(): array
+    public static function getTestRawTypeData(): array
     {
         return [
             ['test'],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
@@ -67,7 +67,7 @@ class ReadPreferenceTest extends BaseTestCase
         $this->assertReadPreferenceHint($readPreference, $groups->getHints()[Query::HINT_READ_PREFERENCE], $tags);
     }
 
-    public function provideReadPreferenceHints(): array
+    public static function provideReadPreferenceHints(): array
     {
         return [
             [ReadPreference::RP_PRIMARY, []],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
@@ -56,7 +56,7 @@ class SplObjectHashCollisionsTest extends BaseTestCase
         $this->expectCount('embeddedDocumentsRegistry', $leftover);
     }
 
-    public function provideParentAssociationsIsCleared(): array
+    public static function provideParentAssociationsIsCleared(): array
     {
         return [
             [

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2002Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2002Test.php
@@ -30,7 +30,7 @@ class GH2002Test extends BaseTestCase
         self::assertArraySubset($expectedReference, $data['parentDocument']);
     }
 
-    public function getValidReferenceData(): array
+    public static function getValidReferenceData(): array
     {
         return [
             'discriminatedDocument' => [
@@ -73,7 +73,7 @@ class GH2002Test extends BaseTestCase
         $this->dm->getUnitOfWork()->getPersistenceBuilder()->prepareInsertData($document);
     }
 
-    public function getInvalidReferenceData(): array
+    public static function getInvalidReferenceData(): array
     {
         return [
             'referenceWithPartialDiscriminatorMapUnlistedDocument' => [

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
@@ -87,7 +87,7 @@ class GH560Test extends BaseTestCase
         self::assertEquals($called, $listener->called);
     }
 
-    public function provideDocumentIds(): array
+    public static function provideDocumentIds(): array
     {
         return [
             [123456],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
@@ -96,7 +96,7 @@ class GH852Test extends BaseTestCase
         self::assertCount(4, $docs);
     }
 
-    public function provideIdGenerators(): array
+    public static function provideIdGenerators(): array
     {
         $binDataType = Binary::TYPE_GENERIC;
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractAnnotationDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractAnnotationDriverTestCase.php
@@ -167,7 +167,7 @@ abstract class AbstractAnnotationDriverTestCase extends AbstractMappingDriverTes
         $annotationDriver->loadMetadataForClass(get_class($wrong), $cm);
     }
 
-    public function provideClassCanBeMappedByOneAbstractDocument(): ?Generator
+    public static function provideClassCanBeMappedByOneAbstractDocument(): ?Generator
     {
         yield [
             /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -685,7 +685,7 @@ class ClassMetadataTest extends BaseTestCase
         ]);
     }
 
-    public function provideRepositoryMethodCanNotBeCombinedWithSkipLimitAndSort(): Generator
+    public static function provideRepositoryMethodCanNotBeCombinedWithSkipLimitAndSort(): Generator
     {
         yield ['skip', 5];
         yield ['limit', 5];
@@ -763,7 +763,7 @@ class ClassMetadataTest extends BaseTestCase
         $cm->mapField($config);
     }
 
-    public function provideOwningAndInversedRefsNeedTargetDocument(): array
+    public static function provideOwningAndInversedRefsNeedTargetDocument(): array
     {
         return [
             [['type' => 'one', 'mappedBy' => 'post']],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php
@@ -224,7 +224,7 @@ class PersistenceBuilderTest extends BaseTestCase
      *
      * @return array
      */
-    public function getDocumentsAndExpectedData(): array
+    public static function getDocumentsAndExpectedData(): array
     {
         return [
             [new ConfigurableProduct('Test Product'), ['name' => 'Test Product']],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -206,7 +206,7 @@ class BuilderTest extends BaseTestCase
         self::assertEquals($expected, $q1['newObj']['$addToSet'][$field]);
     }
 
-    public function provideArrayUpdateOperatorsOnReferenceMany(): Generator
+    public static function provideArrayUpdateOperatorsOnReferenceMany(): Generator
     {
         yield [ChildA::class, 'featureFullMany'];
         yield [ChildB::class, 'featureSimpleMany'];
@@ -232,7 +232,7 @@ class BuilderTest extends BaseTestCase
         self::assertEquals($expected, $q1['newObj']['$set'][$field]);
     }
 
-    public function provideArrayUpdateOperatorsOnReferenceOne(): Generator
+    public static function provideArrayUpdateOperatorsOnReferenceOne(): Generator
     {
         yield [ChildA::class, 'featureFull'];
         yield [ChildB::class, 'featureSimple'];
@@ -490,7 +490,7 @@ class BuilderTest extends BaseTestCase
         self::assertSame($qb, $qb->$method(...$args));
     }
 
-    public function provideProxiedExprMethods(): array
+    public static function provideProxiedExprMethods(): array
     {
         return [
             'field()' => ['field', ['fieldName']],
@@ -577,9 +577,9 @@ class BuilderTest extends BaseTestCase
         self::assertEquals($expected, $qb->debug('select'));
     }
 
-    public function provideSelectProjections(): array
+    public static function provideSelectProjections(): array
     {
-        return $this->provideProjections(true);
+        return self::provideProjections(true);
     }
 
     /**
@@ -595,9 +595,9 @@ class BuilderTest extends BaseTestCase
         self::assertEquals($expected, $qb->debug('select'));
     }
 
-    public function provideExcludeProjections(): array
+    public static function provideExcludeProjections(): array
     {
-        return $this->provideProjections(false);
+        return self::provideProjections(false);
     }
 
     /**
@@ -607,7 +607,7 @@ class BuilderTest extends BaseTestCase
      *
      * @return array
      */
-    private function provideProjections(bool $include): array
+    private static function provideProjections(bool $include): array
     {
         $project = $include ? 1 : 0;
 
@@ -713,7 +713,7 @@ class BuilderTest extends BaseTestCase
         self::assertEquals(['foo' => $expectedOrder], $qb->debug('sort'));
     }
 
-    public function provideSortOrders(): array
+    public static function provideSortOrders(): array
     {
         return [
             [1, 1],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/CriteriaMergerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/CriteriaMergerTest.php
@@ -22,7 +22,7 @@ class CriteriaMergerTest extends TestCase
         self::assertSame($merged, call_user_func_array([new CriteriaMerger(), 'merge'], $args));
     }
 
-    public function provideMerge(): array
+    public static function provideMerge(): array
     {
         return [
             'no args' => [

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -396,7 +396,7 @@ class ExprTest extends BaseTestCase
         self::assertEquals(['$in' => [['x' => 1]], '$lt' => 2], $expr->getQuery());
     }
 
-    public function provideGeoJsonPoint(): array
+    public static function provideGeoJsonPoint(): array
     {
         $coordinates = [1, 2];
         $json        = ['type' => 'Point', 'coordinates' => $coordinates];
@@ -559,7 +559,7 @@ class ExprTest extends BaseTestCase
         self::assertEquals(['$geoIntersects' => $expected], $expr->getQuery());
     }
 
-    public function provideGeoJsonPolygon(): array
+    public static function provideGeoJsonPolygon(): array
     {
         $coordinates = [[[0, 0], [1, 1], [1, 0], [0, 0]]];
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/QueryExpressionVisitorTest.php
@@ -43,7 +43,7 @@ class QueryExpressionVisitorTest extends BaseTestCase
         self::assertEquals($expectedQuery, $expr->getQuery());
     }
 
-    public function provideComparisons(): array
+    public static function provideComparisons(): array
     {
         $builder = new ExpressionBuilder();
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -437,7 +437,7 @@ class QueryTest extends BaseTestCase
         $query->getIterator();
     }
 
-    public function provideQueryTypesThatDoNotReturnAnIterator(): array
+    public static function provideQueryTypesThatDoNotReturnAnIterator(): array
     {
         return [
             [Query::TYPE_FIND_AND_UPDATE, 'findOneAndUpdate'],

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -534,10 +534,7 @@ EOT;
         $database
             ->expects($this->exactly(2))
             ->method('createCollection')
-            ->withConsecutive(
-                ['fs.files', $this->writeOptions($expectedWriteOptions)],
-                ['fs.chunks', $this->writeOptions($expectedWriteOptions)],
-            );
+            ->with(self::stringStartsWith('fs.'), $this->writeOptions($expectedWriteOptions));
 
         $this->schemaManager->createDocumentCollection(File::class, $maxTimeMs, $writeConcern);
     }
@@ -812,7 +809,7 @@ EOT;
         self::assertSame($expected, $this->schemaManager->isMongoIndexEquivalentToDocumentIndex(new IndexInfo($mongoIndex), $documentIndex));
     }
 
-    public function dataIsMongoIndexEquivalentToDocumentIndex(): array
+    public static function dataIsMongoIndexEquivalentToDocumentIndex(): array
     {
         return [
             'keysSame' => [
@@ -1029,7 +1026,7 @@ EOT;
         self::assertSame($expected, $this->schemaManager->isMongoIndexEquivalentToDocumentIndex(new IndexInfo($mongoIndex), $documentIndex));
     }
 
-    public function dataIsMongoTextIndexEquivalentToDocumentIndex(): array
+    public static function dataIsMongoTextIndexEquivalentToDocumentIndex(): array
     {
         return [
             'keysSame' => [

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/DateImmutableTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/DateImmutableTypeTest.php
@@ -87,7 +87,7 @@ class DateImmutableTypeTest extends TestCase
         $type->convertToDatabaseValue($value);
     }
 
-    public function provideInvalidDateValues(): array
+    public static function provideInvalidDateValues(): array
     {
         return [
             'array'  => [[]],
@@ -140,7 +140,7 @@ class DateImmutableTypeTest extends TestCase
         $this->assertTimestampEquals($output, $return);
     }
 
-    public function provideDatabaseToPHPValues(): array
+    public static function provideDatabaseToPHPValues(): array
     {
         $yesterday = strtotime('yesterday');
         $mongoDate = new UTCDateTime($yesterday * 1000);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
@@ -87,7 +87,7 @@ class DateTypeTest extends TestCase
         $type->convertToDatabaseValue($value);
     }
 
-    public function provideInvalidDateValues(): array
+    public static function provideInvalidDateValues(): array
     {
         return [
             'array'  => [[]],
@@ -140,7 +140,7 @@ class DateTypeTest extends TestCase
         $this->assertTimestampEquals($output, $return);
     }
 
-    public function provideDatabaseToPHPValues(): array
+    public static function provideDatabaseToPHPValues(): array
     {
         $yesterday = strtotime('yesterday');
         $mongoDate = new UTCDateTime($yesterday * 1000);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/IdTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/IdTypeTest.php
@@ -32,7 +32,7 @@ class IdTypeTest extends TestCase
         self::assertInstanceOf(ObjectId::class, $type->convertToDatabaseValue($value));
     }
 
-    public function provideInvalidObjectIdConstructorArguments(): array
+    public static function provideInvalidObjectIdConstructorArguments(): array
     {
         return [
             'integer' => [1],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
@@ -33,7 +33,7 @@ class TypeTest extends BaseTestCase
         self::assertEquals($test, $type->convertToPHPValue($type->convertToDatabaseValue($test)));
     }
 
-    public function provideTypes(): array
+    public static function provideTypes(): array
     {
         return [
             'id' => [Type::getType(Type::ID), '507f1f77bcf86cd799439011'],
@@ -73,7 +73,7 @@ class TypeTest extends BaseTestCase
         self::assertEquals($test, $type->convertToDatabaseValue($test));
     }
 
-    public function provideTypesForIdempotent(): array
+    public static function provideTypesForIdempotent(): array
     {
         return [
             'id' => [Type::getType(Type::ID), new ObjectId()],

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -269,7 +269,7 @@ class UnitOfWorkTest extends BaseTestCase
         self::assertFalse($this->uow->isScheduledForUpdate($arrayTest));
     }
 
-    public function getScheduleForUpdateWithArraysTests(): array
+    public static function getScheduleForUpdateWithArraysTests(): array
     {
         return [
             [


### PR DESCRIPTION
#### Summary

Makes all test data providers `static`. This is to fix PHPUnit 10 deprecations.

See #2509 
