### PR TITLE
Add $search stage to aggregation pipeline builder

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -544,6 +544,19 @@ class Builder
     }
 
     /**
+     * The $search stage performs a full-text search on the specified field or
+     * fields which must be covered by an Atlas Search index.
+     *
+     * @see https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#mongodb-pipeline-pipe.-search
+     */
+    public function search(): Stage\Search
+    {
+        $stage = new Stage\Search($this);
+
+        return $this->addStage($stage);
+    }
+
+    /**
      * Adds new fields to documents. $set outputs documents that contain all
      * existing fields from the input documents and newly added fields.
      *

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -366,6 +366,17 @@ abstract class Stage
     }
 
     /**
+     * The $search stage performs a full-text search on the specified field or
+     * fields which must be covered by an Atlas Search index.
+     *
+     * @see https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#mongodb-pipeline-pipe.-search
+     */
+    public function search(): Stage\Search
+    {
+        return $this->builder->search();
+    }
+
+    /**
      * Adds new fields to documents. $set outputs documents that contain all
      * existing fields from the input documents and newly added fields.
      *

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
+
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Aggregation\Stage;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SearchOperator;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsAllSearchOperators;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsAllSearchOperatorsTrait;
+
+/**
+ * @psalm-type CountType = 'lowerBound'|'total'
+ * @psalm-type SearchStageExpression = array{
+ *     '$search': object{
+ *         index?: string,
+ *         count?: object{
+ *            type: CountType,
+ *            threshold?: int,
+ *         },
+ *         highlight?: object{
+ *             path: string,
+ *             maxCharsToExamine?: int,
+ *             maxNumPassages?: int,
+ *         },
+ *         returnStoredSource?: bool,
+ *         autocomplete?: object,
+ *         compound?: object,
+ *         embeddedDocument?: object,
+ *         equals?: object,
+ *         exists?: object,
+ *         geoShape?: object,
+ *         geoWithin?: object,
+ *         moreLikeThis?: object,
+ *         near?: object,
+ *         phrase?: object,
+ *         queryString?: object,
+ *         range?: object,
+ *         regex?: object,
+ *         text?: object,
+ *         wildcard?: object,
+ *     }
+ * }
+ */
+class Search extends Stage implements SupportsAllSearchOperators
+{
+    use SupportsAllSearchOperatorsTrait;
+
+    private string $indexName         = '';
+    private ?object $count            = null;
+    private ?object $highlight        = null;
+    private ?bool $returnStoredSource = null;
+    private ?SearchOperator $operator = null;
+
+    public function __construct(Builder $builder)
+    {
+        parent::__construct($builder);
+    }
+
+    /** @psalm-return SearchStageExpression */
+    public function getExpression(): array
+    {
+        $params = (object) [];
+
+        if ($this->indexName) {
+            $params->index = $this->indexName;
+        }
+
+        if ($this->count) {
+            $params->count = $this->count;
+        }
+
+        if ($this->highlight) {
+            $params->highlight = $this->highlight;
+        }
+
+        if ($this->returnStoredSource !== null) {
+            $params->returnStoredSource = $this->returnStoredSource;
+        }
+
+        if ($this->operator !== null) {
+            $operatorName          = $this->operator->getOperatorName();
+            $params->$operatorName = $this->operator->getOperatorParams();
+        }
+
+        return ['$search' => $params];
+    }
+
+    public function index(string $name): static
+    {
+        $this->indexName = $name;
+
+        return $this;
+    }
+
+    /** @psalm-param CountType $type */
+    public function countDocuments(string $type, ?int $threshold = null): static
+    {
+        $this->count = (object) ['type' => $type];
+
+        if ($threshold !== null) {
+            $this->count->threshold = $threshold;
+        }
+
+        return $this;
+    }
+
+    public function highlight(string $path, ?int $maxCharsToExamine = null, ?int $maxNumPassages = null): static
+    {
+        $this->highlight = (object) ['path' => $path];
+
+        if ($maxCharsToExamine !== null) {
+            $this->highlight->maxCharsToExamine = $maxCharsToExamine;
+        }
+
+        if ($maxNumPassages !== null) {
+            $this->highlight->maxNumPassages = $maxNumPassages;
+        }
+
+        return $this;
+    }
+
+    public function returnStoredSource(bool $returnStoredSource = true): static
+    {
+        $this->returnStoredSource = $returnStoredSource;
+
+        return $this;
+    }
+
+    /**
+     * @param T $operator
+     *
+     * @return T
+     *
+     * @template T of SearchOperator
+     */
+    protected function addOperator(SearchOperator $operator): SearchOperator
+    {
+        return $this->operator = $operator;
+    }
+
+    protected function getSearchStage(): static
+    {
+        return $this;
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/AbstractSearchOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/AbstractSearchOperator.php
@@ -36,7 +36,7 @@ abstract class AbstractSearchOperator extends Stage implements SearchOperator
     }
 
     /** @return array<string, object> */
-    public function getExpression(): array
+    final public function getExpression(): array
     {
         return [$this->getOperatorName() => $this->getOperatorParams()];
     }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/AbstractSearchOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/AbstractSearchOperator.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+/** @internal */
+abstract class AbstractSearchOperator extends Stage implements SearchOperator
+{
+    public function __construct(private Search $search)
+    {
+        parent::__construct($search->builder);
+    }
+
+    public function index(string $name): Search
+    {
+        return $this->search->index($name);
+    }
+
+    public function countDocuments(string $type, ?int $threshold = null): Search
+    {
+        return $this->search->countDocuments($type, $threshold);
+    }
+
+    public function highlight(string $path, ?int $maxCharsToExamine = null, ?int $maxNumPassages = null): Search
+    {
+        return $this->search->highlight($path, $maxCharsToExamine, $maxNumPassages);
+    }
+
+    public function returnStoredSource(bool $returnStoredSource): Search
+    {
+        return $this->search->returnStoredSource($returnStoredSource);
+    }
+
+    /** @return array<string, object> */
+    public function getExpression(): array
+    {
+        return [$this->getOperatorName() => $this->getOperatorParams()];
+    }
+
+    protected function getSearchStage(): Search
+    {
+        return $this->search;
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Autocomplete.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Autocomplete.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use function array_values;
+
+/** @internal */
+class Autocomplete extends AbstractSearchOperator implements ScoredSearchOperator
+{
+    use ScoredSearchOperatorTrait;
+
+    /** @var list<string> */
+    private array $query;
+    private string $path;
+    private string $tokenOrder = '';
+    private ?object $fuzzy     = null;
+
+    public function __construct(Search $search, string $path, string ...$query)
+    {
+        parent::__construct($search);
+
+        $this->query(...$query);
+        $this->path($path);
+    }
+
+    public function query(string ...$query): static
+    {
+        $this->query = array_values($query);
+
+        return $this;
+    }
+
+    public function path(string $path): static
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    public function tokenOrder(string $order): static
+    {
+        $this->tokenOrder = $order;
+
+        return $this;
+    }
+
+    public function fuzzy(?int $maxEdits = null, ?int $prefixLength = null, ?int $maxExpansions = null): static
+    {
+        $this->fuzzy = (object) [];
+        if ($maxEdits !== null) {
+            $this->fuzzy->maxEdits = $maxEdits;
+        }
+
+        if ($prefixLength !== null) {
+            $this->fuzzy->prefixLength = $prefixLength;
+        }
+
+        if ($maxExpansions !== null) {
+            $this->fuzzy->maxExpansions = $maxExpansions;
+        }
+
+        return $this;
+    }
+
+    public function getOperatorName(): string
+    {
+        return 'autocomplete';
+    }
+
+    public function getOperatorParams(): object
+    {
+        $params = (object) [
+            'query' => $this->query,
+            'path' => $this->path,
+        ];
+
+        if ($this->tokenOrder) {
+            $params->tokenOrder = $this->tokenOrder;
+        }
+
+        if ($this->fuzzy) {
+            $params->fuzzy = $this->fuzzy;
+        }
+
+        return $this->appendScore($params);
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Autocomplete.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Autocomplete.php
@@ -8,7 +8,11 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use function array_values;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-search/autocomplete/
+ */
 class Autocomplete extends AbstractSearchOperator implements ScoredSearchOperator
 {
     use ScoredSearchOperatorTrait;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound.php
@@ -8,7 +8,11 @@ use Closure;
 
 use function array_map;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-search/compound/
+ */
 class Compound extends AbstractSearchOperator implements CompoundSearchOperatorInterface, ScoredSearchOperator
 {
     use ScoredSearchOperatorTrait;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use Closure;
+
+use function array_map;
+
+/** @internal */
+class Compound extends AbstractSearchOperator implements CompoundSearchOperatorInterface, ScoredSearchOperator
+{
+    use ScoredSearchOperatorTrait;
+    use SupportsCompoundableOperatorsTrait;
+
+    /** @var array<string, list<SearchOperator>> */
+    private array $operators = [
+        'must' => [],
+        'mustNot' => [],
+        'should' => [],
+        'filter' => [],
+    ];
+
+    private string $currentClause    = 'must';
+    private ?int $minimumShouldMatch = null;
+
+    /**
+     * @param T $operator
+     *
+     * @return T
+     *
+     * @template T of SearchOperator
+     */
+    protected function addOperator(SearchOperator $operator): SearchOperator
+    {
+        $this->operators[$this->currentClause][] = $operator;
+
+        return $operator;
+    }
+
+    public function must(): static
+    {
+        $this->currentClause = 'must';
+
+        return $this;
+    }
+
+    public function mustNot(): static
+    {
+        $this->currentClause = 'mustNot';
+
+        return $this;
+    }
+
+    public function should(?int $minimumShouldMatch = null): static
+    {
+        $this->currentClause = 'should';
+
+        if ($minimumShouldMatch !== null) {
+            $this->minimumShouldMatch($minimumShouldMatch);
+        }
+
+        return $this;
+    }
+
+    public function filter(): static
+    {
+        $this->currentClause = 'filter';
+
+        return $this;
+    }
+
+    public function minimumShouldMatch(int $minimumShouldMatch): static
+    {
+        $this->minimumShouldMatch = $minimumShouldMatch;
+
+        return $this;
+    }
+
+    public function getOperatorName(): string
+    {
+        return 'compound';
+    }
+
+    public function getOperatorParams(): object
+    {
+        $params = (object) [];
+
+        foreach ($this->operators as $clause => $operators) {
+            if (! $operators) {
+                continue;
+            }
+
+            $params->$clause = array_map(
+                static function (SearchOperator $operator): object {
+                    return (object) [
+                        $operator->getOperatorName() => $operator->getOperatorParams(),
+                    ];
+                },
+                $operators,
+            );
+        }
+
+        if ($this->minimumShouldMatch !== null) {
+            $params->minimumShouldMatch = $this->minimumShouldMatch;
+        }
+
+        return $this->appendScore($params);
+    }
+
+    protected function getAddOperatorClosure(): Closure
+    {
+        return Closure::fromCallable([$this, 'addOperator']);
+    }
+
+    protected function getCompoundStage(): Compound
+    {
+        return $this;
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedAutocomplete.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedAutocomplete.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Autocomplete;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundedSearchOperatorTrait;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsCompoundableOperatorsTrait;
+
+/** @internal */
+class CompoundedAutocomplete extends Autocomplete implements CompoundSearchOperatorInterface
+{
+    use CompoundedSearchOperatorTrait;
+    use SupportsCompoundableOperatorsTrait;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedEmbeddedDocument.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedEmbeddedDocument.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundedSearchOperatorTrait;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\EmbeddedDocument;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SearchOperator;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsCompoundableOperatorsTrait;
+
+/** @internal */
+class CompoundedEmbeddedDocument extends EmbeddedDocument implements CompoundSearchOperatorInterface
+{
+    use CompoundedSearchOperatorTrait;
+    use SupportsCompoundableOperatorsTrait;
+
+    /**
+     * @param T $operator
+     *
+     * @return T
+     *
+     * @template T of SearchOperator
+     */
+    protected function addOperator(SearchOperator $operator): SearchOperator
+    {
+        // Any operator we add should be added to the EmbeddedDocument operator,
+        // not the Compound operator we're nested in.
+        return EmbeddedDocument::addOperator($operator);
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedEquals.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedEquals.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundedSearchOperatorTrait;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Equals;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsCompoundableOperatorsTrait;
+
+/** @internal */
+class CompoundedEquals extends Equals implements CompoundSearchOperatorInterface
+{
+    use CompoundedSearchOperatorTrait;
+    use SupportsCompoundableOperatorsTrait;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedExists.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedExists.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundedSearchOperatorTrait;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Exists;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsCompoundableOperatorsTrait;
+
+/** @internal */
+class CompoundedExists extends Exists implements CompoundSearchOperatorInterface
+{
+    use CompoundedSearchOperatorTrait;
+    use SupportsCompoundableOperatorsTrait;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedGeoShape.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedGeoShape.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundedSearchOperatorTrait;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\GeoShape;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsCompoundableOperatorsTrait;
+
+/** @internal */
+class CompoundedGeoShape extends GeoShape implements CompoundSearchOperatorInterface
+{
+    use CompoundedSearchOperatorTrait;
+    use SupportsCompoundableOperatorsTrait;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedGeoWithin.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedGeoWithin.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundedSearchOperatorTrait;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\GeoWithin;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsCompoundableOperatorsTrait;
+
+/** @internal */
+class CompoundedGeoWithin extends GeoWithin implements CompoundSearchOperatorInterface
+{
+    use CompoundedSearchOperatorTrait;
+    use SupportsCompoundableOperatorsTrait;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedMoreLikeThis.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedMoreLikeThis.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundedSearchOperatorTrait;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\MoreLikeThis;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsCompoundableOperatorsTrait;
+
+/** @internal */
+class CompoundedMoreLikeThis extends MoreLikeThis implements CompoundSearchOperatorInterface
+{
+    use CompoundedSearchOperatorTrait;
+    use SupportsCompoundableOperatorsTrait;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedNear.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedNear.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundedSearchOperatorTrait;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Near;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsCompoundableOperatorsTrait;
+
+/** @internal */
+class CompoundedNear extends Near implements CompoundSearchOperatorInterface
+{
+    use CompoundedSearchOperatorTrait;
+    use SupportsCompoundableOperatorsTrait;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedPhrase.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedPhrase.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundedSearchOperatorTrait;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Phrase;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsCompoundableOperatorsTrait;
+
+/** @internal */
+class CompoundedPhrase extends Phrase implements CompoundSearchOperatorInterface
+{
+    use CompoundedSearchOperatorTrait;
+    use SupportsCompoundableOperatorsTrait;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedQueryString.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedQueryString.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundedSearchOperatorTrait;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\QueryString;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsCompoundableOperatorsTrait;
+
+/** @internal */
+class CompoundedQueryString extends QueryString implements CompoundSearchOperatorInterface
+{
+    use CompoundedSearchOperatorTrait;
+    use SupportsCompoundableOperatorsTrait;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedRange.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedRange.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundedSearchOperatorTrait;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Range;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsCompoundableOperatorsTrait;
+
+/** @internal */
+class CompoundedRange extends Range implements CompoundSearchOperatorInterface
+{
+    use CompoundedSearchOperatorTrait;
+    use SupportsCompoundableOperatorsTrait;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedRegex.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedRegex.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundedSearchOperatorTrait;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Regex;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsCompoundableOperatorsTrait;
+
+/** @internal */
+class CompoundedRegex extends Regex implements CompoundSearchOperatorInterface
+{
+    use CompoundedSearchOperatorTrait;
+    use SupportsCompoundableOperatorsTrait;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedText.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedText.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundedSearchOperatorTrait;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsCompoundableOperatorsTrait;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Text;
+
+/** @internal */
+class CompoundedText extends Text implements CompoundSearchOperatorInterface
+{
+    use CompoundedSearchOperatorTrait;
+    use SupportsCompoundableOperatorsTrait;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedWildcard.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedWildcard.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundedSearchOperatorTrait;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsCompoundableOperatorsTrait;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Wildcard;
+
+/** @internal */
+class CompoundedWildcard extends Wildcard implements CompoundSearchOperatorInterface
+{
+    use CompoundedSearchOperatorTrait;
+    use SupportsCompoundableOperatorsTrait;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/CompoundSearchOperatorInterface.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/CompoundSearchOperatorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface CompoundSearchOperatorInterface extends SupportsCompoundableSearchOperators
+{
+    public function must(): Compound;
+
+    public function mustNot(): Compound;
+
+    public function should(?int $minimumShouldMatch = null): Compound;
+
+    public function filter(): Compound;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/CompoundedSearchOperatorTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/CompoundedSearchOperatorTrait.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use Closure;
+use LogicException;
+
+use function sprintf;
+
+/** @internal */
+trait CompoundedSearchOperatorTrait
+{
+    public function __construct(private Compound $compound, private Closure $addOperator, ...$args)
+    {
+        if (! $this instanceof CompoundSearchOperatorInterface) {
+            throw new LogicException(sprintf('Can only use %s on classes extending %s.', self::class, CompoundSearchOperatorInterface::class));
+        }
+
+        parent::__construct(...$args);
+    }
+
+    public function must(): Compound
+    {
+        return $this->compound->must();
+    }
+
+    public function mustNot(): Compound
+    {
+        return $this->compound->mustNot();
+    }
+
+    public function should(?int $minimumShouldMatch = null): Compound
+    {
+        return $this->compound->should($minimumShouldMatch);
+    }
+
+    public function filter(): Compound
+    {
+        return $this->compound->filter();
+    }
+
+    /**
+     * @param T $operator
+     *
+     * @return T
+     *
+     * @template T of SearchOperator
+     */
+    protected function addOperator(SearchOperator $operator): SearchOperator
+    {
+        return $this->getAddOperatorClosure()($operator);
+    }
+
+    protected function getAddOperatorClosure(): Closure
+    {
+        return $this->addOperator;
+    }
+
+    protected function getCompoundStage(): Compound
+    {
+        return $this->compound;
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/EmbeddedDocument.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/EmbeddedDocument.php
@@ -6,7 +6,11 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-search/embeddedDocument/
+ */
 class EmbeddedDocument extends AbstractSearchOperator implements SupportsEmbeddableSearchOperators, ScoredSearchOperator
 {
     use SupportsAllSearchOperatorsTrait;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/EmbeddedDocument.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/EmbeddedDocument.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+/** @internal */
+class EmbeddedDocument extends AbstractSearchOperator implements SupportsEmbeddableSearchOperators, ScoredSearchOperator
+{
+    use SupportsAllSearchOperatorsTrait;
+    use ScoredSearchOperatorTrait;
+
+    private string $path;
+    private ?SearchOperator $operator = null;
+
+    public function __construct(Search $search, string $path)
+    {
+        parent::__construct($search);
+
+        $this->path($path);
+    }
+
+    public function path(string $path): static
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    /**
+     * @param T $operator
+     *
+     * @return T
+     *
+     * @template T of SearchOperator
+     */
+    protected function addOperator(SearchOperator $operator): SearchOperator
+    {
+        return $this->operator = $operator;
+    }
+
+    public function getOperatorName(): string
+    {
+        return 'embeddedDocument';
+    }
+
+    public function getOperatorParams(): object
+    {
+        $params = (object) ['path' => $this->path];
+
+        if ($this->operator) {
+            $params->operator = (object) $this->operator->getExpression();
+        }
+
+        return $this->appendScore($params);
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Equals.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Equals.php
@@ -8,7 +8,11 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-search/equals/
+ */
 class Equals extends AbstractSearchOperator implements ScoredSearchOperator
 {
     use ScoredSearchOperatorTrait;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Equals.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Equals.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\UTCDateTime;
+
+/** @internal */
+class Equals extends AbstractSearchOperator implements ScoredSearchOperator
+{
+    use ScoredSearchOperatorTrait;
+
+    private string $path = '';
+
+    /** @var mixed */
+    private $value;
+
+    /** @param string|int|float|ObjectId|UTCDateTime|null $value */
+    public function __construct(Search $search, string $path = '', $value = null)
+    {
+        parent::__construct($search);
+
+        $this
+            ->path($path)
+            ->value($value);
+    }
+
+    public function path(string $path): static
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    /** @param string|int|float|ObjectId|UTCDateTime|null $value */
+    public function value($value): static
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function getOperatorName(): string
+    {
+        return 'equals';
+    }
+
+    public function getOperatorParams(): object
+    {
+        $params = (object) [
+            'path' => $this->path,
+            'value' => $this->value,
+        ];
+
+        return $this->appendScore($params);
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Exists.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Exists.php
@@ -14,12 +14,6 @@ class Exists extends AbstractSearchOperator
         parent::__construct($search);
     }
 
-    /** @return array<string, object> */
-    public function getExpression(): array
-    {
-        return [$this->getOperatorName() => $this->getOperatorParams()];
-    }
-
     public function getOperatorName(): string
     {
         return 'exists';

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Exists.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Exists.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+/** @internal */
+class Exists extends AbstractSearchOperator
+{
+    public function __construct(Search $search, private string $path = '')
+    {
+        parent::__construct($search);
+    }
+
+    /** @return array<string, object> */
+    public function getExpression(): array
+    {
+        return [$this->getOperatorName() => $this->getOperatorParams()];
+    }
+
+    public function getOperatorName(): string
+    {
+        return 'exists';
+    }
+
+    public function getOperatorParams(): object
+    {
+        return (object) ['path' => $this->path];
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Exists.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Exists.php
@@ -6,7 +6,11 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-search/exists/
+ */
 class Exists extends AbstractSearchOperator
 {
     public function __construct(Search $search, private string $path = '')

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoShape.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoShape.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use GeoJson\Geometry\Geometry;
+use GeoJson\Geometry\LineString;
+use GeoJson\Geometry\MultiPolygon;
+use GeoJson\Geometry\Point;
+use GeoJson\Geometry\Polygon;
+
+/** @internal */
+class GeoShape extends AbstractSearchOperator implements ScoredSearchOperator
+{
+    use ScoredSearchOperatorTrait;
+
+    /** @var list<string> */
+    private array $path      = [];
+    private string $relation = '';
+
+    /** @var LineString|Point|Polygon|MultiPolygon|array|null */
+    private $geometry = null;
+
+    /** @param LineString|Point|Polygon|MultiPolygon|array|null $geometry */
+    public function __construct(Search $search, $geometry = null, string $relation = '', string ...$path)
+    {
+        parent::__construct($search);
+
+        $this
+            ->geometry($geometry)
+            ->relation($relation)
+            ->path(...$path);
+    }
+
+    public function path(string ...$path): static
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    public function relation(string $relation): static
+    {
+        $this->relation = $relation;
+
+        return $this;
+    }
+
+    /** @param LineString|Point|Polygon|MultiPolygon|array|null $geometry */
+    public function geometry($geometry): static
+    {
+        $this->geometry = $geometry;
+
+        return $this;
+    }
+
+    public function getOperatorName(): string
+    {
+        return 'geoShape';
+    }
+
+    public function getOperatorParams(): object
+    {
+        $params = (object) [
+            'path' => $this->path,
+            'relation' => $this->relation,
+            'geometry' => $this->geometry instanceof Geometry
+                ? $this->geometry->jsonSerialize()
+                : $this->geometry,
+        ];
+
+        return $this->appendScore($params);
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoShape.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoShape.php
@@ -11,7 +11,11 @@ use GeoJson\Geometry\MultiPolygon;
 use GeoJson\Geometry\Point;
 use GeoJson\Geometry\Polygon;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-search/geoShape/
+ */
 class GeoShape extends AbstractSearchOperator implements ScoredSearchOperator
 {
     use ScoredSearchOperatorTrait;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoWithin.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoWithin.php
@@ -10,7 +10,11 @@ use GeoJson\Geometry\MultiPolygon;
 use GeoJson\Geometry\Point;
 use GeoJson\Geometry\Polygon;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-search/geoWithin/
+ */
 class GeoWithin extends AbstractSearchOperator implements ScoredSearchOperator
 {
     use ScoredSearchOperatorTrait;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoWithin.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoWithin.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use GeoJson\Geometry\Geometry;
+use GeoJson\Geometry\MultiPolygon;
+use GeoJson\Geometry\Point;
+use GeoJson\Geometry\Polygon;
+
+/** @internal */
+class GeoWithin extends AbstractSearchOperator implements ScoredSearchOperator
+{
+    use ScoredSearchOperatorTrait;
+
+    /** @var list<string> */
+    private array $path      = [];
+    private string $relation = '';
+    private ?object $box     = null;
+    private ?object $circle  = null;
+
+    /** @var array|MultiPolygon|Polygon|null */
+    private $geometry = null;
+
+    public function __construct(Search $search, string ...$path)
+    {
+        parent::__construct($search);
+
+        $this->path(...$path);
+    }
+
+    public function path(string ...$path): static
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    /**
+     * @param array|Point $bottomLeft
+     * @param array|Point $topRight
+     */
+    public function box($bottomLeft, $topRight): static
+    {
+        $this->box = (object) [
+            'bottomLeft' => $this->convertGeometry($bottomLeft),
+            'topRight' => $this->convertGeometry($topRight),
+        ];
+
+        return $this;
+    }
+
+    /**
+     * @param array|Point $center
+     * @param int|float   $radius
+     */
+    public function circle($center, $radius): static
+    {
+        $this->circle = (object) [
+            'center' => $this->convertGeometry($center),
+            'radius' => $radius,
+        ];
+
+        return $this;
+    }
+
+    /** @param Polygon|MultiPolygon|array $geometry */
+    public function geometry($geometry): static
+    {
+        $this->geometry = $geometry;
+
+        return $this;
+    }
+
+    public function getOperatorName(): string
+    {
+        return 'geoWithin';
+    }
+
+    public function getOperatorParams(): object
+    {
+        $params = (object) ['path' => $this->path];
+
+        if ($this->box) {
+            $params->box = $this->box;
+        }
+
+        if ($this->circle) {
+            $params->circle = $this->circle;
+        }
+
+        if ($this->geometry) {
+            $params->geometry = $this->convertGeometry($this->geometry);
+        }
+
+        return $this->appendScore($params);
+    }
+
+    /**
+     * @param array|Geometry $geometry
+     *
+     * @return array
+     */
+    private function convertGeometry($geometry): array
+    {
+        if (! $geometry instanceof Geometry) {
+            return $geometry;
+        }
+
+        return $geometry->jsonSerialize();
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/MoreLikeThis.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/MoreLikeThis.php
@@ -8,7 +8,11 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use function array_values;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-search/moreLikeThis/
+ */
 class MoreLikeThis extends AbstractSearchOperator
 {
     /** @var list<array<string, mixed>|object> */

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/MoreLikeThis.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/MoreLikeThis.php
@@ -22,12 +22,6 @@ class MoreLikeThis extends AbstractSearchOperator
         $this->like = array_values($documents);
     }
 
-    /** @return array<string, object> */
-    public function getExpression(): array
-    {
-        return [$this->getOperatorName() => $this->getOperatorParams()];
-    }
-
     public function getOperatorName(): string
     {
         return 'moreLikeThis';

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/MoreLikeThis.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/MoreLikeThis.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use function array_values;
+
+/** @internal */
+class MoreLikeThis extends AbstractSearchOperator
+{
+    /** @var list<array<string, mixed>|object> */
+    private array $like = [];
+
+    /** @param array<string, mixed>|object $documents */
+    public function __construct(Search $search, ...$documents)
+    {
+        parent::__construct($search);
+
+        $this->like = array_values($documents);
+    }
+
+    /** @return array<string, object> */
+    public function getExpression(): array
+    {
+        return [$this->getOperatorName() => $this->getOperatorParams()];
+    }
+
+    public function getOperatorName(): string
+    {
+        return 'moreLikeThis';
+    }
+
+    public function getOperatorParams(): object
+    {
+        return (object) ['like' => $this->like];
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Near.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Near.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use GeoJson\Geometry\Geometry;
+use GeoJson\Geometry\Point;
+use MongoDB\BSON\UTCDateTime;
+
+/** @internal */
+class Near extends AbstractSearchOperator implements ScoredSearchOperator
+{
+    use ScoredSearchOperatorTrait;
+
+    /** @var int|float|UTCDateTime|array|Point|null */
+    private $origin;
+
+    /** @var int|float|null */
+    private $pivot;
+
+    /** @var list<string> */
+    private array $path;
+
+    /**
+     * @param int|float|UTCDateTime|array|Point|null $origin
+     * @param int|float|null                         $pivot
+     */
+    public function __construct(Search $search, $origin = null, $pivot = null, string ...$path)
+    {
+        parent::__construct($search);
+
+        $this
+            ->origin($origin)
+            ->pivot($pivot)
+            ->path(...$path);
+    }
+
+    /** @param int|float|UTCDateTime|array|Point|null $origin */
+    public function origin($origin): static
+    {
+        $this->origin = $origin;
+
+        return $this;
+    }
+
+    /** @param int|float|null $pivot */
+    public function pivot($pivot): static
+    {
+        $this->pivot = $pivot;
+
+        return $this;
+    }
+
+    public function path(string ...$path): static
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    public function getOperatorName(): string
+    {
+        return 'near';
+    }
+
+    public function getOperatorParams(): object
+    {
+        $params = (object) [
+            'origin' => $this->origin instanceof Geometry
+                ? $this->origin->jsonSerialize()
+                : $this->origin,
+            'pivot' => $this->pivot,
+            'path' => $this->path,
+        ];
+
+        return $this->appendScore($params);
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Near.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Near.php
@@ -9,7 +9,11 @@ use GeoJson\Geometry\Geometry;
 use GeoJson\Geometry\Point;
 use MongoDB\BSON\UTCDateTime;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-search/near/
+ */
 class Near extends AbstractSearchOperator implements ScoredSearchOperator
 {
     use ScoredSearchOperatorTrait;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Phrase.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Phrase.php
@@ -6,7 +6,11 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use function array_values;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-search/phrase/
+ */
 class Phrase extends AbstractSearchOperator implements ScoredSearchOperator
 {
     use ScoredSearchOperatorTrait;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Phrase.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Phrase.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use function array_values;
+
+/** @internal */
+class Phrase extends AbstractSearchOperator implements ScoredSearchOperator
+{
+    use ScoredSearchOperatorTrait;
+
+    /** @var list<string> */
+    private array $query = [];
+
+    /** @var list<string> */
+    private array $path = [];
+    private ?int $slop  = null;
+
+    public function query(string ...$query): static
+    {
+        $this->query = array_values($query);
+
+        return $this;
+    }
+
+    public function path(string ...$path): static
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    public function slop(int $slop): static
+    {
+        $this->slop = $slop;
+
+        return $this;
+    }
+
+    public function getOperatorName(): string
+    {
+        return 'phrase';
+    }
+
+    public function getOperatorParams(): object
+    {
+        $params = (object) [
+            'query' => $this->query,
+            'path' => $this->path,
+        ];
+
+        if ($this->slop !== null) {
+            $params->slop = $this->slop;
+        }
+
+        return $this->appendScore($params);
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/QueryString.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/QueryString.php
@@ -6,7 +6,11 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-search/queryString/
+ */
 class QueryString extends AbstractSearchOperator implements ScoredSearchOperator
 {
     use ScoredSearchOperatorTrait;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/QueryString.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/QueryString.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+/** @internal */
+class QueryString extends AbstractSearchOperator implements ScoredSearchOperator
+{
+    use ScoredSearchOperatorTrait;
+
+    private string $query;
+    private string $defaultPath;
+
+    public function __construct(Search $search, string $query = '', string $defaultPath = '')
+    {
+        parent::__construct($search);
+
+        $this
+            ->query($query)
+            ->defaultPath($defaultPath);
+    }
+
+    public function query(string $query): static
+    {
+        $this->query = $query;
+
+        return $this;
+    }
+
+    public function defaultPath(string $defaultPath): static
+    {
+        $this->defaultPath = $defaultPath;
+
+        return $this;
+    }
+
+    public function getOperatorName(): string
+    {
+        return 'queryString';
+    }
+
+    public function getOperatorParams(): object
+    {
+        $params = (object) [
+            'query' => $this->query,
+            'defaultPath' => $this->defaultPath,
+        ];
+
+        return $this->appendScore($params);
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Range.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Range.php
@@ -6,7 +6,11 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use MongoDB\BSON\UTCDateTime;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-search/range/
+ */
 class Range extends AbstractSearchOperator implements ScoredSearchOperator
 {
     use ScoredSearchOperatorTrait;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Range.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Range.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use MongoDB\BSON\UTCDateTime;
+
+/** @internal */
+class Range extends AbstractSearchOperator implements ScoredSearchOperator
+{
+    use ScoredSearchOperatorTrait;
+
+    /** @var int|float|UTCDateTime|null */
+    private $gt = null;
+
+    /** @var int|float|UTCDateTime|null */
+    private $lt = null;
+
+    private bool $includeLowerBound = false;
+    private bool $includeUpperBound = false;
+
+    /** @var list<string> */
+    private array $path;
+
+    /** @param int|float|UTCDateTime|null $value */
+    public function gt($value): static
+    {
+        $this->gt                = $value;
+        $this->includeLowerBound = false;
+
+        return $this;
+    }
+
+    /** @param int|float|UTCDateTime|null $value */
+    public function gte($value): static
+    {
+        $this->gt                = $value;
+        $this->includeLowerBound = true;
+
+        return $this;
+    }
+
+    /** @param int|float|UTCDateTime|null $value */
+    public function lt($value): static
+    {
+        $this->lt                = $value;
+        $this->includeLowerBound = false;
+
+        return $this;
+    }
+
+    /** @param int|float|UTCDateTime|null $value */
+    public function lte($value): static
+    {
+        $this->lt                = $value;
+        $this->includeLowerBound = true;
+
+        return $this;
+    }
+
+    public function path(string ...$path): static
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    public function getOperatorName(): string
+    {
+        return 'range';
+    }
+
+    public function getOperatorParams(): object
+    {
+        $params = (object) ['path' => $this->path];
+
+        if ($this->gt !== null) {
+            $name          = $this->includeLowerBound ? 'gte' : 'gt';
+            $params->$name = $this->gt;
+        }
+
+        if ($this->lt !== null) {
+            $name          = $this->includeLowerBound ? 'lte' : 'lt';
+            $params->$name = $this->lt;
+        }
+
+        return $this->appendScore($params);
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Regex.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Regex.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+/** @internal */
+class Regex extends AbstractSearchOperator implements ScoredSearchOperator
+{
+    use ScoredSearchOperatorTrait;
+
+    /** @var list<string> */
+    private array $query = [];
+
+    /** @var list<string> */
+    private array $path               = [];
+    private ?bool $allowAnalyzedField = null;
+
+    public function query(string ...$query): static
+    {
+        $this->query = $query;
+
+        return $this;
+    }
+
+    public function path(string ...$path): static
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    public function allowAnalyzedField(bool $allowAnalyzedField = true): static
+    {
+        $this->allowAnalyzedField = $allowAnalyzedField;
+
+        return $this;
+    }
+
+    public function getOperatorName(): string
+    {
+        return 'regex';
+    }
+
+    public function getOperatorParams(): object
+    {
+        $params = (object) [
+            'query' => $this->query,
+            'path' => $this->path,
+        ];
+
+        if ($this->allowAnalyzedField !== null) {
+            $params->allowAnalyzedField = $this->allowAnalyzedField;
+        }
+
+        return $this->appendScore($params);
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Regex.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Regex.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-search/regex/
+ */
 class Regex extends AbstractSearchOperator implements ScoredSearchOperator
 {
     use ScoredSearchOperatorTrait;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/ScoredSearchOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/ScoredSearchOperator.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface ScoredSearchOperator
+{
+    public function boostScore(?float $value = null, ?string $path = null, ?float $undefined = null): static;
+
+    public function constantScore(float $value): static;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/ScoredSearchOperatorTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/ScoredSearchOperatorTrait.php
@@ -9,7 +9,7 @@ trait ScoredSearchOperatorTrait
 {
     private ?object $score = null;
 
-    protected function appendScore(object $params): object
+    private function appendScore(object $params): object
     {
         if (! $this->score) {
             return $params;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/ScoredSearchOperatorTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/ScoredSearchOperatorTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+/** @internal */
+trait ScoredSearchOperatorTrait
+{
+    private ?object $score = null;
+
+    protected function appendScore(object $params): object
+    {
+        if (! $this->score) {
+            return $params;
+        }
+
+        $params->score = $this->score;
+
+        return $params;
+    }
+
+    public function boostScore(?float $value = null, ?string $path = null, ?float $undefined = null): static
+    {
+        $boost = (object) [];
+        if ($value !== null) {
+            $boost->value = $value;
+        }
+
+        if ($path !== null) {
+            $boost->path = $path;
+        }
+
+        if ($undefined !== null) {
+            $boost->undefined = $undefined;
+        }
+
+        $this->score = (object) ['boost' => $boost];
+
+        return $this;
+    }
+
+    public function constantScore(float $value): static
+    {
+        $this->score = (object) [
+            'constant' => (object) ['value' => $value],
+        ];
+
+        return $this;
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SearchOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SearchOperator.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+/** @internal */
+interface SearchOperator
+{
+    /**
+     * @internal
+     *
+     * @return array<string, object>
+     */
+    public function getExpression(): array;
+
+    /** @internal */
+    public function getOperatorName(): string;
+
+    /** @internal */
+    public function getOperatorParams(): object;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsAllSearchOperators.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsAllSearchOperators.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface SupportsAllSearchOperators extends SupportsAutocompleteOperator, SupportsCompoundOperator, SupportsEmbeddedDocumentOperator, SupportsEqualsOperator, SupportsExistsOperator, SupportsGeoShapeOperator, SupportsGeoWithinOperator, SupportsMoreLikeThisOperator, SupportsNearOperator, SupportsPhraseOperator, SupportsQueryStringOperator, SupportsRangeOperator, SupportsRegexOperator, SupportsTextOperator, SupportsWildcardOperator
+{
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsAllSearchOperatorsTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsAllSearchOperatorsTrait.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use GeoJson\Geometry\LineString;
+use GeoJson\Geometry\MultiPolygon;
+use GeoJson\Geometry\Point;
+use GeoJson\Geometry\Polygon;
+use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\UTCDateTime;
+
+/** @internal */
+trait SupportsAllSearchOperatorsTrait
+{
+    abstract protected function getSearchStage(): Search;
+
+    /**
+     * @param T $operator
+     *
+     * @return T
+     *
+     * @template T of SearchOperator
+     */
+    abstract protected function addOperator(SearchOperator $operator): SearchOperator;
+
+    public function autocomplete(string $path = '', string ...$query): Autocomplete
+    {
+        return $this->addOperator(new Autocomplete($this->getSearchStage(), $path, ...$query));
+    }
+
+    public function compound(): Compound
+    {
+        return $this->addOperator(new Compound($this->getSearchStage()));
+    }
+
+    public function embeddedDocument(string $path = ''): EmbeddedDocument
+    {
+        return $this->addOperator(new EmbeddedDocument($this->getSearchStage(), $path));
+    }
+
+    /** @param string|int|float|ObjectId|UTCDateTime|null $value */
+    public function equals(string $path = '', $value = null): Equals
+    {
+        return $this->addOperator(new Equals($this->getSearchStage(), $path, $value));
+    }
+
+    public function exists(string $path): Exists
+    {
+        return $this->addOperator(new Exists($this->getSearchStage(), $path));
+    }
+
+    /** @param LineString|Point|Polygon|MultiPolygon|array|null $geometry */
+    public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape
+    {
+        return $this->addOperator(new GeoShape($this->getSearchStage(), $geometry, $relation, ...$path));
+    }
+
+    public function geoWithin(string ...$path): GeoWithin
+    {
+        return $this->addOperator(new GeoWithin($this->getSearchStage(), ...$path));
+    }
+
+    /** @param array<string, mixed>|object $documents */
+    public function moreLikeThis(...$documents): MoreLikeThis
+    {
+        return $this->addOperator(new MoreLikeThis($this->getSearchStage(), ...$documents));
+    }
+
+    /**
+     * @param int|float|UTCDateTime|array|Point|null $origin
+     * @param int|float|null                         $pivot
+     */
+    public function near($origin = null, $pivot = null, string ...$path): Near
+    {
+        return $this->addOperator(new Near($this->getSearchStage(), $origin, $pivot, ...$path));
+    }
+
+    public function phrase(): Phrase
+    {
+        return $this->addOperator(new Phrase($this->getSearchStage()));
+    }
+
+    public function queryString(string $query = '', string $defaultPath = ''): QueryString
+    {
+        return $this->addOperator(new QueryString($this->getSearchStage(), $query, $defaultPath));
+    }
+
+    public function range(): Range
+    {
+        return $this->addOperator(new Range($this->getSearchStage()));
+    }
+
+    public function regex(): Regex
+    {
+        return $this->addOperator(new Regex($this->getSearchStage()));
+    }
+
+    public function text(): Text
+    {
+        return $this->addOperator(new Text($this->getSearchStage()));
+    }
+
+    public function wildcard(): Wildcard
+    {
+        return $this->addOperator(new Wildcard($this->getSearchStage()));
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsAutocompleteOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsAutocompleteOperator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface SupportsAutocompleteOperator
+{
+    public function autocomplete(string $path = '', string ...$query): Autocomplete;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsCompoundOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsCompoundOperator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface SupportsCompoundOperator
+{
+    public function compound(): Compound;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsCompoundableOperatorsTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsCompoundableOperatorsTrait.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use Closure;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedAutocomplete;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedEmbeddedDocument;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedEquals;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedExists;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedGeoShape;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedGeoWithin;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedMoreLikeThis;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedNear;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedPhrase;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedQueryString;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedRange;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedRegex;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedText;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedWildcard;
+use GeoJson\Geometry\LineString;
+use GeoJson\Geometry\MultiPolygon;
+use GeoJson\Geometry\Point;
+use GeoJson\Geometry\Polygon;
+use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\UTCDateTime;
+
+/** @internal */
+trait SupportsCompoundableOperatorsTrait
+{
+    abstract protected function getSearchStage(): Search;
+
+    abstract protected function getCompoundStage(): Compound;
+
+    abstract protected function getAddOperatorClosure(): Closure;
+
+    /**
+     * @param T $operator
+     *
+     * @return T
+     *
+     * @template T of SearchOperator
+     */
+    abstract protected function addOperator(SearchOperator $operator): SearchOperator;
+
+    /** return Autocomplete&CompoundSearchOperatorInterface */
+    public function autocomplete(string $path = '', string ...$query): Autocomplete
+    {
+        return $this->addOperator(new CompoundedAutocomplete($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path, ...$query));
+    }
+
+    /** @return EmbeddedDocument&CompoundSearchOperatorInterface */
+    public function embeddedDocument(string $path = ''): EmbeddedDocument
+    {
+        return $this->addOperator(new CompoundedEmbeddedDocument($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path));
+    }
+
+    /**
+     * @param string|int|float|ObjectId|UTCDateTime|null $value
+     *
+     * @return Equals&CompoundSearchOperatorInterface
+     */
+    public function equals(string $path = '', $value = null): Equals
+    {
+        return $this->addOperator(new CompoundedEquals($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path, $value));
+    }
+
+    /** @return Exists&CompoundSearchOperatorInterface */
+    public function exists(string $path): Exists
+    {
+        return $this->addOperator(new CompoundedExists($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path));
+    }
+
+    /**
+     * @param LineString|Point|Polygon|MultiPolygon|array|null $geometry
+     *
+     * @return GeoShape&CompoundSearchOperatorInterface
+     */
+    public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape
+    {
+        return $this->addOperator(new CompoundedGeoShape($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $geometry, $relation, ...$path));
+    }
+
+    /** @return GeoWithin&CompoundSearchOperatorInterface */
+    public function geoWithin(string ...$path): GeoWithin
+    {
+        return $this->addOperator(new CompoundedGeoWithin($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), ...$path));
+    }
+
+    /**
+     * @param array<string, mixed>|object $documents
+     *
+     * @return MoreLikeThis&CompoundSearchOperatorInterface
+     */
+    public function moreLikeThis(...$documents): MoreLikeThis
+    {
+        return $this->addOperator(new CompoundedMoreLikeThis($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), ...$documents));
+    }
+
+    /**
+     * @param int|float|UTCDateTime|array|Point|null $origin
+     * @param int|float|null                         $pivot
+     *
+     * @return Near&CompoundSearchOperatorInterface
+     */
+    public function near($origin = null, $pivot = null, string ...$path): Near
+    {
+        return $this->addOperator(new CompoundedNear($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $origin, $pivot, ...$path));
+    }
+
+    /** @return Phrase&CompoundSearchOperatorInterface */
+    public function phrase(): Phrase
+    {
+        return $this->addOperator(new CompoundedPhrase($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
+    }
+
+    /** @return QueryString&CompoundSearchOperatorInterface */
+    public function queryString(string $query = '', string $defaultPath = ''): QueryString
+    {
+        return $this->addOperator(new CompoundedQueryString($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $query, $defaultPath));
+    }
+
+    /** @return Range&CompoundSearchOperatorInterface */
+    public function range(): Range
+    {
+        return $this->addOperator(new CompoundedRange($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
+    }
+
+    /** @return Regex&CompoundSearchOperatorInterface */
+    public function regex(): Regex
+    {
+        return $this->addOperator(new CompoundedRegex($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
+    }
+
+    /** @return Text&CompoundSearchOperatorInterface */
+    public function text(): Text
+    {
+        return $this->addOperator(new CompoundedText($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
+    }
+
+    /** @return Wildcard&CompoundSearchOperatorInterface */
+    public function wildcard(): Wildcard
+    {
+        return $this->addOperator(new CompoundedWildcard($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsCompoundableSearchOperators.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsCompoundableSearchOperators.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface SupportsCompoundableSearchOperators extends SupportsAutocompleteOperator, SupportsEmbeddedDocumentOperator, SupportsEqualsOperator, SupportsExistsOperator, SupportsGeoShapeOperator, SupportsGeoWithinOperator, SupportsMoreLikeThisOperator, SupportsNearOperator, SupportsPhraseOperator, SupportsQueryStringOperator, SupportsRangeOperator, SupportsRegexOperator, SupportsTextOperator, SupportsWildcardOperator
+{
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsEmbeddableSearchOperators.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsEmbeddableSearchOperators.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface SupportsEmbeddableSearchOperators extends SupportsAutocompleteOperator, SupportsCompoundOperator, SupportsEqualsOperator, SupportsExistsOperator, SupportsGeoShapeOperator, SupportsGeoWithinOperator, SupportsNearOperator, SupportsPhraseOperator, SupportsQueryStringOperator, SupportsRangeOperator, SupportsRegexOperator, SupportsTextOperator, SupportsWildcardOperator
+{
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsEmbeddedDocumentOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsEmbeddedDocumentOperator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface SupportsEmbeddedDocumentOperator
+{
+    public function embeddedDocument(string $path = ''): EmbeddedDocument;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsEqualsOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsEqualsOperator.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\UTCDateTime;
+
+interface SupportsEqualsOperator
+{
+    /** @param string|int|float|ObjectId|UTCDateTime|null $value */
+    public function equals(string $path = '', $value = null): Equals;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsExistsOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsExistsOperator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface SupportsExistsOperator
+{
+    public function exists(string $path): Exists;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsGeoShapeOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsGeoShapeOperator.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use GeoJson\Geometry\LineString;
+use GeoJson\Geometry\MultiPolygon;
+use GeoJson\Geometry\Point;
+use GeoJson\Geometry\Polygon;
+
+interface SupportsGeoShapeOperator
+{
+    /** @param LineString|Point|Polygon|MultiPolygon|array|null $geometry */
+    public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsGeoWithinOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsGeoWithinOperator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface SupportsGeoWithinOperator
+{
+    public function geoWithin(string ...$path): GeoWithin;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsMoreLikeThisOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsMoreLikeThisOperator.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface SupportsMoreLikeThisOperator
+{
+    /** @param array<string, mixed>|object $documents */
+    public function moreLikeThis(...$documents): MoreLikeThis;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsNearOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsNearOperator.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use GeoJson\Geometry\Point;
+use MongoDB\BSON\UTCDateTime;
+
+interface SupportsNearOperator
+{
+    /**
+     * @param int|float|UTCDateTime|array|Point|null $origin
+     * @param int|float|null                         $pivot
+     */
+    public function near($origin = null, $pivot = null, string ...$path): Near;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsPhraseOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsPhraseOperator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface SupportsPhraseOperator
+{
+    public function phrase(): Phrase;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsQueryStringOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsQueryStringOperator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface SupportsQueryStringOperator
+{
+    public function queryString(string $query = '', string $defaultPath = ''): QueryString;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsRangeOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsRangeOperator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface SupportsRangeOperator
+{
+    public function range(): Range;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsRegexOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsRegexOperator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface SupportsRegexOperator
+{
+    public function regex(): Regex;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsTextOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsTextOperator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface SupportsTextOperator
+{
+    public function text(): Text;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsWildcardOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsWildcardOperator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+interface SupportsWildcardOperator
+{
+    public function wildcard(): Wildcard;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Text.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Text.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+use function array_values;
+
+/** @internal */
+class Text extends AbstractSearchOperator implements ScoredSearchOperator
+{
+    use ScoredSearchOperatorTrait;
+
+    /** @var list<string> */
+    private array $query = [];
+
+    /** @var list<string> */
+    private array $path      = [];
+    private ?object $fuzzy   = null;
+    private string $synonyms = '';
+
+    public function query(string ...$query): static
+    {
+        $this->query = array_values($query);
+
+        return $this;
+    }
+
+    public function path(string ...$path): static
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    public function fuzzy(?int $maxEdits = null, ?int $prefixLength = null, ?int $maxExpansions = null): static
+    {
+        $this->fuzzy = (object) [];
+        if ($maxEdits !== null) {
+            $this->fuzzy->maxEdits = $maxEdits;
+        }
+
+        if ($prefixLength !== null) {
+            $this->fuzzy->prefixLength = $prefixLength;
+        }
+
+        if ($maxExpansions !== null) {
+            $this->fuzzy->maxExpansions = $maxExpansions;
+        }
+
+        return $this;
+    }
+
+    public function synonyms(string $synonyms): static
+    {
+        $this->synonyms = $synonyms;
+
+        return $this;
+    }
+
+    public function getOperatorName(): string
+    {
+        return 'text';
+    }
+
+    public function getOperatorParams(): object
+    {
+        $params = (object) [
+            'query' => $this->query,
+            'path' => $this->path,
+        ];
+
+        if ($this->fuzzy) {
+            $params->fuzzy = $this->fuzzy;
+        }
+
+        if ($this->synonyms) {
+            $params->synonyms = $this->synonyms;
+        }
+
+        return $this->appendScore($params);
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Text.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Text.php
@@ -6,7 +6,11 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use function array_values;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-search/text/
+ */
 class Text extends AbstractSearchOperator implements ScoredSearchOperator
 {
     use ScoredSearchOperatorTrait;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Wildcard.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Wildcard.php
@@ -9,10 +9,54 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
  *
  * @see https://www.mongodb.com/docs/atlas/atlas-search/wildcard/
  */
-class Wildcard extends Regex
+class Wildcard extends AbstractSearchOperator implements ScoredSearchOperator
 {
+    use ScoredSearchOperatorTrait;
+
+    /** @var list<string> */
+    private array $query = [];
+
+    /** @var list<string> */
+    private array $path               = [];
+    private ?bool $allowAnalyzedField = null;
+
+    public function query(string ...$query): static
+    {
+        $this->query = $query;
+
+        return $this;
+    }
+
+    public function path(string ...$path): static
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    public function allowAnalyzedField(bool $allowAnalyzedField = true): static
+    {
+        $this->allowAnalyzedField = $allowAnalyzedField;
+
+        return $this;
+    }
+
     public function getOperatorName(): string
     {
         return 'wildcard';
+    }
+
+    public function getOperatorParams(): object
+    {
+        $params = (object) [
+            'query' => $this->query,
+            'path' => $this->path,
+        ];
+
+        if ($this->allowAnalyzedField !== null) {
+            $params->allowAnalyzedField = $this->allowAnalyzedField;
+        }
+
+        return $this->appendScore($params);
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Wildcard.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Wildcard.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+
+/** @internal */
+class Wildcard extends Regex
+{
+    public function getOperatorName(): string
+    {
+        return 'wildcard';
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Wildcard.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Wildcard.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-search/wildcard/
+ */
 class Wildcard extends Regex
 {
     public function getOperatorName(): string

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,6 +121,331 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Out.php
 
 		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedAutocomplete\\:\\:__construct\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedAutocomplete.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedAutocomplete\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedAutocomplete.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedAutocomplete\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedAutocomplete.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedEmbeddedDocument\\:\\:__construct\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedEmbeddedDocument.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedEmbeddedDocument\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedEmbeddedDocument.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedEmbeddedDocument\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedEmbeddedDocument.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedEquals\\:\\:__construct\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedEquals.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedEquals\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedEquals.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedEquals\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedEquals.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedExists\\:\\:__construct\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedExists.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedExists\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedExists.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedExists\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedExists.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedGeoShape\\:\\:__construct\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedGeoShape.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedGeoShape\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedGeoShape.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedGeoShape\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedGeoShape.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedGeoWithin\\:\\:__construct\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedGeoWithin.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedGeoWithin\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedGeoWithin.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedGeoWithin\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedGeoWithin.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedMoreLikeThis\\:\\:__construct\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedMoreLikeThis.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedMoreLikeThis\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedMoreLikeThis.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedMoreLikeThis\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedMoreLikeThis.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedNear\\:\\:__construct\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedNear.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedNear\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedNear.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedNear\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedNear.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedPhrase\\:\\:__construct\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedPhrase.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedPhrase\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedPhrase.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedPhrase\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedPhrase.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedQueryString\\:\\:__construct\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedQueryString.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedQueryString\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedQueryString.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedQueryString\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedQueryString.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedRange\\:\\:__construct\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedRange.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedRange\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedRange.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedRange\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedRange.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedRegex\\:\\:__construct\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedRegex.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedRegex\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedRegex.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedRegex\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedRegex.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedText\\:\\:__construct\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedText.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedText\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedText.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedText\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedText.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedWildcard\\:\\:__construct\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedWildcard.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedWildcard\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedWildcard.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\\\CompoundedWildcard\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedWildcard.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\EmbeddedDocument\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/EmbeddedDocument.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\EmbeddedDocument\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/EmbeddedDocument.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\GeoShape\\:\\:__construct\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoShape.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\GeoShape\\:\\:geometry\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoShape.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\GeoShape\\:\\:\\$geometry type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoShape.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\GeoWithin\\:\\:box\\(\\) has parameter \\$bottomLeft with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoWithin.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\GeoWithin\\:\\:box\\(\\) has parameter \\$topRight with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoWithin.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\GeoWithin\\:\\:circle\\(\\) has parameter \\$center with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoWithin.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\GeoWithin\\:\\:convertGeometry\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoWithin.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\GeoWithin\\:\\:convertGeometry\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoWithin.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\GeoWithin\\:\\:geometry\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoWithin.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\GeoWithin\\:\\:\\$geometry type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoWithin.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\GeoWithin\\:\\:\\$relation is never read, only written\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoWithin.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Near\\:\\:__construct\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Near.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Near\\:\\:origin\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Near.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Near\\:\\:\\$origin type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Near.php
+
+		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Range\\:\\:\\$includeUpperBound is never read, only written\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Range.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\SupportsGeoShapeOperator\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsGeoShapeOperator.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\SupportsNearOperator\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsNearOperator.php
+
+		-
 			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\UnionWith\\:\\:getExpression\\(\\) has invalid return type Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\UnionWithStageExpression\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
@@ -339,6 +664,21 @@ parameters:
 			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Aggregation\\\\Stage\\\\ProjectTest\\:\\:testAccumulatorsWithMultipleArguments\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Aggregation\\\\Stage\\\\SearchTest\\:\\:testSearchCompoundOperators\\(\\) has parameter \\$expectedOperator with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Aggregation\\\\Stage\\\\SearchTest\\:\\:testSearchEmbeddedDocumentOperators\\(\\) has parameter \\$expectedOperator with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Aggregation\\\\Stage\\\\SearchTest\\:\\:testSearchOperators\\(\\) has parameter \\$expectedOperator with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
 
 		-
 			message: "#^Constant DOCTRINE_MONGODB_DATABASE not found\\.$#"

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
@@ -1,0 +1,1274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
+
+use Closure;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\AbstractSearchOperator;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
+use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
+use Doctrine\ODM\MongoDB\Tests\BaseTest;
+use Generator;
+use GeoJson\Geometry\Point;
+use GeoJson\Geometry\Polygon;
+use MongoDB\BSON\UTCDateTime;
+use PHPUnit\Framework\Constraint\IsInstanceOf;
+
+use function array_combine;
+use function array_map;
+use function array_merge;
+
+class SearchTest extends BaseTest
+{
+    use AggregationTestTrait;
+
+    public static function provideAutocompleteBuilders(): Generator
+    {
+        yield 'Autocomplete required only' => [
+            'expectedOperator' => [
+                'autocomplete' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => 'content',
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->autocomplete('content', 'MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('content');
+            },
+        ];
+
+        yield 'Autocomplete with token order' => [
+            'expectedOperator' => [
+                'autocomplete' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => 'content',
+                    'tokenOrder' => 'any',
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->autocomplete()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('content')
+                    ->tokenOrder('any');
+            },
+        ];
+
+        yield 'Autocomplete with boost score' => [
+            'expectedOperator' => [
+                'autocomplete' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => 'content',
+                    'score' => (object) [
+                        'boost' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->autocomplete()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('content')
+                    ->boostScore(1.5);
+            },
+        ];
+
+        yield 'Autocomplete with constant score' => [
+            'expectedOperator' => [
+                'autocomplete' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => 'content',
+                    'score' => (object) [
+                        'constant' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->autocomplete()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('content')
+                    ->constantScore(1.5);
+            },
+        ];
+
+        yield 'Autocomplete with fuzzy search' => [
+            'expectedOperator' => [
+                'autocomplete' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => 'content',
+                    'fuzzy' => (object) [
+                        'maxEdits' => 1,
+                        'prefixLength' => 2,
+                        'maxExpansions' => 3,
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->autocomplete()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('content')
+                    ->fuzzy(1, 2, 3);
+            },
+        ];
+    }
+
+    public static function provideCompoundBuilders(): Generator
+    {
+        yield 'Compound with single must clause' => [
+            'expectedOperator' => [
+                'compound' => (object) [
+                    'must' => [
+                        (object) [
+                            'text' => (object) [
+                                'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                                'path' => ['items.content'],
+                                'synonyms' => 'mySynonyms',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->compound()
+                    ->must()
+                        ->text()
+                            ->path('items.content')
+                            ->query('MongoDB', 'Aggregation', 'Pipeline')
+                            ->synonyms('mySynonyms');
+            },
+        ];
+
+        yield 'Compound with multiple must clauses' => [
+            'expectedOperator' => [
+                'compound' => (object) [
+                    'must' => [
+                        (object) [
+                            'text' => (object) [
+                                'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                                'path' => ['items.content'],
+                                'synonyms' => 'mySynonyms',
+                            ],
+                        ],
+                        (object) [
+                            'near' => (object) [
+                                'origin' => 5,
+                                'pivot' => 3,
+                                'path' => ['value1', 'value2'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->compound()
+                    ->must()
+                        ->text()
+                            ->path('items.content')
+                            ->query('MongoDB', 'Aggregation', 'Pipeline')
+                            ->synonyms('mySynonyms')
+                        ->near(5, 3, 'value1', 'value2');
+            },
+        ];
+
+        yield 'Compound with must and mustNot clauses' => [
+            'expectedOperator' => [
+                'compound' => (object) [
+                    'must' => [
+                        (object) [
+                            'text' => (object) [
+                                'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                                'path' => ['items.content'],
+                                'synonyms' => 'mySynonyms',
+                            ],
+                        ],
+                    ],
+                    'mustNot' => [
+                        (object) [
+                            'exists' => (object) ['path' => 'hidden'],
+                        ],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->compound()
+                    ->must()
+                        ->text()
+                            ->path('items.content')
+                            ->query('MongoDB', 'Aggregation', 'Pipeline')
+                            ->synonyms('mySynonyms')
+                    ->mustNot()
+                        ->exists('hidden');
+            },
+        ];
+    }
+
+    public static function provideEmbeddedDocumentBuilders(): Generator
+    {
+        yield 'EmbeddedDocument with single text operator' => [
+            'expectedOperator' => [
+                'embeddedDocument' => (object) [
+                    'path' => 'items',
+                    'operator' => (object) [
+                        'text' => (object) [
+                            'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                            'path' => ['items.content'],
+                            'synonyms' => 'mySynonyms',
+                        ],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->embeddedDocument('items')
+                    ->text()
+                        ->path('items.content')
+                        ->query('MongoDB', 'Aggregation', 'Pipeline')
+                        ->synonyms('mySynonyms');
+            },
+        ];
+    }
+
+    public static function provideEmbeddedDocumentCompoundBuilders(): Generator
+    {
+        yield 'EmbeddedDocument with compound operator' => [
+            'expectedOperator' => [
+                'embeddedDocument' => (object) [
+                    'path' => 'items',
+                    'operator' => (object) [
+                        'compound' => (object) [
+                            'must' => [
+                                (object) [
+                                    'text' => (object) [
+                                        'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                                        'path' => ['items.content'],
+                                        'synonyms' => 'mySynonyms',
+                                    ],
+                                ],
+                                (object) [
+                                    'near' => (object) [
+                                        'origin' => 5,
+                                        'pivot' => 3,
+                                        'path' => ['items.value1'],
+                                    ],
+                                ],
+                            ],
+                            'mustNot' => [
+                                (object) [
+                                    'exists' => (object) ['path' => 'items.hidden'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->embeddedDocument('items')
+                    ->compound()
+                        ->must()
+                            ->text()
+                                ->path('items.content')
+                                ->query('MongoDB', 'Aggregation', 'Pipeline')
+                                ->synonyms('mySynonyms')
+                            ->near(5, 3, 'items.value1')
+                        ->mustNot()
+                            ->exists('items.hidden');
+            },
+        ];
+    }
+
+    public static function provideEqualsBuilders(): Generator
+    {
+        yield 'Equals required only' => [
+            'expectedOperator' => [
+                'equals' => (object) [
+                    'path' => 'content',
+                    'value' => 'MongoDB Aggregation Pipeline',
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->equals('content', 'MongoDB Aggregation Pipeline');
+            },
+        ];
+
+        yield 'Equals with boost score' => [
+            'expectedOperator' => [
+                'equals' => (object) [
+                    'path' => 'content',
+                    'value' => 'MongoDB Aggregation Pipeline',
+                    'score' => (object) [
+                        'boost' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->equals()
+                    ->path('content')
+                    ->value('MongoDB Aggregation Pipeline')
+                    ->boostScore(1.5);
+            },
+        ];
+
+        yield 'Equals with constant score' => [
+            'expectedOperator' => [
+                'equals' => (object) [
+                    'path' => 'content',
+                    'value' => 'MongoDB Aggregation Pipeline',
+                    'score' => (object) [
+                        'constant' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->equals()
+                    ->path('content')
+                    ->value('MongoDB Aggregation Pipeline')
+                    ->constantScore(1.5);
+            },
+        ];
+    }
+
+    public static function provideExistsBuilders(): Generator
+    {
+        yield 'Exists required only' => [
+            'expectedOperator' => [
+                'exists' => (object) ['path' => 'content'],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->exists('content');
+            },
+        ];
+    }
+
+    public static function provideGeoShapeBuilders(): Generator
+    {
+        yield 'CompoundedGeoShape required only' => [
+            'expectedOperator' => [
+                'geoShape' => (object) [
+                    'path' => ['location1', 'location2'],
+                    'relation' => 'contains',
+                    'geometry' => ['coordinates' => [12.345, 23.456], 'type' => 'Point'],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->geoShape(
+                    new Point([12.345, 23.456]),
+                    'contains',
+                    'location1',
+                    'location2',
+                );
+            },
+        ];
+
+        yield 'CompoundedGeoShape with boost score' => [
+            'expectedOperator' => [
+                'geoShape' => (object) [
+                    'path' => ['location'],
+                    'relation' => 'contains',
+                    'geometry' => ['coordinates' => [12.345, 23.456], 'type' => 'Point'],
+                    'score' => (object) [
+                        'boost' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->geoShape()
+                    ->path('location')
+                    ->relation('contains')
+                    ->geometry(new Point([12.345, 23.456]))
+                    ->boostScore(1.5);
+            },
+        ];
+
+        yield 'CompoundedGeoShape with constant score' => [
+            'expectedOperator' => [
+                'geoShape' => (object) [
+                    'path' => ['location'],
+                    'relation' => 'contains',
+                    'geometry' => ['coordinates' => [12.345, 23.456], 'type' => 'Point'],
+                    'score' => (object) [
+                        'constant' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->geoShape()
+                    ->path('location')
+                    ->relation('contains')
+                    ->geometry(new Point([12.345, 23.456]))
+                    ->constantScore(1.5);
+            },
+        ];
+    }
+
+    public static function provideGeoWithinBuilders(): Generator
+    {
+        yield 'GeoWithin box' => [
+            'expectedOperator' => [
+                'geoWithin' => (object) [
+                    'path' => ['location1', 'location2'],
+                    'box' => (object) [
+                        'bottomLeft' => ['coordinates' => [-12.345, -23.456], 'type' => 'Point'],
+                        'topRight' => ['coordinates' => [12.345, 23.456], 'type' => 'Point'],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->geoWithin('location1', 'location2')
+                    ->box(new Point([-12.345, -23.456]), new Point([12.345, 23.456]));
+            },
+        ];
+
+        yield 'GeoWithin circle' => [
+            'expectedOperator' => [
+                'geoWithin' => (object) [
+                    'path' => ['location'],
+                    'circle' => (object) [
+                        'center' => ['coordinates' => [12.345, 23.456], 'type' => 'Point'],
+                        'radius' => 3.14,
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->geoWithin()
+                    ->path('location')
+                    ->circle(new Point([12.345, 23.456]), 3.14);
+            },
+        ];
+
+        yield 'GeoWithin geometry' => [
+            'expectedOperator' => [
+                'geoWithin' => (object) [
+                    'path' => ['location'],
+                    'geometry' => [
+                        'coordinates' => [
+                            [[0, 0], [0, 4], [4, 4], [4, 0], [0, 0]],
+                            [[1, 1], [1, 3], [3, 3], [3, 1], [1, 1]],
+                        ],
+                        'type' => 'Polygon',
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->geoWithin()
+                    ->path('location')
+                    ->geometry(new Polygon([
+                        [[0, 0], [0, 4], [4, 4], [4, 0], [0, 0]],
+                        [[1, 1], [1, 3], [3, 3], [3, 1], [1, 1]],
+                    ]));
+            },
+        ];
+
+        yield 'GeoWithin with boost score' => [
+            'expectedOperator' => [
+                'geoWithin' => (object) [
+                    'path' => ['location'],
+                    'circle' => (object) [
+                        'center' => ['coordinates' => [12.345, 23.456], 'type' => 'Point'],
+                        'radius' => 3.14,
+                    ],
+                    'score' => (object) [
+                        'boost' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->geoWithin()
+                    ->path('location')
+                    ->circle(new Point([12.345, 23.456]), 3.14)
+                    ->boostScore(1.5);
+            },
+        ];
+
+        yield 'GeoWithin with constant score' => [
+            'expectedOperator' => [
+                'geoWithin' => (object) [
+                    'path' => ['location'],
+                    'circle' => (object) [
+                        'center' => ['coordinates' => [12.345, 23.456], 'type' => 'Point'],
+                        'radius' => 3.14,
+                    ],
+                    'score' => (object) [
+                        'constant' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->geoWithin()
+                    ->path('location')
+                    ->circle(new Point([12.345, 23.456]), 3.14)
+                    ->constantScore(1.5);
+            },
+        ];
+    }
+
+    public static function provideMoreLikeThisBuilders(): Generator
+    {
+        yield 'MoreLikeThis with single like' => [
+            'expectedOperator' => [
+                'moreLikeThis' => (object) ['like' => [['title' => 'The Godfather']]],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->moreLikeThis(['title' => 'The Godfather']);
+            },
+        ];
+
+        yield 'MoreLikeThis with multiple documents' => [
+            'expectedOperator' => [
+                'moreLikeThis' => (object) [
+                    'like' => [
+                        ['title' => 'The Godfather'],
+                        ['title' => 'The Green Mile'],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->moreLikeThis(['title' => 'The Godfather'], ['title' => 'The Green Mile']);
+            },
+        ];
+    }
+
+    public static function provideNearBuilders(): Generator
+    {
+        yield 'Near with number' => [
+            'expectedOperator' => [
+                'near' => (object) [
+                    'origin' => 5,
+                    'pivot' => 3,
+                    'path' => ['value1', 'value2'],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->near(5, 3, 'value1', 'value2');
+            },
+        ];
+
+        $date = new UTCDateTime();
+
+        yield 'Near with date' => [
+            'expectedOperator' => [
+                'near' => (object) [
+                    'origin' => $date,
+                    'pivot' => 2,
+                    'path' => ['createdAt'],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) use ($date) {
+                return $stage->near()
+                    ->path('createdAt')
+                    ->origin($date)
+                    ->pivot(2);
+            },
+        ];
+
+        yield 'Near with point' => [
+            'expectedOperator' => [
+                'near' => (object) [
+                    'origin' => ['coordinates' => [12.345, 23.456], 'type' => 'Point'],
+                    'pivot' => 2,
+                    'path' => ['createdAt'],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->near()
+                    ->path('createdAt')
+                    ->origin(new Point([12.345, 23.456]))
+                    ->pivot(2);
+            },
+        ];
+    }
+
+    public static function providePhraseBuilders(): Generator
+    {
+        yield 'Phrase required only' => [
+            'expectedOperator' => [
+                'phrase' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['title', 'content'],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->phrase()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('title', 'content');
+            },
+        ];
+
+        yield 'Phrase with slop' => [
+            'expectedOperator' => [
+                'phrase' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['content'],
+                    'slop' => 3,
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->phrase()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('content')
+                    ->slop(3);
+            },
+        ];
+
+        yield 'Phrase with boost score' => [
+            'expectedOperator' => [
+                'phrase' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['content'],
+                    'score' => (object) [
+                        'boost' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->phrase()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('content')
+                    ->boostScore(1.5);
+            },
+        ];
+
+        yield 'Phrase with constant score' => [
+            'expectedOperator' => [
+                'phrase' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['content'],
+                    'score' => (object) [
+                        'constant' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->phrase()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('content')
+                    ->constantScore(1.5);
+            },
+        ];
+    }
+
+    public static function provideQueryStringBuilders(): Generator
+    {
+        yield 'QueryString required only' => [
+            'expectedOperator' => [
+                'queryString' => (object) [
+                    'query' => 'MongoDB Aggregation Pipeline',
+                    'defaultPath' => 'content',
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->queryString('MongoDB Aggregation Pipeline', 'content');
+            },
+        ];
+
+        yield 'QueryString with boost score' => [
+            'expectedOperator' => [
+                'queryString' => (object) [
+                    'query' => 'content:pipeline OR title:pipeline',
+                    'defaultPath' => 'content',
+                    'score' => (object) [
+                        'boost' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->queryString()
+                    ->query('content:pipeline OR title:pipeline')
+                    ->defaultPath('content')
+                    ->boostScore(1.5);
+            },
+        ];
+
+        yield 'QueryString with constant score' => [
+            'expectedOperator' => [
+                'queryString' => (object) [
+                    'query' => 'content:pipeline OR title:pipeline',
+                    'defaultPath' => 'content',
+                    'score' => (object) [
+                        'constant' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->queryString()
+                    ->query('content:pipeline OR title:pipeline')
+                    ->defaultPath('content')
+                    ->constantScore(1.5);
+            },
+        ];
+    }
+
+    public static function provideRangeBuilders(): Generator
+    {
+        yield 'Range gt only' => [
+            'expectedOperator' => [
+                'range' => (object) [
+                    'path' => ['field1', 'field2'],
+                    'gt' => 5,
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->range()
+                    ->path('field1', 'field2')
+                    ->gt(5);
+            },
+        ];
+
+        yield 'Range gte only' => [
+            'expectedOperator' => [
+                'range' => (object) [
+                    'path' => ['field1', 'field2'],
+                    'gte' => 5,
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->range()
+                    ->path('field1', 'field2')
+                    ->gte(5);
+            },
+        ];
+
+        yield 'Range lt only' => [
+            'expectedOperator' => [
+                'range' => (object) [
+                    'path' => ['field1', 'field2'],
+                    'lt' => 5,
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->range()
+                    ->path('field1', 'field2')
+                    ->lt(5);
+            },
+        ];
+
+        yield 'Range lte only' => [
+            'expectedOperator' => [
+                'range' => (object) [
+                    'path' => ['field1', 'field2'],
+                    'lte' => 5,
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->range()
+                    ->path('field1', 'field2')
+                    ->lte(5);
+            },
+        ];
+
+        yield 'Range both bounds' => [
+            'expectedOperator' => [
+                'range' => (object) [
+                    'path' => ['field1', 'field2'],
+                    'lte' => 10,
+                    'gte' => 5,
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->range()
+                    ->path('field1', 'field2')
+                    ->lte(10)
+                    ->gte(5);
+            },
+        ];
+
+        yield 'Range with boost score' => [
+            'expectedOperator' => [
+                'range' => (object) [
+                    'path' => ['field1', 'field2'],
+                    'lte' => 10,
+                    'gte' => 5,
+                    'score' => (object) [
+                        'boost' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->range()
+                    ->path('field1', 'field2')
+                    ->lte(10)
+                    ->gte(5)
+                    ->boostScore(1.5);
+            },
+        ];
+
+        yield 'Range with constant score' => [
+            'expectedOperator' => [
+                'range' => (object) [
+                    'path' => ['field1', 'field2'],
+                    'lte' => 10,
+                    'gte' => 5,
+                    'score' => (object) [
+                        'constant' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->range()
+                    ->path('field1', 'field2')
+                    ->lte(10)
+                    ->gte(5)
+                    ->constantScore(1.5);
+            },
+        ];
+    }
+
+    public static function provideRegexBuilders(): Generator
+    {
+        yield 'Regex required only' => [
+            'expectedOperator' => [
+                'regex' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['title', 'content'],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->regex()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('title', 'content');
+            },
+        ];
+
+        yield 'Regex with allowAnalyzedField true' => [
+            'expectedOperator' => [
+                'regex' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['title', 'content'],
+                    'allowAnalyzedField' => true,
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->regex()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('title', 'content')
+                    ->allowAnalyzedField();
+            },
+        ];
+
+        yield 'Regex with allowAnalyzedField false' => [
+            'expectedOperator' => [
+                'regex' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['title', 'content'],
+                    'allowAnalyzedField' => false,
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->regex()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('title', 'content')
+                    ->allowAnalyzedField(false);
+            },
+        ];
+
+        yield 'Regex with boost score' => [
+            'expectedOperator' => [
+                'regex' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['title', 'content'],
+                    'score' => (object) [
+                        'boost' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->regex()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('title', 'content')
+                    ->boostScore(1.5);
+            },
+        ];
+
+        yield 'Regex with constant score' => [
+            'expectedOperator' => [
+                'regex' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['title', 'content'],
+                    'score' => (object) [
+                        'constant' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->regex()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('title', 'content')
+                    ->constantScore(1.5);
+            },
+        ];
+    }
+
+    public static function provideTextBuilders(): Generator
+    {
+        yield 'Text required only' => [
+            'expectedOperator' => [
+                'text' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['title', 'content'],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->text()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('title', 'content');
+            },
+        ];
+
+        yield 'Text with synonyms' => [
+            'expectedOperator' => [
+                'text' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['content'],
+                    'synonyms' => 'mySynonyms',
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->text()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('content')
+                    ->synonyms('mySynonyms');
+            },
+        ];
+
+        yield 'Text with boost score' => [
+            'expectedOperator' => [
+                'text' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['content'],
+                    'score' => (object) [
+                        'boost' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->text()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('content')
+                    ->boostScore(1.5);
+            },
+        ];
+
+        yield 'Text with constant score' => [
+            'expectedOperator' => [
+                'text' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['content'],
+                    'score' => (object) [
+                        'constant' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->text()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('content')
+                    ->constantScore(1.5);
+            },
+        ];
+
+        yield 'Text with fuzzy search' => [
+            'expectedOperator' => [
+                'text' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['content'],
+                    'fuzzy' => (object) [
+                        'maxEdits' => 1,
+                        'prefixLength' => 2,
+                        'maxExpansions' => 3,
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->text()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('content')
+                    ->fuzzy(1, 2, 3);
+            },
+        ];
+    }
+
+    public static function provideWildcardBuilders(): Generator
+    {
+        yield 'Wildcard required only' => [
+            'expectedOperator' => [
+                'wildcard' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['title', 'content'],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->wildcard()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('title', 'content');
+            },
+        ];
+
+        yield 'Wildcard with allowAnalyzedField true' => [
+            'expectedOperator' => [
+                'wildcard' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['title', 'content'],
+                    'allowAnalyzedField' => true,
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->wildcard()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('title', 'content')
+                    ->allowAnalyzedField();
+            },
+        ];
+
+        yield 'Wildcard with allowAnalyzedField false' => [
+            'expectedOperator' => [
+                'wildcard' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['title', 'content'],
+                    'allowAnalyzedField' => false,
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->wildcard()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('title', 'content')
+                    ->allowAnalyzedField(false);
+            },
+        ];
+
+        yield 'Wildcard with boost score' => [
+            'expectedOperator' => [
+                'wildcard' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['title', 'content'],
+                    'score' => (object) [
+                        'boost' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->wildcard()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('title', 'content')
+                    ->boostScore(1.5);
+            },
+        ];
+
+        yield 'Wildcard with constant score' => [
+            'expectedOperator' => [
+                'wildcard' => (object) [
+                    'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
+                    'path' => ['title', 'content'],
+                    'score' => (object) [
+                        'constant' => (object) ['value' => 1.5],
+                    ],
+                ],
+            ],
+            /** @param Search|CompoundSearchOperatorInterface $stage */
+            'createOperator' => static function ($stage) {
+                return $stage->wildcard()
+                    ->query('MongoDB', 'Aggregation', 'Pipeline')
+                    ->path('title', 'content')
+                    ->constantScore(1.5);
+            },
+        ];
+    }
+
+    /**
+     * @dataProvider provideAutocompleteBuilders
+     * @dataProvider provideCompoundBuilders
+     * @dataProvider provideEmbeddedDocumentBuilders
+     * @dataProvider provideEmbeddedDocumentCompoundBuilders
+     * @dataProvider provideEqualsBuilders
+     * @dataProvider provideExistsBuilders
+     * @dataProvider provideGeoShapeBuilders
+     * @dataProvider provideGeoWithinBuilders
+     * @dataProvider provideMoreLikeThisBuilders
+     * @dataProvider provideNearBuilders
+     * @dataProvider providePhraseBuilders
+     * @dataProvider provideQueryStringBuilders
+     * @dataProvider provideRangeBuilders
+     * @dataProvider provideRegexBuilders
+     * @dataProvider provideTextBuilders
+     * @dataProvider provideWildcardBuilders
+     */
+    public function testSearchOperators(array $expectedOperator, Closure $createOperator): void
+    {
+        $baseExpected = [
+            'index' => 'my_search_index',
+            'highlight' => (object) [
+                'path' => 'content',
+                'maxCharsToExamine' => 2,
+                'maxNumPassages' => 3,
+            ],
+            'count' => (object) [
+                'type' => 'lowerBound',
+                'threshold' => 1000,
+            ],
+            'returnStoredSource' => true,
+        ];
+
+        $searchStage = new Search($this->getTestAggregationBuilder());
+        $searchStage
+            ->index('my_search_index');
+
+        $result = $createOperator($searchStage);
+
+        self::logicalOr(
+            new IsInstanceOf(AbstractSearchOperator::class),
+            new IsInstanceOf(Search::class),
+        );
+
+        $result
+            ->highlight('content', 2, 3)
+            ->countDocuments('lowerBound', 1000)
+            ->returnStoredSource();
+
+        self::assertEquals(
+            ['$search' => (object) array_merge($baseExpected, $expectedOperator)],
+            $searchStage->getExpression(),
+        );
+    }
+
+    /**
+     * @dataProvider provideAutocompleteBuilders
+     * @dataProvider provideEmbeddedDocumentBuilders
+     * @dataProvider provideEqualsBuilders
+     * @dataProvider provideExistsBuilders
+     * @dataProvider provideGeoShapeBuilders
+     * @dataProvider provideGeoWithinBuilders
+     * @dataProvider provideMoreLikeThisBuilders
+     * @dataProvider provideNearBuilders
+     * @dataProvider providePhraseBuilders
+     * @dataProvider provideQueryStringBuilders
+     * @dataProvider provideRangeBuilders
+     * @dataProvider provideRegexBuilders
+     * @dataProvider provideTextBuilders
+     * @dataProvider provideWildcardBuilders
+     */
+    public function testSearchCompoundOperators(array $expectedOperator, Closure $createOperator): void
+    {
+        $searchStage = new Search($this->getTestAggregationBuilder());
+        $compound    = $searchStage
+            ->index('my_search_index')
+            ->compound();
+
+        $compound = $createOperator($compound->must());
+        $compound = $createOperator($compound->mustNot());
+        $compound = $createOperator($compound->should(2));
+        $compound = $createOperator($compound->filter());
+
+        self::assertInstanceOf(CompoundSearchOperatorInterface::class, $compound);
+
+        $keys = ['must', 'mustNot', 'should', 'filter'];
+
+        $expected = (object) [
+            'index' => 'my_search_index',
+            'compound' => (object) array_combine(
+                $keys,
+                array_map(
+                    static fn (string $value): array => [(object) $expectedOperator],
+                    $keys,
+                ),
+            ),
+        ];
+
+        $expected->compound->minimumShouldMatch = 2;
+
+        self::assertEquals(
+            ['$search' => $expected],
+            $searchStage->getExpression(),
+        );
+    }
+
+    /**
+     * @dataProvider provideAutocompleteBuilders
+     * @dataProvider provideCompoundBuilders
+     * @dataProvider provideEqualsBuilders
+     * @dataProvider provideExistsBuilders
+     * @dataProvider provideGeoShapeBuilders
+     * @dataProvider provideGeoWithinBuilders
+     * @dataProvider provideMoreLikeThisBuilders
+     * @dataProvider provideNearBuilders
+     * @dataProvider providePhraseBuilders
+     * @dataProvider provideQueryStringBuilders
+     * @dataProvider provideRangeBuilders
+     * @dataProvider provideRegexBuilders
+     * @dataProvider provideTextBuilders
+     * @dataProvider provideWildcardBuilders
+     */
+    public function testSearchEmbeddedDocumentOperators(array $expectedOperator, Closure $createOperator): void
+    {
+        $searchStage = new Search($this->getTestAggregationBuilder());
+        $embedded    = $searchStage
+            ->index('my_search_index')
+            ->embeddedDocument('foo');
+
+        $createOperator($embedded);
+
+        $expected = (object) [
+            'index' => 'my_search_index',
+            'embeddedDocument' => (object) [
+                'path' => 'foo',
+                'operator' => (object) $expectedOperator,
+            ],
+        ];
+
+        self::assertEquals(
+            ['$search' => $expected],
+            $searchStage->getExpression(),
+        );
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | #2460 

#### Summary

<!-- Provide a summary your change. -->

This adds the [`$search` aggregation pipeline stage](https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#mongodb-pipeline-pipe.-search) to the aggregation builder. This stage only works on MongoDB Atlas with Search indexes.

The following is missing from this PR:
* The [`span` operator](https://www.mongodb.com/docs/atlas/atlas-search/span/) - I'm currently looking into the documentation as it is using undocumented operators
* The [`facet` collector](https://www.mongodb.com/docs/atlas/atlas-search/facet/) - this is relevant for the `$searchMeta` stage but would conflict with the `facet` stage that people could add down the line. For now, users should use the [`$$SEARCH_META` aggregation variable](https://www.mongodb.com/docs/atlas/atlas-search/facet/#std-label-fts-facet-aggregation-variable)
* Documentation on how to create indexes (which is only possible through Atlas) and how to use the `$search` stage itself.