### PR TITLE
Support new aggregation pipeline stages in builder

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
@@ -17,6 +17,7 @@ use MongoDB\Driver\Cursor;
 use function array_merge;
 use function assert;
 
+/** @psalm-import-type PipelineExpression from Builder */
 final class Aggregation implements IteratorAggregate
 {
     private DocumentManager $dm;
@@ -25,7 +26,10 @@ final class Aggregation implements IteratorAggregate
 
     private Collection $collection;
 
-    /** @var array<string, mixed> */
+    /**
+     * @var array<string, mixed>
+     * @psalm-var PipelineExpression
+     */
     private array $pipeline;
 
     /** @var array<string, mixed> */
@@ -36,6 +40,7 @@ final class Aggregation implements IteratorAggregate
     /**
      * @param array<string, mixed> $pipeline
      * @param array<string, mixed> $options
+     * @psalm-param PipelineExpression $pipeline
      */
     public function __construct(DocumentManager $dm, ?ClassMetadata $classMetadata, Collection $collection, array $pipeline, array $options = [], bool $rewindable = true)
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -29,6 +29,8 @@ use function trigger_deprecation;
  * Fluent interface for building aggregation pipelines.
  *
  * @psalm-import-type SortShape from Sort
+ * @psalm-import-type StageExpression from Stage
+ * @psalm-type PipelineExpression = list<StageExpression>
  */
 class Builder
 {
@@ -269,6 +271,7 @@ class Builder
      * given.
      *
      * @return array<array<string, mixed>>
+     * @psalm-return PipelineExpression
      */
     // phpcs:enable Squiz.Commenting.FunctionComment.ExtraParamComment
     public function getPipeline(/* bool $applyFilters = true */): array

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -443,6 +443,20 @@ class Builder
     }
 
     /**
+     * Writes the results of the aggregation pipeline to a specified collection.
+     * The $merge operator must be the last stage in the pipeline.
+     *
+     * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/merge/
+     */
+    public function merge(): Stage\Merge
+    {
+        $stage = new Stage\Merge($this, $this->dm);
+        $this->addStage($stage);
+
+        return $stage;
+    }
+
+    /**
      * Takes the documents returned by the aggregation pipeline and writes them
      * to a specified collection. This must be the last stage in the pipeline.
      *

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -83,9 +83,8 @@ class Builder
     public function addFields(): Stage\AddFields
     {
         $stage = new Stage\AddFields($this);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -103,9 +102,8 @@ class Builder
     public function bucket(): Stage\Bucket
     {
         $stage = new Stage\Bucket($this, $this->dm, $this->class);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -125,9 +123,8 @@ class Builder
     public function bucketAuto(): Stage\BucketAuto
     {
         $stage = new Stage\BucketAuto($this, $this->dm, $this->class);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -141,9 +138,8 @@ class Builder
     public function collStats(): Stage\CollStats
     {
         $stage = new Stage\CollStats($this);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -155,9 +151,8 @@ class Builder
     public function count(string $fieldName): Stage\Count
     {
         $stage = new Stage\Count($this, $fieldName);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -168,9 +163,8 @@ class Builder
     public function densify(string $fieldName): Stage\Densify
     {
         $stage = new Stage\Densify($this, $fieldName);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -208,9 +202,8 @@ class Builder
     public function facet(): Stage\Facet
     {
         $stage = new Stage\Facet($this);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -221,9 +214,8 @@ class Builder
     public function fill(): Stage\Fill
     {
         $stage = new Stage\Fill($this);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -244,9 +236,8 @@ class Builder
     public function geoNear($x, $y = null): Stage\GeoNear
     {
         $stage = new Stage\GeoNear($this, $x, $y);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -347,9 +338,8 @@ class Builder
     public function graphLookup(string $from): Stage\GraphLookup
     {
         $stage = new Stage\GraphLookup($this, $from, $this->dm, $this->class);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -361,9 +351,8 @@ class Builder
     public function group(): Stage\Group
     {
         $stage = new Stage\Group($this);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -384,9 +373,8 @@ class Builder
     public function indexStats(): Stage\IndexStats
     {
         $stage = new Stage\IndexStats($this);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -397,9 +385,8 @@ class Builder
     public function limit(int $limit): Stage\Limit
     {
         $stage = new Stage\Limit($this, $limit);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -412,9 +399,8 @@ class Builder
     public function lookup(string $from): Stage\Lookup
     {
         $stage = new Stage\Lookup($this, $from, $this->dm, $this->class);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -426,9 +412,8 @@ class Builder
     public function match(): Stage\MatchStage
     {
         $stage = new Stage\MatchStage($this);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -451,9 +436,8 @@ class Builder
     public function merge(): Stage\Merge
     {
         $stage = new Stage\Merge($this, $this->dm);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -465,9 +449,8 @@ class Builder
     public function out(string $from): Stage\Out
     {
         $stage = new Stage\Out($this, $from, $this->dm);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -480,9 +463,8 @@ class Builder
     public function project(): Stage\Project
     {
         $stage = new Stage\Project($this);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -494,9 +476,8 @@ class Builder
     public function redact(): Stage\Redact
     {
         $stage = new Stage\Redact($this);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -513,9 +494,8 @@ class Builder
     public function replaceRoot($expression = null): Stage\ReplaceRoot
     {
         $stage = new Stage\ReplaceRoot($this, $this->dm, $this->class, $expression);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -534,9 +514,8 @@ class Builder
     public function replaceWith($expression = null): Stage\ReplaceWith
     {
         $stage = new Stage\ReplaceWith($this, $this->dm, $this->class, $expression);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -557,9 +536,8 @@ class Builder
     public function sample(int $size): Stage\Sample
     {
         $stage = new Stage\Sample($this, $size);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -573,9 +551,8 @@ class Builder
     public function set(): Stage\Set
     {
         $stage = new Stage\Set($this);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -587,9 +564,8 @@ class Builder
     public function skip(int $skip): Stage\Skip
     {
         $stage = new Stage\Skip($this, $skip);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -610,9 +586,8 @@ class Builder
         $fields = is_array($fieldName) ? $fieldName : [$fieldName => $order];
         // fixme: move to sort stage
         $stage = new Stage\Sort($this, $this->getDocumentPersister()->prepareSort($fields));
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -624,9 +599,8 @@ class Builder
     public function sortByCount(string $expression): Stage\SortByCount
     {
         $stage = new Stage\SortByCount($this, $expression, $this->dm, $this->class);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -639,9 +613,8 @@ class Builder
     public function unionWith(string $collection): Stage\UnionWith
     {
         $stage = new Stage\UnionWith($this, $this->dm, $collection);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -652,9 +625,8 @@ class Builder
     public function unset(string ...$fields): Stage\UnsetStage
     {
         $stage = new Stage\UnsetStage($this, $this->getDocumentPersister(), ...$fields);
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
@@ -668,15 +640,18 @@ class Builder
     {
         // Fixme: move field name translation to stage
         $stage = new Stage\Unwind($this, $this->getDocumentPersister()->prepareFieldName($fieldName));
-        $this->addStage($stage);
 
-        return $stage;
+        return $this->addStage($stage);
     }
 
     /**
      * Allows adding an arbitrary stage to the pipeline
      *
-     * @return Stage The method returns the stage given as an argument
+     * @param T $stage
+     *
+     * @return T The method returns the stage given as an argument
+     *
+     * @template T of Stage
      */
     public function addStage(Stage $stage): Stage
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -214,6 +214,19 @@ class Builder
     }
 
     /**
+     * Populates null and missing field values within documents.
+     *
+     * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/fill/
+     */
+    public function fill(): Stage\Fill
+    {
+        $stage = new Stage\Fill($this);
+        $this->addStage($stage);
+
+        return $stage;
+    }
+
+    /**
      * Outputs documents in order of nearest to farthest from a specified point.
      *
      * A GeoJSON point may be provided as the first and only argument for

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -563,6 +563,22 @@ class Builder
     }
 
     /**
+     * Adds new fields to documents. $set outputs documents that contain all
+     * existing fields from the input documents and newly added fields.
+     *
+     * The $set stage is an alias for $addFields.
+     *
+     * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/set/
+     */
+    public function set(): Stage\Set
+    {
+        $stage = new Stage\Set($this);
+        $this->addStage($stage);
+
+        return $stage;
+    }
+
+    /**
      * Skips over the specified number of documents that pass into the stage and
      * passes the remaining documents to the next stage in the pipeline.
      *

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -630,6 +630,19 @@ class Builder
     }
 
     /**
+     * Removes/excludes fields from documents.
+     *
+     * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/unset/
+     */
+    public function unset(string ...$fields): Stage\UnsetStage
+    {
+        $stage = new Stage\UnsetStage($this, $this->getDocumentPersister(), ...$fields);
+        $this->addStage($stage);
+
+        return $stage;
+    }
+
+    /**
      * Deconstructs an array field from the input documents to output a document
      * for each element. Each output document is the input document with the
      * value of the array field replaced by the element.

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -630,6 +630,21 @@ class Builder
     }
 
     /**
+     * Performs a union of two collections. $unionWith combines pipeline results
+     * from two collections into a single result set. The stage outputs the
+     * combined result set (including duplicates) to the next stage.
+     *
+     * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/unionWith/
+     */
+    public function unionWith(string $collection): Stage\UnionWith
+    {
+        $stage = new Stage\UnionWith($this, $this->dm, $collection);
+        $this->addStage($stage);
+
+        return $stage;
+    }
+
+    /**
      * Removes/excludes fields from documents.
      *
      * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/unset/

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -519,6 +519,27 @@ class Builder
     }
 
     /**
+     * Replaces the input document with the specified document. The operation
+     * replaces all existing fields in the input document, including the _id
+     * field. With $replaceWith, you can promote an embedded document to the
+     * top-level. You can also specify a new document as the replacement.
+     *
+     * The $replaceWith stage is an alias for $replaceRoot.
+     *
+     * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/replaceWith/
+     *
+     * @param string|mixed[]|Expr|null $expression Optional. A replacement expression that
+     * resolves to a document.
+     */
+    public function replaceWith($expression = null): Stage\ReplaceWith
+    {
+        $stage = new Stage\ReplaceWith($this, $this->dm, $this->class, $expression);
+        $this->addStage($stage);
+
+        return $stage;
+    }
+
+    /**
      * Controls if resulting iterator should be wrapped with CachingIterator.
      */
     public function rewindable(bool $rewindable = true): self

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -161,6 +161,19 @@ class Builder
     }
 
     /**
+     * Creates new documents in a sequence of documents where certain values in a field are missing.
+     *
+     * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/densify/
+     */
+    public function densify(string $fieldName): Stage\Densify
+    {
+        $stage = new Stage\Densify($this, $fieldName);
+        $this->addStage($stage);
+
+        return $stage;
+    }
+
+    /**
      * Executes the aggregation pipeline
      *
      * @deprecated This method was deprecated in doctrine/mongodb-odm 2.2. Please use getAggregation() instead.

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
@@ -19,6 +19,7 @@ use function assert;
 use function func_get_args;
 use function is_array;
 use function is_string;
+use function sprintf;
 use function substr;
 
 /**
@@ -469,7 +470,10 @@ class Expr implements GenericOperatorsInterface
      */
     public function expression($value): self
     {
-        $this->requiresCurrentField(__METHOD__);
+        if (! $this->currentField) {
+            throw new LogicException(sprintf('%s requires setting a current field using field().', __METHOD__));
+        }
+
         $this->expr[$this->currentField] = $this->ensureArray($value);
 
         return $this;
@@ -1683,18 +1687,6 @@ class Expr implements GenericOperatorsInterface
         }
 
         return $this;
