### PR TITLE
Support Symfony 7 by adding return types conditionally

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,17 +29,27 @@ jobs:
           - "server"
         dependencies:
           - "highest"
+        symfony-version:
+          - "stable"
         include:
           - dependencies: "lowest"
             php-version: "8.1"
             mongodb-version: "4.4"
             driver-version: "1.11.0"
             topology: "server"
+            symfony-version: "stable"
           - topology: "sharded_cluster"
             php-version: "8.2"
             mongodb-version: "4.4"
             driver-version: "stable"
             dependencies: "highest"
+            symfony-version: "stable"
+          - topology: "server"
+            php-version: "8.2"
+            mongodb-version: "6.0"
+            driver-version: "stable"
+            dependencies: "highest"
+            symfony-version: "7"
 
     steps:
       - name: "Checkout"
@@ -77,6 +87,17 @@ jobs:
       # This allows installing symfony/console 3.4 and 6
       - name: "Remove phpbench/phpbench"
         run: composer remove --no-update --dev phpbench/phpbench
+
+      - name: "Configure Symfony v7@dev"
+        if: "${{ matrix.symfony-version == '7' }}"
+        run: |
+          composer config minimum-stability dev
+          # not yet ready for v7
+          composer remove --no-update --dev vimeo/psalm
+          # update symfony deps
+          composer require --no-update symfony/console:^7@dev
+          composer require --no-update symfony/var-dumper:^7@dev
+          composer require --no-update --dev symfony/cache:^7@dev
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command\ClearCache;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Tools\Console\Command\CommandCompatibility;
 use InvalidArgumentException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,11 +20,9 @@ use const PHP_EOL;
  */
 class MetadataCommand extends Command
 {
-    /**
-     * @see \Symfony\Component\Console\Command\Command
-     *
-     * @return void
-     */
+    use CommandCompatibility;
+
+    /** @return void */
     protected function configure()
     {
         $this
@@ -36,8 +35,7 @@ EOT
         );
     }
 
