### PR TITLE
Fix psalm build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,12 +42,12 @@
         "doctrine/coding-standard": "^11.0",
         "jmikola/geojson": "^1.0",
         "phpbench/phpbench": "^1.0.0@dev",
-        "phpstan/phpstan": "^1.9.4",
+        "phpstan/phpstan": "^1.10.11",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.5.5 || ^10.0.15",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/cache": "^4.4 || ^5.0 || ^6.0",
-        "vimeo/psalm": "^5.7.7"
+        "vimeo/psalm": "^5.9.0"
     },
     "suggest": {
         "ext-bcmath": "Decimal128 type support"

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1467,7 +1467,7 @@ final class DocumentPersister
     /**
      * Returns the list of discriminator values for the given ClassMetadata
      *
-     * @psalm-return list<class-string>
+     * @psalm-return list<class-string|null>
      */
     private function getClassDiscriminatorValues(ClassMetadata $metadata): array
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -145,7 +145,7 @@ parameters:
             path: lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
 
         -
-            message: "#^Parameter \\#2 \\$options of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<object\\>\\:\\:addIndex\\(\\) expects array\\{background\\?\\: bool, bits\\?\\: int, default_language\\?\\: string, expireAfterSeconds\\?\\: int, language_override\\?\\: string, min\\?\\: float, max\\?\\: float, name\\?\\: string, \\.\\.\\.\\}, array\\<string, non\\-empty\\-array\\<string, array\\<int\\|string, mixed\\>\\|bool\\|float\\|int\\|string\\|null\\>\\|bool\\|float\\|int\\|string\\|null\\> given\\.$#"
+            message: "#^Parameter \\#2 \\$options of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<object\\>\\:\\:addIndex\\(\\) expects array\\{background\\?\\: bool, bits\\?\\: int, default_language\\?\\: string, expireAfterSeconds\\?\\: int, language_override\\?\\: string, min\\?\\: float, max\\?\\: float, name\\?\\: string, \\.\\.\\.\\}, array\\<string, non\\-empty\\-array\\<string, array\\<int\\<0, max\\>\\|string, mixed\\>\\|bool\\|float\\|int\\|string\\|null\\>\\|bool\\|float\\|int\\|string\\|null\\> given\\.$#"
             count: 1
             path: lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.6.0@e784128902dfe01d489c4123d69918a9f3c1eac5">
+<files psalm-version="5.9.0@8b9ad1eb9e8b7d3101f949291da2b9f7767cd163">
   <file src="lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php">
     <MissingTemplateParam>
       <code>IteratorAggregate</code>
@@ -12,8 +12,8 @@
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Configuration.php">
     <TypeDoesNotContainType>
-      <code>$reflectionClass-&gt;implementsInterface(GridFSRepository::class)</code>
-      <code>$reflectionClass-&gt;implementsInterface(ObjectRepository::class)</code>
+      <code><![CDATA[$reflectionClass->implementsInterface(GridFSRepository::class)]]></code>
+      <code><![CDATA[$reflectionClass->implementsInterface(ObjectRepository::class)]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/DocumentManager.php">
@@ -33,7 +33,7 @@
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php">
     <ImplementedReturnTypeMismatch>
-      <code>array&lt;string|null&gt;</code>
+      <code><![CDATA[array<string|null>]]></code>
     </ImplementedReturnTypeMismatch>
     <InvalidArgument>
       <code>$mapping</code>
@@ -43,29 +43,29 @@
       <code>$mapping</code>
     </InvalidArgument>
     <InvalidArrayOffset>
-      <code>[$this-&gt;identifier =&gt; $this-&gt;getIdentifierValue($object)]</code>
+      <code><![CDATA[[$this->identifier => $this->getIdentifierValue($object)]]]></code>
     </InvalidArrayOffset>
     <InvalidPropertyAssignmentValue>
-      <code>$this-&gt;associationMappings</code>
-      <code>$this-&gt;associationMappings</code>
-      <code>$this-&gt;fieldMappings</code>
+      <code><![CDATA[$this->associationMappings]]></code>
+      <code><![CDATA[$this->associationMappings]]></code>
+      <code><![CDATA[$this->fieldMappings]]></code>
     </InvalidPropertyAssignmentValue>
     <InvalidReturnStatement>
       <code>$mapping</code>
       <code>$mapping</code>
-      <code>array_filter(
-            $this-&gt;associationMappings,
-            static fn ($assoc) =&gt; ! empty($assoc['embedded'])
-        )</code>
+      <code><![CDATA[array_filter(
+            $this->associationMappings,
+            static fn ($assoc) => ! empty($assoc['embedded'])
+        )]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code>FieldMapping</code>
       <code>FieldMappingConfig</code>
-      <code>array&lt;string, FieldMapping&gt;</code>
+      <code><![CDATA[array<string, FieldMapping>]]></code>
     </InvalidReturnType>
     <LessSpecificImplementedReturnType>
       <code>array</code>
-      <code>array&lt;string|null&gt;</code>
+      <code><![CDATA[array<string|null>]]></code>
     </LessSpecificImplementedReturnType>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php">
@@ -84,64 +84,64 @@
       <code>$options</code>
     </InvalidArgument>
     <NoInterfaceProperties>
-      <code>$xmlRoot-&gt;field</code>
-      <code>$xmlRoot-&gt;id</code>
-      <code>$xmlRoot-&gt;{'also-load-methods'}</code>
-      <code>$xmlRoot-&gt;{'default-discriminator-value'}</code>
-      <code>$xmlRoot-&gt;{'discriminator-field'}</code>
-      <code>$xmlRoot-&gt;{'discriminator-map'}</code>
-      <code>$xmlRoot-&gt;{'embed-many'}</code>
-      <code>$xmlRoot-&gt;{'embed-one'}</code>
-      <code>$xmlRoot-&gt;{'indexes'}</code>
-      <code>$xmlRoot-&gt;{'lifecycle-callbacks'}</code>
-      <code>$xmlRoot-&gt;{'read-preference'}</code>
-      <code>$xmlRoot-&gt;{'reference-many'}</code>
-      <code>$xmlRoot-&gt;{'reference-one'}</code>
-      <code>$xmlRoot-&gt;{'schema-validation'}</code>
-      <code>$xmlRoot-&gt;{'shard-key'}</code>
+      <code><![CDATA[$xmlRoot->field]]></code>
+      <code><![CDATA[$xmlRoot->id]]></code>
+      <code><![CDATA[$xmlRoot->{'also-load-methods'}]]></code>
+      <code><![CDATA[$xmlRoot->{'default-discriminator-value'}]]></code>
+      <code><![CDATA[$xmlRoot->{'discriminator-field'}]]></code>
+      <code><![CDATA[$xmlRoot->{'discriminator-map'}]]></code>
+      <code><![CDATA[$xmlRoot->{'embed-many'}]]></code>
+      <code><![CDATA[$xmlRoot->{'embed-one'}]]></code>
+      <code><![CDATA[$xmlRoot->{'indexes'}]]></code>
+      <code><![CDATA[$xmlRoot->{'lifecycle-callbacks'}]]></code>
+      <code><![CDATA[$xmlRoot->{'read-preference'}]]></code>
+      <code><![CDATA[$xmlRoot->{'reference-many'}]]></code>
+      <code><![CDATA[$xmlRoot->{'reference-one'}]]></code>
+      <code><![CDATA[$xmlRoot->{'schema-validation'}]]></code>
+      <code><![CDATA[$xmlRoot->{'shard-key'}]]></code>
     </NoInterfaceProperties>
     <RedundantCast>
-      <code>(bool) $mapping['background']</code>
-      <code>(bool) $mapping['sparse']</code>
-      <code>(bool) $mapping['unique']</code>
-      <code>(string) $mapping['index-name']</code>
+      <code><![CDATA[(bool) $mapping['background']]]></code>
+      <code><![CDATA[(bool) $mapping['sparse']]]></code>
+      <code><![CDATA[(bool) $mapping['unique']]]></code>
+      <code><![CDATA[(string) $mapping['index-name']]]></code>
     </RedundantCast>
     <RedundantCondition>
       <code>assert($attributes instanceof SimpleXMLElement)</code>
-      <code>isset($xmlRoot-&gt;field)</code>
-      <code>isset($xmlRoot-&gt;id)</code>
-      <code>isset($xmlRoot-&gt;{'default-discriminator-value'})</code>
-      <code>isset($xmlRoot-&gt;{'discriminator-field'})</code>
-      <code>isset($xmlRoot-&gt;{'discriminator-map'})</code>
-      <code>isset($xmlRoot-&gt;{'embed-many'})</code>
-      <code>isset($xmlRoot-&gt;{'embed-one'})</code>
-      <code>isset($xmlRoot-&gt;{'indexes'})</code>
-      <code>isset($xmlRoot-&gt;{'lifecycle-callbacks'})</code>
-      <code>isset($xmlRoot-&gt;{'read-preference'})</code>
-      <code>isset($xmlRoot-&gt;{'reference-many'})</code>
-      <code>isset($xmlRoot-&gt;{'reference-one'})</code>
-      <code>isset($xmlRoot-&gt;{'schema-validation'})</code>
-      <code>isset($xmlRoot-&gt;{'shard-key'})</code>
+      <code><![CDATA[isset($xmlRoot->field)]]></code>
+      <code><![CDATA[isset($xmlRoot->id)]]></code>
+      <code><![CDATA[isset($xmlRoot->{'default-discriminator-value'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'discriminator-field'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'discriminator-map'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'embed-many'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'embed-one'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'indexes'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'lifecycle-callbacks'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'read-preference'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'reference-many'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'reference-one'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'schema-validation'})]]></code>
+      <code><![CDATA[isset($xmlRoot->{'shard-key'})]]></code>
     </RedundantCondition>
     <TypeDoesNotContainType>
-      <code>$xmlRoot-&gt;getName() === 'document'</code>
-      <code>$xmlRoot-&gt;getName() === 'embedded-document'</code>
-      <code>$xmlRoot-&gt;getName() === 'gridfs-file'</code>
-      <code>$xmlRoot-&gt;getName() === 'mapped-superclass'</code>
-      <code>$xmlRoot-&gt;getName() === 'query-result-document'</code>
-      <code>$xmlRoot-&gt;getName() === 'view'</code>
-      <code>isset($xmlRoot-&gt;{'also-load-methods'})</code>
+      <code><![CDATA[$xmlRoot->getName() === 'document']]></code>
+      <code><![CDATA[$xmlRoot->getName() === 'embedded-document']]></code>
+      <code><![CDATA[$xmlRoot->getName() === 'gridfs-file']]></code>
+      <code><![CDATA[$xmlRoot->getName() === 'mapped-superclass']]></code>
+      <code><![CDATA[$xmlRoot->getName() === 'query-result-document']]></code>
+      <code><![CDATA[$xmlRoot->getName() === 'view']]></code>
+      <code><![CDATA[isset($xmlRoot->{'also-load-methods'})]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/PersistentCollection/AbstractPersistentCollectionFactory.php">
     <InvalidArgument>
-      <code>new PersistentCollection($coll, $dm, $dm-&gt;getUnitOfWork())</code>
-      <code>new PersistentCollection($coll, $dm, $dm-&gt;getUnitOfWork())</code>
+      <code><![CDATA[new PersistentCollection($coll, $dm, $dm->getUnitOfWork())]]></code>
+      <code><![CDATA[new PersistentCollection($coll, $dm, $dm->getUnitOfWork())]]></code>
     </InvalidArgument>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php">
     <RedundantCondition>
-      <code>is_object($this-&gt;coll)</code>
+      <code><![CDATA[is_object($this->coll)]]></code>
     </RedundantCondition>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php">
@@ -151,7 +151,7 @@
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Proxy/Resolver/CachingClassNameResolver.php">
     <InvalidPropertyAssignmentValue>
-      <code>$this-&gt;resolvedNames</code>
+      <code><![CDATA[$this->resolvedNames]]></code>
     </InvalidPropertyAssignmentValue>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Proxy/Resolver/ProxyManagerClassNameResolver.php">
@@ -164,10 +164,10 @@
       <code>$query</code>
     </InvalidArgument>
     <InvalidPropertyAssignmentValue>
-      <code>$this-&gt;query</code>
-      <code>$this-&gt;query</code>
-      <code>$this-&gt;query</code>
-      <code>$this-&gt;query</code>
+      <code><![CDATA[$this->query]]></code>
+      <code><![CDATA[$this->query]]></code>
+      <code><![CDATA[$this->query]]></code>
+      <code><![CDATA[$this->query]]></code>
     </InvalidPropertyAssignmentValue>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Query/Query.php">
@@ -179,11 +179,6 @@
     <LessSpecificImplementedReturnType>
       <code>array</code>
     </LessSpecificImplementedReturnType>
-  </file>
-  <file src="lib/Doctrine/ODM/MongoDB/SchemaManager.php">
-    <InvalidArrayOffset>
-      <code>$documentIndexWeights[$key]</code>
-    </InvalidArrayOffset>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php">
     <UndefinedInterfaceMethod>
@@ -253,16 +248,16 @@
       <code>$mapping</code>
     </InvalidArgument>
     <InvalidPropertyAssignmentValue>
-      <code>$this-&gt;parentAssociations</code>
+      <code><![CDATA[$this->parentAssociations]]></code>
     </InvalidPropertyAssignmentValue>
     <InvalidReturnStatement>
       <code>$divided</code>
     </InvalidReturnStatement>
     <InvalidReturnType>
-      <code>array&lt;class-string, array{0: ClassMetadata&lt;object&gt;, 1: array&lt;string, object&gt;}&gt;</code>
+      <code><![CDATA[array<class-string, array{0: ClassMetadata<object>, 1: array<string, object>}>]]></code>
     </InvalidReturnType>
     <NullableReturnStatement>
-      <code>$mapping['targetDocument']</code>
+      <code><![CDATA[$mapping['targetDocument']]]></code>
     </NullableReturnStatement>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/ClassMetadataTestUtil.php">
@@ -275,12 +270,12 @@
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php">
     <InvalidArgument>
-      <code>$class-&gt;associationMappings['ref']</code>
-      <code>$class-&gt;associationMappings['ref1']</code>
-      <code>$class-&gt;associationMappings['ref2']</code>
-      <code>$class-&gt;associationMappings['ref3']</code>
-      <code>$class-&gt;associationMappings['ref4']</code>
-      <code>['storeAs' =&gt; ClassMetadata::REFERENCE_STORE_AS_DB_REF]</code>
+      <code><![CDATA[$class->associationMappings['ref']]]></code>
+      <code><![CDATA[$class->associationMappings['ref1']]]></code>
+      <code><![CDATA[$class->associationMappings['ref2']]]></code>
+      <code><![CDATA[$class->associationMappings['ref3']]]></code>
+      <code><![CDATA[$class->associationMappings['ref4']]]></code>
+      <code><![CDATA[['storeAs' => ClassMetadata::REFERENCE_STORE_AS_DB_REF]]]></code>
     </InvalidArgument>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/DocumentRepositoryTest.php">
@@ -288,12 +283,95 @@
       <code>new ArrayCollection([$project])</code>
     </InvalidArgument>
   </file>
+  <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php">
+    <UndefinedInterfaceMethod>
+      <code><![CDATA[$malarzm->friends]]></code>
+      <code><![CDATA[$malarzm->friends]]></code>
+      <code><![CDATA[$malarzm->friends]]></code>
+      <code><![CDATA[$malarzm->friends]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->inception]]></code>
+      <code><![CDATA[$user->phonebooks]]></code>
+      <code><![CDATA[$user->phonebooks]]></code>
+      <code><![CDATA[$user->phonebooks]]></code>
+      <code><![CDATA[$user->phonebooks]]></code>
+      <code><![CDATA[$user->phonebooks]]></code>
+      <code><![CDATA[$user->phonebooks]]></code>
+      <code><![CDATA[$user->phonenumbers]]></code>
+      <code><![CDATA[$user->phonenumbers]]></code>
+      <code><![CDATA[$user->phonenumbers]]></code>
+      <code><![CDATA[$user->phonenumbers]]></code>
+      <code><![CDATA[$user->phonenumbers]]></code>
+      <code><![CDATA[$user->phonenumbers]]></code>
+      <code><![CDATA[$user->phonenumbers]]></code>
+      <code><![CDATA[$user->phonenumbers]]></code>
+      <code><![CDATA[$user->phonenumbersArray]]></code>
+      <code><![CDATA[$user->phonenumbersArray]]></code>
+      <code><![CDATA[$user->phonenumbersArray]]></code>
+      <code><![CDATA[$user->phonenumbersArray]]></code>
+      <code><![CDATA[$user->phonenumbersArray]]></code>
+      <code>clear</code>
+    </UndefinedInterfaceMethod>
+  </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php">
     <InvalidArgument>
-      <code>[$user-&gt;categories[0]-&gt;children, $user-&gt;categories[1]-&gt;children]</code>
-      <code>[$user-&gt;categories[0]-&gt;children[0]-&gt;children, $user-&gt;categories[0]-&gt;children[1]-&gt;children]</code>
-      <code>[$user-&gt;categories[0]-&gt;children[0]-&gt;children, $user-&gt;categories[0]-&gt;children[1]-&gt;children]</code>
+      <code><![CDATA[[$user->categories[0]->children, $user->categories[1]->children]]]></code>
+      <code><![CDATA[[$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children]]]></code>
+      <code><![CDATA[[$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children]]]></code>
     </InvalidArgument>
+  </file>
+  <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php">
+    <UndefinedInterfaceMethod>
+      <code>$phonenumbers</code>
+      <code>$phonenumbers</code>
+    </UndefinedInterfaceMethod>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php">
     <InvalidArgument>
@@ -302,6 +380,16 @@
       <code>$j</code>
       <code>$j</code>
     </InvalidArgument>
+    <UndefinedInterfaceMethod>
+      <code><![CDATA[$d->coll]]></code>
+      <code><![CDATA[$d->coll]]></code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/DetachedDocumentTest.php">
+    <UndefinedInterfaceMethod>
+      <code>$phonenumbers</code>
+      <code>$phonenumbers</code>
+    </UndefinedInterfaceMethod>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/CachingIteratorTest.php">
     <MissingTemplateParam>
@@ -310,14 +398,14 @@
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceEmbeddedDocumentsTest.php">
     <InvalidArgument>
-      <code>new ArrayCollection([
+      <code><![CDATA[new ArrayCollection([
             new Issue('Issue #1', 'Issue #1 on Sub Project #1'),
             new Issue('Issue #2', 'Issue #2 on Sub Project #1'),
-        ])</code>
-      <code>new ArrayCollection([
+        ])]]></code>
+      <code><![CDATA[new ArrayCollection([
             new Issue('Issue #1', 'Issue #1 on Sub Project #2'),
             new Issue('Issue #2', 'Issue #2 on Sub Project #2'),
-        ])</code>
+        ])]]></code>
     </InvalidArgument>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/RepositoriesTest.php">
@@ -327,13 +415,19 @@
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php">
     <InvalidArgument>
-      <code>['upsert' =&gt; true]</code>
+      <code><![CDATA[['upsert' => true]]]></code>
     </InvalidArgument>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php">
     <InvalidArgument>
-      <code>$doc-&gt;embeds</code>
+      <code><![CDATA[$doc->embeds]]></code>
     </InvalidArgument>
+  </file>
+  <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php">
+    <UndefinedInterfaceMethod>
+      <code><![CDATA[$doc->embeds]]></code>
+      <code><![CDATA[$doc->embeds]]></code>
+    </UndefinedInterfaceMethod>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH245Test.php">
     <RedundantCondition>
@@ -366,13 +460,19 @@
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH597Test.php">
     <InvalidPropertyAssignmentValue>
-      <code>new ArrayCollection([
+      <code><![CDATA[new ArrayCollection([
             new GH597Comment('Comment 1'),
             new GH597Comment('Comment 2'),
             new GH597Comment('Comment 3'),
-        ])</code>
+        ])]]></code>
       <code>new ArrayCollection([$referenceMany1, $referenceMany2])</code>
     </InvalidPropertyAssignmentValue>
+  </file>
+  <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php">
+    <UndefinedInterfaceMethod>
+      <code><![CDATA[$parent->refMany]]></code>
+      <code><![CDATA[$parent->refMany]]></code>
+    </UndefinedInterfaceMethod>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM29Test.php">
     <InvalidArgument>
@@ -384,29 +484,29 @@
       <code>DocumentManager</code>
     </InvalidNullableReturnType>
     <NullableReturnStatement>
-      <code>$this-&gt;dm</code>
+      <code><![CDATA[$this->dm]]></code>
     </NullableReturnStatement>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php">
     <InvalidArgument>
       <code>$config</code>
       <code>$mapping</code>
-      <code>[
-            'fieldName' =&gt; 'assoc',
-            'reference' =&gt; true,
-            'type' =&gt; 'many',
-            'targetDocument' =&gt; 'stdClass',
-            'repositoryMethod' =&gt; 'fetch',
-            $prop =&gt; $value,
-        ]</code>
-      <code>[
-            'fieldName' =&gt; 'enum',
-            'enumType' =&gt; Card::class,
-        ]</code>
-      <code>[
-            'fieldName' =&gt; 'enum',
-            'enumType' =&gt; SuitNonBacked::class,
-        ]</code>
+      <code><![CDATA[[
+            'fieldName' => 'assoc',
+            'reference' => true,
+            'type' => 'many',
+            'targetDocument' => 'stdClass',
+            'repositoryMethod' => 'fetch',
+            $prop => $value,
+        ]]]></code>
+      <code><![CDATA[[
+            'fieldName' => 'enum',
+            'enumType' => Card::class,
+        ]]]></code>
+      <code><![CDATA[[
+            'fieldName' => 'enum',
+            'enumType' => SuitNonBacked::class,
+        ]]]></code>
     </InvalidArgument>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php">
@@ -416,7 +516,7 @@
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php">
     <InvalidArgument>
-      <code>['type' =&gt; -1]</code>
+      <code><![CDATA[['type' => -1]]]></code>
     </InvalidArgument>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php">

--- a/psalm.xml
+++ b/psalm.xml
@@ -19,9 +19,6 @@
             <file name="lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup/Match.php" />
             <file name="lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Match.php" />
             <file name="tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/User.php" />
-            <!-- Remove CollWithPHP81Types once Psalm supports native intersection https://github.com/vimeo/psalm/issues/6413 -->
-            <file name="tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/DefaultPersistentCollectionGeneratorTest.php" />
-            <file name="tests/Doctrine/ODM/MongoDB/Tests/PersistentCollection/CollWithPHP81Types.php" />
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -213,17 +213,20 @@ class DocumentManagerTest extends BaseTestCase
         self::assertInstanceOf(ObjectId::class, $dbRef);
 
         $dbRef = $this->dm->createReference($r, $class->associationMappings['ref2']);
+        self::assertIsArray($dbRef);
         self::assertCount(2, $dbRef);
         self::assertArrayHasKey('$ref', $dbRef);
         self::assertArrayHasKey('$id', $dbRef);
 
         $dbRef = $this->dm->createReference($r, $class->associationMappings['ref3']);
+        self::assertIsArray($dbRef);
         self::assertCount(3, $dbRef);
         self::assertArrayHasKey('$ref', $dbRef);
         self::assertArrayHasKey('$id', $dbRef);
         self::assertArrayHasKey('$db', $dbRef);
 
         $dbRef = $this->dm->createReference($r, $class->associationMappings['ref4']);
+        self::assertIsArray($dbRef);
         self::assertCount(1, $dbRef);
         self::assertArrayHasKey('id', $dbRef);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
@@ -382,6 +382,7 @@ class ReferencePrimerTest extends BaseTestCase
         $this->dm->flush();
         $this->dm->clear();
 
+        /** @var array<int, array<int, mixed>> $invokedArgs */
         $invokedArgs = [];
         $primer      = static function (DocumentManager $dm, ClassMetadata $class, array $ids, array $hints) use (&$invokedArgs) {
             $invokedArgs[] = func_get_args();
@@ -395,6 +396,8 @@ class ReferencePrimerTest extends BaseTestCase
             ->getQuery()
             ->toArray();
 
+        self::assertIsArray($invokedArgs[0]);
+        self::assertIsArray($invokedArgs[1]);
         self::assertCount(2, $invokedArgs, 'Primer was invoked once for each referenced class.');
         self::assertArrayHasKey(Query::HINT_READ_PREFERENCE, $invokedArgs[0][3], 'Primer was invoked with UnitOfWork hints from original query.');
         self::assertSame($readPreference, $invokedArgs[0][3][Query::HINT_READ_PREFERENCE], 'Primer was invoked with UnitOfWork hints from original query.');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
@@ -55,6 +55,7 @@ class ShardKeyTest extends BaseTestCase
         self::assertSame('update', $lastQuery->getCommandName());
 
         $command = $lastQuery->getCommand();
+        self::assertIsArray($command->updates);
         self::assertCount(1, $command->updates);
         self::assertEquals($o->key, $command->updates[0]->q->k);
     }
@@ -71,6 +72,7 @@ class ShardKeyTest extends BaseTestCase
         self::assertSame('update', $lastQuery->getCommandName());
 
         $command = $lastQuery->getCommand();
+        self::assertIsArray($command->updates);
         self::assertCount(1, $command->updates);
         self::assertEquals($o->key, $command->updates[0]->q->k);
         self::assertTrue($command->updates[0]->upsert);
@@ -89,6 +91,7 @@ class ShardKeyTest extends BaseTestCase
         self::assertSame('delete', $lastQuery->getCommandName());
 
         $command = $lastQuery->getCommand();
+        self::assertIsArray($command->deletes);
         self::assertCount(1, $command->deletes);
         self::assertEquals($o->key, $command->deletes[0]->q->k);
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | task
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->

After https://github.com/doctrine/mongodb-odm/pull/2512 some new errors appeared I guess because PHPUnit added some assertions.

This PR has some of the changes done in https://github.com/doctrine/mongodb-odm/pull/2519 and also ignores some errors related to https://github.com/vimeo/psalm/issues/9607, that are fixed in `2.6.x` because `get_class` was removed in https://github.com/doctrine/mongodb-odm/pull/2515 when dropping support for PHP 7.4
