### PR TITLE
Drop support for symfony components <5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,9 @@
         "jean85/pretty-package-versions": "^1.3.0 || ^2.0.1",
         "mongodb/mongodb": "^1.10.0",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
-        "symfony/console": "^3.4 || ^4.1 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0",
-        "symfony/var-dumper": "^3.4 || ^4.1 || ^5.0 || ^6.0 || ^7.0"
+        "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "ext-bcmath": "*",
@@ -46,7 +46,7 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.6 || ^10.0.15",
         "squizlabs/php_codesniffer": "^3.5",
-        "symfony/cache": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/cache": "^5.4 || ^6.0 || ^7.0",
         "vimeo/psalm": "^5.9.0"
     },
     "suggest": {


### PR DESCRIPTION
Now we're just a bit less restrictive than the currently released bundle (it's `^5.4 || ^6.2` + upcoming 7.0)