-    /** @return int */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $dm = $this->getHelper('documentManager')->getDocumentManager();
         assert($dm instanceof DocumentManager);

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/CommandCompatibility.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/CommandCompatibility.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tools\Console\Command;
+
+use ReflectionMethod;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+if ((new ReflectionMethod(Command::class, 'execute'))->hasReturnType()) {
+    /** @internal */
+    trait CommandCompatibility
+    {
+        protected function execute(InputInterface $input, OutputInterface $output): int
+        {
+            return $this->doExecute($input, $output);
+        }
+    }
+} else {
+    /** @internal */
+    trait CommandCompatibility
+    {
+        /**
+         * {@inheritDoc}
+         *
+         * @return int
+         */
+        protected function execute(InputInterface $input, OutputInterface $output)
+        {
+            return $this->doExecute($input, $output);
+        }
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php
@@ -6,9 +6,11 @@ namespace Doctrine\ODM\MongoDB\Tools\Console\Command;
 
 use Doctrine\ODM\MongoDB\Tools\Console\MetadataFilter;
 use InvalidArgumentException;
-use Symfony\Component\Console;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 use function assert;
 use function count;
@@ -25,13 +27,11 @@ use const PHP_EOL;
 /**
  * Command to (re)generate the hydrator classes used by doctrine.
  */
-class GenerateHydratorsCommand extends Console\Command\Command
+class GenerateHydratorsCommand extends Command
 {
-    /**
-     * @see Console\Command\Command
-     *
-     * @return void
-     */
+    use CommandCompatibility;
+
+    /** @return void */
     protected function configure()
     {
         $this
@@ -56,8 +56,7 @@ EOT
         );
     }
 
-    /** @return int */
-    protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $filter = $input->getOption('filter');
         assert(is_array($filter));

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GeneratePersistentCollectionsCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GeneratePersistentCollectionsCommand.php
@@ -6,9 +6,11 @@ namespace Doctrine\ODM\MongoDB\Tools\Console\Command;
 
 use Doctrine\ODM\MongoDB\Tools\Console\MetadataFilter;
 use InvalidArgumentException;
-use Symfony\Component\Console;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 use function assert;
 use function count;
@@ -25,13 +27,11 @@ use const PHP_EOL;
 /**
  * Command to (re)generate the persistent collection classes used by doctrine.
  */
-class GeneratePersistentCollectionsCommand extends Console\Command\Command
+class GeneratePersistentCollectionsCommand extends Command
 {
-    /**
-     * @see Console\Command\Command
-     *
-     * @return void
-     */
+    use CommandCompatibility;
+
+    /** @return void */
     protected function configure()
     {
         $this
@@ -56,8 +56,7 @@ EOT
             );
     }
 
-    /** @return int */
-    protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $filter = $input->getOption('filter');
         assert(is_array($filter));

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateProxiesCommand.php
@@ -9,8 +9,10 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Tools\Console\MetadataFilter;
 use InvalidArgumentException;
-use Symfony\Component\Console;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 use function array_filter;
 use function assert;
@@ -29,13 +31,11 @@ use const PHP_EOL;
 /**
  * Command to (re)generate the proxy classes used by doctrine.
  */
-class GenerateProxiesCommand extends Console\Command\Command
+class GenerateProxiesCommand extends Command
 {
-    /**
-     * @see Console\Command\Command
-     *
-     * @return void
-     */
+    use CommandCompatibility;
+
+    /** @return void */
     protected function configure()
     {
         $this
@@ -55,8 +55,7 @@ EOT
         );
     }
 
-    /** @return int */
-    protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $filter = $input->getOption('filter');
         assert(is_array($filter));

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/QueryCommand.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command;
 
 use LogicException;
-use Symfony\Component\Console;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 
@@ -21,13 +23,11 @@ use const JSON_THROW_ON_ERROR;
 /**
  * Command to query mongodb and inspect the outputted results from your document classes.
  */
-class QueryCommand extends Console\Command\Command
+class QueryCommand extends Command
 {
-    /**
-     * @see Console\Command\Command
-     *
-     * @return void
-     */
+    use CommandCompatibility;
+
+    /** @return void */
     protected function configure()
     {
         $this
@@ -69,8 +69,7 @@ EOT
         );
     }
 
-    /** @return int */
-    protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $query = $input->getArgument('query');
         assert(is_string($query));

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/CreateCommand.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tools\Console\Command\Schema;
 
 use BadMethodCallException;
 use Doctrine\ODM\MongoDB\SchemaManager;
+use Doctrine\ODM\MongoDB\Tools\Console\Command\CommandCompatibility;
 use MongoDB\Driver\WriteConcern;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -19,6 +20,8 @@ use function ucfirst;
 
 class CreateCommand extends AbstractCommand
 {
+    use CommandCompatibility;
+
     /** @var string[] */
     private array $createOrder = [self::COLLECTION, self::INDEX];
 
@@ -36,8 +39,7 @@ class CreateCommand extends AbstractCommand
             ->setDescription('Create databases, collections and indexes for your documents');
     }
 
-    /** @return int */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $create = array_filter($this->createOrder, static fn (string $option): bool => (bool) $input->getOption($option));
 

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/DropCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command\Schema;
 
 use Doctrine\ODM\MongoDB\SchemaManager;
+use Doctrine\ODM\MongoDB\Tools\Console\Command\CommandCompatibility;
 use MongoDB\Driver\WriteConcern;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -18,6 +19,8 @@ use function ucfirst;
 
 class DropCommand extends AbstractCommand
 {
+    use CommandCompatibility;
+
     /** @var string[] */
     private array $dropOrder = [self::INDEX, self::COLLECTION, self::DB];
 
@@ -35,8 +38,7 @@ class DropCommand extends AbstractCommand
             ->setDescription('Drop databases, collections and indexes for your documents');
     }
 
-    /** @return int */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $drop = array_filter($this->dropOrder, static fn (string $option): bool => (bool) $input->getOption($option));
 

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ShardCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ShardCommand.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tools\Console\Command\Schema;
 
 use BadMethodCallException;
 use Doctrine\ODM\MongoDB\SchemaManager;
+use Doctrine\ODM\MongoDB\Tools\Console\Command\CommandCompatibility;
 use MongoDB\Driver\WriteConcern;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -17,6 +18,8 @@ use function sprintf;
 
 class ShardCommand extends AbstractCommand
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -28,8 +31,7 @@ class ShardCommand extends AbstractCommand
             ->setDescription('Enable sharding for selected documents');
     }
 
-    /** @return int */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $class = $input->getOption('class');
 

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/UpdateCommand.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tools\Console\Command\Schema;
 
 use BadMethodCallException;
 use Doctrine\ODM\MongoDB\SchemaManager;
+use Doctrine\ODM\MongoDB\Tools\Console\Command\CommandCompatibility;
 use MongoDB\Driver\WriteConcern;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -17,6 +18,8 @@ use function sprintf;
 
 class UpdateCommand extends AbstractCommand
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -29,8 +32,7 @@ class UpdateCommand extends AbstractCommand
             ->setDescription('Update indexes and validation rules for your documents');
     }
 
