### PR TITLE
Add sort operator to $search stage

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -236,10 +236,8 @@ abstract class Stage
      * Limits the number of documents passed to the next stage in the pipeline.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/limit/
-     *
-     * @return Stage\Limit
      */
-    public function limit(int $limit)
+    public function limit(int $limit): self
     {
         return $this->builder->limit($limit);
     }
@@ -434,10 +432,8 @@ abstract class Stage
      *
      * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
      * @param int|string                       $order     Field order (if one field is specified)
-     *
-     * @return Stage\Sort
      */
-    public function sort($fieldName, $order = null)
+    public function sort($fieldName, $order = null): self
     {
         return $this->builder->sort($fieldName, $order);
     }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -434,8 +434,10 @@ abstract class Stage
      *
      * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
      * @param int|string                       $order     Field order (if one field is specified)
+     *
+     * @return Stage\Sort
      */
-    public function sort($fieldName, $order = null): Stage\Sort
+    public function sort($fieldName, $order = null)
     {
         return $this->builder->sort($fieldName, $order);
     }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
@@ -17,6 +17,8 @@ use function strtolower;
 
 /**
  * @psalm-type CountType = 'lowerBound'|'total'
+ * @psalm-type SortMetaKeywords = 'searchScore'
+ * @psalm-type SortMeta = array{'$meta': SortMetaKeywords}
  * @psalm-type SearchStageExpression = array{
  *     '$search': object{
  *         index?: string,
@@ -58,7 +60,9 @@ class Search extends Stage implements SupportsAllSearchOperators
     private ?object $highlight        = null;
     private ?bool $returnStoredSource = null;
     private ?SearchOperator $operator = null;
-    private array $sort               = [];
+
+    /** @var array<string, -1|1|SortMeta> */
+    private array $sort = [];
 
     public function __construct(Builder $builder)
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
@@ -16,9 +16,11 @@ use function is_string;
 use function strtolower;
 
 /**
+ * @psalm-import-type SortDirectionKeywords from Sort
  * @psalm-type CountType = 'lowerBound'|'total'
  * @psalm-type SortMetaKeywords = 'searchScore'
  * @psalm-type SortMeta = array{'$meta': SortMetaKeywords}
+ * @psalm-type SortShape = array<string, int|SortMeta|SortDirectionKeywords>
  * @psalm-type SearchStageExpression = array{
  *     '$search': object{
  *         index?: string,
@@ -143,6 +145,12 @@ class Search extends Stage implements SupportsAllSearchOperators
         return $this;
     }
 
+    /**
+     * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
+     * @param int|string                       $order     Field order (if one field is specified)
+     * @psalm-param SortShape|string $fieldName
+     * @psalm-param int|SortMeta|SortDirectionKeywords|null $order
+     */
     public function sort($fieldName, $order = null): static
     {
         $allowedMetaSort = ['searchScore'];

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/AbstractSearchOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/AbstractSearchOperator.php
@@ -35,6 +35,11 @@ abstract class AbstractSearchOperator extends Stage implements SearchOperator
         return $this->search->returnStoredSource($returnStoredSource);
     }
 
+    public function sort($fieldName, $order = null): Search
+    {
+        return $this->search->sort($fieldName, $order);
+    }
+
     /**
      * @return array<string, object>
      * @psalm-return non-empty-array<non-empty-string, object>

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/AbstractSearchOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/AbstractSearchOperator.php
@@ -6,8 +6,16 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @psalm-import-type SortDirectionKeywords from Sort
+ * @psalm-import-type SortMetaKeywords from Search
+ * @psalm-import-type SortMeta from Search
+ * @psalm-import-type SortShape from Search
+ */
 abstract class AbstractSearchOperator extends Stage implements SearchOperator
 {
     public function __construct(private Search $search)
@@ -35,6 +43,12 @@ abstract class AbstractSearchOperator extends Stage implements SearchOperator
         return $this->search->returnStoredSource($returnStoredSource);
     }
 
