### PR TITLE
Add $setWindowFields aggregation pipeline stage and window operators

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -572,6 +572,20 @@ class Builder
     }
 
     /**
+     * Performs operations on a specified span of documents in a collection,
+     * known as a window, and returns the results based on the chosen window
+     * operator.
+     *
+     * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/setWindowFields/
+     */
+    public function setWindowFields(): Stage\SetWindowFields
+    {
+        $stage = new Stage\SetWindowFields($this);
+
+        return $this->addStage($stage);
+    }
+
+    /**
      * Skips over the specified number of documents that pass into the stage and
      * passes the remaining documents to the next stage in the pipeline.
      *

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Expr.php
@@ -22,6 +22,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Operator\StringOperators;
 use Doctrine\ODM\MongoDB\Aggregation\Operator\TimestampOperators;
 use Doctrine\ODM\MongoDB\Aggregation\Operator\TrigonometryOperators;
 use Doctrine\ODM\MongoDB\Aggregation\Operator\TypeOperators;
+use Doctrine\ODM\MongoDB\Aggregation\Operator\WindowOperators;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
@@ -63,7 +64,8 @@ class Expr implements
     StringOperators,
     TimestampOperators,
     TrigonometryOperators,
-    TypeOperators
+    TypeOperators,
+    WindowOperators
 {
     /** @var array<string, mixed> */
     private array $expr = [];
@@ -262,6 +264,16 @@ class Expr implements
         return $this->operator('$count', []);
     }
 