-    }
-
-    /**
-     * Ensure that a current field has been set.
-     *
-     * @throws LogicException if a current field has not been set.
-     */
-    private function requiresCurrentField(?string $method = null): void
-    {
-        if (! $this->currentField) {
-            throw new LogicException(($method ?: 'This method') . ' requires you set a current field using field().');
-        }
     }
 
     /** @throws BadMethodCallException if there is no current switch operator. */

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
@@ -24,6 +24,8 @@ use function substr;
 
 /**
  * Fluent interface for building aggregation pipelines.
+ *
+ * @psalm-type OperatorExpression = array<string, mixed>|object
  */
 class Expr implements GenericOperatorsInterface
 {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -413,6 +413,18 @@ abstract class Stage
     }
 
     /**
+     * Performs a union of two collections. $unionWith combines pipeline results
+     * from two collections into a single result set. The stage outputs the
+     * combined result set (including duplicates) to the next stage.
+     *
+     * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/unionWith/
+     */
+    public function unionWith(string $collection): Stage\UnionWith
+    {
+        return $this->builder->unionWith($collection);
+    }
+
+    /**
      * Removes/excludes fields from documents.
      *
      * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/unset/

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -159,6 +159,16 @@ abstract class Stage
     }
 
     /**
+     * Populates null and missing field values within documents.
+     *
+     * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/fill/
+     */
+    public function fill(): Stage\Fill
+    {
+        return $this->builder->fill();
+    }
+
+    /**
      * Outputs documents in order of nearest to farthest from a specified point.
      * You can only use this as the first stage of a pipeline.
      *

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -137,6 +137,16 @@ abstract class Stage
     }
 
     /**
+     * Creates new documents in a sequence of documents where certain values in a field are missing.
+     *
+     * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/densify/
+     */
+    public function densify(string $fieldName): Stage\Densify
+    {
+        return $this->builder->densify($fieldName);
+    }
+
+    /**
      * Processes multiple aggregation pipelines within a single stage on the
      * same set of input documents.
      *

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -413,6 +413,16 @@ abstract class Stage
     }
 
     /**
+     * Removes/excludes fields from documents.
+     *
+     * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/unset/
+     */
+    public function unset(string ...$fields): Stage\UnsetStage
+    {
+        return $this->builder->unset(...$fields);
+    }
+
+    /**
      * Deconstructs an array field from the input documents to output a document
      * for each element. Each output document is the input document with the
      * value of the array field replaced by the element.

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -324,6 +324,24 @@ abstract class Stage
     }
 
     /**
+     * Replaces the input document with the specified document. The operation
+     * replaces all existing fields in the input document, including the _id
+     * field. With $replaceWith, you can promote an embedded document to the
+     * top-level. You can also specify a new document as the replacement.
+     *
+     * The $replaceWith stage is an alias for $replaceRoot.
+     *
+     * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/replaceWith/
+     *
+     * @param string|mixed[]|Expr|null $expression Optional. A replacement expression that
+     * resolves to a document.
+     */
+    public function replaceWith($expression = null): Stage\ReplaceWith
+    {
+        return $this->builder->replaceWith($expression);
+    }
+
+    /**
      * Controls if resulting iterator should be wrapped with CachingIterator.
      */
     public function rewindable(bool $rewindable = true): self

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -263,6 +263,17 @@ abstract class Stage
     }
 
     /**
+     * Writes the results of the aggregation pipeline to a specified collection.
+     * The $merge operator must be the last stage in the pipeline.
+     *
+     * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/merge/
+     */
+    public function merge(): Stage\Merge
+    {
+        return $this->builder->merge();
+    }
+
+    /**
      * Takes the documents returned by the aggregation pipeline and writes them
      * to a specified collection. This must be the last stage in the pipeline.
      *

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -13,6 +13,9 @@ use function trigger_deprecation;
  * Fluent interface for building aggregation pipelines.
  *
  * @internal
+ *
+ * @psalm-import-type PipelineExpression from Builder
+ * @psalm-type StageExpression = non-empty-array<non-empty-string, mixed>|object
  */
 abstract class Stage
 {
@@ -186,6 +189,7 @@ abstract class Stage
      * Returns the assembled aggregation pipeline
      *
      * @return array<array<string, mixed>>
+     * @psalm-return PipelineExpression
      */
     public function getPipeline(): array
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -362,6 +362,19 @@ abstract class Stage
     }
 
     /**
+     * Adds new fields to documents. $set outputs documents that contain all
+     * existing fields from the input documents and newly added fields.
+     *
+     * The $set stage is an alias for $addFields.
+     *
+     * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/set/
+     */
+    public function set(): Stage\Set
+    {
+        return $this->builder->set();
+    }
+
+    /**
      * Skips over the specified number of documents that pass into the stage and
      * passes the remaining documents to the next stage in the pipeline.
      *

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AbstractReplace.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AbstractReplace.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
+
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Aggregation\Expr;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
+use Doctrine\ODM\MongoDB\Types\Type;
+
+use function array_map;
+use function is_array;
+use function is_string;
+use function substr;
+
+abstract class AbstractReplace extends Operator
+{
+    /** @var string|mixed[]|Expr|null */
+    protected $expression;
+    protected DocumentManager $dm;
+    protected ClassMetadata $class;
+
+    /** @param string|mixed[]|Expr|null $expression */
+    final public function __construct(Builder $builder, DocumentManager $documentManager, ClassMetadata $class, $expression = null)
+    {
+        Operator::__construct($builder);
+
+        $this->dm         = $documentManager;
+        $this->class      = $class;
+        $this->expression = $expression;
+    }
+
+    private function getDocumentPersister(): DocumentPersister
+    {
+        return $this->dm->getUnitOfWork()->getDocumentPersister($this->class->name);
+    }
+
+    /** @return array|string */
+    protected function getReplaceExpression()
+    {
+        return $this->expression !== null ? $this->convertExpression($this->expression) : $this->expr->getExpression();
+    }
+
+    /**
+     * @param mixed[]|string|mixed $expression
+     *
+     * @return mixed[]|string|mixed
+     */
+    private function convertExpression($expression)
+    {
+        if (is_array($expression)) {
+            return array_map([$this, 'convertExpression'], $expression);
+        }
+
+        if (is_string($expression) && substr($expression, 0, 1) === '$') {
+            return '$' . $this->getDocumentPersister()->prepareFieldName(substr($expression, 1));
+        }
+
+        return Type::convertPHPToDatabaseValue(Expr::convertExpression($expression));
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AddFields.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AddFields.php
@@ -7,12 +7,21 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 /**
  * Fluent interface for adding a $addFields stage to an aggregation pipeline.
  */
-final class AddFields extends Operator
+class AddFields extends Operator
 {
+    private bool $isSet = false;
+
+    protected function isSet(): void
+    {
+        $this->isSet = true;
+    }
+
     public function getExpression(): array
     {
+        $name = $this->isSet ? '$set' : '$addFields';
+
         return [
-            '$addFields' => $this->expr->getExpression(),
+            $name => $this->expr->getExpression(),
         ];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AddFields.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AddFields.php
@@ -7,21 +7,10 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 /**
  * Fluent interface for adding a $addFields stage to an aggregation pipeline.
  */
-class AddFields extends Operator
+final class AddFields extends Operator
 {
-    private bool $isSet = false;
-
-    protected function isSet(): void
-    {
-        $this->isSet = true;
-    }
-
     public function getExpression(): array
     {
-        $name = $this->isSet ? '$set' : '$addFields';
-
-        return [
-            $name => $this->expr->getExpression(),
-        ];
+        return ['$addFields' => $this->expr->getExpression()];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AddFields.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AddFields.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
+use Doctrine\ODM\MongoDB\Aggregation\Expr;
+
 /**
  * Fluent interface for adding a $addFields stage to an aggregation pipeline.
+ *
+ * @psalm-import-type OperatorExpression from Expr
+ * @psalm-type AddFieldsStageExpression = array{'$addFields': array<string, OperatorExpression|mixed>}
  */
 final class AddFields extends Operator
 {
+    /** @return AddFieldsStageExpression */
     public function getExpression(): array
     {
         return ['$addFields' => $this->expr->getExpression()];

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/CollStats.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/CollStats.php
@@ -9,6 +9,13 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 /**
  * Fluent interface for adding a $collStats stage to an aggregation pipeline.
+ *
+ * @psalm-type CollStatsStageExpression = array{
+ *     '$collStats': array{
+ *         latencyStats?: array{histograms?: bool},
+ *         storageStats?: array{},
+ *     }
+ * }
  */
 class CollStats extends Stage
 {
@@ -45,6 +52,7 @@ class CollStats extends Stage
         return $this;
     }
 
+    /** @psalm-return CollStatsStageExpression */
     public function getExpression(): array
     {
         $collStats = [];

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Count.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Count.php
@@ -9,6 +9,8 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 /**
  * Fluent interface for adding a $count stage to an aggregation pipeline.
+ *
+ * @psalm-type CountStageExpression = array{'$count': string}
  */
 class Count extends Stage
 {
@@ -21,6 +23,7 @@ class Count extends Stage
         $this->fieldName = $fieldName;
     }
 
+    /** @psalm-return CountStageExpression */
     public function getExpression(): array
     {
         return [

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
@@ -12,6 +12,20 @@ use function array_values;
 
 /**
  * Fluent interface for adding a $densify stage to an aggregation pipeline.
+ *
+ * @psalm-type BoundsType = 'full'|'partition'|array{0: int|float|UTCDateTime, 1: int|float|UTCDateTime}
+ * @psalm-type UnitType = 'year'|'month'|'week'|'day'|'hour'|'minute'|'second'|'millisecond'
+ * @psalm-type DensifyStageExpression = array{
+ *     '$densify': object{
+ *         field: string,
+ *         partitionByFields?: list<string>,
+ *         range?: object{
+ *             bounds: BoundsType,
+ *             step: int|float,
+ *             unit?: UnitType
+ *         }
+ *     }
+ * }
  */
 class Densify extends Stage
 {
@@ -37,8 +51,10 @@ class Densify extends Stage
     }
 
     /**
-     * @param array{0: int|float|UTCDateTime, 1: int|float|UTCDateTime}|string $bounds
-     * @param int|float                                                        $step
+     * @param array|string $bounds
+     * @param int|float    $step
+     * @psalm-param BoundsType  $bounds
+     * @psalm-param ''|UnitType $unit
      */
     public function range($bounds, $step, string $unit = ''): self
     {
@@ -54,6 +70,7 @@ class Densify extends Stage
         return $this;
     }
 
+    /** @psalm-return DensifyStageExpression */
     public function getExpression(): array
     {
         $params = (object) ['field' => $this->field];

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
+
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Aggregation\Stage;
+
+/**
+ * Fluent interface for adding a $densify stage to an aggregation pipeline.
+ */
+class Densify extends Stage
+{
+    private string $field;
+
+    /** @var array<string> */
+    private array $partitionByFields = [];
+
+    private ?object $range = null;
+
+    public function __construct(Builder $builder, string $fieldName)
+    {
+        parent::__construct($builder);
+
+        $this->field = $fieldName;
+    }
+
+    public function partitionByFields(string ...$fields): self
+    {
+        $this->partitionByFields = $fields;
+
+        return $this;
+    }
+
+    /**
+     * @param array{0: int, 1: int}|string $bounds
+     * @param int|float                    $step
+     */
+    public function range($bounds, $step, string $unit = ''): self
+    {
+        $this->range = (object) [
+            'bounds' => $bounds,
+            'step' => $step,
+        ];
+
+        if ($unit !== '') {
+            $this->range->unit = $unit;
+        }
+
+        return $this;
+    }
+
+    public function getExpression(): array
+    {
+        $params = (object) ['field' => $this->field];
+
+        if ($this->partitionByFields) {
+            $params->partitionByFields = $this->partitionByFields;
+        }
+
+        if ($this->range) {
+            $params->range = $this->range;
+        }
+
+        return ['$densify' => $params];
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
@@ -19,9 +19,9 @@ use function array_values;
  *     '$densify': object{
  *         field: string,
  *         partitionByFields?: list<string>,
- *         range?: object{
- *             bounds: BoundsType,
- *             step: int|float,
+ *         range: object{
+ *             bounds?: BoundsType,
+ *             step?: int|float,
  *             unit?: UnitType
  *         }
  *     }
@@ -34,13 +34,14 @@ class Densify extends Stage
     /** @var array<string> */
     private array $partitionByFields = [];
 
-    private ?object $range = null;
+    private object $range;
 
     public function __construct(Builder $builder, string $fieldName)
     {
         parent::__construct($builder);
 
         $this->field = $fieldName;
+        $this->range = (object) [];
     }
 
     public function partitionByFields(string ...$fields): self
@@ -73,14 +74,13 @@ class Densify extends Stage
     /** @psalm-return DensifyStageExpression */
     public function getExpression(): array
     {
-        $params = (object) ['field' => $this->field];
+        $params = (object) [
+            'field' => $this->field,
+            'range' => $this->range,
+        ];
 
         if ($this->partitionByFields) {
             $params->partitionByFields = $this->partitionByFields;
-        }
-
-        if ($this->range) {
-            $params->range = $this->range;
         }
 
         return ['$densify' => $params];

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
@@ -7,6 +7,8 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
 
+use function array_values;
+
 /**
  * Fluent interface for adding a $densify stage to an aggregation pipeline.
  */
@@ -28,7 +30,7 @@ class Densify extends Stage
 
     public function partitionByFields(string ...$fields): self
     {
-        $this->partitionByFields = $fields;
+        $this->partitionByFields = array_values($fields);
 
         return $this;
     }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
+use MongoDB\BSON\UTCDateTime;
 
 use function array_values;
 
@@ -36,8 +37,8 @@ class Densify extends Stage
     }
 
     /**
-     * @param array{0: int, 1: int}|string $bounds
-     * @param int|float                    $step
+     * @param array{0: int|float|UTCDateTime, 1: int|float|UTCDateTime}|string $bounds
+     * @param int|float                                                        $step
      */
     public function range($bounds, $step, string $unit = ''): self
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Facet.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Facet.php
@@ -47,7 +47,7 @@ class Facet extends Stage
     {
         /** @psalm-suppress RedundantPropertyInitializationCheck because the property might not be set yet */
         if (! isset($this->field)) {
-            throw new LogicException(__METHOD__ . ' requires you set a current field using field().');
+            throw new LogicException(__METHOD__ . ' requires setting a current field using field().');
         }
 
         if ($builder instanceof Stage) {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Facet.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Facet.php
@@ -13,6 +13,9 @@ use function array_map;
 
 /**
  * Fluent interface for adding a $facet stage to an aggregation pipeline.
+ *
+ * @psalm-import-type PipelineExpression from Builder
+ * @psalm-type FacetStageExpression = array{'$facet': array<string, PipelineExpression>}
  */
 class Facet extends Stage
 {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill.php
@@ -26,7 +26,7 @@ use function strtolower;
  *         partitionBy?: string|OperatorExpression,
  *         partitionByFields?: list<string>,
  *         sortBy?: SortShape,
- *         output?: array,
+ *         output: array,
  *     }
  * }
  */
@@ -41,11 +41,13 @@ class Fill extends Stage
     /** @var array<string, int> */
     private array $sortBy = [];
 
-    private ?Output $output = null;
+    private Output $output;
 
     public function __construct(Builder $builder)
     {
         parent::__construct($builder);
+
+        $this->output = new Output($this->builder, $this);
     }
 
     /** @param mixed|Expr $expression */
@@ -86,16 +88,14 @@ class Fill extends Stage
 
     public function output(): Output
     {
-        if (! $this->output) {
-            $this->output = new Output($this->builder, $this);
-        }
-
         return $this->output;
     }
 
     public function getExpression(): array
     {
-        $params = (object) [];
+        $params = (object) [
+            'output' => (object) $this->output->getExpression(),
+        ];
 
         if ($this->partitionBy) {
             $params->partitionBy = $this->partitionBy instanceof Expr
@@ -109,10 +109,6 @@ class Fill extends Stage
 
         if ($this->sortBy) {
             $params->sortBy = (object) $this->sortBy;
-        }
-
-        if ($this->output) {
-            $params->output = (object) $this->output->getExpression();
         }
 
         return ['$fill' => $params];

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill.php
@@ -17,7 +17,18 @@ use function strtolower;
 /**
  * Fluent interface for adding a $fill stage to an aggregation pipeline.
  *
- * @psalm-type SortShape = array<string, int|string>
+ * @psalm-import-type SortDirectionKeywords from Sort
+ * @psalm-import-type OperatorExpression from Expr
+ * @psalm-type SortDirection = int|SortDirectionKeywords
+ * @psalm-type SortShape = array<string, SortDirection>
+ * @psalm-type FillStageExpression = array{
+ *     '$fill': array{
+ *         partitionBy?: string|OperatorExpression,
+ *         partitionByFields?: list<string>,
+ *         sortBy?: SortShape,
+ *         output?: array,
+ *     }
+ * }
  */
 class Fill extends Stage
 {
@@ -56,6 +67,7 @@ class Fill extends Stage
      * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
      * @param int|string                       $order     Field order (if one field is specified)
      * @psalm-param SortShape|string           $fieldName
+     * @psalm-param SortDirection|null         $order
      */
     public function sortBy($fieldName, $order = null): self
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill.php
@@ -86,7 +86,9 @@ class Fill extends Stage
         $params = (object) [];
 
         if ($this->partitionBy) {
-            $params->partitionBy = $this->partitionBy;
+            $params->partitionBy = $this->partitionBy instanceof Expr
+                ? $this->partitionBy->getExpression()
+                : $this->partitionBy;
         }
 
         if ($this->partitionByFields) {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill.php
@@ -9,6 +9,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Expr;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Fill\Output;
 
+use function array_values;
 use function is_array;
 use function is_string;
 use function strtolower;
@@ -46,7 +47,7 @@ class Fill extends Stage
 
     public function partitionByFields(string ...$fields): self
     {
-        $this->partitionByFields = $fields;
+        $this->partitionByFields = array_values($fields);
 
         return $this;
     }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
+
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Aggregation\Expr;
+use Doctrine\ODM\MongoDB\Aggregation\Stage;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Fill\Output;
+
+use function is_array;
+use function is_string;
+use function strtolower;
+
+/**
+ * Fluent interface for adding a $fill stage to an aggregation pipeline.
+ *
+ * @psalm-type SortShape = array<string, int|string>
+ */
+class Fill extends Stage
+{
+    /** @var mixed|Expr|null */
+    private $partitionBy = null;
+
+    /** @var array<string> */
+    private array $partitionByFields = [];
+
+    /** @var array<string, int> */
+    private array $sortBy = [];
+
+    private ?Output $output = null;
+
+    public function __construct(Builder $builder)
+    {
+        parent::__construct($builder);
+    }
+
+    /** @param mixed|Expr $expression */
+    public function partitionBy($expression): self
+    {
+        $this->partitionBy = $expression;
+
+        return $this;
+    }
+
+    public function partitionByFields(string ...$fields): self
+    {
+        $this->partitionByFields = $fields;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
+     * @param int|string                       $order     Field order (if one field is specified)
+     * @psalm-param SortShape|string           $fieldName
+     */
+    public function sortBy($fieldName, $order = null): self
+    {
+        $fields = is_array($fieldName) ? $fieldName : [$fieldName => $order ?? 1];
+
+        foreach ($fields as $fieldName => $order) {
+            if (is_string($order)) {
+                $order = strtolower($order) === 'asc' ? 1 : -1;
+            }
+
+            $this->sortBy[$fieldName] = $order;
+        }
+
+        return $this;
+    }
+
+    public function output(): Output
+    {
+        if (! $this->output) {
+            $this->output = new Output($this->builder, $this);
+        }
+
+        return $this->output;
+    }
+
+    public function getExpression(): array
+    {
+        $params = (object) [];
+
+        if ($this->partitionBy) {
+            $params->partitionBy = $this->partitionBy;
+        }
+
+        if ($this->partitionByFields) {
+            $params->partitionByFields = $this->partitionByFields;
+        }
+
+        if ($this->sortBy) {
+            $params->sortBy = (object) $this->sortBy;
+        }
+
+        if ($this->output) {
+            $params->output = (object) $this->output->getExpression();
+        }
+
+        return ['$fill' => $params];
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill/Output.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill/Output.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Fill;
+
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Aggregation\Expr;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Fill;
+use LogicException;
+
+use function func_get_args;
+
+/**
+ * Fluent builder for output param of $fill stage
+ *
+ * @psalm-import-type SortShape from Fill
+ */
+class Output extends Fill
+{
+    private Fill $fill;
+
+    private string $currentField = '';
+
+    /** @var array<string, array<string, mixed>> */
+    private $output = [];
+
+    public function __construct(Builder $builder, Fill $fill)
+    {
+        parent::__construct($builder);
+
+        $this->fill = $fill;
+    }
+
+    /** @param mixed|Expr $expression */
+    public function partitionBy($expression): Fill
+    {
+        return $this->fill->partitionBy($expression);
+    }
+
+    public function partitionByFields(string ...$fields): Fill
+    {
+        return $this->fill->partitionByFields(...$fields);
+    }
+
+    /**
+     * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
+     * @param int|string                       $order     Field order (if one field is specified)
+     * @psalm-param SortShape|string           $fieldName
+     */
+    public function sortBy($fieldName, $order = null): Fill
+    {
+        return $this->fill->sortBy(...func_get_args());
+    }
+
+    /**
+     * Set the current field for building the expression.
+     */
+    public function field(string $fieldName): self
+    {
+        $this->currentField = $fieldName;
+
+        return $this;
+    }
+
+    public function linear(): self
+    {
+        $this->requiresCurrentField(__METHOD__);
+        $this->output[$this->currentField] = ['method' => 'linear'];
+
+        return $this;
+    }
+
+    public function locf(): self
+    {
+        $this->requiresCurrentField(__METHOD__);
+        $this->output[$this->currentField] = ['method' => 'locf'];
+
+        return $this;
+    }
+
+    /** @param mixed|Expr $expression */
+    public function value($expression): self
+    {
+        $this->requiresCurrentField(__METHOD__);
+        $this->output[$this->currentField] = [
+            'value' => $expression instanceof Expr ? $expression->getExpression() : $expression,
+        ];
+
+        return $this;
+    }
+
+    public function getExpression(): array
+    {
+        return $this->output;
+    }
+
+    /**
+     * Ensure that a current field has been set.
+     *
+     * @throws LogicException if a current field has not been set.
+     */
+    private function requiresCurrentField(?string $method = null): void
+    {
+        if (! $this->currentField) {
+            throw new LogicException(($method ?: 'This method') . ' requires you set a current field using field().');
+        }
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill/Output.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill/Output.php
@@ -10,6 +10,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\Fill;
 use LogicException;
 
 use function func_get_args;
+use function sprintf;
 
 /**
  * Fluent builder for output param of $fill stage
@@ -100,10 +101,10 @@ class Output extends Fill
      *
      * @throws LogicException if a current field has not been set.
      */
-    private function requiresCurrentField(?string $method = null): void
+    private function requiresCurrentField(string $method): void
     {
         if (! $this->currentField) {
-            throw new LogicException(($method ?: 'This method') . ' requires you set a current field using field().');
+            throw new LogicException(sprintf('%s requires setting a current field using field().', $method));
         }
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill/Output.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill/Output.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Fill;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Expr;
+use Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Fill;
 use LogicException;
 
@@ -17,7 +18,7 @@ use function sprintf;
  *
  * @psalm-import-type SortShape from Fill
  */
-class Output extends Fill
+class Output extends Stage
 {
     private Fill $fill;
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Group.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Group.php
@@ -9,6 +9,8 @@ use Doctrine\ODM\MongoDB\Aggregation\Expr;
 
 /**
  * Fluent interface for adding a $group stage to an aggregation pipeline.
+ *
+ * @psalm-type GroupStageExpression = array{'$group': array<string, mixed>}
  */
 class Group extends Operator
 {
@@ -22,6 +24,7 @@ class Group extends Operator
         $this->expr = $builder->expr();
     }
 
+    /** @psalm-return GroupStageExpression */
     public function getExpression(): array
     {
         return [

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/IndexStats.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/IndexStats.php
@@ -9,9 +9,12 @@ use stdClass;
 
 /**
  * Fluent interface for adding a $indexStats stage to an aggregation pipeline.
+ *
+ * @psalm-type IndexStatsStageExpression = array{'$indexStats': object}
  */
 class IndexStats extends Stage
 {
+    /** @psalm-return IndexStatsStageExpression */
     public function getExpression(): array
     {
         return [

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Limit.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Limit.php
@@ -9,6 +9,8 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 /**
  * Fluent interface for adding a $limit stage to an aggregation pipeline.
+ *
+ * @psalm-type LimitStageExpression = array{'$limit': int}
  */
 class Limit extends Stage
 {
@@ -21,6 +23,7 @@ class Limit extends Stage
         $this->limit = $limit;
     }
 
+    /** @psalm-return LimitStageExpression */
     public function getExpression(): array
     {
         return [

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
@@ -35,7 +35,7 @@ class Merge extends Stage
     private array $let = [];
 
     /**
-     * @var string|array|Builder
+     * @var string|array|Builder|Stage
      * @psalm-var WhenMatchedParam
      */
     private $whenMatched;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Aggregation\Expr;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\Persistence\Mapping\MappingException;
@@ -31,7 +32,7 @@ class Merge extends Stage
     /** @var list<string> */
     private array $on = [];
 
-    /** @var array<string, string> */
+    /** @var array<string, mixed|Expr> */
     private array $let = [];
 
     /**
@@ -104,7 +105,7 @@ class Merge extends Stage
      * Use the variable expressions to access the fields from
      * the joined collection's documents that are input to the pipeline.
      *
-     * @param array<string, string> $let
+     * @param array<string, mixed|Expr> $let
      */
     public function let(array $let): self
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
+
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Aggregation\Stage;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\Persistence\Mapping\MappingException;
+use InvalidArgumentException;
+
+use function array_values;
+use function count;
+use function is_array;
+
+/**
+ * @psalm-type OutputCollection = string|array{db: string, coll: string}
+ * @psalm-type WhenMatchedParam = Builder|Stage|string|list<array<string, mixed>>
+ */
+class Merge extends Stage
+{
+    private DocumentManager $dm;
+
+    /**
+     * @var string|array
+     * @psalm-var OutputCollection
+     */
+    private $into;
+
+    /** @var list<string> */
+    private array $on = [];
+
+    /** @var array<string, string> */
+    private array $let = [];
+
+    /**
+     * @var string|array|Builder
+     * @psalm-var WhenMatchedParam
+     */
+    private $whenMatched;
+
+    private ?string $whenNotMatched = null;
+
+    public function __construct(Builder $builder, DocumentManager $documentManager)
+    {
+        parent::__construct($builder);
+
+        $this->dm = $documentManager;
+    }
+
+    public function getExpression(): array
+    {
+        $params = (object) [
+            'into' => $this->into,
+        ];
+
+        if ($this->on) {
+            $params->on = count($this->on) === 1 ? $this->on[0] : $this->on;
+        }
+
+        if ($this->let) {
+            $params->let = $this->let;
+        }
+
+        if ($this->whenMatched) {
+            $params->whenMatched = $this->whenMatched instanceof Builder
+                ? $this->whenMatched->getPipeline(false)
+                : $this->whenMatched;
+        }
+
+        if ($this->whenNotMatched) {
+            $params->whenNotMatched = $this->whenNotMatched;
+        }
+
+        return ['$merge' => $params];
+    }
+
+    /**
+     * @param string|array $collection
+     * @psalm-param OutputCollection $collection
+     */
+    public function into($collection): self
+    {
+        if (is_array($collection)) {
+            $this->into = $collection;
+
+            return $this;
+        }
+
+        try {
+            $class      = $this->dm->getClassMetadata($collection);
+            $this->into = $class->getCollection();
+        } catch (MappingException $e) {
+            $this->into = $collection;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Optional. Specifies variables to use in the pipeline stages.
+     *
+     * Use the variable expressions to access the fields from
+     * the joined collection's documents that are input to the pipeline.
+     *
+     * @param array<string, string> $let
+     */
+    public function let(array $let): self
+    {
+        $this->let = $let;
+
+        return $this;
+    }
+
+    public function on(string ...$fields): self
+    {
+        $this->on = array_values($fields);
+
+        return $this;
+    }
+
+    /**
+     * @param string|array|Builder|Stage $whenMatched
+     * @psalm-param WhenMatchedParam $whenMatched
+     */
+    public function whenMatched($whenMatched): self
+    {
+        if ($whenMatched instanceof Stage) {
+            $this->whenMatched = $whenMatched->builder;
+        } else {
+            $this->whenMatched = $whenMatched;
+        }
+
+        if ($this->builder === $this->whenMatched) {
+            throw new InvalidArgumentException('Cannot use the same Builder instance for $merge whenMatched pipeline.');
+        }
+
+        return $this;
+    }
+
+    public function whenNotMatched(string $whenNotMatched): self
+    {
+        $this->whenNotMatched = $whenNotMatched;
+
+        return $this;
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
@@ -16,8 +16,20 @@ use function count;
 use function is_array;
 
 /**
+ * @psalm-import-type PipelineExpression from Builder
  * @psalm-type OutputCollection = string|array{db: string, coll: string}
- * @psalm-type WhenMatchedParam = Builder|Stage|string|list<array<string, mixed>>
+ * @psalm-type WhenMatchedType = 'replace'|'keepExisting'|'merge'|'fail'|PipelineExpression
+ * @psalm-type WhenMatchedParamType = Builder|Stage|WhenMatchedType
+ * @psalm-type WhenNotMatchedType = 'insert'|'discard'|'fail'
+ * @psalm-type MergeStageExpression = array{
+ *     '$merge': object{
+ *         into: OutputCollection,
+ *         on?: string|list<string>,
+ *         let?: array<string, mixed|Expr>,
+ *         whenMatched?: WhenMatchedType,
+ *         whenNotMatched?: WhenNotMatchedType,
+ *     }
+ * }
  */
 class Merge extends Stage
 {
@@ -37,7 +49,7 @@ class Merge extends Stage
 
     /**
      * @var string|array|Builder|Stage
-     * @psalm-var WhenMatchedParam
+     * @psalm-var WhenMatchedParamType
      */
     private $whenMatched;
 
@@ -50,6 +62,7 @@ class Merge extends Stage
         $this->dm = $documentManager;
     }
 
+    /** @psalm-return MergeStageExpression */
     public function getExpression(): array
     {
         $params = (object) [
@@ -123,7 +136,7 @@ class Merge extends Stage
 
     /**
      * @param string|array|Builder|Stage $whenMatched
-     * @psalm-param WhenMatchedParam $whenMatched
+     * @psalm-param WhenMatchedParamType $whenMatched
      */
     public function whenMatched($whenMatched): self
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Out.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Out.php
@@ -11,11 +11,21 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\MappingException as BaseMappingException;
 
+use function is_array;
+
+/**
+ * @psalm-import-type OutputCollection from Merge
+ * @psalm-type OutStageExpression = array{'$out': OutputCollection}
+ */
 class Out extends Stage
 {
     private DocumentManager $dm;
 
-    private string $collection;
+    /**
+     * @var array|string
+     * @psalm-var OutputCollection
+     */
+    private $out;
 
     public function __construct(Builder $builder, string $collection, DocumentManager $documentManager)
     {
@@ -28,16 +38,26 @@ class Out extends Stage
     public function getExpression(): array
     {
         return [
-            '$out' => $this->collection,
+            '$out' => $this->out,
         ];
     }
 
-    public function out(string $collection): Stage\Out
+    /**
+     * @param string|array $collection
+     * @psalm-param OutputCollection $collection
+     */
+    public function out($collection): Stage\Out
     {
+        if (is_array($collection)) {
+            $this->out = $collection;
+
+            return $this;
+        }
+
         try {
             $class = $this->dm->getClassMetadata($collection);
         } catch (BaseMappingException $e) {
-            $this->collection = $collection;
+            $this->out = $collection;
 
             return $this;
         }
@@ -53,6 +73,6 @@ class Out extends Stage
             throw MappingException::cannotUseShardedCollectionInOutStage($classMetadata->name);
         }
 
-        $this->collection = $classMetadata->getCollection();
+        $this->out = $classMetadata->getCollection();
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Project.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Project.php
@@ -10,9 +10,13 @@ use function func_get_args;
 
 /**
  * Fluent interface for adding a $project stage to an aggregation pipeline.
+ *
+ * @psalm-import-type OperatorExpression from Expr
+ * @psalm-type ProjectStageExpression = array{'$project': array<string, OperatorExpression|mixed>}
  */
 class Project extends Operator
 {
+    /** @psalm-return ProjectStageExpression */
     public function getExpression(): array
     {
         return [

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Redact.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Redact.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
+use Doctrine\ODM\MongoDB\Aggregation\Expr;
+
 /**
  * Fluent interface for adding a $redact stage to an aggregation pipeline.
+ *
+ * @psalm-import-type OperatorExpression from Expr
+ * @psalm-type SetStageExpression = array{'$redact': array<string, OperatorExpression|mixed>}
  */
 class Redact extends Operator
 {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceRoot.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceRoot.php
@@ -4,68 +4,25 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
-use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Expr;
-use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
-use Doctrine\ODM\MongoDB\Types\Type;
 
-use function array_map;
-use function is_array;
-use function is_string;
-use function substr;
-
-class ReplaceRoot extends Operator
+/**
+ * @psalm-import-type OperatorExpression from Expr
+ * @psalm-type ReplaceRootStageExpression = array{
+ *     '$replaceRoot': array{
+ *         newRoot: OperatorExpression|string,
+ *     }
+ * }
+ */
+class ReplaceRoot extends AbstractReplace
 {
-    private DocumentManager $dm;
-
-    private ClassMetadata $class;
-
-    /** @var string|mixed[]|Expr|null */
-    private $expression;
-
-    /** @param string|mixed[]|Expr|null $expression */
-    public function __construct(Builder $builder, DocumentManager $documentManager, ClassMetadata $class, $expression = null)
-    {
-        parent::__construct($builder);
-
-        $this->dm         = $documentManager;
-        $this->class      = $class;
-        $this->expression = $expression;
-    }
-
+    /** @return ReplaceRootStageExpression */
     public function getExpression(): array
     {
-        $expression = $this->expression !== null ? $this->convertExpression($this->expression) : $this->expr->getExpression();
-
         return [
             '$replaceRoot' => [
-                'newRoot' => is_array($expression) ? (object) $expression : $expression,
+                'newRoot' => $this->getReplaceExpression(),
             ],
         ];
-    }
-
-    /**
-     * @param mixed[]|string|mixed $expression
-     *
-     * @return mixed[]|string|mixed
-     */
-    private function convertExpression($expression)
-    {
-        if (is_array($expression)) {
-            return array_map([$this, 'convertExpression'], $expression);
-        }
-
-        if (is_string($expression) && substr($expression, 0, 1) === '$') {
-            return '$' . $this->getDocumentPersister()->prepareFieldName(substr($expression, 1));
-        }
-
-        return Type::convertPHPToDatabaseValue(Expr::convertExpression($expression));
-    }
-
-    private function getDocumentPersister(): DocumentPersister
-    {
-        return $this->dm->getUnitOfWork()->getDocumentPersister($this->class->name);
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceWith.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceWith.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
+
+class ReplaceWith extends ReplaceRoot
+{
+    public function getExpression(): array
+    {
+        $expression = parent::getExpression();
+
+        return [
+            '$replaceWith' => $expression['$replaceRoot']['newRoot'],
+        ];
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceWith.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceWith.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
-class ReplaceWith extends ReplaceRoot
+use Doctrine\ODM\MongoDB\Aggregation\Expr;
+
+/**
+ * @psalm-import-type OperatorExpression from Expr
+ * @psalm-type ReplaceWithStageExpression = array{'$replaceWith': OperatorExpression|string}
+ */
+class ReplaceWith extends AbstractReplace
 {
+    /** @return ReplaceWithStageExpression */
     public function getExpression(): array
     {
-        $expression = parent::getExpression();
-
-        return [
-            '$replaceWith' => $expression['$replaceRoot']['newRoot'],
-        ];
+        return ['$replaceWith' => $this->getReplaceExpression()];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Sample.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Sample.php
@@ -9,6 +9,8 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 /**
  * Fluent interface for adding a $sample stage to an aggregation pipeline.
+ *
+ * @psalm-type SampleStageExpression = array{'$sample': array{size: int}}
  */
 class Sample extends Stage
 {
@@ -21,6 +23,7 @@ class Sample extends Stage
         $this->size = $size;
     }
 
+    /** @psalm-return SampleStageExpression */
     public function getExpression(): array
     {
         return [

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Set.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Set.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
+use Doctrine\ODM\MongoDB\Aggregation\Expr;
+
 /**
  * Fluent interface for adding a $set stage to an aggregation pipeline.
+ *
+ * @psalm-import-type OperatorExpression from Expr
+ * @psalm-type SetStageExpression = array{'$set': array<string, OperatorExpression|mixed>}
  */
 final class Set extends Operator
 {
+    /** @psalm-return SetStageExpression */
     public function getExpression(): array
     {
         return ['$set' => $this->expr->getExpression()];

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Set.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Set.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
-use Doctrine\ODM\MongoDB\Aggregation\Builder;
-
-class Set extends AddFields
+/**
+ * Fluent interface for adding a $set stage to an aggregation pipeline.
+ */
+final class Set extends Operator
 {
-    public function __construct(Builder $builder)
+    public function getExpression(): array
     {
-        parent::__construct($builder);
-
-        $this->isSet();
+        return ['$set' => $this->expr->getExpression()];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Set.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Set.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
+
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+
+class Set extends AddFields
+{
+    public function __construct(Builder $builder)
+    {
+        parent::__construct($builder);
+
+        $this->isSet();
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Skip.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Skip.php
@@ -9,6 +9,8 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 /**
  * Fluent interface for adding a $skip stage to an aggregation pipeline.
+ *
+ * @psalm-type SkipStageExpression = array{'$skip': int}
  */
 class Skip extends Stage
 {
@@ -21,6 +23,7 @@ class Skip extends Stage
         $this->skip = $skip;
     }
 
+    /** @return SkipStageExpression */
     public function getExpression(): array
     {
         return [

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Sort.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Sort.php
@@ -16,8 +16,12 @@ use function strtolower;
  * Fluent interface for adding a $sort stage to an aggregation pipeline.
  *
  * @psalm-type SortMetaKeywords = 'textScore'|'indexKey'
- * @psalm-type SortMeta = array{"$meta": SortMetaKeywords}
- * @psalm-type SortShape = array<string, int|SortMeta|string>
+ * @psalm-type SortDirectionKeywords = 'asc'|'desc'
+ * @psalm-type SortMeta = array{'$meta': SortMetaKeywords}
+ * @psalm-type SortShape = array<string, int|SortMeta|SortDirectionKeywords>
+ * @psalm-type SortStageExpression = array{
+ *     '$sort': array<string, int|SortMeta>
+ * }
  */
 class Sort extends Stage
 {
@@ -27,7 +31,8 @@ class Sort extends Stage
     /**
      * @param array<string, int|string|array<string, string>>|string $fieldName Field name or array of field/order pairs
      * @param int|string                                             $order     Field order (if one field is specified)
-     * @psalm-param SortShape|string                       $fieldName
+     * @psalm-param SortShape|string                        $fieldName
+     * @psalm-param int|SortMeta|SortDirectionKeywords|null $order
      */
     public function __construct(Builder $builder, $fieldName, $order = null)
     {
@@ -50,6 +55,7 @@ class Sort extends Stage
         }
     }
 
+    /** @psalm-return SortStageExpression */
     public function getExpression(): array
     {
         return [

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SortByCount.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SortByCount.php
@@ -11,6 +11,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 
 use function substr;
 
+/** @psalm-type SortByCountStageExpression = array{'$sortByCount': string} */
 class SortByCount extends Stage
 {
     private string $fieldName;
@@ -28,6 +29,7 @@ class SortByCount extends Stage
         $this->fieldName   = '$' . $documentPersister->prepareFieldName(substr($fieldName, 1));
     }
 
+    /** @psalm-return SortByCountStageExpression */
     public function getExpression(): array
     {
         return [

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
@@ -23,7 +23,7 @@ class UnionWith extends Stage
 
     /**
      * @var array|Builder|null
-     * @psalm-var Pipeline|null
+     * @psalm-var ?Pipeline
      */
     private $pipeline = null;
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
@@ -13,7 +13,14 @@ use InvalidArgumentException;
 /**
  * Fluent interface for adding a $unionWith stage to an aggregation pipeline.
  *
- * @psalm-type Pipeline = Builder|Stage|list<array<string, mixed>>
+ * @psalm-import-type PipelineExpression from Builder
+ * @psalm-type PipelineParamType = array|Builder|Stage|PipelineExpression
+ * @psalm-type UnionWithStageExpression = array{
+ *     '$unionWith': object{
+ *         coll: string,
+ *         pipeline?: PipelineExpression,
+ *     }
+ * }
  */
 class UnionWith extends Stage
 {
@@ -23,7 +30,7 @@ class UnionWith extends Stage
 
     /**
      * @var array|Builder|null
-     * @psalm-var ?Pipeline
+     * @psalm-var ?PipelineParamType
      */
     private $pipeline = null;
 
@@ -43,7 +50,7 @@ class UnionWith extends Stage
 
     /**
      * @param array|Builder|Stage $pipeline
-     * @psalm-param Pipeline $pipeline
+     * @psalm-param PipelineParamType $pipeline
      */
     public function pipeline($pipeline): self
     {
@@ -60,6 +67,7 @@ class UnionWith extends Stage
         return $this;
     }
 
+    /** @psalm-return UnionWithStageExpression */
     public function getExpression(): array
     {
         $params = (object) ['coll' => $this->collection];

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
+
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Aggregation\Stage;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\Persistence\Mapping\MappingException;
+use InvalidArgumentException;
+
+/**
+ * Fluent interface for adding a $unionWith stage to an aggregation pipeline.
+ *
+ * @psalm-type Pipeline = Builder|Stage|list<array<string, mixed>>
+ */
+class UnionWith extends Stage
+{
+    private DocumentManager $dm;
+
+    private string $collection;
+
+    /**
+     * @var array|Builder|null
+     * @psalm-var Pipeline|null
+     */
+    private $pipeline = null;
+
+    public function __construct(Builder $builder, DocumentManager $documentManager, string $collection)
+    {
+        parent::__construct($builder);
+
+        $this->dm = $documentManager;
+
+        try {
+            $class            = $this->dm->getClassMetadata($collection);
+            $this->collection = $class->getCollection();
+        } catch (MappingException $e) {
+            $this->collection = $collection;
+        }
+    }
+
+    /**
+     * @param array|Builder|Stage $pipeline
+     * @psalm-param Pipeline $pipeline
+     */
+    public function pipeline($pipeline): self
+    {
+        if ($pipeline instanceof Stage) {
+            $this->pipeline = $pipeline->builder;
+        } else {
+            $this->pipeline = $pipeline;
+        }
+
+        if ($this->builder === $this->pipeline) {
+            throw new InvalidArgumentException('Cannot use the same Builder instance for $unionWith pipeline.');
+        }
+
+        return $this;
+    }
+
+    public function getExpression(): array
+    {
+        $params = (object) ['coll' => $this->collection];
+
+        if ($this->pipeline) {
+            $params->pipeline = $this->pipeline instanceof Builder
+                ? $this->pipeline->getPipeline(false)
+                : $this->pipeline;
+        }
+
+        return ['$unionWith' => $params];
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnsetStage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnsetStage.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
+
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Aggregation\Stage;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
+
+use function array_map;
+use function array_values;
+
+/**
+ * Fluent interface for adding an $unset stage to an aggregation pipeline.
+ */
+class UnsetStage extends Stage
+{
+    private DocumentPersister $documentPersister;
+
+    /** @var list<string> */
+    private array $fields;
+
+    public function __construct(Builder $builder, DocumentPersister $documentPersister, string ...$fields)
+    {
+        parent::__construct($builder);
+
+        $this->documentPersister = $documentPersister;
+        $this->fields            = array_values($fields);
+    }
+
+    public function getExpression(): array
+    {
+        return [
+            '$unset' => array_map([$this->documentPersister, 'prepareFieldName'], $this->fields),
+        ];
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnsetStage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnsetStage.php
@@ -13,6 +13,8 @@ use function array_values;
 
 /**
  * Fluent interface for adding an $unset stage to an aggregation pipeline.
+ *
+ * @psalm-type UnsetStageExpression = array{'$unset': list<string>}
  */
 class UnsetStage extends Stage
 {
@@ -29,6 +31,7 @@ class UnsetStage extends Stage
         $this->fields            = array_values($fields);
     }
 
+    /** @return UnsetStageExpression */
     public function getExpression(): array
     {
         return [

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Unwind.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Unwind.php
@@ -9,6 +9,14 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 /**
  * Fluent interface for adding a $unwind stage to an aggregation pipeline.
+ *
+ * @psalm-type UnwindStageExpression = array{
+ *     '$unwind': string|array{
+ *         path: string,
+ *         includeArrayIndex?: string,
+ *         preserveNullAndEmptyArrays?: bool,
+ *     }
+ * }
  */
 class Unwind extends Stage
 {
@@ -25,6 +33,7 @@ class Unwind extends Stage
         $this->fieldName = $fieldName;
     }
 
+    /** @psalm-return UnwindStageExpression */
     public function getExpression(): array
     {
         // Fallback behavior for MongoDB < 3.2
@@ -36,12 +45,12 @@ class Unwind extends Stage
 
         $unwind = ['path' => $this->fieldName];
 
-        foreach (['includeArrayIndex', 'preserveNullAndEmptyArrays'] as $option) {
-            if (! $this->$option) {
-                continue;
-            }
+        if ($this->includeArrayIndex) {
+            $unwind['includeArrayIndex'] = $this->includeArrayIndex;
+        }
 
-            $unwind[$option] = $this->$option;
+        if ($this->preserveNullAndEmptyArrays) {
+            $unwind['preserveNullAndEmptyArrays'] = $this->preserveNullAndEmptyArrays;
         }
 
         return ['$unwind' => $unwind];

--- a/lib/Doctrine/ODM/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Expr.php
@@ -162,7 +162,7 @@ class Expr
      */
     public function addToSet($valueOrExpression): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $this->newObj['$addToSet'][$this->currentField] = static::convertExpression($valueOrExpression, $this->class);
 
         return $this;
@@ -188,7 +188,7 @@ class Expr
      */
     protected function bit(string $operator, int $value): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $this->newObj['$bit'][$this->currentField][$operator] = $value;
 
         return $this;
@@ -227,7 +227,7 @@ class Expr
      */
     public function bitsAllClear($value): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
 
         return $this->operator('$bitsAllClear', $value);
     }
@@ -243,7 +243,7 @@ class Expr
      */
     public function bitsAllSet($value): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
 
         return $this->operator('$bitsAllSet', $value);
     }
@@ -259,7 +259,7 @@ class Expr
      */
     public function bitsAnyClear($value): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
 
         return $this->operator('$bitsAnyClear', $value);
     }
@@ -275,7 +275,7 @@ class Expr
      */
     public function bitsAnySet($value): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
 
         return $this->operator('$bitsAnySet', $value);
     }
@@ -345,7 +345,7 @@ class Expr
             throw new InvalidArgumentException('Type for currentDate operator must be date or timestamp.');
         }
 
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $this->newObj['$currentDate'][$this->currentField]['$type'] = $type;
 
         return $this;
@@ -646,7 +646,7 @@ class Expr
      */
     public function inc($value): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $this->newObj['$inc'][$this->currentField] = $value;
 
         return $this;
@@ -657,7 +657,7 @@ class Expr
      */
     public function includesReferenceTo(object $document): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $mapping   = $this->getReferenceMapping();
         $reference = $this->dm->createReference($document, $mapping);
         $storeAs   = $mapping['storeAs'] ?? null;
@@ -755,7 +755,7 @@ class Expr
      */
     public function max($value): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $this->newObj['$max'][$this->currentField] = $value;
 
         return $this;
@@ -771,7 +771,7 @@ class Expr
      */
     public function min($value): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $this->newObj['$min'][$this->currentField] = $value;
 
         return $this;
@@ -803,7 +803,7 @@ class Expr
      */
     public function mul($value): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $this->newObj['$mul'][$this->currentField] = $value;
 
         return $this;
@@ -929,7 +929,7 @@ class Expr
      */
     public function popFirst(): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $this->newObj['$pop'][$this->currentField] = -1;
 
         return $this;
@@ -943,7 +943,7 @@ class Expr
      */
     public function popLast(): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $this->newObj['$pop'][$this->currentField] = 1;
 
         return $this;
@@ -973,7 +973,7 @@ class Expr
      */
     public function pull($valueOrExpression): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $this->newObj['$pull'][$this->currentField] = static::convertExpression($valueOrExpression, $this->class);
 
         return $this;
@@ -990,7 +990,7 @@ class Expr
      */
     public function pullAll(array $values): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $this->newObj['$pullAll'][$this->currentField] = $values;
 
         return $this;
@@ -1024,7 +1024,7 @@ class Expr
             );
         }
 
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $this->newObj['$push'][$this->currentField] = $valueOrExpression;
 
         return $this;
@@ -1051,7 +1051,7 @@ class Expr
      */
     public function references(object $document): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $mapping   = $this->getReferenceMapping();
         $reference = $this->dm->createReference($document, $mapping);
         $storeAs   = $mapping['storeAs'] ?? null;
@@ -1100,7 +1100,7 @@ class Expr
      */
     public function rename(string $name): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $this->newObj['$rename'][$this->currentField] = $name;
 
         return $this;
@@ -1120,7 +1120,7 @@ class Expr
      */
     public function set($value, bool $atomic = true): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         assert($this->currentField !== null);
 
         if ($atomic) {
@@ -1184,7 +1184,7 @@ class Expr
      */
     public function setOnInsert($value): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $this->newObj['$setOnInsert'][$this->currentField] = $value;
 
         return $this;
@@ -1289,7 +1289,7 @@ class Expr
      */
     public function unsetField(): self
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         $this->newObj['$unset'][$this->currentField] = 1;
 
         return $this;
@@ -1319,7 +1319,7 @@ class Expr
      */
     private function getReferenceMapping(): array
     {
-        $this->requiresCurrentField();
+        $this->requiresCurrentField(__METHOD__);
         assert($this->currentField !== null);
 
         try {
@@ -1368,10 +1368,10 @@ class Expr
      *
      * @throws LogicException If a current field has not been set.
      */
-    private function requiresCurrentField(): void
+    private function requiresCurrentField(string $method): void
     {
         if (! $this->currentField) {
-            throw new LogicException('This method requires you set a current field using field().');
+            throw new LogicException(sprintf('%s requires setting a current field using field().', $method));
         }
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -157,6 +157,7 @@ parameters:
                 - lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
                 - lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
                 - lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Out.php
+                - lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
 
         # $this->mapping['targetDocument'] is class-string<T>
         -

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,246 +1,876 @@
 parameters:
-    ignoreErrors:
-        # Adding a parameter would be BC-break
-        -
-            message: "#^PHPDoc tag @param references unknown parameter\\: \\$applyFilters$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+	ignoreErrors:
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Builder\\:\\:getPipeline\\(\\) should return array\\<int, non\\-empty\\-array\\<non\\-empty\\-string, mixed\\>\\|object\\> but returns array\\<array\\<string, mixed\\>\\>\\.$#"
+			count: 2
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
 
-        # Making classes final as suggested would be a BC-break
-        -
-            message: "#^Unsafe usage of new static\\(\\)\\.$#"
-            paths:
-                 - lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
-                 - lib/Doctrine/ODM/MongoDB/DocumentManager.php
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Builder\\:\\:getPipeline\\(\\) should return array\\<int, non\\-empty\\-array\\<non\\-empty\\-string, mixed\\>\\|object\\> but returns non\\-empty\\-array\\<array\\<string, mixed\\>\\>\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
 
-        # This cannot be solved the way it is, see https://github.com/vimeo/psalm/issues/5788
-        -
-            message: "#^Return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadataFactory\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getMetadataFactory\\(\\) should be compatible with return type \\(Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadataFactory\\<Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\>\\) of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getMetadataFactory\\(\\)$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/DocumentManager.php
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$applyFilters$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
 
-        # The limit option in GeoNear has been removed in MongoDB 4.2 in favor of $limit stage
-        -
-            message: "#^Return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\GeoNear\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\GeoNear\\:\\:limit\\(\\) should be compatible with return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Limit\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\:\\:limit\\(\\)$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GeoNear.php
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
 
-        -
-            message: "#DOCTRINE_MONGODB_DATABASE not found\\.$#"
-            paths:
-                - tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
-                - tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
-                - tests/Doctrine/ODM/MongoDB/Tests/Id/IncrementGeneratorTest.php
-                - tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\AbstractReplace\\:\\:getReplaceExpression\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AbstractReplace.php
 
-        -
-            message: "#DOCTRINE_MONGODB_SERVER not found\\.$#"
-            paths:
-                - tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Densify\\:\\:getExpression\\(\\) has invalid return type Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\DensifyStageExpression\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
 
-        -
-            message: "#^Parameter \\#1 \\$builder of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Facet\\:\\:pipeline\\(\\) expects Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Builder\\|Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage, stdClass given\\.$#"
-            count: 1
-            path: tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FacetTest.php
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Densify\\:\\:getExpression\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
 
-        -
-            message: "#^Expression \"\\$groups\\[0\\]\" on a separate line does not do anything\\.$#"
-            count: 1
-            path: tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+		-
+			message: "#^PHPDoc tag @return with type Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\DensifyStageExpression is incompatible with native type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
 
-        -
-            message: "#^Unreachable statement \\- code above always terminates\\.$#"
-            count: 1
-            path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
+		-
+			message: "#^Return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\GeoNear\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\GeoNear\\:\\:limit\\(\\) should be compatible with return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Limit\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\:\\:limit\\(\\)$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GeoNear.php
 
-        -
-            message: "#^Parameter \\#1 \\$primer of method Doctrine\\\\ODM\\\\MongoDB\\\\Query\\\\Builder\\:\\:prime\\(\\) expects bool\\|\\(callable\\(\\)\\: mixed\\), 1 given\\.$#"
-            count: 1
-            path: tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+		-
+			message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getClassMetadata\\(\\)$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup.php
 
-        # Support for doctrine/collections v1
-        -
-            message: '#^Method Doctrine\\ODM\\MongoDB\\PersistentCollection\:\:add\(\) with return type void returns true but should not return anything\.$#'
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Lookup\\:\\:getExpression\\(\\) has invalid return type Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\LookupStageExpression\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
 
-        # import type in PHPStan does not work, see https://github.com/phpstan/phpstan/issues/5091
-        -
-            message: "#^Access to offset '.+' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\.$#"
-            count: 12
-            path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Lookup\\:\\:getExpression\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
 
-        # import type in PHPStan does not work, see https://github.com/phpstan/phpstan/issues/5091
-        -
-            message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:getMapping\\(\\) should return array\\{type\\: string, fieldName\\: string, name\\: string, isCascadeRemove\\: bool, isCascadePersist\\: bool, isCascadeRefresh\\: bool, isCascadeMerge\\: bool, isCascadeDetach\\: bool, \\.\\.\\.\\} but returns Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\|null\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+		-
+			message: "#^PHPDoc tag @return with type Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\LookupStageExpression is incompatible with native type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
 
-        # import type in PHPStan does not work, see https://github.com/phpstan/phpstan/issues/5091
-        -
-            message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:\\$mapping has unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping as its type\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+		-
+			message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getClassMetadata\\(\\)$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
 
-        # import type in PHPStan does not work, see https://github.com/phpstan/phpstan/issues/5091
-        -
-            message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\<TKey of \\(int\\|string\\),T of object\\>\\:\\:\\$mapping \\(Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\|null\\) does not accept array\\<string, array\\<int\\|string, mixed\\>\\|bool\\|int\\|string\\|null\\>\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Merge\\:\\:getExpression\\(\\) has invalid return type Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\MergeStageExpression\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
 
-        # That statement is never reached because DateTimeInterface is either DateTimeImmutable or DateTime
-        -
-            message: "#^Unreachable statement \\- code above always terminates\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/Types/DateImmutableType.php
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Merge\\:\\:getExpression\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
 
-        # These classes are not final
-        -
-            message: "#^Unsafe call to private method Doctrine\\\\ODM\\\\MongoDB\\\\Query\\\\Expr\\:\\:convertExpression\\(\\) through static::\\.$#"
-            count: 3
-            path: lib/Doctrine/ODM/MongoDB/Query/Expr.php
+		-
+			message: "#^PHPDoc tag @return with type Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\MergeStageExpression is incompatible with native type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
 
-        -
-            message: "#^Unsafe call to private method Doctrine\\\\ODM\\\\MongoDB\\\\Types\\\\DateType\\:\\:craftDateTime\\(\\) through static::\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/Types/DateType.php
+		-
+			message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getClassMetadata\\(\\)$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
 
-        # False positive, the exception is thrown
-        -
-            message: "#^Dead catch \\- MongoDB\\\\Driver\\\\Exception\\\\BulkWriteException is never thrown in the try block\\.$#"
-            count: 1
-            path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
+		-
+			message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getClassMetadata\\(\\)$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Out.php
 
-        # Properties are not covariant
-        -
-            message: "#^PHPDoc type Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocumentWithDiscriminator\\> of property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentDocumentWithDiscriminator\\:\\:\\$embeddedChildren is not covariant with PHPDoc type array\\<Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocument\\>\\|Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocument\\> of overridden property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentDocument\\:\\:\\$embeddedChildren\\.$#"
-            count: 1
-            path: tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\UnionWith\\:\\:getExpression\\(\\) has invalid return type Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\UnionWithStageExpression\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
 
-        -
-            message: "#^PHPDoc type array\\<Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocumentWithDiscriminator\\>\\|Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocumentWithDiscriminator\\> of property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentDocumentWithDiscriminator\\:\\:\\$referencedChildren is not covariant with PHPDoc type array\\<Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocument\\>\\|Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocument\\> of overridden property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentDocument\\:\\:\\$referencedChildren\\.$#"
-            count: 1
-            path: tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\UnionWith\\:\\:getExpression\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
 
-        -
-            message: "#^PHPDoc type array\\<Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocumentWithDiscriminator\\>\\|Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocumentWithDiscriminator\\> of property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentDocumentWithoutDiscriminator\\:\\:\\$embeddedChildren is not covariant with PHPDoc type array\\<Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocument\\>\\|Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocument\\> of overridden property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentDocument\\:\\:\\$embeddedChildren\\.$#"
-            count: 1
-            path: tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\UnionWith\\:\\:pipeline\\(\\) has parameter \\$pipeline with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
 
-        -
-            message: "#^PHPDoc type array\\<Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocumentWithDiscriminator\\>\\|Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocumentWithDiscriminator\\> of property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentDocumentWithoutDiscriminator\\:\\:\\$referencedChildren is not covariant with PHPDoc type array\\<Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocument\\>\\|Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocument\\> of overridden property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentDocument\\:\\:\\$referencedChildren\\.$#"
-            count: 1
-            path: tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+		-
+			message: "#^PHPDoc tag @return with type Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\UnionWithStageExpression is incompatible with native type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
 
-        # Collection elements cannot be covariant, see https://github.com/doctrine/collections/pull/220
-        -
-            message: "#^Parameter \\#2 \\$projects of class Documents\\\\Developer constructor expects Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Documents\\\\Project\\>\\|null, Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Documents\\\\SubProject\\> given\\.$#"
-            count: 1
-            path: tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\UnionWith\\:\\:\\$pipeline type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
 
-        # When iterating over SimpleXMLElement, we cannot know the key values
-        -
-            message: "#^Parameter \\#2 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\Driver\\\\XmlDriver\\:\\:addFieldMapping\\(\\) expects array#"
-            count: 2
-            path: lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+		-
+			message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getClassMetadata\\(\\)$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
 
-        -
-            message: "#^Parameter \\#2 \\$options of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<object\\>\\:\\:addIndex\\(\\) expects array\\{background\\?\\: bool, bits\\?\\: int, default_language\\?\\: string, expireAfterSeconds\\?\\: int, language_override\\?\\: string, min\\?\\: float, max\\?\\: float, name\\?\\: string, \\.\\.\\.\\}, array\\<string, non\\-empty\\-array\\<string, array\\<int\\|string, mixed\\>\\|bool\\|float\\|int\\|string\\|null\\>\\|bool\\|float\\|int\\|string\\|null\\> given\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+		-
+			message: "#^Return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadataFactory\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getMetadataFactory\\(\\) should be compatible with return type \\(Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadataFactory\\<Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<object\\>\\>\\) of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getMetadataFactory\\(\\)$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/DocumentManager.php
 
-        # This is handled by a try-catch block
-        -
-            message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getClassMetadata\\(\\)$#"
-            paths:
-                - lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup.php
-                - lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
-                - lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
-                - lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Out.php
-                - lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/DocumentManager.php
 
-        # $this->mapping['targetDocument'] is class-string<T>
-        -
-            message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getClassMetadata\\(\\)$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+		-
+			message: "#^Method Doctrine\\\\Persistence\\\\Event\\\\OnClearEventArgs\\<Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\>\\:\\:__construct\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Event/OnClearEventArgs.php
 
-        # complains about types for arguments we do not use/care
-        -
-            message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Proxy\\\\Factory\\\\StaticProxyFactory\\:\\:createInitializer\\(\\) should return Closure\\(ProxyManager\\\\Proxy\\\\GhostObjectInterface\\<TDocument of object\\>&TDocument of object\\=, string\\=, array\\<string, mixed\\>\\=, Closure\\|null\\=, array\\<string, mixed\\>\\=\\)\\: bool but returns Closure\\(ProxyManager\\\\Proxy\\\\GhostObjectInterface, string, array, mixed, array\\)\\: true\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/Proxy/Factory/StaticProxyFactory.php
+		-
+			message: "#^Parameter \\#1 \\$initializer of method ProxyManager\\\\Proxy\\\\GhostObjectInterface\\<object\\>\\:\\:setProxyInitializer\\(\\) expects \\(Closure\\(ProxyManager\\\\Proxy\\\\GhostObjectInterface\\<object\\>\\=, string\\=, array\\<string, mixed\\>\\=, Closure\\|null\\=, array\\<string, mixed\\>\\=\\)\\: bool\\)\\|null, Closure\\(ProxyManager\\\\Proxy\\\\GhostObjectInterface, string, array, mixed, array\\)\\: true given\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
 
-        -
-            message: "#^Parameter \\#1 \\$initializer of method ProxyManager\\\\Proxy\\\\GhostObjectInterface\\<object\\>\\:\\:setProxyInitializer\\(\\) expects \\(Closure\\(ProxyManager\\\\Proxy\\\\GhostObjectInterface\\<object\\>\\=, string\\=, array\\<string, mixed\\>\\=, Closure\\|null\\=, array\\<string, mixed\\>\\=\\)\\: bool\\)\\|null, Closure\\(ProxyManager\\\\Proxy\\\\GhostObjectInterface, string, array, mixed, array\\)\\: true given\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+		-
+			message: "#^Parameter \\#2 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\Driver\\\\XmlDriver\\:\\:addFieldMapping\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\<int\\|string, non\\-empty\\-array\\<int, string\\>\\|bool\\|string\\> given\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
 
-        # compatibility layer for doctrine/persistence ^2.4 || ^3.0
-        -
-            message: "#.*#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/Event/OnClearEventArgs
+		-
+			message: "#^Parameter \\#2 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\Driver\\\\XmlDriver\\:\\:addFieldMapping\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, non\\-empty\\-array\\<string, array\\<string, string\\>\\|string\\|true\\> given\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
 
-        -
-            message: "#Property .+ is never written, only read.#"
-            path: tests
+		-
+			message: "#^Parameter \\#2 \\$options of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<object\\>\\:\\:addIndex\\(\\) expects array\\{background\\?\\: bool, bits\\?\\: int, default_language\\?\\: string, expireAfterSeconds\\?\\: int, language_override\\?\\: string, min\\?\\: float, max\\?\\: float, name\\?\\: string, \\.\\.\\.\\}, array\\<string, non\\-empty\\-array\\<string, array\\<int\\|string, mixed\\>\\|bool\\|float\\|int\\|string\\|null\\>\\|bool\\|float\\|int\\|string\\|null\\> given\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
 
-        -
-            message: "#Property .+ is never read, only written.#"
-            path: tests
+		-
+			message: "#^Access to offset 'embedded' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
-        -
-            message: "#Property .+ is unused.#"
-            path: tests
+		-
+			message: "#^Access to offset 'isOwningSide' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\.$#"
+			count: 3
+			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
-        -
-            message: "#^Parameter \\#4 \\$query of class Doctrine\\\\ODM\\\\MongoDB\\\\Query\\\\Query constructor expects array\\{distinct\\?\\: string, hint\\?\\: array\\<string, \\-1\\|1\\>\\|string, limit\\?\\: int, maxTimeMS\\?\\: int, multiple\\?\\: bool, new\\?\\: bool, newObj\\?\\: array\\<string, mixed\\>, query\\?\\: array\\<string, mixed\\>, \\.\\.\\.\\}, array\\{type\\: \\-1\\} given\\.$#"
-            count: 1
-            path: tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+		-
+			message: "#^Access to offset 'orphanRemoval' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
-        -
-            message: "#^Parameter \\#2 \\$referenceMapping of method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:createReference\\(\\) expects array\\{type\\: string, fieldName\\: string, name\\: string, isCascadeRemove\\: bool, isCascadePersist\\: bool, isCascadeRefresh\\: bool, isCascadeMerge\\: bool, isCascadeDetach\\: bool, \\.\\.\\.\\}, array\\{storeAs\\: 'dbRef'\\} given\\.$#"
-            count: 1
-            path: tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+		-
+			message: "#^Access to offset 'reference' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
-        # import type in PHPStan does not work, see https://github.com/phpstan/phpstan/issues/5091
-        -
-            message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:\\$hints \\(Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints\\) does not accept default value of type array\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+		-
+			message: "#^Access to offset 'strategy' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\.$#"
+			count: 4
+			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
-        # import type in PHPStan does not work, see https://github.com/phpstan/phpstan/issues/5091
-        -
-            message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:\\$hints has unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints as its type\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+		-
+			message: "#^Access to offset 'targetDocument' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\.$#"
+			count: 2
+			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
-        # import type in PHPStan does not work, see https://github.com/phpstan/phpstan/issues/5091
-        -
-            message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\<TKey of \\(int\\|string\\),T of object\\>\\:\\:\\$hints \\(Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints\\) does not accept array\\<int, mixed\\>\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:add\\(\\) with return type void returns true but should not return anything\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
-        # import type in PHPStan does not work, see https://github.com/phpstan/phpstan/issues/5091
-        -
-            message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:getHints\\(\\) should return array\\<int, mixed\\> but returns Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints\\.$#"
-            count: 1
-            path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:getHints\\(\\) should return array\\<int, mixed\\> but returns Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
-        # breaking types expected by static analysis to check exceptions
-        -
-            message: "#.+mapField\\(\\) expects.+enumType\\: 'Documents81#"
-            count: 2
-            path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:getMapping\\(\\) should return array\\{type\\: string, fieldName\\: string, name\\: string, isCascadeRemove\\: bool, isCascadePersist\\: bool, isCascadeRefresh\\: bool, isCascadeMerge\\: bool, isCascadeDetach\\: bool, \\.\\.\\.\\} but returns Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\|null\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
-        -
-            message: "#has parameter \\$[^\\s]+ with no value type specified in iterable type array\\.$#"
-            count: 6
-            path: tests/*
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:\\$hints \\(Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints\\) does not accept default value of type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
-        # cannot know that Command::getHelper('documentManager') returns a DocumentManagerHelper
-        -
-            message: "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Helper\\\\HelperInterface\\:\\:getDocumentManager\\(\\)\\.$#"
-            count: 7
-            path: lib/Doctrine/ODM/MongoDB/Tools/Console/Command/*
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:\\$hints has unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints as its type\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:\\$mapping has unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping as its type\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\<TKey of \\(int\\|string\\),T of object\\>\\:\\:\\$hints \\(Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints\\) does not accept array\\<int, mixed\\>\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\<TKey of \\(int\\|string\\),T of object\\>\\:\\:\\$mapping \\(Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\|null\\) does not accept array\\<string, array\\<int\\|string, mixed\\>\\|bool\\|int\\|string\\|null\\>\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+
+		-
+			message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getClassMetadata\\(\\)$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Proxy\\\\Factory\\\\StaticProxyFactory\\:\\:createInitializer\\(\\) should return Closure\\(ProxyManager\\\\Proxy\\\\GhostObjectInterface\\<TDocument of object\\>&TDocument of object\\=, string\\=, array\\<string, mixed\\>\\=, Closure\\|null\\=, array\\<string, mixed\\>\\=\\)\\: bool but returns Closure\\(ProxyManager\\\\Proxy\\\\GhostObjectInterface, string, array, mixed, array\\)\\: true\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Proxy/Factory/StaticProxyFactory.php
+
+		-
+			message: "#^Unsafe call to private method Doctrine\\\\ODM\\\\MongoDB\\\\Query\\\\Expr\\:\\:convertExpression\\(\\) through static\\:\\:\\.$#"
+			count: 3
+			path: lib/Doctrine/ODM/MongoDB/Query/Expr.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Helper\\\\HelperInterface\\:\\:getDocumentManager\\(\\)\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Helper\\\\HelperInterface\\:\\:getDocumentManager\\(\\)\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Helper\\\\HelperInterface\\:\\:getDocumentManager\\(\\)\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GeneratePersistentCollectionsCommand.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Helper\\\\HelperInterface\\:\\:getDocumentManager\\(\\)\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Helper\\\\HelperInterface\\:\\:getDocumentManager\\(\\)\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Helper\\\\HelperInterface\\:\\:getDocumentManager\\(\\)\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/AbstractCommand.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Helper\\\\HelperInterface\\:\\:getDocumentManager\\(\\)\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ValidateCommand.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Types/DateImmutableType.php
+
+		-
+			message: "#^Unsafe call to private method Doctrine\\\\ODM\\\\MongoDB\\\\Types\\\\DateType\\:\\:craftDateTime\\(\\) through static\\:\\:\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Types/DateType.php
+
+		-
+			message: "#^Parameter \\#1 \\$builder of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Facet\\:\\:pipeline\\(\\) expects Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Builder\\|Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage, stdClass given\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FacetTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Aggregation\\\\Stage\\\\MatchStageTest\\:\\:testProxiedExprMethods\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
+
+		-
+			message: "#^Constant DOCTRINE_MONGODB_DATABASE not found\\.$#"
+			count: 5
+			path: tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+
+		-
+			message: "#^Constant DOCTRINE_MONGODB_SERVER not found\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\BaseTest\\:\\:assertArraySubset\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\BaseTest\\:\\:assertArraySubset\\(\\) has parameter \\$subset with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+
+		-
+			message: "#^Used constant DOCTRINE_MONGODB_DATABASE not found\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+
+		-
+			message: "#^Used constant DOCTRINE_MONGODB_SERVER not found\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/BaseTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$referenceMapping of method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:createReference\\(\\) expects array\\{type\\: string, fieldName\\: string, name\\: string, isCascadeRemove\\: bool, isCascadePersist\\: bool, isCascadeRefresh\\: bool, isCascadeMerge\\: bool, isCascadeDetach\\: bool, \\.\\.\\.\\}, array\\{storeAs\\: 'dbRef'\\} given\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+
+		-
+			message: "#^Constant DOCTRINE_MONGODB_DATABASE not found\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$projects of class Documents\\\\Developer constructor expects Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Documents\\\\Project\\>\\|null, Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Documents\\\\SubProject\\> given\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
+
+		-
+			message: "#^Used constant DOCTRINE_MONGODB_DATABASE not found\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\CustomDatabaseTest\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/DatabasesTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\DefaultDatabaseTest\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/DatabasesTest.php
+
+		-
+			message: "#^PHPDoc type Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocumentWithDiscriminator\\> of property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentDocumentWithDiscriminator\\:\\:\\$embeddedChildren is not covariant with PHPDoc type array\\<Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocument\\>\\|Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocument\\> of overridden property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentDocument\\:\\:\\$embeddedChildren\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+
+		-
+			message: "#^PHPDoc type array\\<Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocumentWithDiscriminator\\>\\|Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocumentWithDiscriminator\\> of property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentDocumentWithDiscriminator\\:\\:\\$referencedChildren is not covariant with PHPDoc type array\\<Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocument\\>\\|Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocument\\> of overridden property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentDocument\\:\\:\\$referencedChildren\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+
+		-
+			message: "#^PHPDoc type array\\<Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocumentWithDiscriminator\\>\\|Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocumentWithDiscriminator\\> of property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentDocumentWithoutDiscriminator\\:\\:\\$embeddedChildren is not covariant with PHPDoc type array\\<Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocument\\>\\|Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocument\\> of overridden property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentDocument\\:\\:\\$embeddedChildren\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+
+		-
+			message: "#^PHPDoc type array\\<Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocumentWithDiscriminator\\>\\|Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocumentWithDiscriminator\\> of property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentDocumentWithoutDiscriminator\\:\\:\\$referencedChildren is not covariant with PHPDoc type array\\<Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocument\\>\\|Doctrine\\\\Common\\\\Collections\\\\Collection\\<int, Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildDocument\\> of overridden property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentDocument\\:\\:\\$referencedChildren\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\DocumentPersisterTestDocumentWithReferenceToDocumentWithCustomId\\:\\:\\$documentWithCustomId is never read, only written\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\DocumentPersisterTestDocumentWithReferenceToDocumentWithCustomId\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+
+		-
+			message: "#^Expression \"\\$groups\\[0\\]\" on a separate line does not do anything\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ChildObject\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/LifecycleTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\ParentObject\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/LifecycleTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\Hierarchy\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\Ticket\\\\GH1058PersistDocument\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\Ticket\\\\GH1058PersistDocument\\:\\:\\$value is never read, only written\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\Ticket\\\\GH1058UpsertDocument\\:\\:\\$value is never read, only written\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\Ticket\\\\GH1964Document\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1964Test.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\Ticket\\\\GH1990Document\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1990Test.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\Ticket\\\\GH1990Document\\:\\:\\$parent is never read, only written\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1990Test.php
+
+		-
+			message: "#^Dead catch \\- MongoDB\\\\Driver\\\\Exception\\\\BulkWriteException is never thrown in the try block\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\Ticket\\\\GH921Post\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH921Test.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\Ticket\\\\GH921User\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH921Test.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\Ticket\\\\GH999Document\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH999Test.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\Ticket\\\\MODM116Parent\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
+
+		-
+			message: "#^Constant DOCTRINE_MONGODB_DATABASE not found\\.$#"
+			count: 2
+			path: tests/Doctrine/ODM/MongoDB/Tests/Id/IncrementGeneratorTest.php
+
+		-
+			message: "#^Used constant DOCTRINE_MONGODB_DATABASE not found\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Id/IncrementGeneratorTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\AnnotationDriverTestSuper\\:\\:\\$private is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractAnnotationDriverTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\DocumentSubClass2\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\DocumentSubClass2\\:\\:\\$name is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\DocumentSubClass\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\DocumentSubClass\\:\\:\\$name is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\GridFSChildClass\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\GridFSParentClass\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\MappedSuperclassBase\\:\\:\\$mapped1 is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\MappedSuperclassBase\\:\\:\\$mapped2 is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\MappedSuperclassBase\\:\\:\\$mappedRelated1 is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\MappedSuperclassBase\\:\\:\\$transient is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\TransientBaseClass\\:\\:\\$transient1 is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\TransientBaseClass\\:\\:\\$transient2 is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\LoadEventTestDocument\\:\\:\\$about is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\LoadEventTestDocument\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\LoadEventTestDocument\\:\\:\\$name is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest\\.php\\:235\\>\\:\\:mapField\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\{fieldName\\: 'enum', enumType\\: 'Documents81\\\\\\\\Card'\\} given\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest\\.php\\:255\\>\\:\\:mapField\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\{fieldName\\: 'enum', enumType\\: 'Documents81\\\\\\\\SuitNonBacked'\\} given\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+
+		-
+			message: "#^Property DoctrineGlobal_User\\:\\:\\$email is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/Documents/GlobalNamespaceDocument.php
+
+		-
+			message: "#^Property DoctrineGlobal_User\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/Documents/GlobalNamespaceDocument.php
+
+		-
+			message: "#^Property DoctrineGlobal_User\\:\\:\\$username is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/Documents/GlobalNamespaceDocument.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\ShardedCollectionPerClass1\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\ShardedSingleCollInheritance1\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\ShardedSubclass\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Mapping\\\\ShardedSuperclass\\:\\:\\$name is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Query\\\\BuilderTest\\:\\:testExclude\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Query\\\\BuilderTest\\:\\:testProxiedExprMethods\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Query\\\\BuilderTest\\:\\:testSelect\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$primer of method Doctrine\\\\ODM\\\\MongoDB\\\\Query\\\\Builder\\:\\:prime\\(\\) expects bool\\|\\(callable\\(\\)\\: mixed\\), 1 given\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+
+		-
+			message: "#^Constant DOCTRINE_MONGODB_DATABASE not found\\.$#"
+			count: 2
+			path: tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+
+		-
+			message: "#^Parameter \\#4 \\$query of class Doctrine\\\\ODM\\\\MongoDB\\\\Query\\\\Query constructor expects array\\{distinct\\?\\: string, hint\\?\\: array\\<string, \\-1\\|1\\>\\|string, limit\\?\\: int, maxTimeMS\\?\\: int, multiple\\?\\: bool, new\\?\\: bool, newObj\\?\\: array\\<string, mixed\\>, query\\?\\: array\\<string, mixed\\>, \\.\\.\\.\\}, array\\{type\\: \\-1\\} given\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+
+		-
+			message: "#^Used constant DOCTRINE_MONGODB_DATABASE not found\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Tools\\\\GH297\\\\User\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Tools/GH297/User.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Tools\\\\ResolveTargetDocument\\:\\:\\$embedMany is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Tools\\\\ResolveTargetDocument\\:\\:\\$embedOne is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Tools\\\\ResolveTargetDocument\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Tools\\\\ResolveTargetDocument\\:\\:\\$refMany is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Tools\\\\ResolveTargetDocument\\:\\:\\$refOne is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Tools\\\\TargetDocument\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\ArrayTest\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+
+		-
+			message: "#^Property Documents\\\\Account\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/Account.php
+
+		-
+			message: "#^Property Documents\\\\Address\\:\\:\\$test is unused\\.$#"
+			count: 1
+			path: tests/Documents/Address.php
+
+		-
+			message: "#^Property Documents\\\\Album\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/Album.php
+
+		-
+			message: "#^Property Documents\\\\Article\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/Article.php
+
+		-
+			message: "#^Property Documents\\\\Bars\\\\Bar\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/Bars/Bar.php
+
+		-
+			message: "#^Property Documents\\\\Category\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: tests/Documents/Category.php
+
+		-
+			message: "#^Property Documents\\\\Developer\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/Developer.php
+
+		-
+			message: "#^Property Documents\\\\Developer\\:\\:\\$name is never read, only written\\.$#"
+			count: 1
+			path: tests/Documents/Developer.php
+
+		-
+			message: "#^Property Documents\\\\Ecommerce\\\\StockItem\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/Ecommerce/StockItem.php
+
+		-
+			message: "#^Property Documents\\\\Event\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/Event.php
+
+		-
+			message: "#^Property Documents\\\\File\\:\\:\\$chunkSize is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/File.php
+
+		-
+			message: "#^Property Documents\\\\File\\:\\:\\$filename is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/File.php
+
+		-
+			message: "#^Property Documents\\\\File\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/File.php
+
+		-
+			message: "#^Property Documents\\\\File\\:\\:\\$length is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/File.php
+
+		-
+			message: "#^Property Documents\\\\File\\:\\:\\$uploadDate is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/File.php
+
+		-
+			message: "#^Property Documents\\\\FileWithoutChunkSize\\:\\:\\$chunkSize is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/FileWithoutChunkSize.php
+
+		-
+			message: "#^Property Documents\\\\FileWithoutChunkSize\\:\\:\\$filename is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/FileWithoutChunkSize.php
+
+		-
+			message: "#^Property Documents\\\\FileWithoutChunkSize\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/FileWithoutChunkSize.php
+
+		-
+			message: "#^Property Documents\\\\FileWithoutChunkSize\\:\\:\\$length is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/FileWithoutChunkSize.php
+
+		-
+			message: "#^Property Documents\\\\FileWithoutChunkSize\\:\\:\\$uploadDate is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/FileWithoutChunkSize.php
+
+		-
+			message: "#^Property Documents\\\\FileWithoutMetadata\\:\\:\\$filename is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/FileWithoutMetadata.php
+
+		-
+			message: "#^Property Documents\\\\FileWithoutMetadata\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/FileWithoutMetadata.php
+
+		-
+			message: "#^Property Documents\\\\Functional\\\\FavoritesUser\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/Functional/FavoritesUser.php
+
+		-
+			message: "#^Property Documents\\\\Group\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/Group.php
+
+		-
+			message: "#^Property Documents\\\\Message\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/Message.php
+
+		-
+			message: "#^Property Documents\\\\ProfileNotify\\:\\:\\$profileId is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/ProfileNotify.php
+
+		-
+			message: "#^Property Documents\\\\Project\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/Project.php
+
+		-
+			message: "#^Property Documents\\\\SchemaValidated\\:\\:\\$email is unused\\.$#"
+			count: 1
+			path: tests/Documents/SchemaValidated.php
+
+		-
+			message: "#^Property Documents\\\\SchemaValidated\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: tests/Documents/SchemaValidated.php
+
+		-
+			message: "#^Property Documents\\\\SchemaValidated\\:\\:\\$name is unused\\.$#"
+			count: 1
+			path: tests/Documents/SchemaValidated.php
+
+		-
+			message: "#^Property Documents\\\\SchemaValidated\\:\\:\\$phone is unused\\.$#"
+			count: 1
+			path: tests/Documents/SchemaValidated.php
+
+		-
+			message: "#^Property Documents\\\\SchemaValidated\\:\\:\\$status is unused\\.$#"
+			count: 1
+			path: tests/Documents/SchemaValidated.php
+
+		-
+			message: "#^Property Documents\\\\Task\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/Task.php
+
+		-
+			message: "#^Property Documents\\\\Tournament\\\\Participant\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/Tournament/Participant.php
+
+		-
+			message: "#^Property Documents\\\\Tournament\\\\Tournament\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/Tournament/Tournament.php
+
+		-
+			message: "#^Property Documents\\\\UserName\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/UserName.php
+
+		-
+			message: "#^Property Documents\\\\UserName\\:\\:\\$username is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/UserName.php
+
+		-
+			message: "#^Property Documents\\\\UserName\\:\\:\\$viewReference is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/UserName.php
+
+		-
+			message: "#^Property Documents\\\\ViewReference\\:\\:\\$referenceOneViewMappedBy is never written, only read\\.$#"
+			count: 1
+			path: tests/Documents/ViewReference.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -155,6 +155,7 @@ parameters:
             paths:
                 - lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup.php
                 - lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
+                - lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
                 - lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Out.php
 
         # $this->mapping['targetDocument'] is class-string<T>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,11 +5,6 @@
       <code>IteratorAggregate</code>
     </MissingTemplateParam>
   </file>
-  <file src="lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php">
-    <InvalidArgument>
-      <code>$fields</code>
-    </InvalidArgument>
-  </file>
   <file src="lib/Doctrine/ODM/MongoDB/Configuration.php">
     <TypeDoesNotContainType>
       <code><![CDATA[$reflectionClass->implementsInterface(GridFSRepository::class)]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.6.0@e784128902dfe01d489c4123d69918a9f3c1eac5">
+<files psalm-version="5.8.0@9cf4f60a333f779ad3bc704a555920e81d4fdcda">
   <file src="lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php">
     <MissingTemplateParam>
       <code>IteratorAggregate</code>
@@ -12,8 +12,8 @@
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Configuration.php">
     <TypeDoesNotContainType>
-      <code>$reflectionClass-&gt;implementsInterface(GridFSRepository::class)</code>
-      <code>$reflectionClass-&gt;implementsInterface(ObjectRepository::class)</code>
+      <code><![CDATA[$reflectionClass->implementsInterface(GridFSRepository::class)]]></code>
+      <code><![CDATA[$reflectionClass->implementsInterface(ObjectRepository::class)]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/DocumentManager.php">
@@ -33,7 +33,7 @@
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php">
     <ImplementedReturnTypeMismatch>
-      <code>array&lt;string|null&gt;</code>
+      <code><![CDATA[array<string|null>]]></code>
     </ImplementedReturnTypeMismatch>
     <InvalidArgument>
       <code>$mapping</code>
@@ -43,29 +43,29 @@
       <code>$mapping</code>
     </InvalidArgument>
     <InvalidArrayOffset>
-      <code>[$this-&gt;identifier =&gt; $this-&gt;getIdentifierValue($object)]</code>
+      <code><![CDATA[[$this->identifier => $this->getIdentifierValue($object)]]]></code>
     </InvalidArrayOffset>
     <InvalidPropertyAssignmentValue>
-      <code>$this-&gt;associationMappings</code>
-      <code>$this-&gt;associationMappings</code>
-      <code>$this-&gt;fieldMappings</code>
+      <code><![CDATA[$this->associationMappings]]></code>
+      <code><![CDATA[$this->associationMappings]]></code>
+      <code><![CDATA[$this->fieldMappings]]></code>
     </InvalidPropertyAssignmentValue>
     <InvalidReturnStatement>
       <code>$mapping</code>
       <code>$mapping</code>
-      <code>array_filter(
-            $this-&gt;associationMappings,
-            static fn ($assoc) =&gt; ! empty($assoc['embedded'])
-        )</code>
+      <code><![CDATA[array_filter(
+            $this->associationMappings,
+            static fn ($assoc) => ! empty($assoc['embedded'])
+        )]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code>FieldMapping</code>
       <code>FieldMappingConfig</code>
-      <code>array&lt;string, FieldMapping&gt;</code>
+      <code><![CDATA[array<string, FieldMapping>]]></code>
     </InvalidReturnType>
     <LessSpecificImplementedReturnType>
       <code>array</code>
-      <code>array&lt;string|null&gt;</code>
+      <code><![CDATA[array<string|null>]]></code>
     </LessSpecificImplementedReturnType>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php">
@@ -84,64 +84,64 @@
       <code>$options</code>
     </InvalidArgument>
     <NoInterfaceProperties>
-      <code>$xmlRoot-&gt;field</code>
-      <code>$xmlRoot-&gt;id</code>
-      <code>$xmlRoot-&gt;{'also-load-methods'}</code>
-      <code>$xmlRoot-&gt;{'default-discriminator-value'}</code>
-      <code>$xmlRoot-&gt;{'discriminator-field'}</code>
-      <code>$xmlRoot-&gt;{'discriminator-map'}</code>
-      <code>$xmlRoot-&gt;{'embed-many'}</code>
-      <code>$xmlRoot-&gt;{'embed-one'}</code>
-      <code>$xmlRoot-&gt;{'indexes'}</code>
-      <code>$xmlRoot-&gt;{'lifecycle-callbacks'}</code>
-      <code>$xmlRoot-&gt;{'read-preference'}</code>
-      <code>$xmlRoot-&gt;{'reference-many'}</code>
-      <code>$xmlRoot-&gt;{'reference-one'}</code>
-      <code>$xmlRoot-&gt;{'schema-validation'}</code>
-      <code>$xmlRoot-&gt;{'shard-key'}</code>
+      <code><![CDATA[$xmlRoot->field]]></code>
+      <code><![CDATA[$xmlRoot->id]]></code>
+      <code><![CDATA[$xmlRoot->{'also-load-methods'}]]></code>
+      <code><![CDATA[$xmlRoot->{'default-discriminator-value'}]]></code>
+      <code><![CDATA[$xmlRoot->{'discriminator-field'}]]></code>
+      <code><![CDATA[$xmlRoot->{'discriminator-map'}]]></code>
+      <code><![CDATA[$xmlRoot->{'embed-many'}]]></code>
+      <code><![CDATA[$xmlRoot->{'embed-one'}]]></code>
+      <code><![CDATA[$xmlRoot->{'indexes'}]]></code>
+      <code><![CDATA[$xmlRoot->{'lifecycle-callbacks'}]]></code>
+      <code><![CDATA[$xmlRoot->{'read-preference'}]]></code>
+      <code><![CDATA[$xmlRoot->{'reference-many'}]]></code>
+      <code><![CDATA[$xmlRoot->{'reference-one'}]]></code>
+      <code><![CDATA[$xmlRoot->{'schema-validation'}]]></code>
+      <code><![CDATA[$xmlRoot->{'shard-key'}]]></code>
     </NoInterfaceProperties>
     <RedundantCast>
-      <code>(bool) $mapping['background']</code>
-      <code>(bool) $mapping['sparse']</code>
-      <code>(bool) $mapping['unique']</code>
-      <code>(string) $mapping['index-name']</code>
+      <code><![CDATA[(bool) $mapping['background']]]></code>
+      <code><![CDATA[(bool) $mapping['sparse']]]></code>
+      <code><![CDATA[(bool) $mapping['unique']]]></code>
+      <code><![CDATA[(string) $mapping['index-name']]]></code>
     </RedundantCast>
     <RedundantCondition>
       <code>assert($attributes instanceof SimpleXMLElement)</code>
-      <code>isset($xmlRoot-&gt;field)</code>
-      <code>isset($xmlRoot-&gt;id)</code>
-      <code>isset($xmlRoot-&gt;{'default-discriminator-value'})</code>
-      <code>isset($xmlRoot-&gt;{'discriminator-field'})</code>
-      <code>isset($xmlRoot-&gt;{'discriminator-map'})</code>
-      <code>isset($xmlRoot-&gt;{'embed-many'})</code>
-      <code>isset($xmlRoot-&gt;{'embed-one'})</code>
-      <code>isset($xmlRoot-&gt;{'indexes'})</code>
-      <code>isset($xmlRoot-&gt;{'lifecycle-callbacks'})</code>
-      <code>isset($xmlRoot-&gt;{'read-preference'})</code>
-      <code>isset($xmlRoot-&gt;{'reference-many'})</code>
-      <code>isset($xmlRoot-&gt;{'reference-one'})</code>
-      <code>isset($xmlRoot-&gt;{'schema-validation'})</code>
-      <code>isset($xmlRoot-&gt;{'shard-key'})</code>
+      <code><![CDATA[isset($xmlRoot->field)]]></code>
+      <code><![CDATA[isset($xmlRoot->id)]]></code>
+      <code><![CDATA[isset($xmlRoot->{'default-discriminator-value'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'discriminator-field'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'discriminator-map'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'embed-many'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'embed-one'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'indexes'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'lifecycle-callbacks'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'read-preference'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'reference-many'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'reference-one'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'schema-validation'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'shard-key'})]]></code>
     </RedundantCondition>
     <TypeDoesNotContainType>
-      <code>$xmlRoot-&gt;getName() === 'document'</code>
-      <code>$xmlRoot-&gt;getName() === 'embedded-document'</code>
-      <code>$xmlRoot-&gt;getName() === 'gridfs-file'</code>
-      <code>$xmlRoot-&gt;getName() === 'mapped-superclass'</code>
-      <code>$xmlRoot-&gt;getName() === 'query-result-document'</code>
-      <code>$xmlRoot-&gt;getName() === 'view'</code>
-      <code>isset($xmlRoot-&gt;{'also-load-methods'})</code>
+      <code><![CDATA[$xmlRoot->getName() === 'document']]></code>
+      <code><![CDATA[$xmlRoot->getName() === 'embedded-document']]></code>
+      <code><![CDATA[$xmlRoot->getName() === 'gridfs-file']]></code>
+      <code><![CDATA[$xmlRoot->getName() === 'mapped-superclass']]></code>
+      <code><![CDATA[$xmlRoot->getName() === 'query-result-document']]></code>
+      <code><![CDATA[$xmlRoot->getName() === 'view']]></code>
+      <code><![CDATA[isset($xmlRoot->{'also-load-methods'})]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/PersistentCollection/AbstractPersistentCollectionFactory.php">
     <InvalidArgument>
-      <code>new PersistentCollection($coll, $dm, $dm-&gt;getUnitOfWork())</code>
-      <code>new PersistentCollection($coll, $dm, $dm-&gt;getUnitOfWork())</code>
+      <code><![CDATA[new PersistentCollection($coll, $dm, $dm->getUnitOfWork())]]></code>
+      <code><![CDATA[new PersistentCollection($coll, $dm, $dm->getUnitOfWork())]]></code>
     </InvalidArgument>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php">
     <RedundantCondition>
-      <code>is_object($this-&gt;coll)</code>
+      <code><![CDATA[is_object($this->coll)]]></code>
     </RedundantCondition>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php">
@@ -151,7 +151,7 @@
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Proxy/Resolver/CachingClassNameResolver.php">
     <InvalidPropertyAssignmentValue>
-      <code>$this-&gt;resolvedNames</code>
+      <code><![CDATA[$this->resolvedNames]]></code>
     </InvalidPropertyAssignmentValue>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Proxy/Resolver/ProxyManagerClassNameResolver.php">
@@ -164,10 +164,10 @@
       <code>$query</code>
     </InvalidArgument>
     <InvalidPropertyAssignmentValue>
-      <code>$this-&gt;query</code>
-      <code>$this-&gt;query</code>
-      <code>$this-&gt;query</code>
-      <code>$this-&gt;query</code>
+      <code><![CDATA[$this->query]]></code>
+      <code><![CDATA[$this->query]]></code>
+      <code><![CDATA[$this->query]]></code>
+      <code><![CDATA[$this->query]]></code>
     </InvalidPropertyAssignmentValue>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Query/Query.php">
@@ -253,17 +253,22 @@
       <code>$mapping</code>
     </InvalidArgument>
     <InvalidPropertyAssignmentValue>
-      <code>$this-&gt;parentAssociations</code>
+      <code><![CDATA[$this->parentAssociations]]></code>
     </InvalidPropertyAssignmentValue>
     <InvalidReturnStatement>
       <code>$divided</code>
     </InvalidReturnStatement>
     <InvalidReturnType>
-      <code>array&lt;class-string, array{0: ClassMetadata&lt;object&gt;, 1: array&lt;string, object&gt;}&gt;</code>
+      <code><![CDATA[array<class-string, array{0: ClassMetadata<object>, 1: array<string, object>}>]]></code>
     </InvalidReturnType>
     <NullableReturnStatement>
-      <code>$mapping['targetDocument']</code>
+      <code><![CDATA[$mapping['targetDocument']]]></code>
     </NullableReturnStatement>
+  </file>
+  <file src="tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnsetTest.php">
+    <InvalidArgument>
+      <code>$documentPersister</code>
+    </InvalidArgument>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/ClassMetadataTestUtil.php">
     <InvalidReturnStatement>
@@ -275,12 +280,12 @@
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php">
     <InvalidArgument>
-      <code>$class-&gt;associationMappings['ref']</code>
-      <code>$class-&gt;associationMappings['ref1']</code>
-      <code>$class-&gt;associationMappings['ref2']</code>
-      <code>$class-&gt;associationMappings['ref3']</code>
-      <code>$class-&gt;associationMappings['ref4']</code>
-      <code>['storeAs' =&gt; ClassMetadata::REFERENCE_STORE_AS_DB_REF]</code>
+      <code><![CDATA[$class->associationMappings['ref']]]></code>
+      <code><![CDATA[$class->associationMappings['ref1']]]></code>
+      <code><![CDATA[$class->associationMappings['ref2']]]></code>
+      <code><![CDATA[$class->associationMappings['ref3']]]></code>
+      <code><![CDATA[$class->associationMappings['ref4']]]></code>
+      <code><![CDATA[['storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF]]]></code>
     </InvalidArgument>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php">
@@ -290,9 +295,9 @@
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php">
     <InvalidArgument>
-      <code>[$user-&gt;categories[0]-&gt;children, $user-&gt;categories[1]-&gt;children]</code>
-      <code>[$user-&gt;categories[0]-&gt;children[0]-&gt;children, $user-&gt;categories[0]-&gt;children[1]-&gt;children]</code>
-      <code>[$user-&gt;categories[0]-&gt;children[0]-&gt;children, $user-&gt;categories[0]-&gt;children[1]-&gt;children]</code>
+      <code><![CDATA[[$user->categories[0]->children, $user->categories[1]->children]]]></code>
+      <code><![CDATA[[$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children]]]></code>
+      <code><![CDATA[[$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children]]]></code>
     </InvalidArgument>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php">
@@ -310,14 +315,14 @@
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceEmbeddedDocumentsTest.php">
     <InvalidArgument>
-      <code>new ArrayCollection([
+      <code><![CDATA[new ArrayCollection([
             new Issue('Issue #1', 'Issue #1 on Sub Project #1'),
             new Issue('Issue #2', 'Issue #2 on Sub Project #1'),
-        ])</code>
-      <code>new ArrayCollection([
+        ])]]></code>
+      <code><![CDATA[new ArrayCollection([
             new Issue('Issue #1', 'Issue #1 on Sub Project #2'),
             new Issue('Issue #2', 'Issue #2 on Sub Project #2'),
-        ])</code>
+        ])]]></code>
     </InvalidArgument>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/RepositoriesTest.php">
@@ -327,12 +332,12 @@
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php">
     <InvalidArgument>
-      <code>['upsert' =&gt; true]</code>
+      <code><![CDATA[['upsert' => true]]]></code>
     </InvalidArgument>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php">
     <InvalidArgument>
-      <code>$doc-&gt;embeds</code>
+      <code><![CDATA[$doc->embeds]]></code>
     </InvalidArgument>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH245Test.php">
@@ -366,11 +371,11 @@
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH597Test.php">
     <InvalidPropertyAssignmentValue>
-      <code>new ArrayCollection([
+      <code><![CDATA[new ArrayCollection([
             new GH597Comment('Comment 1'),
             new GH597Comment('Comment 2'),
             new GH597Comment('Comment 3'),
-        ])</code>
+        ])]]></code>
       <code>new ArrayCollection([$referenceMany1, $referenceMany2])</code>
     </InvalidPropertyAssignmentValue>
   </file>
@@ -384,29 +389,29 @@
       <code>DocumentManager</code>
     </InvalidNullableReturnType>
     <NullableReturnStatement>
-      <code>$this-&gt;dm</code>
+      <code><![CDATA[$this->dm]]></code>
     </NullableReturnStatement>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php">
     <InvalidArgument>
       <code>$config</code>
       <code>$mapping</code>
-      <code>[
-            'fieldName' =&gt; 'assoc',
-            'reference' =&gt; true,
-            'type' =&gt; 'many',
-            'targetDocument' =&gt; 'stdClass',
-            'repositoryMethod' =&gt; 'fetch',
-            $prop =&gt; $value,
-        ]</code>
-      <code>[
-            'fieldName' =&gt; 'enum',
-            'enumType' =&gt; Card::class,
-        ]</code>
-      <code>[
-            'fieldName' =&gt; 'enum',
-            'enumType' =&gt; SuitNonBacked::class,
-        ]</code>
+      <code><![CDATA[[
+            'fieldName' => 'assoc',
+            'reference' => true,
+            'type' => 'many',
+            'targetDocument' => 'stdClass',
+            'repositoryMethod' => 'fetch',
+            $prop => $value,
+        ]]]></code>
+      <code><![CDATA[[
+            'fieldName' => 'enum',
+            'enumType' => Card::class,
+        ]]]></code>
+      <code><![CDATA[[
+            'fieldName' => 'enum',
+            'enumType' => SuitNonBacked::class,
+        ]]]></code>
     </InvalidArgument>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php">
@@ -416,7 +421,7 @@
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php">
     <InvalidArgument>
-      <code>['type' =&gt; -1]</code>
+      <code><![CDATA[['type' => -1]]]></code>
     </InvalidArgument>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php">

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
@@ -295,7 +295,7 @@ class BuilderTest extends BaseTest
             ],
             [
                 '$replaceRoot' => [
-                    'newRoot' => (object) [
+                    'newRoot' => [
                         'isToday' => [
                             '$eq' => ['$createdAt', new UTCDateTime($dateTime)],
                         ],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
@@ -285,7 +285,7 @@ class BuilderTest extends BaseTest
                 '$group' => [
                     '_id' => [
                         '$cond' => [
-                            'if' => ['$lt' => ['$createdAt', new UTCDateTime((int) $dateTime->format('Uv'))]],
+                            'if' => ['$lt' => ['$createdAt', new UTCDateTime($dateTime)]],
                             'then' => true,
                             'else' => false,
                         ],
@@ -297,7 +297,7 @@ class BuilderTest extends BaseTest
                 '$replaceRoot' => [
                     'newRoot' => (object) [
                         'isToday' => [
-                            '$eq' => ['$createdAt', new UTCDateTime((int) $dateTime->format('Uv'))],
+                            '$eq' => ['$createdAt', new UTCDateTime($dateTime)],
                         ],
                     ],
                 ],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/AddFieldsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/AddFieldsTest.php
@@ -12,7 +12,7 @@ class AddFieldsTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testAddFieldsStage(): void
+    public function testStage(): void
     {
         $addFieldsStage = new AddFields($this->getTestAggregationBuilder());
         $addFieldsStage
@@ -22,7 +22,7 @@ class AddFieldsTest extends BaseTest
         self::assertSame(['$addFields' => ['product' => ['$multiply' => ['$field', 5]]]], $addFieldsStage->getExpression());
     }
 
-    public function testProjectFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketAutoTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketAutoTest.php
@@ -15,7 +15,7 @@ class BucketAutoTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testBucketAutoStage(): void
+    public function testStage(): void
     {
         $bucketStage = new BucketAuto($this->getTestAggregationBuilder(), $this->dm, new ClassMetadata(User::class));
         $bucketStage
@@ -36,7 +36,7 @@ class BucketAutoTest extends BaseTest
         ], $bucketStage->getExpression());
     }
 
-    public function testBucketAutoFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->bucketAuto()
@@ -59,7 +59,7 @@ class BucketAutoTest extends BaseTest
         ], $builder->getPipeline());
     }
 
-    public function testBucketAutoSkipsUndefinedProperties(): void
+    public function testSkipsUndefinedProperties(): void
     {
         $bucketStage = new BucketAuto($this->getTestAggregationBuilder(), $this->dm, new ClassMetadata(User::class));
         $bucketStage

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketTest.php
@@ -15,7 +15,7 @@ class BucketTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testBucketStage(): void
+    public function testStage(): void
     {
         $bucketStage = new Bucket($this->getTestAggregationBuilder(), $this->dm, new ClassMetadata(User::class));
         $bucketStage
@@ -36,7 +36,7 @@ class BucketTest extends BaseTest
         ], $bucketStage->getExpression());
     }
 
-    public function testBucketFromBuilder(): void
+    public function testBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->bucket()
@@ -59,7 +59,7 @@ class BucketTest extends BaseTest
         ], $builder->getPipeline());
     }
 
-    public function testBucketSkipsUndefinedProperties(): void
+    public function testSkipsUndefinedProperties(): void
     {
         $bucketStage = new Bucket($this->getTestAggregationBuilder(), $this->dm, new ClassMetadata(User::class));
         $bucketStage

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/CollStatsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/CollStatsTest.php
@@ -12,14 +12,14 @@ class CollStatsTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testCollStatsStage(): void
+    public function testStage(): void
     {
         $collStatsStage = new CollStats($this->getTestAggregationBuilder());
 
         self::assertSame(['$collStats' => []], $collStatsStage->getExpression());
     }
 
-    public function testCollStatsStageWithLatencyStats(): void
+    public function testStageWithLatencyStats(): void
     {
         $collStatsStage = new CollStats($this->getTestAggregationBuilder());
         $collStatsStage->showLatencyStats();
@@ -27,7 +27,7 @@ class CollStatsTest extends BaseTest
         self::assertSame(['$collStats' => ['latencyStats' => ['histograms' => false]]], $collStatsStage->getExpression());
     }
 
-    public function testCollStatsStageWithLatencyStatsHistograms(): void
+    public function testStageWithLatencyStatsHistograms(): void
     {
         $collStatsStage = new CollStats($this->getTestAggregationBuilder());
         $collStatsStage->showLatencyStats(true);
@@ -35,7 +35,7 @@ class CollStatsTest extends BaseTest
         self::assertSame(['$collStats' => ['latencyStats' => ['histograms' => true]]], $collStatsStage->getExpression());
     }
 
-    public function testCollStatsStageWithStorageStats(): void
+    public function testStageWithStorageStats(): void
     {
         $collStatsStage = new CollStats($this->getTestAggregationBuilder());
         $collStatsStage->showStorageStats();
@@ -43,7 +43,7 @@ class CollStatsTest extends BaseTest
         self::assertSame(['$collStats' => ['storageStats' => []]], $collStatsStage->getExpression());
     }
 
-    public function testCollStatsFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->collStats()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/CountTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/CountTest.php
@@ -12,14 +12,14 @@ class CountTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testCountStage(): void
+    public function testStage(): void
     {
         $countStage = new Count($this->getTestAggregationBuilder(), 'document_count');
 
         self::assertSame(['$count' => 'document_count'], $countStage->getExpression());
     }
 
-    public function testCountFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->count('document_count');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/DensifyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/DensifyTest.php
@@ -12,7 +12,7 @@ class DensifyTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testDensifyStage(): void
+    public function testStage(): void
     {
         $densifyStage = new Densify($this->getTestAggregationBuilder(), 'someField');
         $densifyStage
@@ -34,7 +34,7 @@ class DensifyTest extends BaseTest
         );
     }
 
-    public function testCountFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->densify('someField');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/DensifyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/DensifyTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Densify;
+use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class DensifyTest extends BaseTest
+{
+    use AggregationTestTrait;
+
+    public function testDensifyStage(): void
+    {
+        $densifyStage = new Densify($this->getTestAggregationBuilder(), 'someField');
+        $densifyStage
+            ->partitionByFields('field1', 'field2')
+            ->range('full', 1);
+
+        self::assertEquals(
+            [
+                '$densify' => (object) [
+                    'field' => 'someField',
+                    'partitionByFields' => ['field1', 'field2'],
+                    'range' => (object) [
+                        'bounds' => 'full',
+                        'step' => 1,
+                    ],
+                ],
+            ],
+            $densifyStage->getExpression(),
+        );
+    }
+
+    public function testCountFromBuilder(): void
+    {
+        $builder = $this->getTestAggregationBuilder();
+        $builder->densify('someField');
+
+        self::assertEquals([['$densify' => (object) ['field' => 'someField']]], $builder->getPipeline());
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/DensifyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/DensifyTest.php
@@ -82,8 +82,24 @@ class DensifyTest extends BaseTest
     public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
-        $builder->densify('someField');
+        $builder
+            ->densify('someField')
+            ->range('full', 1, 'minute');
 
-        self::assertEquals([['$densify' => (object) ['field' => 'someField']]], $builder->getPipeline());
+        self::assertEquals(
+            [
+                [
+                    '$densify' => (object) [
+                        'field' => 'someField',
+                        'range' => (object) [
+                            'bounds' => 'full',
+                            'step' => 1,
+                            'unit' => 'minute',
+                        ],
+                    ],
+                ],
+            ],
+            $builder->getPipeline(),
+        );
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/DensifyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/DensifyTest.php
@@ -34,6 +34,51 @@ class DensifyTest extends BaseTest
         );
     }
 
+    public function testStageWithPartialBounds(): void
+    {
+        $densifyStage = new Densify($this->getTestAggregationBuilder(), 'someField');
+        $densifyStage
+            ->partitionByFields('field1', 'field2')
+            ->range([1.5, 2.5], 0.1);
+
+        self::assertEquals(
+            [
+                '$densify' => (object) [
+                    'field' => 'someField',
+                    'partitionByFields' => ['field1', 'field2'],
+                    'range' => (object) [
+                        'bounds' => [1.5, 2.5],
+                        'step' => 0.1,
+                    ],
+                ],
+            ],
+            $densifyStage->getExpression(),
+        );
+    }
+
+    public function testStageWithRangeUnit(): void
+    {
+        $densifyStage = new Densify($this->getTestAggregationBuilder(), 'someField');
+        $densifyStage
+            ->partitionByFields('field1', 'field2')
+            ->range('full', 1, 'minute');
+
+        self::assertEquals(
+            [
+                '$densify' => (object) [
+                    'field' => 'someField',
+                    'partitionByFields' => ['field1', 'field2'],
+                    'range' => (object) [
+                        'bounds' => 'full',
+                        'step' => 1,
+                        'unit' => 'minute',
+                    ],
+                ],
+            ],
+            $densifyStage->getExpression(),
+        );
+    }
+
     public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FacetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FacetTest.php
@@ -15,7 +15,7 @@ class FacetTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testFacetStage(): void
+    public function testStage(): void
     {
         $nestedBuilder = $this->getTestAggregationBuilder();
         $nestedBuilder->sortByCount('$tags');
@@ -35,7 +35,7 @@ class FacetTest extends BaseTest
         ], $facetStage->getExpression());
     }
 
-    public function testFacetFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $nestedBuilder = $this->getTestAggregationBuilder();
         $nestedBuilder->sortByCount('$tags');
@@ -57,7 +57,7 @@ class FacetTest extends BaseTest
         ], $builder->getPipeline());
     }
 
-    public function testFacetThrowsExceptionWithoutFieldName(): void
+    public function testThrowsExceptionWithoutFieldName(): void
     {
         $facetStage = new Facet($this->getTestAggregationBuilder());
 
@@ -67,7 +67,7 @@ class FacetTest extends BaseTest
     }
 
     /** @psalm-suppress InvalidArgument on purpose to throw exception */
-    public function testFacetThrowsExceptionOnInvalidPipeline(): void
+    public function testThrowsExceptionOnInvalidPipeline(): void
     {
         $facetStage = new Facet($this->getTestAggregationBuilder());
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FacetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FacetTest.php
@@ -62,7 +62,7 @@ class FacetTest extends BaseTest
         $facetStage = new Facet($this->getTestAggregationBuilder());
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('requires you set a current field using field().');
+        $this->expectExceptionMessage('requires setting a current field using field().');
         $facetStage->pipeline($this->getTestAggregationBuilder());
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FillTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FillTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Fill;
+use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class FillTest extends BaseTest
+{
+    use AggregationTestTrait;
+
+    public function testFillStage(): void
+    {
+        $fillStage = new Fill($this->getTestAggregationBuilder());
+        $fillStage
+            ->partitionByFields('field1', 'field2')
+            ->sortBy('field1', 1)
+            ->output()
+                ->field('foo')->locf()
+                ->field('bar')->linear()
+                ->field('fixed')->value(0);
+
+        self::assertEquals(
+            [
+                '$fill' => (object) [
+                    'partitionByFields' => ['field1', 'field2'],
+                    'sortBy' => (object) ['field1' => 1],
+                    'output' => (object) [
+                        'foo' => ['method' => 'locf'],
+                        'bar' => ['method' => 'linear'],
+                        'fixed' => ['value' => 0],
+                    ],
+                ],
+            ],
+            $fillStage->getExpression(),
+        );
+    }
+
+    public function testCountFromBuilder(): void
+    {
+        $builder = $this->getTestAggregationBuilder();
+        $builder->fill()
+            ->partitionBy('$field1')
+            ->sortBy('field1', 1)
+            ->output()
+                ->field('foo')->locf()
+                ->field('bar')->linear()
+                ->field('fixed')->value(0);
+
+        self::assertEquals(
+            [
+                [
+                    '$fill' => (object) [
+                        'partitionBy' => '$field1',
+                        'sortBy' => (object) ['field1' => 1],
+                        'output' => (object) [
+                            'foo' => ['method' => 'locf'],
+                            'bar' => ['method' => 'linear'],
+                            'fixed' => ['value' => 0],
+                        ],
+                    ],
+                ],
+            ],
+            $builder->getPipeline(),
+        );
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FillTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FillTest.php
@@ -14,14 +14,18 @@ class FillTest extends BaseTest
 
     public function testStage(): void
     {
-        $fillStage = new Fill($this->getTestAggregationBuilder());
+        $builder   = $this->getTestAggregationBuilder();
+        $fillStage = new Fill($builder);
         $fillStage
             ->partitionByFields('field1', 'field2')
             ->sortBy('field1', 1)
             ->output()
                 ->field('foo')->locf()
                 ->field('bar')->linear()
-                ->field('fixed')->value(0);
+                ->field('fixed')->value(0)
+                ->field('computed')->value(
+                    $builder->expr()->multiply('$value', 5),
+                );
 
         self::assertEquals(
             [
@@ -32,6 +36,33 @@ class FillTest extends BaseTest
                         'foo' => ['method' => 'locf'],
                         'bar' => ['method' => 'linear'],
                         'fixed' => ['value' => 0],
+                        'computed' => ['value' => ['$multiply' => ['$value', 5]]],
+                    ],
+                ],
+            ],
+            $fillStage->getExpression(),
+        );
+    }
+
+    public function testStageWithComplexSort(): void
+    {
+        $fillStage = new Fill($this->getTestAggregationBuilder());
+        $fillStage
+            ->partitionByFields('field1', 'field2')
+            ->sortBy(['field1' => 'asc', 'field2' => 'desc'])
+            ->output()
+                ->field('foo')->locf();
+
+        self::assertEquals(
+            [
+                '$fill' => (object) [
+                    'partitionByFields' => ['field1', 'field2'],
+                    'sortBy' => (object) [
+                        'field1' => 1,
+                        'field2' => -1,
+                    ],
+                    'output' => (object) [
+                        'foo' => ['method' => 'locf'],
                     ],
                 ],
             ],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FillTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FillTest.php
@@ -44,6 +44,30 @@ class FillTest extends BaseTest
         );
     }
 
+    public function testStageWithExpressionAsPartition(): void
+    {
+        $builder   = $this->getTestAggregationBuilder();
+        $fillStage = new Fill($builder);
+        $fillStage
+            ->partitionBy($builder->expr()->year('$field'))
+            ->sortBy('field1', 1)
+            ->output()
+                ->field('foo')->locf();
+
+        self::assertEquals(
+            [
+                '$fill' => (object) [
+                    'partitionBy' => ['$year' => '$field'],
+                    'sortBy' => (object) ['field1' => 1],
+                    'output' => (object) [
+                        'foo' => ['method' => 'locf'],
+                    ],
+                ],
+            ],
+            $fillStage->getExpression(),
+        );
+    }
+
     public function testStageWithComplexSort(): void
     {
         $fillStage = new Fill($this->getTestAggregationBuilder());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FillTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/FillTest.php
@@ -12,7 +12,7 @@ class FillTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testFillStage(): void
+    public function testStage(): void
     {
         $fillStage = new Fill($this->getTestAggregationBuilder());
         $fillStage
@@ -39,7 +39,7 @@ class FillTest extends BaseTest
         );
     }
 
-    public function testCountFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->fill()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GeoNearTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GeoNearTest.php
@@ -12,7 +12,7 @@ class GeoNearTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testGeoNearStage(): void
+    public function testStage(): void
     {
         $geoNearStage = new GeoNear($this->getTestAggregationBuilder(), 0, 0);
         $geoNearStage
@@ -24,7 +24,7 @@ class GeoNearTest extends BaseTest
         self::assertSame(['$geoNear' => $stage], $geoNearStage->getExpression());
     }
 
-    public function testGeoNearFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
@@ -24,7 +24,7 @@ class GraphLookupTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testGraphLookupStage(): void
+    public function testStage(): void
     {
         $graphLookupStage = new GraphLookup($this->getTestAggregationBuilder(), 'employees', $this->dm, new ClassMetadata(User::class));
         $graphLookupStage
@@ -48,7 +48,7 @@ class GraphLookupTest extends BaseTest
         );
     }
 
-    public function testGraphLookupFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->graphLookup('employees')
@@ -74,7 +74,7 @@ class GraphLookupTest extends BaseTest
         );
     }
 
-    public function testGraphLookupWithMatch(): void
+    public function testWithMatch(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->graphLookup('employees')
@@ -152,7 +152,7 @@ class GraphLookupTest extends BaseTest
      *
      * @dataProvider provideEmployeeAggregations
      */
-    public function testGraphLookupWithEmployees(Closure $addGraphLookupStage, array $expectedFields): void
+    public function testWithEmployees(Closure $addGraphLookupStage, array $expectedFields): void
     {
         $this->insertEmployeeTestData();
 
@@ -225,7 +225,7 @@ class GraphLookupTest extends BaseTest
      *
      * @dataProvider provideTravellerAggregations
      */
-    public function testGraphLookupWithTraveller(Closure $addGraphLookupStage, array $expectedFields): void
+    public function testWithTraveller(Closure $addGraphLookupStage, array $expectedFields): void
     {
         $this->insertTravellerTestData();
 
@@ -251,7 +251,7 @@ class GraphLookupTest extends BaseTest
         self::assertCount(3, $result);
     }
 
-    public function testGraphLookupWithUnmappedFields(): void
+    public function testWithUnmappedFields(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
 
@@ -278,7 +278,7 @@ class GraphLookupTest extends BaseTest
         self::assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testGraphLookupWithconnectFromFieldToDifferentTargetClass(): void
+    public function testWithconnectFromFieldToDifferentTargetClass(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GroupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GroupTest.php
@@ -70,7 +70,7 @@ class GroupTest extends BaseTest
         ];
     }
 
-    public function testGroupStage(): void
+    public function testStage(): void
     {
         $groupStage = new Group($this->getTestAggregationBuilder());
         $groupStage
@@ -82,7 +82,7 @@ class GroupTest extends BaseTest
         self::assertSame(['$group' => ['_id' => '$field', 'count' => ['$sum' => 1]]], $groupStage->getExpression());
     }
 
-    public function testGroupFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder
@@ -95,7 +95,7 @@ class GroupTest extends BaseTest
         self::assertSame([['$group' => ['_id' => '$field', 'count' => ['$sum' => 1]]]], $builder->getPipeline());
     }
 
-    public function testGroupWithOperatorInId(): void
+    public function testWithOperatorInId(): void
     {
         $groupStage = new Group($this->getTestAggregationBuilder());
         $groupStage

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/IndexStatsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/IndexStatsTest.php
@@ -13,14 +13,14 @@ class IndexStatsTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testIndexStatsStage(): void
+    public function testStage(): void
     {
         $indexStatsStage = new IndexStats($this->getTestAggregationBuilder());
 
         self::assertEquals(['$indexStats' => new stdClass()], $indexStatsStage->getExpression());
     }
 
-    public function testIndexStatsFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->indexStats();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LimitTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LimitTest.php
@@ -12,14 +12,14 @@ class LimitTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testLimitStage(): void
+    public function testStage(): void
     {
         $limitStage = new Limit($this->getTestAggregationBuilder(), 10);
 
         self::assertSame(['$limit' => 10], $limitStage->getExpression());
     }
 
-    public function testLimitFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->limit(10);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LookupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/LookupTest.php
@@ -20,7 +20,7 @@ class LookupTest extends BaseTest
         $this->insertTestData();
     }
 
-    public function testLookupStage(): void
+    public function testStage(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -47,7 +47,7 @@ class LookupTest extends BaseTest
         self::assertSame('alcaeus', $result[0]['user'][0]['username']);
     }
 
-    public function testLookupStageWithPipelineAsArray(): void
+    public function testStageWithPipelineAsArray(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -91,7 +91,7 @@ class LookupTest extends BaseTest
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testLookupStageWithPipelineAsStage(): void
+    public function testStageWithPipelineAsStage(): void
     {
         $builder               = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $lookupPipelineBuilder = $this->dm->createAggregationBuilder(User::class);
@@ -133,7 +133,7 @@ class LookupTest extends BaseTest
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testLookupThrowsExceptionUsingSameBuilderForPipeline(): void
+    public function testThrowsExceptionUsingSameBuilderForPipeline(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
 
@@ -151,7 +151,7 @@ class LookupTest extends BaseTest
             );
     }
 
-    public function testLookupStageWithPipelineAndLocalForeignFields(): void
+    public function testStageWithPipelineAndLocalForeignFields(): void
     {
         $builder               = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $lookupPipelineBuilder = $this->dm->createAggregationBuilder(User::class);
@@ -192,7 +192,7 @@ class LookupTest extends BaseTest
         $this->assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testLookupStageWithFieldNameTranslation(): void
+    public function testStageWithFieldNameTranslation(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -215,7 +215,7 @@ class LookupTest extends BaseTest
         self::assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testLookupStageWithClassName(): void
+    public function testStageWithClassName(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -244,7 +244,7 @@ class LookupTest extends BaseTest
         self::assertSame('alcaeus', $result[0]['user'][0]['username']);
     }
 
-    public function testLookupStageWithCollectionName(): void
+    public function testStageWithCollectionName(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -272,7 +272,7 @@ class LookupTest extends BaseTest
         self::assertEmpty($result[0]['user']);
     }
 
-    public function testLookupStageReferenceMany(): void
+    public function testStageReferenceMany(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -303,7 +303,7 @@ class LookupTest extends BaseTest
         self::assertSame('malarzm', $result[1]['users'][0]['username']);
     }
 
-    public function testLookupStageReferenceManyStoreAsRef(): void
+    public function testStageReferenceManyStoreAsRef(): void
     {
         $builder = $this->dm->createAggregationBuilder(ReferenceUser::class);
         $builder
@@ -334,7 +334,7 @@ class LookupTest extends BaseTest
         self::assertSame('malarzm', $result[1]['users'][0]['username']);
     }
 
-    public function testLookupStageReferenceOneInverse(): void
+    public function testStageReferenceOneInverse(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
         $builder
@@ -366,7 +366,7 @@ class LookupTest extends BaseTest
         self::assertCount(1, $result[0]['simpleReferenceOneInverse']);
     }
 
-    public function testLookupStageReferenceManyInverse(): void
+    public function testStageReferenceManyInverse(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
         $builder
@@ -398,7 +398,7 @@ class LookupTest extends BaseTest
         self::assertCount(1, $result[0]['simpleReferenceManyInverse']);
     }
 
-    public function testLookupStageReferenceOneInverseStoreAsRef(): void
+    public function testStageReferenceOneInverseStoreAsRef(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
         $builder
@@ -430,7 +430,7 @@ class LookupTest extends BaseTest
         self::assertCount(1, $result[0]['embeddedReferenceOneInverse']);
     }
 
-    public function testLookupStageReferenceManyInverseStoreAsRef(): void
+    public function testStageReferenceManyInverseStoreAsRef(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
         $builder
@@ -489,7 +489,7 @@ class LookupTest extends BaseTest
         $this->dm->flush();
     }
 
-    public function testLookupStageAndDefaultAlias(): void
+    public function testStageAndDefaultAlias(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
         $builder
@@ -512,7 +512,7 @@ class LookupTest extends BaseTest
         self::assertCount(1, $result[0]['simpleReferenceOneInverse']);
     }
 
-    public function testLookupStageAndDefaultAliasOverride(): void
+    public function testStageAndDefaultAliasOverride(): void
     {
         $builder = $this->dm->createAggregationBuilder(User::class);
         $builder

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MatchStageTest.php
@@ -18,7 +18,7 @@ class MatchStageTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testMatchStage(): void
+    public function testStage(): void
     {
         $matchStage = new MatchStage($this->getTestAggregationBuilder());
         $matchStage
@@ -28,7 +28,7 @@ class MatchStageTest extends BaseTest
         self::assertSame(['$match' => ['someField' => 'someValue']], $matchStage->getExpression());
     }
 
-    public function testMatchFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MergeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MergeTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
+
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\SimpleReferenceUser;
+use Documents\User;
+use Generator;
+
+use function is_callable;
+
+class MergeTest extends BaseTest
+{
+    public function testMergeStageWithClassName(): void
+    {
+        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
+        $builder
+            ->merge()
+                ->into(User::class)
+                ->on('_id')
+                ->whenMatched('keepExisting');
+
+        $expectedPipeline = [
+            [
+                '$merge' => (object) [
+                    'into' => 'users',
+                    'on' => '_id',
+                    'whenMatched' => 'keepExisting',
+                ],
+            ],
+        ];
+
+        self::assertEquals($expectedPipeline, $builder->getPipeline());
+    }
+
+    public function testMergeStageWithCollectionName(): void
+    {
+        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
+        $builder
+            ->merge()
+                ->into('someRandomCollectionName')
+                ->let(['foo' => 'bar'])
+                ->whenNotMatched('discard');
+
+        $expectedPipeline = [
+            [
+                '$merge' => (object) [
+                    'into' => 'someRandomCollectionName',
+                    'let' => ['foo' => 'bar'],
+                    'whenNotMatched' => 'discard',
+                ],
+            ],
+        ];
+
+        self::assertEquals($expectedPipeline, $builder->getPipeline());
+    }
+
+    public static function providePipeline(): Generator
+    {
+        // TODO: use $set and $unset once they have been added
+        yield 'Array' => [
+            'pipeline' => [
+                ['$addFields' => ['foo' => 'bar']],
+                ['$project' => ['bar' => false]],
+            ],
+        ];
+
+        yield 'Builder' => [
+            'pipeline' => static function (Builder $builder): Builder {
+                $builder
+                    ->addFields()
+                        ->field('foo')->expression('bar')
+                    ->project()
+                        ->excludeFields(['bar']);
+
+                return $builder;
+            },
+        ];
+    }
+
+    /**
+     * @param array<array<string, mixed>>|callable $pipeline
+     *
+     * @dataProvider providePipeline
+     */
+    public function testMergeStageWithPipeline($pipeline): void
+    {
+        if (is_callable($pipeline)) {
+            $pipeline = $pipeline($this->dm->createAggregationBuilder(SimpleReferenceUser::class));
+        }
+
+        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
+        $builder
+            ->merge()
+                ->into('someRandomCollectionName')
+                ->whenMatched($pipeline);
+
+        $expectedPipeline = [
+            [
+                '$merge' => (object) [
+                    'into' => 'someRandomCollectionName',
+                    'whenMatched' => [
+                        ['$addFields' => ['foo' => 'bar']],
+                        ['$project' => ['bar' => false]],
+                    ],
+                ],
+            ],
+        ];
+
+        self::assertEquals($expectedPipeline, $builder->getPipeline());
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MergeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MergeTest.php
@@ -60,10 +60,10 @@ class MergeTest extends BaseTest
 
     public static function providePipeline(): Generator
     {
-        // TODO: use $set and $unset once they have been added
+        // TODO: use $unset once it has been added
         yield 'Array' => [
             'pipeline' => [
-                ['$addFields' => ['foo' => 'bar']],
+                ['$set' => ['foo' => 'bar']],
                 ['$project' => ['bar' => false]],
             ],
         ];
@@ -71,7 +71,7 @@ class MergeTest extends BaseTest
         yield 'Builder' => [
             'pipeline' => static function (Builder $builder): Builder {
                 $builder
-                    ->addFields()
+                    ->set()
                         ->field('foo')->expression('bar')
                     ->project()
                         ->excludeFields(['bar']);
@@ -103,7 +103,7 @@ class MergeTest extends BaseTest
                 '$merge' => (object) [
                     'into' => 'someRandomCollectionName',
                     'whenMatched' => [
-                        ['$addFields' => ['foo' => 'bar']],
+                        ['$set' => ['foo' => 'bar']],
                         ['$project' => ['bar' => false]],
                     ],
                 ],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MergeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MergeTest.php
@@ -60,11 +60,10 @@ class MergeTest extends BaseTest
 
     public static function providePipeline(): Generator
     {
-        // TODO: use $unset once it has been added
         yield 'Array' => [
             'pipeline' => [
                 ['$set' => ['foo' => 'bar']],
-                ['$project' => ['bar' => false]],
+                ['$unset' => ['bar']],
             ],
         ];
 
@@ -73,8 +72,7 @@ class MergeTest extends BaseTest
                 $builder
                     ->set()
                         ->field('foo')->expression('bar')
-                    ->project()
-                        ->excludeFields(['bar']);
+                    ->unset('bar');
 
                 return $builder;
             },
@@ -104,7 +102,7 @@ class MergeTest extends BaseTest
                     'into' => 'someRandomCollectionName',
                     'whenMatched' => [
                         ['$set' => ['foo' => 'bar']],
-                        ['$project' => ['bar' => false]],
+                        ['$unset' => ['bar']],
                     ],
                 ],
             ],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MergeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MergeTest.php
@@ -14,7 +14,7 @@ use function is_callable;
 
 class MergeTest extends BaseTest
 {
-    public function testMergeStageWithClassName(): void
+    public function testStageWithClassName(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -36,7 +36,7 @@ class MergeTest extends BaseTest
         self::assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testMergeStageWithCollectionName(): void
+    public function testStageWithCollectionName(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -84,7 +84,7 @@ class MergeTest extends BaseTest
      *
      * @dataProvider providePipeline
      */
-    public function testMergeStageWithPipeline($pipeline): void
+    public function testStageWithPipeline($pipeline): void
     {
         if (is_callable($pipeline)) {
             $pipeline = $pipeline($this->dm->createAggregationBuilder(SimpleReferenceUser::class));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MergeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MergeTest.php
@@ -9,6 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTest;
 use Documents\SimpleReferenceUser;
 use Documents\User;
 use Generator;
+use InvalidArgumentException;
 
 use function is_callable;
 
@@ -109,5 +110,20 @@ class MergeTest extends BaseTest
         ];
 
         self::assertEquals($expectedPipeline, $builder->getPipeline());
+    }
+
+    public function testStageWithReusedPipeline(): void
+    {
+        $builder  = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
+        $setStage = $builder->set()
+            ->field('foo')->expression('bar');
+
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('Cannot use the same Builder instance for $merge whenMatched pipeline.');
+
+        $builder
+            ->merge()
+                ->into('someRandomCollectionName')
+                ->whenMatched($setStage);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OutTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OutTest.php
@@ -12,7 +12,7 @@ use Documents\User;
 
 class OutTest extends BaseTest
 {
-    public function testOutStageWithClassName(): void
+    public function testStageWithClassName(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -25,7 +25,7 @@ class OutTest extends BaseTest
         self::assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testOutStageWithCollectionName(): void
+    public function testStageWithCollectionName(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -38,7 +38,7 @@ class OutTest extends BaseTest
         self::assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testOutStageWithShardedClassName(): void
+    public function testStageWithShardedClassName(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $this->expectException(MappingException::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
@@ -16,7 +16,7 @@ class ProjectTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testProjectStage(): void
+    public function testStage(): void
     {
         $projectStage = new Project($this->getTestAggregationBuilder());
         $projectStage
@@ -28,7 +28,7 @@ class ProjectTest extends BaseTest
         self::assertSame(['$project' => ['_id' => false, '$field' => true, '$otherField' => true, 'product' => ['$multiply' => ['$field', 5]]]], $projectStage->getExpression());
     }
 
-    public function testProjectFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/RedactTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/RedactTest.php
@@ -12,7 +12,7 @@ class RedactTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testRedactStage(): void
+    public function testStage(): void
     {
         $builder = $this->getTestAggregationBuilder();
 
@@ -27,7 +27,7 @@ class RedactTest extends BaseTest
         self::assertSame(['$redact' => ['$cond' => ['if' => ['$lte' => ['$accessLevel', 3]], 'then' => '$$KEEP', 'else' => '$$REDACT']]], $redactStage->getExpression());
     }
 
-    public function testRedactFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
@@ -26,7 +26,7 @@ class ReplaceRootTest extends BaseTest
         self::assertEquals(
             [
                 '$replaceRoot' => [
-                    'newRoot' => (object) [
+                    'newRoot' => [
                         'isToday' => ['$eq' => ['$createdAt', $mongoDate]],
                     ],
                 ],
@@ -51,7 +51,7 @@ class ReplaceRootTest extends BaseTest
         self::assertEquals(
             [
                 '$replaceRoot' => [
-                    'newRoot' => (object) [
+                    'newRoot' => [
                         'isToday' => ['$eq' => ['$createdAt', $mongoDate]],
                     ],
                 ],
@@ -72,7 +72,7 @@ class ReplaceRootTest extends BaseTest
         self::assertEquals(
             [
                 '$replaceRoot' => [
-                    'newRoot' => (object) [
+                    'newRoot' => [
                         'someField' => ['$concat' => ['$ip', 'foo']],
                     ],
                 ],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
@@ -17,7 +17,7 @@ class ReplaceRootTest extends BaseTest
         $builder = $this->dm->createAggregationBuilder(User::class);
 
         $dateTime  = new DateTimeImmutable('2000-01-01T00:00Z');
-        $mongoDate = new UTCDateTime((int) $dateTime->format('Uv'));
+        $mongoDate = new UTCDateTime($dateTime);
         $stage     = $builder
             ->replaceRoot()
                 ->field('isToday')
@@ -40,7 +40,7 @@ class ReplaceRootTest extends BaseTest
         $builder = $this->dm->createAggregationBuilder(User::class);
 
         $dateTime  = new DateTimeImmutable('2000-01-01T00:00Z');
-        $mongoDate = new UTCDateTime((int) $dateTime->format('Uv'));
+        $mongoDate = new UTCDateTime($dateTime);
         $stage     = $builder
             ->replaceRoot(
                 $builder->expr()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceWithTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceWithTest.php
@@ -17,7 +17,7 @@ class ReplaceWithTest extends BaseTest
         $builder = $this->dm->createAggregationBuilder(User::class);
 
         $dateTime  = new DateTimeImmutable('2000-01-01T00:00Z');
-        $mongoDate = new UTCDateTime((int) $dateTime->format('Uv'));
+        $mongoDate = new UTCDateTime($dateTime);
         $stage     = $builder
             ->replaceWith()
                 ->field('isToday')
@@ -38,7 +38,7 @@ class ReplaceWithTest extends BaseTest
         $builder = $this->dm->createAggregationBuilder(User::class);
 
         $dateTime  = new DateTimeImmutable('2000-01-01T00:00Z');
-        $mongoDate = new UTCDateTime((int) $dateTime->format('Uv'));
+        $mongoDate = new UTCDateTime($dateTime);
         $stage     = $builder
             ->replaceWith(
                 $builder->expr()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceWithTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceWithTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
+
+use DateTimeImmutable;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\CmsComment;
+use Documents\User;
+use MongoDB\BSON\UTCDateTime;
+
+class ReplaceWithTest extends BaseTest
+{
+    public function testTypeConversion(): void
+    {
+        $builder = $this->dm->createAggregationBuilder(User::class);
+
+        $dateTime  = new DateTimeImmutable('2000-01-01T00:00Z');
+        $mongoDate = new UTCDateTime((int) $dateTime->format('Uv'));
+        $stage     = $builder
+            ->replaceWith()
+                ->field('isToday')
+                ->eq('$createdAt', $dateTime);
+
+        self::assertEquals(
+            [
+                '$replaceWith' => (object) [
+                    'isToday' => ['$eq' => ['$createdAt', $mongoDate]],
+                ],
+            ],
+            $stage->getExpression(),
+        );
+    }
+
+    public function testTypeConversionWithDirectExpression(): void
+    {
+        $builder = $this->dm->createAggregationBuilder(User::class);
+
+        $dateTime  = new DateTimeImmutable('2000-01-01T00:00Z');
+        $mongoDate = new UTCDateTime((int) $dateTime->format('Uv'));
+        $stage     = $builder
+            ->replaceWith(
+                $builder->expr()
+                    ->field('isToday')
+                    ->eq('$createdAt', $dateTime),
+            );
+
+        self::assertEquals(
+            [
+                '$replaceWith' => (object) [
+                    'isToday' => ['$eq' => ['$createdAt', $mongoDate]],
+                ],
+            ],
+            $stage->getExpression(),
+        );
+    }
+
+    public function testFieldNameConversion(): void
+    {
+        $builder = $this->dm->createAggregationBuilder(CmsComment::class);
+
+        $stage = $builder
+            ->replaceWith()
+                ->field('someField')
+                ->concat('$authorIp', 'foo');
+
+        self::assertEquals(
+            [
+                '$replaceWith' => (object) [
+                    'someField' => ['$concat' => ['$ip', 'foo']],
+                ],
+            ],
+            $stage->getExpression(),
+        );
+    }
+
+    public function testFieldNameConversionWithDirectExpression(): void
+    {
+        $builder = $this->dm->createAggregationBuilder(CmsComment::class);
+
+        $stage = $builder
+            ->replaceWith('$authorIp');
+
+        self::assertEquals(
+            ['$replaceWith' => '$ip'],
+            $stage->getExpression(),
+        );
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceWithTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ReplaceWithTest.php
@@ -25,7 +25,7 @@ class ReplaceWithTest extends BaseTest
 
         self::assertEquals(
             [
-                '$replaceWith' => (object) [
+                '$replaceWith' => [
                     'isToday' => ['$eq' => ['$createdAt', $mongoDate]],
                 ],
             ],
@@ -48,7 +48,7 @@ class ReplaceWithTest extends BaseTest
 
         self::assertEquals(
             [
-                '$replaceWith' => (object) [
+                '$replaceWith' => [
                     'isToday' => ['$eq' => ['$createdAt', $mongoDate]],
                 ],
             ],
@@ -67,7 +67,7 @@ class ReplaceWithTest extends BaseTest
 
         self::assertEquals(
             [
-                '$replaceWith' => (object) [
+                '$replaceWith' => [
                     'someField' => ['$concat' => ['$ip', 'foo']],
                 ],
             ],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SampleTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SampleTest.php
@@ -12,14 +12,14 @@ class SampleTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testSampleStage(): void
+    public function testStage(): void
     {
         $sampleStage = new Sample($this->getTestAggregationBuilder(), 10);
 
         self::assertSame(['$sample' => ['size' => 10]], $sampleStage->getExpression());
     }
 
-    public function testSampleFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->sample(10);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SetTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Set;
+use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+
+class SetTest extends BaseTest
+{
+    use AggregationTestTrait;
+
+    public function testSetStage(): void
+    {
+        $setStage = new Set($this->getTestAggregationBuilder());
+        $setStage
+            ->field('product')
+            ->multiply('$field', 5);
+
+        self::assertSame(['$set' => ['product' => ['$multiply' => ['$field', 5]]]], $setStage->getExpression());
+    }
+
+    public function testProjectFromBuilder(): void
+    {
+        $builder = $this->getTestAggregationBuilder();
+        $builder
+            ->set()
+                ->field('product')
+                ->multiply('$field', 5);
+
+        self::assertSame([['$set' => ['product' => ['$multiply' => ['$field', 5]]]]], $builder->getPipeline());
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SetTest.php
@@ -12,7 +12,7 @@ class SetTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testSetStage(): void
+    public function testStage(): void
     {
         $setStage = new Set($this->getTestAggregationBuilder());
         $setStage
@@ -22,7 +22,7 @@ class SetTest extends BaseTest
         self::assertSame(['$set' => ['product' => ['$multiply' => ['$field', 5]]]], $setStage->getExpression());
     }
 
-    public function testProjectFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SkipTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SkipTest.php
@@ -12,14 +12,14 @@ class SkipTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testSkipStage(): void
+    public function testStage(): void
     {
         $skipStage = new Skip($this->getTestAggregationBuilder(), 10);
 
         self::assertSame(['$skip' => 10], $skipStage->getExpression());
     }
 
-    public function testSkipFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->skip(10);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortTest.php
@@ -19,7 +19,7 @@ class SortTest extends BaseTest
      *
      * @dataProvider provideSortOptions
      */
-    public function testSortStage(array $expectedSort, $field, ?string $order = null): void
+    public function testStage(array $expectedSort, $field, ?string $order = null): void
     {
         $sortStage = new Sort($this->getTestAggregationBuilder(), $field, $order);
 
@@ -32,7 +32,7 @@ class SortTest extends BaseTest
      *
      * @dataProvider provideSortOptions
      */
-    public function testSortFromBuilder(array $expectedSort, $field, ?string $order = null): void
+    public function testFromBuilder(array $expectedSort, $field, ?string $order = null): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->sort($field, $order);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnionWithTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnionWithTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
+
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\SimpleReferenceUser;
+use Documents\User;
+
+class UnionWithTest extends BaseTest
+{
+    public function testUnionWithStageWithClassName(): void
+    {
+        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
+        $builder
+            ->unionWith(User::class);
+
+        $expectedPipeline = [
+            ['$unionWith' => (object) ['coll' => 'users']],
+        ];
+
+        self::assertEquals($expectedPipeline, $builder->getPipeline());
+    }
+
+    public function testUnionWithStageWithCollectionName(): void
+    {
+        $unionBuilder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
+        $unionBuilder->match()
+            ->field('foo')->equals('bar');
+
+        $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
+        $builder
+            ->unionWith('someRandomCollectionName')
+                ->pipeline($unionBuilder);
+
+        $expectedPipeline = [
+            [
+                '$unionWith' => (object) [
+                    'coll' => 'someRandomCollectionName',
+                    'pipeline' => [
+                        ['$match' => ['foo' => 'bar']],
+                    ],
+                ],
+            ],
+        ];
+
+        self::assertEquals($expectedPipeline, $builder->getPipeline());
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnionWithTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnionWithTest.php
@@ -10,7 +10,7 @@ use Documents\User;
 
 class UnionWithTest extends BaseTest
 {
-    public function testUnionWithStageWithClassName(): void
+    public function testStageWithClassName(): void
     {
         $builder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $builder
@@ -23,7 +23,7 @@ class UnionWithTest extends BaseTest
         self::assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
-    public function testUnionWithStageWithCollectionName(): void
+    public function testStageWithCollectionName(): void
     {
         $unionBuilder = $this->dm->createAggregationBuilder(SimpleReferenceUser::class);
         $unionBuilder->match()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnsetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnsetTest.php
@@ -13,7 +13,7 @@ class UnsetTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testUnsetStage(): void
+    public function testStage(): void
     {
         $documentPersister = $this->dm->getUnitOfWork()->getDocumentPersister(User::class);
         $unsetStage        = new UnsetStage($this->getTestAggregationBuilder(), $documentPersister, 'id', 'foo', 'bar');
@@ -21,7 +21,7 @@ class UnsetTest extends BaseTest
         self::assertSame(['$unset' => ['_id', 'foo', 'bar']], $unsetStage->getExpression());
     }
 
-    public function testLimitFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->unset('id', 'foo', 'bar');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnsetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnsetTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\UnsetStage;
+use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Documents\User;
+
+class UnsetTest extends BaseTest
+{
+    use AggregationTestTrait;
+
+    public function testUnsetStage(): void
+    {
+        $documentPersister = $this->dm->getUnitOfWork()->getDocumentPersister(User::class);
+        $unsetStage        = new UnsetStage($this->getTestAggregationBuilder(), $documentPersister, 'id', 'foo', 'bar');
+
+        self::assertSame(['$unset' => ['_id', 'foo', 'bar']], $unsetStage->getExpression());
+    }
+
+    public function testLimitFromBuilder(): void
+    {
+        $builder = $this->getTestAggregationBuilder();
+        $builder->unset('id', 'foo', 'bar');
+
+        self::assertSame([['$unset' => ['_id', 'foo', 'bar']]], $builder->getPipeline());
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnwindTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnwindTest.php
@@ -12,14 +12,14 @@ class UnwindTest extends BaseTest
 {
     use AggregationTestTrait;
 
-    public function testUnwindStage(): void
+    public function testStage(): void
     {
         $unwindStage = new Unwind($this->getTestAggregationBuilder(), 'fieldName');
 
         self::assertSame(['$unwind' => 'fieldName'], $unwindStage->getExpression());
     }
 
-    public function testUnwindStageWithNewFields(): void
+    public function testStageWithNewFields(): void
     {
         $unwindStage = new Unwind($this->getTestAggregationBuilder(), 'fieldName');
         $unwindStage
@@ -29,7 +29,7 @@ class UnwindTest extends BaseTest
         self::assertSame(['$unwind' => ['path' => 'fieldName', 'includeArrayIndex' => 'index', 'preserveNullAndEmptyArrays' => true]], $unwindStage->getExpression());
     }
 
-    public function testUnwindFromBuilder(): void
+    public function testFromBuilder(): void
     {
         $builder = $this->getTestAggregationBuilder();
         $builder->unwind('fieldName');


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

This pull requests adds a number of previously unsupported aggregation pipeline stages to the builder:
* `$densify`
* `$fill`
* `$merge`
* `$replaceWith`
* `$set`
* `$unset`
* `$unionWith`

It also leverages templates to allow `Builder::addStage` to indicate that it's returning the exact stage that was given, simplifying code in the Builder class.

This leaves the `$search`, `$searchMeta`, and `$setWindowFields` stages left to be implemented. I'll create separate pull requests for those due to their complexity (especially `$search`). I'll also have a separate pull request to support new pipeline operators.