### PR TITLE
Parameters 2 and 3 in `HydratorFactory::__construct()` are not nullable

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -59,16 +59,22 @@ final class HydratorFactory
 
     /**
      * Which algorithm to use to automatically (re)generate hydrator classes.
+     *
+     * @psalm-var Configuration::AUTOGENERATE_*
      */
     private int $autoGenerate;
 
     /**
      * The namespace that contains all hydrator classes.
+     *
+     * @psalm-var non-empty-string
      */
-    private ?string $hydratorNamespace;
+    private string $hydratorNamespace;
 
     /**
      * The directory that contains all hydrator classes.
+     *
+     * @psalm-var non-empty-string
      */
     private string $hydratorDir;
 
@@ -79,14 +85,21 @@ final class HydratorFactory
      */
     private array $hydrators = [];
 
-    /** @throws HydratorException */
-    public function __construct(DocumentManager $dm, EventManager $evm, ?string $hydratorDir, ?string $hydratorNs, int $autoGenerate)
+    /**
+     * @psalm-param Configuration::AUTOGENERATE_* $autoGenerate
+     *
+     * @throws HydratorException
+     *
+     * @psalm-assert non-empty-string $hydratorDir
+     * @psalm-assert non-empty-string $hydratorNs
+     */
+    public function __construct(DocumentManager $dm, EventManager $evm, string $hydratorDir, string $hydratorNs, int $autoGenerate)
     {
-        if (! $hydratorDir) {
+        if ($hydratorDir === '') {
             throw HydratorException::hydratorDirectoryRequired();
         }
 
-        if (! $hydratorNs) {
+        if ($hydratorNs === '') {
             throw HydratorException::hydratorNamespaceRequired();
         }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | n/a

#### Summary

A falsy loose check is performed in the method's body:

https://github.com/doctrine/mongodb-odm/blob/dacfa0e3c5840b756b58b6dd00c9c717b1725ce6/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php#L84-L90

<!-- Provide a summary your change. -->
