### PR TITLE
Parameter 4 in `Query::__construct()` can not use an empty array as default value

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -57,7 +57,7 @@ use function is_string;
  *     skip?: int,
  *     snapshot?: bool,
  *     sort?: array<string, -1|1|SortMeta>,
- *     type?: Query::TYPE_*,
+ *     type: Query::TYPE_*,
  *     upsert?: bool,
  * }
  * @psalm-import-type Hints from UnitOfWork
@@ -136,7 +136,7 @@ final class Query implements IteratorAggregate
      * @param array<string, mixed>              $options
      * @param array<string, callable|true|null> $primers
      */
-    public function __construct(DocumentManager $dm, ClassMetadata $class, Collection $collection, array $query = [], array $options = [], bool $hydrate = true, bool $refresh = false, array $primers = [], bool $readOnly = false, bool $rewindable = true)
+    public function __construct(DocumentManager $dm, ClassMetadata $class, Collection $collection, array $query, array $options = [], bool $hydrate = true, bool $refresh = false, array $primers = [], bool $readOnly = false, bool $rewindable = true)
     {
         $primers = array_filter($primers);
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -514,11 +514,6 @@
       <code>1</code>
     </InvalidArgument>
   </file>
-  <file src="tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php">
-    <InvalidArgument>
-      <code><![CDATA[['type' => -1]]]></code>
-    </InvalidArgument>
-  </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php">
     <InternalClass>
       <code>new IndexInfoIteratorIterator(new ArrayIterator($indexes))</code>

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -418,6 +418,8 @@ class QueryTest extends BaseTestCase
     public function testConstructorShouldThrowExceptionForInvalidType(): void
     {
         $this->expectException(InvalidArgumentException::class);
+
+        /** @psalm-suppress InvalidArgument */
         new Query($this->dm, new ClassMetadata(User::class), $this->getMockCollection(), ['type' => -1], []);
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | n/a

#### Summary

Offset "type" is explicitly required in the passed array:

https://github.com/doctrine/mongodb-odm/blob/dacfa0e3c5840b756b58b6dd00c9c717b1725ce6/lib/Doctrine/ODM/MongoDB/Query/Query.php#L143

<!-- Provide a summary your change. -->