+    public function covariancePop($expression1, $expression2): static
+    {
+        return $this->operator('$covariancePop', func_get_args());
+    }
+
+    public function covarianceSamp($expression1, $expression2): static
+    {
+        return $this->operator('$covarianceSamp', func_get_args());
+    }
+
     public function dateAdd($startDate, $unit, $amount, $timezone = null): static
     {
         return $this->operator(
@@ -439,9 +451,24 @@ class Expr implements
         return $this;
     }
 
+    public function denseRank(): static
+    {
+        return $this->operator('$denseRank', []);
+    }
+
+    public function derivative($input, string $unit): static
+    {
+        return $this->operator('$derivative', ['input' => $input, 'unit' => $unit]);
+    }
+
     public function divide($expression1, $expression2): static
     {
         return $this->operator('$divide', func_get_args());
+    }
+
+    public function documentNumber(): static
+    {
+        return $this->operator('$documentNumber', []);
     }
 
     public function eq($expression1, $expression2): static
@@ -452,6 +479,21 @@ class Expr implements
     public function exp($exponent): static
     {
         return $this->operator('$exp', $exponent);
+    }
+
+    public function expMovingAvg($input, ?int $n = null, ?float $alpha = null): static
+    {
+        return $this->operator(
+            '$expMovingAvg',
+            $this->filterOptionalNullArguments(
+                [
+                    'input' => $input,
+                    'N' => $n,
+                    'alpha' => $alpha,
+                ],
+                ['N', 'alpha'],
+            ),
+        );
     }
 
     /**
@@ -599,6 +641,11 @@ class Expr implements
         return $this->operator('$indexOfCP', $args);
     }
 
+    public function integral($input, string $unit): static
+    {
+        return $this->operator('$integral', ['input' => $input, 'unit' => $unit]);
+    }
+
     public function isArray($expression): static
     {
         return $this->operator('$isArray', $expression);
@@ -637,6 +684,11 @@ class Expr implements
         return $this->operator('$let', ['vars' => $vars, 'in' => $in]);
     }
 
+    public function linearFill($expression): static
+    {
+        return $this->operator('$linearFill', $expression);
+    }
+
     public function literal($value): static
     {
         return $this->operator('$literal', $value);
@@ -645,6 +697,11 @@ class Expr implements
     public function ln($number): static
     {
         return $this->operator('$ln', $number);
+    }
+
+    public function locf($expression): static
+    {
+        return $this->operator('$locf', $expression);
     }
 
     public function log($number, $base): static
@@ -763,6 +820,11 @@ class Expr implements
         return $this->operator('$range', func_get_args());
     }
 
+    public function rank(): static
+    {
+        return $this->operator('$rank', []);
+    }
+
     public function reduce($input, $initialValue, $in): static
     {
         return $this->operator('$reduce', ['input' => $input, 'initialValue' => $initialValue, 'in' => $in]);
@@ -811,6 +873,21 @@ class Expr implements
     public function setUnion($expression1, $expression2, ...$expressions): static
     {
         return $this->operator('$setUnion', func_get_args());
+    }
+
+    public function shift($output, int $by, $default = null): static
+    {
+        return $this->operator(
+            '$shift',
+            $this->filterOptionalNullArguments(
+                [
+                    'output' => $output,
+                    'by' => $by,
+                    'default' => $default,
+                ],
+                ['default'],
+            ),
+        );
     }
 
     public function size($expression): static

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Operator/ProvidesWindowAccumulatorOperators.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Operator/ProvidesWindowAccumulatorOperators.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Operator;
+
+use Doctrine\ODM\MongoDB\Aggregation\Expr;
+
+use function func_get_args;
+
+/** @internal */
+trait ProvidesWindowAccumulatorOperators
+{
+    abstract protected function getExpr(): Expr;
+
+    public function addToSet($expression): static
+    {
+        $this->getExpr()->addToSet(...func_get_args());
+
+        return $this;
+    }
+
+    public function avg($expression, ...$expressions): static
+    {
+        $this->getExpr()->avg(...func_get_args());
+
+        return $this;
+    }
+
+    public function bottom($output, $sortBy): static
+    {
+        $this->getExpr()->bottom(...func_get_args());
+
+        return $this;
+    }
+
+    public function bottomN($output, $sortBy, $n): static
+    {
+        $this->getExpr()->bottomN(...func_get_args());
+
+        return $this;
+    }
+
+    public function countDocuments(): static
+    {
+        $this->getExpr()->countDocuments();
+
+        return $this;
+    }
+
+    public function covariancePop($expression1, $expression2): static
+    {
+        $this->getExpr()->covariancePop(...func_get_args());
+
+        return $this;
+    }
+
+    public function covarianceSamp($expression1, $expression2): static
+    {
+        $this->getExpr()->covarianceSamp(...func_get_args());
+
+        return $this;
+    }
+
+    public function denseRank(): static
+    {
+        $this->getExpr()->denseRank();
+
+        return $this;
+    }
+
+    public function derivative($input, string $unit): static
+    {
+        $this->getExpr()->derivative(...func_get_args());
+
+        return $this;
+    }
+
+    public function documentNumber(): static
+    {
+        $this->getExpr()->documentNumber();
+
+        return $this;
+    }
+
+    public function expMovingAvg($input, ?int $n = null, ?float $alpha = null): static
+    {
+        $this->getExpr()->expMovingAvg(...func_get_args());
+
+        return $this;
+    }
+
+    public function first($expression): static
+    {
+        $this->getExpr()->first(...func_get_args());
+
+        return $this;
+    }
+
+    public function firstN($expression, $n): static
+    {
+        $this->getExpr()->firstN(...func_get_args());
+
+        return $this;
+    }
+
+    public function integral($input, string $unit): static
+    {
+        $this->getExpr()->integral(...func_get_args());
+
+        return $this;
+    }
+
+    public function last($expression): static
+    {
+        $this->getExpr()->last(...func_get_args());
+
+        return $this;
+    }
+
+    public function lastN($expression, $n): static
+    {
+        $this->getExpr()->lastN(...func_get_args());
+
+        return $this;
+    }
+
+    public function linearFill($expression): static
+    {
+        $this->getExpr()->linearFill(...func_get_args());
+
+        return $this;
+    }
+
+    public function locf($expression): static
+    {
+        $this->getExpr()->locf(...func_get_args());
+
+        return $this;
+    }
+
+    public function max($expression, ...$expressions): static
+    {
+        $this->getExpr()->max(...func_get_args());
+
+        return $this;
+    }
+
+    public function maxN($expression, $n): static
+    {
+        $this->getExpr()->maxN(...func_get_args());
+
+        return $this;
+    }
+
+    public function min($expression, ...$expressions): static
+    {
+        $this->getExpr()->min(...func_get_args());
+
+        return $this;
+    }
+
+    public function minN($expression, $n): static
+    {
+        $this->getExpr()->minN(...func_get_args());
+
+        return $this;
+    }
+
+    public function push($expression): static
+    {
+        $this->getExpr()->push(...func_get_args());
+
+        return $this;
+    }
+
+    public function rank(): static
+    {
+        $this->getExpr()->rank();
+
+        return $this;
+    }
+
+    public function shift($output, int $by, $default = null): static
+    {
+        $this->getExpr()->shift(...func_get_args());
+
+        return $this;
+    }
+
+    public function stdDevPop($expression, ...$expressions): static
+    {
+        $this->getExpr()->stdDevPop(...func_get_args());
+
+        return $this;
+    }
+
+    public function stdDevSamp($expression, ...$expressions): static
+    {
+        $this->getExpr()->stdDevSamp(...func_get_args());
+
+        return $this;
+    }
+
+    public function sum($expression, ...$expressions): static
+    {
+        $this->getExpr()->sum(...func_get_args());
+
+        return $this;
+    }
+
+    public function top($output, $sortBy): static
+    {
+        $this->getExpr()->top(...func_get_args());
+
+        return $this;
+    }
+
+    public function topN($output, $sortBy, $n): static
+    {
+        $this->getExpr()->topN(...func_get_args());
+
+        return $this;
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Operator/ProvidesWindowOperators.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Operator/ProvidesWindowOperators.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Expr;
 use function func_get_args;
 
 /** @internal */
-trait ProvidesWindowAccumulatorOperators
+trait ProvidesWindowOperators
 {
     abstract protected function getExpr(): Expr;
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Operator/WindowOperators.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Operator/WindowOperators.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Operator;
+
+use Doctrine\ODM\MongoDB\Aggregation\Expr;
+
+/**
+ * Interface containing all window aggregation pipeline operators.
+ *
+ * This interface can be used for type hinting, but must not be implemented by
+ * users. Methods WILL be added to the public API in future minor versions.
+ *
+ * @internal
+ */
+interface WindowOperators
+{
+    /**
+     * Returns an array of unique expression values for each group.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/addToSet/
+     *
+     * @param mixed|Expr $expression
+     */
+    public function addToSet($expression): static;
+
+    /**
+     * Returns the average value of numeric values. Ignores non-numeric values.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/avg/
+     *
+     * @param mixed|Expr $expression
+     */
+    public function avg($expression): static;
+
+    /**
+     * Returns the bottom element within a group according to the specified sort
+     * order.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/bottom/
+     *
+     * @param mixed|Expr                $output
+     * @param array<string, int|string> $sortBy
+     */
+    public function bottom($output, $sortBy): static;
+
+    /**
+     * Returns the n bottom elements within a group according to the specified
+     * sort order.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/bottomN/
+     *
+     * @param mixed|Expr                $output
+     * @param array<string, int|string> $sortBy
+     * @param mixed|Expr                $n
+     */
+    public function bottomN($output, $sortBy, $n): static;
+
+    /**
+     * Returns the number of documents in a group.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/count/
+     */
+    public function countDocuments(): static;
+
+    /**
+     * Returns the population covariance of two numeric expressions.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/covariancePop/
+     *
+     * @param mixed|Expr $expression1
+     * @param mixed|Expr $expression2
+     */
+    public function covariancePop($expression1, $expression2): static;
+
+    /**
+     * Returns the sample covariance of two numeric expressions.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/covarianceSamp/
+     *
+     * @param mixed|Expr $expression1
+     * @param mixed|Expr $expression2
+     */
+    public function covarianceSamp($expression1, $expression2): static;
+
+    /**
+     * Returns the document position (rank) relative to other documents in the
+     * current partition. There are no gaps in the ranks. Ties receive the same
+     * rank.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/denseRank/
+     */
+    public function denseRank(): static;
+
+    /**
+     * Returns the average rate of change within the specified window.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/derivative/
+     *
+     * @param mixed|Expr $input
+     */
+    public function derivative($input, string $unit): static;
+
+    /**
+     * Returns the position of a document in the current partition. Ties result
+     * in different adjacent document numbers.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/documentNumber/
+     */
+    public function documentNumber(): static;
+
+    /**
+     * Returns the exponential moving average for the numeric expression.
+     *
+     * You must provide either n or alpha. You cannot provide both.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/expMovingAvg/
+     *
+     * @param mixed|Expr $input
+     * @param int|null   $n     An integer that specifies the number of historical documents that have a significant mathematical weight in the exponential moving average calculation, with the most recent documents contributing the most weight.
+     * @param float|null $alpha A double that specifies the exponential decay value to use in the exponential moving average calculation. A higher alpha value assigns a lower mathematical significance to previous results from the calculation.
+     */
+    public function expMovingAvg($input, ?int $n = null, ?float $alpha = null): static;
+
+    /**
+     * Returns the value that results from applying an expression to the first
+     * document in a group of documents. Only meaningful when documents are in
+     * a defined order.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/first/
+     *
+     * @param mixed|Expr $expression
+     */
+    public function first($expression): static;
+
+    /**
+     * Returns the value that results from applying an expression to the first n
+     * documents in a group of documents. Only meaningful when documents are in
+     * a defined order.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/firstN/
+     *
+     * @param mixed|Expr $expression
+     * @param mixed|Expr $n
+     */
+    public function firstN($expression, $n): static;
+
+    /**
+     * Returns the approximation of the area under a curve.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/integral/
+     *
+     * @param mixed|Expr $input
+     */
+    public function integral($input, string $unit): static;
+
+    /**
+     * Returns the value that results from applying an expression to the last
+     * document in a group of documents. Only meaningful when documents are in
+     * a defined order.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/last/
+     *
+     * @param mixed|Expr $expression
+     */
+    public function last($expression): static;
+
+    /**
+     * Returns the value that results from applying an expression to the last n
+     * documents in a group of documents. Only meaningful when documents are in
+     * a defined order.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/lastN/
+     *
+     * @param mixed|Expr $expression
+     * @param mixed|Expr $n
+     */
+    public function lastN($expression, $n): static;
+
+    /**
+     * Fills null and missing fields in a window using linear interpolation
+     * based on surrounding field values.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/linearFill/
+     *
+     * @param mixed|Expr $expression
+     */
+    public function linearFill($expression): static;
+
+    /**
+     * Last observation carried forward. Sets values for null and missing fields
+     * in a window to the last non-null value for the field.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/locf/
+     *
+     * @param mixed|Expr $expression
+     */
+    public function locf($expression): static;
+
+    /**
+     * Returns the highest expression value for each group.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/max/
+     *
+     * @param mixed|Expr $expression
+     */
+    public function max($expression): static;
+
+    /**
+     * Returns the highest n expression values for each group.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/maxN/
+     *
+     * @param mixed|Expr $expression
+     * @param mixed|Expr $n
+     */
+    public function maxN($expression, $n): static;
+
+    /**
+     * Returns the lowest expression value for each group.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/min/
+     *
+     * @param mixed|Expr $expression
+     */
+    public function min($expression): static;
+
+    /**
+     * Returns the lowest n expression values for each group.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/minN/
+     *
+     * @param mixed|Expr $expression
+     * @param mixed|Expr $n
+     */
+    public function minN($expression, $n): static;
+
+    /**
+     * Returns an array of expression values for documents in each group.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/push/
+     *
+     * @param mixed|Expr $expression
+     */
+    public function push($expression): static;
+
+    /**
+     * Returns the document position (rank) relative to other documents in the
+     * current partition. If multiple documents occupy the same rank, $rank
+     * places the document with the subsequent value at a rank with a gap.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/rank/
+     */
+    public function rank(): static;
+
+    /**
+     * Returns the value from an expression applied to a document in a specified
+     * position relative to the current document in the current partition.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/shift/
+     *
+     * @param mixed|Expr      $output
+     * @param mixed|Expr|null $default
+     */
+    public function shift($output, int $by, $default = null): static;
+
+    /**
+     * Returns the population standard deviation of the input values.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevPop/
+     *
+     * @param mixed|Expr $expression
+     */
+    public function stdDevPop($expression): static;
+
+    /**
+     * Returns the sample standard deviation of the input values.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevSamp/
+     *
+     * @param mixed|Expr $expression
+     */
+    public function stdDevSamp($expression): static;
+
+    /**
+     * Calculates the collective sum of numeric values. Ignores non-numeric
+     * values.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sum/
+     *
+     * @param mixed|Expr $expression
+     */
+    public function sum($expression): static;
+
+    /**
+     * Returns the top element within a group according to the specified sort
+     * order.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/top/
+     *
+     * @param mixed|Expr                $output
+     * @param array<string, int|string> $sortBy
+     */
+    public function top($output, $sortBy): static;
+
+    /**
+     * Returns the n top elements within a group according to the specified sort
+     * order.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/topN/
+     *
+     * @param mixed|Expr                $output
+     * @param array<string, int|string> $sortBy
+     * @param mixed|Expr                $n
+     */
+    public function topN($output, $sortBy, $n): static;
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -391,6 +391,18 @@ abstract class Stage
     }
 
     /**
+     * Performs operations on a specified span of documents in a collection,
+     * known as a window, and returns the results based on the chosen window
+     * operator.
+     *
+     * @see https://www.mongodb.com/docs/rapid/reference/operator/aggregation/setWindowFields/
+     */
+    public function setWindowFields(): Stage\SetWindowFields
+    {
+        return $this->builder->setWindowFields();
+    }
+
+    /**
      * Skips over the specified number of documents that pass into the stage and
      * passes the remaining documents to the next stage in the pipeline.
      *

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SetWindowFields.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SetWindowFields.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
+
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Aggregation\Expr;
+use Doctrine\ODM\MongoDB\Aggregation\Stage;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\SetWindowFields\Output;
+
+use function is_array;
+use function is_string;
+use function strtolower;
+
+/**
+ * @psalm-import-type SortDirectionKeywords from Sort
+ * @psalm-import-type OperatorExpression from Expr
+ * @psalm-type SortDirection = int|SortDirectionKeywords
+ * @psalm-type SortShape = array<string, SortDirection>
+ * @psalm-type SetWindowFieldsStageExpression = array{
+ *     '$setWindowFields': object{
+ *         partitionBy?: string|OperatorExpression,
+ *         sortBy?: SortShape,
+ *         output: object,
+ *     }
+ * }
+ */
+class SetWindowFields extends Stage
+{
+    /** @var mixed|Expr|null */
+    private $partitionBy = null;
+
+    /** @var array<string, int> */
+    private array $sortBy = [];
+
+    private Output $output;
+
+    public function __construct(Builder $builder)
+    {
+        parent::__construct($builder);
+
+        $this->output = new Output($this->builder, $this);
+    }
+
+    /** @param mixed|Expr $expression */
+    public function partitionBy($expression): static
+    {
+        $this->partitionBy = $expression;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
+     * @param int|string                       $order     Field order (if one field is specified)
+     * @psalm-param SortShape|string           $fieldName
+     * @psalm-param SortDirection|null         $order
+     */
+    public function sortBy($fieldName, $order = null): static
+    {
+        $fields = is_array($fieldName) ? $fieldName : [$fieldName => $order ?? 1];
+
+        foreach ($fields as $fieldName => $order) {
+            if (is_string($order)) {
+                $order = strtolower($order) === 'asc' ? 1 : -1;
+            }
+
+            $this->sortBy[$fieldName] = $order;
+        }
+
+        return $this;
+    }
+
+    public function output(): Output
+    {
+        return $this->output;
+    }
+
+    /** @psalm-return SetWindowFieldsStageExpression */
+    public function getExpression(): array
+    {
+        $params = (object) [
+            'output' => (object) $this->output->getExpression(),
+        ];
+
+        if ($this->partitionBy) {
+            $params->partitionBy = $this->partitionBy instanceof Expr
+                ? $this->partitionBy->getExpression()
+                : $this->partitionBy;
+        }
+
+        if ($this->sortBy) {
+            $params->sortBy = (object) $this->sortBy;
+        }
+
+        return ['$setWindowFields' => $params];
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SetWindowFields/Output.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SetWindowFields/Output.php
@@ -6,7 +6,7 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage\SetWindowFields;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Expr;
-use Doctrine\ODM\MongoDB\Aggregation\Operator\ProvidesWindowAccumulatorOperators;
+use Doctrine\ODM\MongoDB\Aggregation\Operator\ProvidesWindowOperators;
 use Doctrine\ODM\MongoDB\Aggregation\Operator\WindowOperators;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Operator;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\SetWindowFields;
@@ -33,7 +33,7 @@ use function sprintf;
  */
 class Output extends Operator implements WindowOperators
 {
-    use ProvidesWindowAccumulatorOperators;
+    use ProvidesWindowOperators;
 
     private string $currentField = '';
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SetWindowFields/Output.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SetWindowFields/Output.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Aggregation\Stage\SetWindowFields;
+
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Aggregation\Expr;
+use Doctrine\ODM\MongoDB\Aggregation\Operator\ProvidesWindowAccumulatorOperators;
+use Doctrine\ODM\MongoDB\Aggregation\Operator\WindowOperators;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Operator;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\SetWindowFields;
+use LogicException;
+
+use function array_filter;
+use function array_map;
+use function array_merge_recursive;
+use function func_get_args;
+use function sprintf;
+
+/**
+ * Fluent builder for output param of $setWindowFields stage
+ *
+ * @psalm-import-type SortShape from SetWindowFields
+ * @psalm-type WindowBound = 'current'|'unbounded'|int
+ * @psalm-type WindowBounds = array{0: WindowBound, 1: WindowBound}
+ * @psalm-type WindowUnit = 'year'|'quarter'|'month'|'week'|'day'|'hour'|'minute'|'second'|'millisecond'
+ * @psalm-type Window = object{
+ *     document?: WindowBounds,
+ *     range?: WindowBounds,
+ *     unit?: WindowUnit,
+ * }
+ */
+class Output extends Operator implements WindowOperators
+{
+    use ProvidesWindowAccumulatorOperators;
+
+    private string $currentField = '';
+
+    /**
+     * @var array
+     * @psalm-var array<string, Window>
+     */
+    private array $windows = [];
+
+    public function __construct(Builder $builder, private SetWindowFields $setWindowFields)
+    {
+        parent::__construct($builder);
+    }
+
+    /** @param mixed|Expr $expression */
+    public function partitionBy($expression): SetWindowFields
+    {
+        return $this->setWindowFields->partitionBy($expression);
+    }
+
+    /**
+     * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
+     * @param int|string                       $order     Field order (if one field is specified)
+     * @psalm-param SortShape|string           $fieldName
+     */
+    public function sortBy($fieldName, $order = null): SetWindowFields
+    {
+        return $this->setWindowFields->sortBy(...func_get_args());
+    }
+
+    /**
+     * Set the current field for building the expression.
+     */
+    public function field(string $fieldName): static
+    {
+        $this->currentField = $fieldName;
+        $this->expr->field($fieldName);
+
+        return $this;
+    }
+
+    /**
+     * Specifies the window boundaries and parameters.
+     *
+     * @psalm-param WindowBounds|null $documents
+     * @psalm-param WindowBounds|null $range
+     * @psalm-param WindowUnit|null $unit
+     */
+    public function window(?array $documents = null, ?array $range = null, ?string $unit = null): static
+    {
+        $this->requiresCurrentField(__METHOD__);
+
+        $this->windows[$this->currentField] = (object) array_filter(
+            [
+                'documents' => $documents,
+                'range' => $range,
+                'unit' => $unit,
+            ],
+            static fn ($value): bool => $value !== null,
+        );
+
+        return $this;
+    }
+
+    public function getExpression(): array
+    {
+        return array_merge_recursive(
+            $this->expr->getExpression(),
+            array_map(
+                static fn ($window): object => (object) ['window' => $window],
+                $this->windows,
+            ),
+        );
+    }
+
+    protected function getExpr(): Expr
+    {
+        return $this->expr;
+    }
+
+    /**
+     * Ensure that a current field has been set.
+     *
+     * @throws LogicException if a current field has not been set.
+     */
+    private function requiresCurrentField(string $method): void
+    {
+        if (! $this->currentField) {
+            throw new LogicException(sprintf('%s requires setting a current field using field().', $method));
+        }
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -471,6 +471,16 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsNearOperator.php
 
 		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\SetWindowFields\\:\\:getExpression\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SetWindowFields.php
+
+		-
+			message: "#^PHPDoc tag @return with type mixed is not subtype of native type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SetWindowFields.php
+
+		-
 			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\UnionWith\\:\\:getExpression\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
@@ -699,6 +709,16 @@ parameters:
 			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Aggregation\\\\Stage\\\\SearchTest\\:\\:testSearchOperators\\(\\) has parameter \\$expectedOperator with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Aggregation\\\\Stage\\\\SetWindowFieldsTest\\:\\:testOperators\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SetWindowFieldsTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Aggregation\\\\Stage\\\\SetWindowFieldsTest\\:\\:testOperators\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SetWindowFieldsTest.php
 
 		-
 			message: "#^Constant DOCTRINE_MONGODB_DATABASE not found\\.$#"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -23,6 +23,8 @@ parameters:
   checkMissingVarTagTypehint: true
   checkMissingTypehints: true
   checkMissingIterableValueType: true
+  # Disabled due to inconsistent errors upon encountering psalm types
+  reportUnmatchedIgnoredErrors: false
 
 # To be removed when reaching phpstan level 6
 rules:

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationOperatorsProviderTrait.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationOperatorsProviderTrait.php
@@ -1446,6 +1446,87 @@ trait AggregationOperatorsProviderTrait
         ];
     }
 
+    public function provideWindowExpressionOperators(): Generator
+    {
+        yield 'covariancePop' => [
+            'expected' => ['$covariancePop' => ['$field1', '$field2']],
+            'operator' => 'covariancePop',
+            'args' => ['$field1', '$field2'],
+        ];
+
+        yield 'covarianceSamp' => [
+            'expected' => ['$covarianceSamp' => ['$field1', '$field2']],
+            'operator' => 'covarianceSamp',
+            'args' => ['$field1', '$field2'],
+        ];
+
+        yield 'denseRank' => [
+            'expected' => ['$denseRank' => []],
+            'operator' => 'denseRank',
+            'args' => [],
+        ];
+
+        yield 'derivative' => [
+            'expected' => ['$derivative' => ['input' => '$field', 'unit' => 'second']],
+            'operator' => 'derivative',
+            'args' => ['$field', 'second'],
+        ];
+
+        yield 'documentNumber' => [
+            'expected' => ['$documentNumber' => []],
+            'operator' => 'documentNumber',
+            'args' => [],
+        ];
+
+        yield 'expMovingAvgWithN' => [
+            'expected' => ['$expMovingAvg' => ['input' => '$field', 'N' => 5]],
+            'operator' => 'expMovingAvg',
+            'args' => ['$field', 5],
+        ];
+
+        yield 'expMovingAvgWithAlpha' => [
+            'expected' => ['$expMovingAvg' => ['input' => '$field', 'alpha' => 0.5]],
+            'operator' => 'expMovingAvg',
+            'args' => ['$field', null, 0.5],
+        ];
+
+        yield 'integral' => [
+            'expected' => ['$integral' => ['input' => '$field', 'unit' => 'second']],
+            'operator' => 'integral',
+            'args' => ['$field', 'second'],
+        ];
+
+        yield 'linearFill' => [
+            'expected' => ['$linearFill' => '$field'],
+            'operator' => 'linearFill',
+            'args' => ['$field'],
+        ];
+
+        yield 'locf' => [
+            'expected' => ['$locf' => '$field'],
+            'operator' => 'locf',
+            'args' => ['$field'],
+        ];
+
+        yield 'rank' => [
+            'expected' => ['$rank' => []],
+            'operator' => 'rank',
+            'args' => [],
+        ];
+
+        yield 'shiftWithoutDefault' => [
+            'expected' => ['$shift' => ['output' => '$field', 'by' => -1]],
+            'operator' => 'shift',
+            'args' => ['$field', -1],
+        ];
+
+        yield 'shiftWithDefault' => [
+            'expected' => ['$shift' => ['output' => '$field', 'by' => -1, 'default' => '$defaultField']],
+            'operator' => 'shift',
+            'args' => ['$field', -1, '$defaultField'],
+        ];
+    }
+
     protected function createExpr(): Expr
     {
         return new Expr($this->dm, new ClassMetadata(User::class));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/ExprTest.php
@@ -35,6 +35,7 @@ class ExprTest extends BaseTestCase
      * @dataProvider provideTimestampExpressionOperators
      * @dataProvider provideTrigonometryExpressionOperators
      * @dataProvider provideTypeExpressionOperators
+     * @dataProvider provideWindowExpressionOperators
      */
     public function testGenericOperator(array $expected, string $operator, $args): void
     {
@@ -66,6 +67,7 @@ class ExprTest extends BaseTestCase
      * @dataProvider provideTimestampExpressionOperators
      * @dataProvider provideTrigonometryExpressionOperators
      * @dataProvider provideTypeExpressionOperators
+     * @dataProvider provideWindowExpressionOperators
      */
     public function testGenericOperatorWithField(array $expected, string $operator, $args): void
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SetWindowFieldsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SetWindowFieldsTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
+
+use Doctrine\ODM\MongoDB\Aggregation\Stage\SetWindowFields;
+use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationOperatorsProviderTrait;
+use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+
+use function array_merge;
+
+class SetWindowFieldsTest extends BaseTestCase
+{
+    use AggregationTestTrait;
+    use AggregationOperatorsProviderTrait;
+
+    public function testStage(): void
+    {
+        $builder              = $this->getTestAggregationBuilder();
+        $setWindowFieldsStage = new SetWindowFields($builder);
+        $setWindowFieldsStage
+            ->partitionBy($builder->expr()->year('field1'))
+            ->sortBy('field1', 1)
+            ->output()
+                ->field('foo')->locf('$foo')
+                ->field('bar')->linearFill('$bar')
+                ->field('previous')->shift('$$ROOT', -1)
+                ->field('documentsSum')
+                    ->sum('$amount')
+                    ->window(['unbounded', 'current'])
+                ->field('rangeSum')
+                    ->sum('$amount')
+                    ->window(null, [-1, 1])
+                ->field('rangeSumWithUnit')
+                    ->sum('$amount')
+                    ->window(null, ['current', 'unbounded'], 'second');
+
+        self::assertEquals(
+            [
+                '$setWindowFields' => (object) [
+                    'partitionBy' => ['$year' => 'field1'],
+                    'sortBy' => (object) ['field1' => 1],
+                    'output' => (object) [
+                        'foo' => ['$locf' => '$foo'],
+                        'bar' => ['$linearFill' => '$bar'],
+                        'previous' => [
+                            '$shift' => [
+                                'output' => '$$ROOT',
+                                'by' => -1,
+                            ],
+                        ],
+                        'documentsSum' => [
+                            '$sum' => '$amount',
+                            'window' => (object) ['documents' => ['unbounded', 'current']],
+                        ],
+                        'rangeSum' => [
+                            '$sum' => '$amount',
+                            'window' => (object) ['range' => [-1, 1]],
+                        ],
+                        'rangeSumWithUnit' => [
+                            '$sum' => '$amount',
+                            'window' => (object) [
+                                'range' => ['current', 'unbounded'],
+                                'unit' => 'second',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $setWindowFieldsStage->getExpression(),
+        );
+    }
+
+    /**
+     * @dataProvider provideGroupAccumulatorExpressionOperators
+     * @dataProvider provideWindowExpressionOperators
+     */
+    public function testOperators(array $expected, string $operator, $args): void
+    {
+        $args = $this->resolveArgs($args);
+
+        $builder              = $this->getTestAggregationBuilder();
+        $setWindowFieldsStage = new SetWindowFields($builder);
+        $setWindowFieldsStage
+            ->partitionBy($builder->expr()->year('field1'))
+            ->sortBy('field1', 1)
+            ->output()
+                ->field('foo')
+                ->$operator(...$args)
+                ->window(['unbounded', 'current']);
+
+        self::assertEquals(
+            [
+                '$setWindowFields' => (object) [
+                    'partitionBy' => ['$year' => 'field1'],
+                    'sortBy' => (object) ['field1' => 1],
+                    'output' => (object) [
+                        'foo' => array_merge(
+                            $expected,
+                            ['window' => (object) ['documents' => ['unbounded', 'current']]],
+                        ),
+                    ],
+                ],
+            ],
+            $setWindowFieldsStage->getExpression(),
+        );
+    }
+
+    public function testStageWithComplexSort(): void
+    {
+        $setWindowFieldsStage = new SetWindowFields($this->getTestAggregationBuilder());
+        $setWindowFieldsStage
+            ->partitionBy('$field1')
+            ->sortBy(['field1' => 'asc', 'field2' => 'desc'])
+            ->output()
+                ->field('foo')->locf('$foo');
+
+        self::assertEquals(
+            [
+                '$setWindowFields' => (object) [
+                    'partitionBy' => '$field1',
+                    'sortBy' => (object) [
+                        'field1' => 1,
+                        'field2' => -1,
+                    ],
+                    'output' => (object) [
+                        'foo' => ['$locf' => '$foo'],
+                    ],
+                ],
+            ],
+            $setWindowFieldsStage->getExpression(),
+        );
+    }
+
+    public function testFromBuilder(): void
+    {
+        $builder = $this->getTestAggregationBuilder();
+        $builder->setWindowFields()
+            ->partitionBy('$field1')
+            ->sortBy('field1', 1)
+            ->output()
+                ->field('foo')->locf('$foo');
+
+        self::assertEquals(
+            [
+                [
+                    '$setWindowFields' => (object) [
+                        'partitionBy' => '$field1',
+                        'sortBy' => (object) ['field1' => 1],
+                        'output' => (object) [
+                            'foo' => ['$locf' => '$foo'],
+                        ],
+                    ],
+                ],
+            ],
+            $builder->getPipeline(),
+        );
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->
Last but not least, this pull request adds support for window operators and the `$setWindowFields` aggregation pipeline stage to the builder. There is some code duplication between group accumulators and window operators, as the latter includes all group accumulators except for `$mergeObjects`. To avoid polluting the interfaces and traits, I've decided to accept the duplication considering that the methods only proxy calls to the `Expr` class.