+    /**
+     * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
+     * @param int|string                       $order     Field order (if one field is specified)
+     * @psalm-param SortShape|string $fieldName
+     * @psalm-param int|SortMeta|SortDirectionKeywords|null $order
+     */
     public function sort($fieldName, $order = null): Search
     {
         return $this->search->sort($fieldName, $order);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Circular definition detected in type alias PipelineExpression\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
-
-		-
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$applyFilters$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -51,24 +46,9 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket/AbstractOutput.php
 
 		-
-			message: "#^Circular definition detected in type alias FacetStageExpression\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Facet.php
-
-		-
-			message: "#^Return type \\(static\\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\GeoNear\\)\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\GeoNear\\:\\:limit\\(\\) should be compatible with return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Limit\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\:\\:limit\\(\\)$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GeoNear.php
-
-		-
 			message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getClassMetadata\\(\\)$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup.php
-
-		-
-			message: "#^Circular definition detected in type alias PipelineParamType\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
 
 		-
 			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Lookup\\:\\:getExpression\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -84,21 +64,6 @@ parameters:
 			message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getClassMetadata\\(\\)$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
-
-		-
-			message: "#^Circular definition detected in type alias MergeStageExpression\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
-
-		-
-			message: "#^Circular definition detected in type alias WhenMatchedParamType\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
-
-		-
-			message: "#^Circular definition detected in type alias WhenMatchedType\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
 
 		-
 			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Merge\\:\\:whenMatched\\(\\) has parameter \\$whenMatched with no value type specified in iterable type array\\.$#"
@@ -129,16 +94,6 @@ parameters:
 			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
-
-		-
-			message: "#^Return type \\(static\\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\)\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\:\\:sort\\(\\) should be compatible with return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Sort\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\:\\:sort\\(\\)$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
-
-		-
-			message: "#^Return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\AbstractSearchOperator\\:\\:sort\\(\\) should be compatible with return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Sort\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\:\\:sort\\(\\)$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/AbstractSearchOperator.php
 
 		-
 			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -51,16 +51,6 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket/AbstractOutput.php
 
 		-
-			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Densify\\:\\:getExpression\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
-
-		-
-			message: "#^PHPDoc tag @return with type mixed is not subtype of native type array\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
-
-		-
 			message: "#^Circular definition detected in type alias FacetStageExpression\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Facet.php
@@ -96,6 +86,11 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
 
 		-
+			message: "#^Circular definition detected in type alias MergeStageExpression\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
+
+		-
 			message: "#^Circular definition detected in type alias WhenMatchedParamType\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
@@ -106,17 +101,7 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
 
 		-
-			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Merge\\:\\:getExpression\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
-
-		-
 			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Merge\\:\\:whenMatched\\(\\) has parameter \\$whenMatched with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
-
-		-
-			message: "#^PHPDoc tag @return with type mixed is not subtype of native type array\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
 
@@ -141,19 +126,19 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
 
 		-
-			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\:\\:getExpression\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
-
-		-
 			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\:\\:near\\(\\) has parameter \\$origin with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
 
 		-
-			message: "#^PHPDoc tag @return with type mixed is not subtype of native type array\\.$#"
+			message: "#^Return type \\(static\\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\)\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\:\\:sort\\(\\) should be compatible with return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Sort\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\:\\:sort\\(\\)$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
+
+		-
+			message: "#^Return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\AbstractSearchOperator\\:\\:sort\\(\\) should be compatible with return type \\(Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Sort\\) of method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\:\\:sort\\(\\)$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/AbstractSearchOperator.php
 
 		-
 			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Search\\\\Compound\\:\\:geoShape\\(\\) has parameter \\$geometry with no value type specified in iterable type array\\.$#"
@@ -471,27 +456,7 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsNearOperator.php
 
 		-
-			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\SetWindowFields\\:\\:getExpression\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SetWindowFields.php
-
-		-
-			message: "#^PHPDoc tag @return with type mixed is not subtype of native type array\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SetWindowFields.php
-
-		-
-			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\UnionWith\\:\\:getExpression\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
-
-		-
 			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\UnionWith\\:\\:pipeline\\(\\) has parameter \\$pipeline with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
-
-		-
-			message: "#^PHPDoc tag @return with type mixed is not subtype of native type array\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
 
@@ -707,6 +672,11 @@ parameters:
 
 		-
 			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Aggregation\\\\Stage\\\\SearchTest\\:\\:testSearchOperators\\(\\) has parameter \\$expectedOperator with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Aggregation\\\\Stage\\\\SearchTest\\:\\:testSearchOperatorsWithSort\\(\\) has parameter \\$expectedOperator with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,10 +17,16 @@ parameters:
   ignoreErrors:
       # Ignore typing providers in tests
       - '#^Method Doctrine\\ODM\\MongoDB\\Tests\\[^:]+(Test)::(get\w+|data\w+|provide\w+)\(\) return type has no value type specified in iterable type (array|iterable)\.#'
+
+      # Ignore circular references in Psalm types
+      - message: '#^Circular definition detected in type alias#'
+        path: lib/Doctrine/ODM/MongoDB/Aggregation/
+
   # To be removed when reaching phpstan level 6
   checkMissingVarTagTypehint: true
   checkMissingTypehints: true
   checkMissingIterableValueType: true
+
   # Disabled due to inconsistent errors upon encountering psalm types
   reportUnmatchedIgnoredErrors: false
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,6 +5,18 @@
       <code>IteratorAggregate</code>
     </MissingTemplateParam>
   </file>
+  <file src="lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php">
+    <MoreSpecificImplementedParamType>
+      <code>$fieldName</code>
+      <code>$order</code>
+    </MoreSpecificImplementedParamType>
+  </file>
+  <file src="lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/AbstractSearchOperator.php">
+    <MoreSpecificImplementedParamType>
+      <code>$fieldName</code>
+      <code>$order</code>
+    </MoreSpecificImplementedParamType>
+  </file>
   <file src="lib/Doctrine/ODM/MongoDB/Configuration.php">
     <TypeDoesNotContainType>
       <code><![CDATA[$reflectionClass->implementsInterface(ClassMetadataFactoryInterface::class)]]></code>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
@@ -1182,6 +1182,53 @@ class SearchTest extends BaseTestCase
     }
 
     #[DataProvider('provideAutocompleteBuilders')]