-    /** @return int */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $class            = $input->getOption('class');
         $updateValidators = ! $input->getOption('disable-validators');

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ValidateCommand.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Command/Schema/ValidateCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command\Schema;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Tools\Console\Command\CommandCompatibility;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -16,6 +17,8 @@ use function unserialize;
 
 class ValidateCommand extends Command
 {
+    use CommandCompatibility;
+
     /** @return void */
     protected function configure()
     {
@@ -29,8 +32,7 @@ EOT
             );
     }
 
-    /** @return int */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    private function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $dm = $this->getHelper('documentManager')->getDocumentManager();
         assert($dm instanceof DocumentManager);

--- a/lib/Doctrine/ODM/MongoDB/Tools/Console/Helper/DocumentManagerHelper.php
+++ b/lib/Doctrine/ODM/MongoDB/Tools/Console/Helper/DocumentManagerHelper.php
@@ -5,13 +5,38 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tools\Console\Helper;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use ReflectionMethod;
 use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Helper\HelperInterface;
+
+if ((new ReflectionMethod(HelperInterface::class, 'getName'))->hasReturnType()) {
+    /** @internal */
+    trait DocumentManagerHelperCompatibility
+    {
+        public function getName(): string
+        {
+            return 'documentManager';
+        }
+    }
+} else {
+    /** @internal */
+    trait DocumentManagerHelperCompatibility
+    {
+        /** @return string */
+        public function getName()
+        {
+            return 'documentManager';
+        }
+    }
+}
 
 /**
  * Symfony console component helper for accessing a DocumentManager instance.
  */
 class DocumentManagerHelper extends Helper
 {
+    use DocumentManagerHelperCompatibility;
+
     /** @var DocumentManager */
     protected $dm;
 
@@ -23,15 +48,5 @@ class DocumentManagerHelper extends Helper
     public function getDocumentManager(): DocumentManager
     {
         return $this->dm;
-    }
-
-    /**
-     * Get the canonical name of this helper.
-     *
-     * @see \Symfony\Component\Console\Helper\HelperInterface::getName()
-     */
-    public function getName(): string
-    {
-        return 'documentManager';
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -60,10 +60,13 @@
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>lib/Doctrine/ODM/MongoDB/Mapping/Driver/CompatibilityAnnotationDriver.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/ODM/MongoDB/Tools/Console/Command/CommandCompatibility.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/ODM/MongoDB/Tools/Console/Helper/DocumentManagerHelper.php</exclude-pattern>
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 
     <rule ref="Squiz.Classes.ClassFileName.NoMatch">
+        <exclude-pattern>lib/Doctrine/ODM/MongoDB/Tools/Console/Helper/DocumentManagerHelper.php</exclude-pattern>
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -209,6 +209,11 @@
       <code>getDocumentManager</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/Doctrine/ODM/MongoDB/Tools/Console/Command/CommandCompatibility.php">
+    <DuplicateClass>
+      <code>CommandCompatibility</code>
+    </DuplicateClass>
+  </file>
   <file src="lib/Doctrine/ODM/MongoDB/Tools/Console/Command/GenerateHydratorsCommand.php">
     <UndefinedInterfaceMethod>
       <code>getDocumentManager</code>
@@ -238,6 +243,11 @@
     <UndefinedInterfaceMethod>
       <code>getDocumentManager</code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ODM/MongoDB/Tools/Console/Helper/DocumentManagerHelper.php">
+    <DuplicateClass>
+      <code>DocumentManagerHelperCompatibility</code>
+    </DuplicateClass>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Tools/Console/MetadataFilter.php">
     <MissingTemplateParam>


### PR DESCRIPTION
Similar to https://github.com/doctrine/orm/pull/10919

In https://github.com/doctrine/mongodb-odm/pull/2558 we allowed Symfony 7, but we were not testing it.