### PR TITLE
[Removed strict xml validation]

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -681,7 +681,7 @@ class XmlDriver extends FileDriver
             libxml_clear_errors();
 
             if (! $document->schemaValidate(__DIR__ . '/../../../../../../doctrine-mongo-mapping.xsd')) {
-                throw MappingException::xmlMappingFileInvalid($filename, $this->formatErrors(libxml_get_errors()));
+                return;
             }
         } finally {
             libxml_use_internal_errors($previousUseErrors);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         |improvement
| BC Break     | yes


#### Summary
Removed strict xml validation. Before due this not able to use external gedmo extension.
https://github.com/doctrine/mongodb-odm/issues/2529