+    #[DataProvider('provideCompoundBuilders')]
+    #[DataProvider('provideEmbeddedDocumentBuilders')]
+    #[DataProvider('provideEqualsBuilders')]
+    #[DataProvider('provideExistsBuilders')]
+    #[DataProvider('provideGeoShapeBuilders')]
+    #[DataProvider('provideGeoWithinBuilders')]
+    #[DataProvider('provideMoreLikeThisBuilders')]
+    #[DataProvider('provideNearBuilders')]
+    #[DataProvider('providePhraseBuilders')]
+    #[DataProvider('provideQueryStringBuilders')]
+    #[DataProvider('provideRangeBuilders')]
+    #[DataProvider('provideRegexBuilders')]
+    #[DataProvider('provideTextBuilders')]
+    #[DataProvider('provideWildcardBuilders')]
+    public function testSearchOperatorsWithSort(array $expectedOperator, Closure $createOperator): void
+    {
+        $baseExpected = [
+            'index' => 'my_search_index',
+            'sort' => (object) [
+                'unused' => ['$meta' => 'searchScore'],
+                'date' => -1,
+                'bar' => 1,
+            ],
+        ];
+
+        $searchStage = new Search($this->getTestAggregationBuilder());
+        $searchStage
+            ->index('my_search_index');
+
+        $result = $createOperator($searchStage);
+
+        self::logicalOr(
+            new IsInstanceOf(AbstractSearchOperator::class),
+            new IsInstanceOf(Search::class),
+        );
+
+        $result
+            ->sort(['unused' => 'searchScore', 'date' => -1])
+            ->sort(['bar' => 1]);
+
+        self::assertEquals(
+            ['$search' => (object) array_merge($baseExpected, $expectedOperator)],
+            $searchStage->getExpression(),
+        );
+    }
+
+    #[DataProvider('provideAutocompleteBuilders')]
     #[DataProvider('provideEmbeddedDocumentBuilders')]
     #[DataProvider('provideEqualsBuilders')]
     #[DataProvider('provideExistsBuilders')]


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

This adds the missing `sort` operator to the builder for the `$search` aggregation pipeline stage.
