### PR TITLE
Use CursorInterface type instead of Cursor

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
@@ -12,10 +12,9 @@ use Doctrine\ODM\MongoDB\Iterator\UnrewindableIterator;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use IteratorAggregate;
 use MongoDB\Collection;
-use MongoDB\Driver\Cursor;
+use MongoDB\Driver\CursorInterface;
 
 use function array_merge;
-use function assert;
 
 /** @psalm-import-type PipelineExpression from Builder */
 final class Aggregation implements IteratorAggregate
@@ -35,12 +34,11 @@ final class Aggregation implements IteratorAggregate
         $options = array_merge($this->options, ['cursor' => true]);
 
         $cursor = $this->collection->aggregate($this->pipeline, $options);
-        assert($cursor instanceof Cursor);
 
         return $this->prepareIterator($cursor);
     }
 
-    private function prepareIterator(Cursor $cursor): Iterator
+    private function prepareIterator(CursorInterface&Iterator $cursor): Iterator
     {
         if ($this->classMetadata) {
             $cursor = new HydratingIterator($cursor, $this->dm->getUnitOfWork(), $this->classMetadata);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #2395

#### Summary

I still have the same issue, I want to move from `execute()` to `getAggregation()->getIterator()` but this class is completely locked in and we have no way to unit test this:

https://github.com/api-platform/core/blob/92a81f024541054b9322e7457b75c721261e14e0/src/Doctrine/Odm/State/ItemProvider.php#L74

The assertion above is fine I can disable it, but in fact I wonder why you wouldn't do `instanceof CursorInterface`, what if someone implements another Cursor? We can't use the `Aggregation` type, nor the `AggregationBuilder` (as the signature of `getAggregation` forces the use of the final class `Aggregation`) nor the `DocumentRepository`, which forces the use of the `AggregationBuilder`... 

Can you help providing a solution for library maintainers? Thanks!