### PR TITLE
Use PHPUnit 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "phpbench/phpbench": "^1.0.0",
         "phpstan/phpstan": "^1.10.11",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.6 || ^10.0.15",
+        "phpunit/phpunit": "^10.4",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/cache": "^5.4 || ^6.0 || ^7.0",
         "vimeo/psalm": "^5.9.0"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -981,12 +981,12 @@ parameters:
 			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest\\.php\\:230\\>\\:\\:mapField\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\{fieldName\\: 'enum', enumType\\: 'Documents\\\\\\\\Card'\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest\\.php\\:231\\>\\:\\:mapField\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\{fieldName\\: 'enum', enumType\\: 'Documents\\\\\\\\Card'\\} given\\.$#"
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest\\.php\\:249\\>\\:\\:mapField\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\{fieldName\\: 'enum', enumType\\: 'Documents\\\\\\\\SuitNonBacked'\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest\\.php\\:250\\>\\:\\:mapField\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\{fieldName\\: 'enum', enumType\\: 'Documents\\\\\\\\SuitNonBacked'\\} given\\.$#"
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
         failOnRisky="true"
         stopOnFailure="false"
         bootstrap="tests/bootstrap.php"
-        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
         cacheDirectory=".phpunit.cache"
 >
     <testsuites>
@@ -15,11 +15,11 @@
             <directory>./tests/Doctrine/</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">./lib/Doctrine/ODM/MongoDB</directory>
         </include>
-    </coverage>
+    </source>
     <groups>
         <exclude>
             <group>performance</group>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationOperatorsProviderTrait.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/AggregationOperatorsProviderTrait.php
@@ -1446,7 +1446,7 @@ trait AggregationOperatorsProviderTrait
         ];
     }
 
-    public function provideWindowExpressionOperators(): Generator
+    public static function provideWindowExpressionOperators(): Generator
     {
         yield 'covariancePop' => [
             'expected' => ['$covariancePop' => ['$field1', '$field2']],

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/ExprTest.php
@@ -9,6 +9,7 @@ use Closure;
 use Doctrine\ODM\MongoDB\Aggregation\Expr;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ExprTest extends BaseTestCase
 {
@@ -17,26 +18,25 @@ class ExprTest extends BaseTestCase
     /**
      * @param array<string, string>          $expected
      * @param Closure(Expr): mixed[]|mixed[] $args
-     *
-     * @dataProvider provideAccumulatorExpressionOperators
-     * @dataProvider provideArithmeticExpressionOperators
-     * @dataProvider provideArrayExpressionOperators
-     * @dataProvider provideBooleanExpressionOperators
-     * @dataProvider provideComparisonExpressionOperators
-     * @dataProvider provideConditionalExpressionOperators
-     * @dataProvider provideCustomExpressionOperators
-     * @dataProvider provideDataSizeExpressionOperators
-     * @dataProvider provideDateExpressionOperators
-     * @dataProvider provideGroupAccumulatorExpressionOperators
-     * @dataProvider provideMiscExpressionOperators
-     * @dataProvider provideObjectExpressionOperators
-     * @dataProvider provideSetExpressionOperators
-     * @dataProvider provideStringExpressionOperators
-     * @dataProvider provideTimestampExpressionOperators
-     * @dataProvider provideTrigonometryExpressionOperators
-     * @dataProvider provideTypeExpressionOperators
-     * @dataProvider provideWindowExpressionOperators
      */
+    #[DataProvider('provideAccumulatorExpressionOperators')]
+    #[DataProvider('provideArithmeticExpressionOperators')]
+    #[DataProvider('provideArrayExpressionOperators')]
+    #[DataProvider('provideBooleanExpressionOperators')]
+    #[DataProvider('provideComparisonExpressionOperators')]
+    #[DataProvider('provideConditionalExpressionOperators')]
+    #[DataProvider('provideCustomExpressionOperators')]
+    #[DataProvider('provideDataSizeExpressionOperators')]
+    #[DataProvider('provideDateExpressionOperators')]
+    #[DataProvider('provideGroupAccumulatorExpressionOperators')]
+    #[DataProvider('provideMiscExpressionOperators')]
+    #[DataProvider('provideObjectExpressionOperators')]
+    #[DataProvider('provideSetExpressionOperators')]
+    #[DataProvider('provideStringExpressionOperators')]
+    #[DataProvider('provideTimestampExpressionOperators')]
+    #[DataProvider('provideTrigonometryExpressionOperators')]
+    #[DataProvider('provideTypeExpressionOperators')]
+    #[DataProvider('provideWindowExpressionOperators')]
     public function testGenericOperator(array $expected, string $operator, $args): void
     {
         $expr = $this->createExpr();
@@ -49,26 +49,25 @@ class ExprTest extends BaseTestCase
     /**
      * @param array<string, string>          $expected
      * @param Closure(Expr): mixed[]|mixed[] $args
-     *
-     * @dataProvider provideAccumulatorExpressionOperators
-     * @dataProvider provideArithmeticExpressionOperators
-     * @dataProvider provideArrayExpressionOperators
-     * @dataProvider provideBooleanExpressionOperators
-     * @dataProvider provideComparisonExpressionOperators
-     * @dataProvider provideConditionalExpressionOperators
-     * @dataProvider provideCustomExpressionOperators
-     * @dataProvider provideDataSizeExpressionOperators
-     * @dataProvider provideDateExpressionOperators
-     * @dataProvider provideGroupAccumulatorExpressionOperators
-     * @dataProvider provideMiscExpressionOperators
-     * @dataProvider provideObjectExpressionOperators
-     * @dataProvider provideSetExpressionOperators
-     * @dataProvider provideStringExpressionOperators
-     * @dataProvider provideTimestampExpressionOperators
-     * @dataProvider provideTrigonometryExpressionOperators
-     * @dataProvider provideTypeExpressionOperators
-     * @dataProvider provideWindowExpressionOperators
      */
+    #[DataProvider('provideAccumulatorExpressionOperators')]
+    #[DataProvider('provideArithmeticExpressionOperators')]
+    #[DataProvider('provideArrayExpressionOperators')]
+    #[DataProvider('provideBooleanExpressionOperators')]
+    #[DataProvider('provideComparisonExpressionOperators')]
+    #[DataProvider('provideConditionalExpressionOperators')]
+    #[DataProvider('provideCustomExpressionOperators')]
+    #[DataProvider('provideDataSizeExpressionOperators')]
+    #[DataProvider('provideDateExpressionOperators')]
+    #[DataProvider('provideGroupAccumulatorExpressionOperators')]
+    #[DataProvider('provideMiscExpressionOperators')]
+    #[DataProvider('provideObjectExpressionOperators')]
+    #[DataProvider('provideSetExpressionOperators')]
+    #[DataProvider('provideStringExpressionOperators')]
+    #[DataProvider('provideTimestampExpressionOperators')]
+    #[DataProvider('provideTrigonometryExpressionOperators')]
+    #[DataProvider('provideTypeExpressionOperators')]
+    #[DataProvider('provideWindowExpressionOperators')]
     public function testGenericOperatorWithField(array $expected, string $operator, $args): void
     {
         $expr = $this->createExpr();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketAutoTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketAutoTest.php
@@ -13,6 +13,7 @@ use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsComment;
 use Documents\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class BucketAutoTest extends BaseTestCase
 {
@@ -22,9 +23,8 @@ class BucketAutoTest extends BaseTestCase
     /**
      * @param array<string, string>          $expected
      * @param mixed[]|Closure(Expr): mixed[] $args
-     *
-     * @dataProvider provideGroupAccumulatorExpressionOperators
      */
+    #[DataProvider('provideGroupAccumulatorExpressionOperators')]
     public function testGroupAccumulators(array $expected, string $operator, $args): void
     {
         $args = $this->resolveArgs($args);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/BucketTest.php
@@ -13,6 +13,7 @@ use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsComment;
 use Documents\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class BucketTest extends BaseTestCase
 {
@@ -22,9 +23,8 @@ class BucketTest extends BaseTestCase
     /**
      * @param array<string, string>          $expected
      * @param mixed[]|Closure(Expr): mixed[] $args
-     *
-     * @dataProvider provideGroupAccumulatorExpressionOperators
      */
+    #[DataProvider('provideGroupAccumulatorExpressionOperators')]
     public function testGroupAccumulators(array $expected, string $operator, $args): void
     {
         $args = $this->resolveArgs($args);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GeoNearTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GeoNearTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\GeoNear;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class GeoNearTest extends BaseTestCase
 {
@@ -37,11 +38,8 @@ class GeoNearTest extends BaseTestCase
         self::assertSame([['$geoNear' => $stage]], $builder->getPipeline());
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @dataProvider provideOptionalSettings
-     */
+    /** @param mixed $value */
+    #[DataProvider('provideOptionalSettings')]
     public function testOptionalSettings(string $field, $value): void
     {
         $geoNearStage = new GeoNear($this->getTestAggregationBuilder(), 0, 0);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
@@ -16,6 +16,7 @@ use Documents\GraphLookup\Employee;
 use Documents\GraphLookup\ReportingHierarchy;
 use Documents\GraphLookup\Traveller;
 use Documents\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function array_merge;
 use function count;
@@ -149,9 +150,8 @@ class GraphLookupTest extends BaseTestCase
     /**
      * @param Closure(Builder): GraphLookup $addGraphLookupStage
      * @param array<string, string>         $expectedFields
-     *
-     * @dataProvider provideEmployeeAggregations
      */
+    #[DataProvider('provideEmployeeAggregations')]
     public function testWithEmployees(Closure $addGraphLookupStage, array $expectedFields): void
     {
         $this->insertEmployeeTestData();
@@ -222,9 +222,8 @@ class GraphLookupTest extends BaseTestCase
     /**
      * @param Closure(Builder): GraphLookup $addGraphLookupStage
      * @param array<string, string>         $expectedFields
-     *
-     * @dataProvider provideTravellerAggregations
      */
+    #[DataProvider('provideTravellerAggregations')]
     public function testWithTraveller(Closure $addGraphLookupStage, array $expectedFields): void
     {
         $this->insertTravellerTestData();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GroupTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GroupTest.php
@@ -10,6 +10,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\Group;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationOperatorsProviderTrait;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class GroupTest extends BaseTestCase
 {
@@ -19,9 +20,8 @@ class GroupTest extends BaseTestCase
     /**
      * @param array<string, string>          $expected
      * @param mixed[]|Closure(Expr): mixed[] $args
-     *
-     * @dataProvider provideGroupAccumulatorExpressionOperators
      */
+    #[DataProvider('provideGroupAccumulatorExpressionOperators')]
     public function testGroupAccumulators(array $expected, string $operator, $args): void
     {
         $groupStage = new Group($this->getTestAggregationBuilder());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MergeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/MergeTest.php
@@ -10,6 +10,7 @@ use Documents\SimpleReferenceUser;
 use Documents\User;
 use Generator;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function is_callable;
 
@@ -80,11 +81,8 @@ class MergeTest extends BaseTestCase
         ];
     }
 
-    /**
-     * @param array<array<string, mixed>>|callable $pipeline
-     *
-     * @dataProvider providePipeline
-     */
+    /** @param array<array<string, mixed>>|callable $pipeline */
+    #[DataProvider('providePipeline')]
     public function testStageWithPipeline($pipeline): void
     {
         if (is_callable($pipeline)) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OperatorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OperatorTest.php
@@ -11,6 +11,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\Operator;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationOperatorsProviderTrait;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class OperatorTest extends BaseTestCase
 {
@@ -20,23 +21,22 @@ class OperatorTest extends BaseTestCase
     /**
      * @param array<string, mixed>           $expected
      * @param mixed[]|Closure(Expr): mixed[] $args
-     *
-     * @dataProvider provideAccumulatorExpressionOperators
-     * @dataProvider provideArithmeticExpressionOperators
-     * @dataProvider provideArrayExpressionOperators
-     * @dataProvider provideBooleanExpressionOperators
-     * @dataProvider provideComparisonExpressionOperators
-     * @dataProvider provideConditionalExpressionOperators
-     * @dataProvider provideDataSizeExpressionOperators
-     * @dataProvider provideDateExpressionOperators
-     * @dataProvider provideMiscExpressionOperators
-     * @dataProvider provideObjectExpressionOperators
-     * @dataProvider provideSetExpressionOperators
-     * @dataProvider provideStringExpressionOperators
-     * @dataProvider provideTimestampExpressionOperators
-     * @dataProvider provideTrigonometryExpressionOperators
-     * @dataProvider provideTypeExpressionOperators
      */
+    #[DataProvider('provideAccumulatorExpressionOperators')]
+    #[DataProvider('provideArithmeticExpressionOperators')]
+    #[DataProvider('provideArrayExpressionOperators')]
+    #[DataProvider('provideBooleanExpressionOperators')]
+    #[DataProvider('provideComparisonExpressionOperators')]
+    #[DataProvider('provideConditionalExpressionOperators')]
+    #[DataProvider('provideDataSizeExpressionOperators')]
+    #[DataProvider('provideDateExpressionOperators')]
+    #[DataProvider('provideMiscExpressionOperators')]
+    #[DataProvider('provideObjectExpressionOperators')]
+    #[DataProvider('provideSetExpressionOperators')]
+    #[DataProvider('provideStringExpressionOperators')]
+    #[DataProvider('provideTimestampExpressionOperators')]
+    #[DataProvider('provideTrigonometryExpressionOperators')]
+    #[DataProvider('provideTypeExpressionOperators')]
     public function testProxiedExpressionOperators(array $expected, string $operator, $args): void
     {
         $stage = $this->getStubStage();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
@@ -8,6 +8,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\Project;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationOperatorsProviderTrait;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ProjectTest extends BaseTestCase
 {
@@ -39,7 +40,7 @@ class ProjectTest extends BaseTestCase
         self::assertSame([['$project' => ['_id' => false, '$field' => true, '$otherField' => true, 'product' => ['$multiply' => ['$field', 5]]]]], $builder->getPipeline());
     }
 
-    /** @dataProvider provideAccumulatorExpressionOperators */
+    #[DataProvider('provideAccumulatorExpressionOperators')]
     public function testAccumulatorsWithMultipleArguments(array $expected, string $operator, $args): void
     {
         $projectStage = new Project($this->getTestAggregationBuilder());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
@@ -14,6 +14,7 @@ use Generator;
 use GeoJson\Geometry\Point;
 use GeoJson\Geometry\Polygon;
 use MongoDB\BSON\UTCDateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Constraint\IsInstanceOf;
 
 use function array_combine;
@@ -1126,24 +1127,22 @@ class SearchTest extends BaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider provideAutocompleteBuilders
-     * @dataProvider provideCompoundBuilders
-     * @dataProvider provideEmbeddedDocumentBuilders
-     * @dataProvider provideEmbeddedDocumentCompoundBuilders
-     * @dataProvider provideEqualsBuilders
-     * @dataProvider provideExistsBuilders
-     * @dataProvider provideGeoShapeBuilders
-     * @dataProvider provideGeoWithinBuilders
-     * @dataProvider provideMoreLikeThisBuilders
-     * @dataProvider provideNearBuilders
-     * @dataProvider providePhraseBuilders
-     * @dataProvider provideQueryStringBuilders
-     * @dataProvider provideRangeBuilders
-     * @dataProvider provideRegexBuilders
-     * @dataProvider provideTextBuilders
-     * @dataProvider provideWildcardBuilders
-     */
+    #[DataProvider('provideAutocompleteBuilders')]
+    #[DataProvider('provideCompoundBuilders')]
+    #[DataProvider('provideEmbeddedDocumentBuilders')]
+    #[DataProvider('provideEmbeddedDocumentCompoundBuilders')]
+    #[DataProvider('provideEqualsBuilders')]
+    #[DataProvider('provideExistsBuilders')]
+    #[DataProvider('provideGeoShapeBuilders')]
+    #[DataProvider('provideGeoWithinBuilders')]
+    #[DataProvider('provideMoreLikeThisBuilders')]
+    #[DataProvider('provideNearBuilders')]
+    #[DataProvider('providePhraseBuilders')]
+    #[DataProvider('provideQueryStringBuilders')]
+    #[DataProvider('provideRangeBuilders')]
+    #[DataProvider('provideRegexBuilders')]
+    #[DataProvider('provideTextBuilders')]
+    #[DataProvider('provideWildcardBuilders')]
     public function testSearchOperators(array $expectedOperator, Closure $createOperator): void
     {
         $baseExpected = [
@@ -1182,22 +1181,20 @@ class SearchTest extends BaseTestCase
         );
     }
 
-    /**
-     * @dataProvider provideAutocompleteBuilders
-     * @dataProvider provideEmbeddedDocumentBuilders
-     * @dataProvider provideEqualsBuilders
-     * @dataProvider provideExistsBuilders
-     * @dataProvider provideGeoShapeBuilders
-     * @dataProvider provideGeoWithinBuilders
-     * @dataProvider provideMoreLikeThisBuilders
-     * @dataProvider provideNearBuilders
-     * @dataProvider providePhraseBuilders
-     * @dataProvider provideQueryStringBuilders
-     * @dataProvider provideRangeBuilders
-     * @dataProvider provideRegexBuilders
-     * @dataProvider provideTextBuilders
-     * @dataProvider provideWildcardBuilders
-     */
+    #[DataProvider('provideAutocompleteBuilders')]
+    #[DataProvider('provideEmbeddedDocumentBuilders')]
+    #[DataProvider('provideEqualsBuilders')]
+    #[DataProvider('provideExistsBuilders')]
+    #[DataProvider('provideGeoShapeBuilders')]
+    #[DataProvider('provideGeoWithinBuilders')]
+    #[DataProvider('provideMoreLikeThisBuilders')]
+    #[DataProvider('provideNearBuilders')]
+    #[DataProvider('providePhraseBuilders')]
+    #[DataProvider('provideQueryStringBuilders')]
+    #[DataProvider('provideRangeBuilders')]
+    #[DataProvider('provideRegexBuilders')]
+    #[DataProvider('provideTextBuilders')]
+    #[DataProvider('provideWildcardBuilders')]
     public function testSearchCompoundOperators(array $expectedOperator, Closure $createOperator): void
     {
         $searchStage = new Search($this->getTestAggregationBuilder());
@@ -1233,22 +1230,20 @@ class SearchTest extends BaseTestCase
         );
     }
 
-    /**
-     * @dataProvider provideAutocompleteBuilders
-     * @dataProvider provideCompoundBuilders
-     * @dataProvider provideEqualsBuilders
-     * @dataProvider provideExistsBuilders
-     * @dataProvider provideGeoShapeBuilders
-     * @dataProvider provideGeoWithinBuilders
-     * @dataProvider provideMoreLikeThisBuilders
-     * @dataProvider provideNearBuilders
-     * @dataProvider providePhraseBuilders
-     * @dataProvider provideQueryStringBuilders
-     * @dataProvider provideRangeBuilders
-     * @dataProvider provideRegexBuilders
-     * @dataProvider provideTextBuilders
-     * @dataProvider provideWildcardBuilders
-     */
+    #[DataProvider('provideAutocompleteBuilders')]
+    #[DataProvider('provideCompoundBuilders')]
+    #[DataProvider('provideEqualsBuilders')]
+    #[DataProvider('provideExistsBuilders')]
+    #[DataProvider('provideGeoShapeBuilders')]
+    #[DataProvider('provideGeoWithinBuilders')]
+    #[DataProvider('provideMoreLikeThisBuilders')]
+    #[DataProvider('provideNearBuilders')]
+    #[DataProvider('providePhraseBuilders')]
+    #[DataProvider('provideQueryStringBuilders')]
+    #[DataProvider('provideRangeBuilders')]
+    #[DataProvider('provideRegexBuilders')]
+    #[DataProvider('provideTextBuilders')]
+    #[DataProvider('provideWildcardBuilders')]
     public function testSearchEmbeddedDocumentOperators(array $expectedOperator, Closure $createOperator): void
     {
         $searchStage = new Search($this->getTestAggregationBuilder());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SetWindowFieldsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SetWindowFieldsTest.php
@@ -8,6 +8,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\SetWindowFields;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationOperatorsProviderTrait;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function array_merge;
 
@@ -73,10 +74,8 @@ class SetWindowFieldsTest extends BaseTestCase
         );
     }
 
-    /**
-     * @dataProvider provideGroupAccumulatorExpressionOperators
-     * @dataProvider provideWindowExpressionOperators
-     */
+    #[DataProvider('provideGroupAccumulatorExpressionOperators')]
+    #[DataProvider('provideWindowExpressionOperators')]
     public function testOperators(array $expected, string $operator, $args): void
     {
         $args = $this->resolveArgs($args);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SortTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /** @psalm-import-type SortShape from Sort */
 class SortTest extends BaseTestCase
@@ -16,9 +17,8 @@ class SortTest extends BaseTestCase
     /**
      * @param string|array<string, string> $field
      * @psalm-param SortShape $expectedSort
-     *
-     * @dataProvider provideSortOptions
      */
+    #[DataProvider('provideSortOptions')]
     public function testStage(array $expectedSort, $field, ?string $order = null): void
     {
         $sortStage = new Sort($this->getTestAggregationBuilder(), $field, $order);
@@ -29,9 +29,8 @@ class SortTest extends BaseTestCase
     /**
      * @param string|array<string, string> $field
      * @psalm-param SortShape $expectedSort
-     *
-     * @dataProvider provideSortOptions
      */
+    #[DataProvider('provideSortOptions')]
     public function testFromBuilder(array $expectedSort, $field, ?string $order = null): void
     {
         $builder = $this->getTestAggregationBuilder();

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -32,6 +32,7 @@ use Documents\User;
 use InvalidArgumentException;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Client;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use stdClass;
 
@@ -129,7 +130,7 @@ class DocumentManagerTest extends BaseTestCase
         ];
     }
 
-    /** @dataProvider dataMethodsAffectedByNoObjectArguments */
+    #[DataProvider('dataMethodsAffectedByNoObjectArguments')]
     public function testThrowsExceptionOnNonObjectValues(string $methodName): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -147,7 +148,7 @@ class DocumentManagerTest extends BaseTestCase
         ];
     }
 
-    /** @dataProvider dataAffectedByErrorIfClosedException */
+    #[DataProvider('dataAffectedByErrorIfClosedException')]
     public function testAffectedByErrorIfClosedException(string $methodName): void
     {
         $this->expectException(MongoDBException::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
@@ -16,6 +16,7 @@ use Documents\Page;
 use Documents\Phonebook;
 use Documents\Phonenumber;
 use MongoDB\BSON\ObjectId;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * CollectionPersister will throw exception when collection with atomicSet
@@ -86,11 +87,8 @@ class AtomicSetTest extends BaseTestCase
         self::assertEquals('12345678', $user->phonenumbers[0]->getPhonenumber());
     }
 
-    /**
-     * @param mixed[]|ArrayCollection<int, mixed>|null $clearWith
-     *
-     * @dataProvider provideAtomicCollectionUnset
-     */
+    /** @param mixed[]|ArrayCollection<int, mixed>|null $clearWith */
+    #[DataProvider('provideAtomicCollectionUnset')]
     public function testAtomicCollectionUnset($clearWith): void
     {
         $user                 = new AtomicSetUser('Maciej');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
@@ -7,10 +7,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\Binary;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class BinDataTest extends BaseTestCase
 {
-    /** @dataProvider provideData */
+    #[DataProvider('provideData')]
     public function testBinData(string $field, string $data, int $type): void
     {
         $test         = new BinDataTestUser();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
@@ -9,6 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\User;
 use InvalidArgumentException;
 use MongoDB\BSON\UTCDateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function time;
 
@@ -39,9 +40,8 @@ class DateTest extends BaseTestCase
     /**
      * @param DateTime|UTCDateTime $oldValue
      * @param DateTime|UTCDateTime $newValue
-     *
-     * @dataProvider provideEquivalentDates
      */
+    #[DataProvider('provideEquivalentDates')]
     public function testDateInstanceChangeDoesNotCauseUpdateIfValueIsTheSame($oldValue, $newValue): void
     {
         $user = new User();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -20,6 +20,7 @@ use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
 use MongoDB\Driver\WriteConcern;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
 
 use function get_debug_type;
@@ -118,7 +119,7 @@ class DocumentPersisterTest extends BaseTestCase
         self::assertCount(1, $documents);
     }
 
-    /** @dataProvider getTestPrepareFieldNameData */
+    #[DataProvider('getTestPrepareFieldNameData')]
     public function testPrepareFieldName(string $fieldName, string $expected): void
     {
         self::assertEquals($expected, $this->documentPersister->prepareFieldName($fieldName));
@@ -167,11 +168,8 @@ class DocumentPersisterTest extends BaseTestCase
         );
     }
 
-    /**
-     * @param array<array-key, string> $hashId
-     *
-     * @dataProvider provideHashIdentifiers
-     */
+    /** @param array<array-key, string> $hashId */
+    #[DataProvider('provideHashIdentifiers')]
     public function testPrepareQueryOrNewObjWithHashId(array $hashId): void
     {
         $class             = DocumentPersisterTestHashIdDocument::class;
@@ -183,11 +181,8 @@ class DocumentPersisterTest extends BaseTestCase
         self::assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
     }
 
-    /**
-     * @param array<array-key, string> $hashId
-     *
-     * @dataProvider provideHashIdentifiers
-     */
+    /** @param array<array-key, string> $hashId */
+    #[DataProvider('provideHashIdentifiers')]
     public function testPrepareQueryOrNewObjWithHashIdAndInOperators(array $hashId): void
     {
         $class             = DocumentPersisterTestHashIdDocument::class;
@@ -222,9 +217,8 @@ class DocumentPersisterTest extends BaseTestCase
     /**
      * @param array<string, mixed> $expected
      * @param array<string, mixed> $query
-     *
-     * @dataProvider queryProviderForCustomTypeId
      */
+    #[DataProvider('queryProviderForCustomTypeId')]
     public function testPrepareQueryOrNewObjWithCustomTypedId(array $expected, array $query): void
     {
         $class             = DocumentPersisterTestDocumentWithCustomId::class;
@@ -238,7 +232,7 @@ class DocumentPersisterTest extends BaseTestCase
         );
     }
 
-    /** @dataProvider queryProviderForDocumentWithReferenceToDocumentWithCustomTypedId */
+    #[DataProvider('queryProviderForDocumentWithReferenceToDocumentWithCustomTypedId')]
     public function testPrepareQueryOrNewObjWithReferenceToDocumentWithCustomTypedId(Closure $getTestCase): void
     {
         Type::registerType('DocumentPersisterCustomId', DocumentPersisterCustomIdType::class);
@@ -379,11 +373,8 @@ class DocumentPersisterTest extends BaseTestCase
         ];
     }
 
-    /**
-     * @param array<array-key, string> $hashId
-     *
-     * @dataProvider provideHashIdentifiers
-     */
+    /** @param array<array-key, string> $hashId */
+    #[DataProvider('provideHashIdentifiers')]
     public function testPrepareQueryOrNewObjWithSimpleReferenceToTargetDocumentWithHashIdType(array $hashId): void
     {
         $class             = DocumentPersisterTestDocument::class;
@@ -458,11 +449,8 @@ class DocumentPersisterTest extends BaseTestCase
         self::assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
     }
 
-    /**
-     * @param array<array-key, string> $hashId
-     *
-     * @dataProvider provideHashIdentifiers
-     */
+    /** @param array<array-key, string> $hashId */
+    #[DataProvider('provideHashIdentifiers')]
     public function testPrepareQueryOrNewObjWithDBRefReferenceToTargetDocumentWithHashIdType(array $hashId): void
     {
         $class             = DocumentPersisterTestDocument::class;
@@ -502,9 +490,8 @@ class DocumentPersisterTest extends BaseTestCase
     /**
      * @param array<string, mixed> $expected
      * @param array<string, mixed> $query
-     *
-     * @dataProvider queryProviderForComplexRefWithObjectValue
      */
+    #[DataProvider('queryProviderForComplexRefWithObjectValue')]
     public function testPrepareQueryOrNewObjWithComplexRefToTargetDocumentFieldWithObjectValue(array $expected, array $query): void
     {
         $class             = DocumentPersisterTestDocument::class;
@@ -577,11 +564,8 @@ class DocumentPersisterTest extends BaseTestCase
         self::assertEquals($expected, $documentPersister->prepareQueryOrNewObj($value));
     }
 
-    /**
-     * @param array<array-key, string> $hashId
-     *
-     * @dataProvider provideHashIdentifiers
-     */
+    /** @param array<array-key, string> $hashId */
+    #[DataProvider('provideHashIdentifiers')]
     public function testPrepareQueryOrNewObjWithEmbeddedReferenceToTargetDocumentWithHashIdType(array $hashId): void
     {
         $class             = DocumentPersisterTestDocument::class;
@@ -644,9 +628,8 @@ class DocumentPersisterTest extends BaseTestCase
     /**
      * @param int|string $writeConcern
      * @psalm-param class-string $class
-     *
-     * @dataProvider dataProviderTestWriteConcern
      */
+    #[DataProvider('dataProviderTestWriteConcern')]
     public function testExecuteInsertsRespectsWriteConcern(string $class, $writeConcern): void
     {
         $documentPersister = $this->uow->getDocumentPersister($class);
@@ -668,9 +651,8 @@ class DocumentPersisterTest extends BaseTestCase
     /**
      * @param int|string $writeConcern
      * @psalm-param class-string $class
-     *
-     * @dataProvider dataProviderTestWriteConcern
      */
+    #[DataProvider('dataProviderTestWriteConcern')]
     public function testExecuteUpsertsRespectsWriteConcern(string $class, $writeConcern): void
     {
         $documentPersister = $this->uow->getDocumentPersister($class);
@@ -693,9 +675,8 @@ class DocumentPersisterTest extends BaseTestCase
     /**
      * @param int|string $writeConcern
      * @psalm-param class-string $class
-     *
-     * @dataProvider dataProviderTestWriteConcern
      */
+    #[DataProvider('dataProviderTestWriteConcern')]
     public function testRemoveRespectsWriteConcern(string $class, $writeConcern): void
     {
         $documentPersister = $this->uow->getDocumentPersister($class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
@@ -9,10 +9,11 @@ use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Sharded\ShardedByUser;
 use Documents\Sharded\ShardedOne;
 use Documents\Sharded\ShardedOneWithDifferentKey;
+use PHPUnit\Framework\Attributes\Group;
 
 use function iterator_to_array;
 
-/** @group sharding */
+#[Group('sharding')]
 class EnsureShardingTest extends BaseTestCase
 {
     public function setUp(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -49,6 +49,7 @@ use Documents\UserUpsertChild;
 use Documents\UserUpsertIdStrategyNone;
 use InvalidArgumentException;
 use MongoDB\BSON\ObjectId;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function assert;
 use function bcscale;
@@ -80,11 +81,8 @@ class FunctionalTest extends BaseTestCase
         ];
     }
 
-    /**
-     * @param ObjectId|string $id
-     *
-     * @dataProvider provideUpsertObjects
-     */
+    /** @param ObjectId|string $id */
+    #[DataProvider('provideUpsertObjects')]
     public function testUpsertObject(string $className, $id, string $discriminator): void
     {
         $user           = new $className();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
@@ -14,6 +14,7 @@ use InvalidArgumentException;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function class_exists;
 use function date;
@@ -162,11 +163,8 @@ class IdTest extends BaseTestCase
         self::assertEquals('test', $class->idGenerator->getSalt());
     }
 
-    /**
-     * @param int|float $user2Id
-     *
-     * @dataProvider provideEqualButNotIdenticalIds
-     */
+    /** @param int|float $user2Id */
+    #[DataProvider('provideEqualButNotIdenticalIds')]
     public function testEqualButNotIdenticalIds(string $user1Id, $user2Id): void
     {
         self::assertNotSame($user1Id, $user2Id);
@@ -211,9 +209,8 @@ class IdTest extends BaseTestCase
     /**
      * @param mixed $id
      * @param mixed $expected
-     *
-     * @dataProvider getTestIdTypesAndStrategiesData
      */
+    #[DataProvider('getTestIdTypesAndStrategiesData')]
     public function testIdTypesAndStrategies(string $type, string $strategy, $id = null, $expected = null, ?string $expectedMongoType = null): void
     {
         $className = $this->createIdTestClass($type, $strategy);
@@ -308,7 +305,7 @@ class IdTest extends BaseTestCase
         ];
     }
 
-    /** @dataProvider getTestBinIdsData */
+    #[DataProvider('getTestBinIdsData')]
     public function testBinIds(string $type, int $expectedMongoBinDataType, string $id): void
     {
         $className = $this->createIdTestClass($type, 'none');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
@@ -20,6 +20,7 @@ use InvalidArgumentException;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 use function time;
 
@@ -284,7 +285,7 @@ class LockTest extends BaseTestCase
         $this->dm->flush();
     }
 
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testLockVersionedDocument(): void
     {
         $article        = new LockInt();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/MemoryUsageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/MemoryUsageTest.php
@@ -7,6 +7,8 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsPhonenumber;
 use Documents\CmsUser;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Group;
 
 use function current;
 use function end;
@@ -17,14 +19,13 @@ use function memory_get_usage;
 use function round;
 use function sprintf;
 
-/** @group performance */
+#[Group('performance')]
 class MemoryUsageTest extends BaseTestCase
 {
     /**
      * Output for jwage "Memory increased by 14.09 kb"
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testMemoryUsage(): void
     {
         $memoryUsage = [];

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedCollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedCollectionsTest.php
@@ -10,10 +10,11 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Phonebook;
 use Documents\Phonenumber;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class NestedCollectionsTest extends BaseTestCase
 {
-    /** @dataProvider provideStrategy */
+    #[DataProvider('provideStrategy')]
     public function testStrategy(string $field): void
     {
         $doc         = new DocWithNestedCollections();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryTest.php
@@ -18,6 +18,7 @@ use IteratorAggregate;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 use function array_values;
 use function assert;
@@ -532,9 +533,8 @@ class QueryTest extends BaseTestCase
 
     /**
      * Checks that the query class runs a ReplaceOne operation internally
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testReplaceDocumentRunsReplaceOperation(): void
     {
         $this->dm->createQueryBuilder(Article::class)
@@ -563,7 +563,7 @@ class QueryTest extends BaseTestCase
             ->execute();
     }
 
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testFindAndReplaceDocumentRunsFindAndReplaceOperation(): void
     {
         $this->dm->createQueryBuilder(Article::class)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RawTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RawTypeTest.php
@@ -8,14 +8,12 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RawTypeTest extends BaseTestCase
 {
-    /**
-     * @param mixed $value
-     *
-     * @dataProvider getTestRawTypeData
-     */
+    /** @param mixed $value */
+    #[DataProvider('getTestRawTypeData')]
     public function testRawType($value): void
     {
         $test      = new RawType();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
@@ -12,6 +12,7 @@ use Documents\Group;
 use Documents\User;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /** @psalm-type ReadPreferenceTagShape = array{dc?: string, usage?: string} */
 class ReadPreferenceTest extends BaseTestCase
@@ -43,11 +44,8 @@ class ReadPreferenceTest extends BaseTestCase
         self::assertArrayNotHasKey(Query::HINT_READ_PREFERENCE, $groups->getHints());
     }
 
-    /**
-     * @psalm-param ReadPreferenceTagShape[] $tags
-     *
-     * @dataProvider provideReadPreferenceHints
-     */
+    /** @psalm-param ReadPreferenceTagShape[] $tags */
+    #[DataProvider('provideReadPreferenceHints')]
     public function testHintIsSetOnQuery(int $readPreference, array $tags = []): void
     {
         $this->skipTestIfSharded(User::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
@@ -32,6 +32,7 @@ use Documents\SimpleReferenceUser;
 use Documents\User;
 use InvalidArgumentException;
 use MongoDB\Driver\ReadPreference;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use ProxyManager\Proxy\GhostObjectInterface;
 
 use function assert;
@@ -69,7 +70,7 @@ class ReferencePrimerTest extends BaseTestCase
             ->toArray();
     }
 
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testFieldPrimingCanBeToggled(): void
     {
         $this->dm->createQueryBuilder(User::class)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ShardKeyTest.php
@@ -9,11 +9,12 @@ use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Sharded\ShardedOne;
 use MongoDB\BSON\ObjectId;
+use PHPUnit\Framework\Attributes\Group;
 
 use function assert;
 use function end;
 
-/** @group sharding */
+#[Group('sharding')]
 class ShardKeyTest extends BaseTestCase
 {
     private CommandLogger $logger;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
@@ -8,15 +8,13 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionObject;
 
 class SplObjectHashCollisionsTest extends BaseTestCase
 {
-    /**
-     * @param callable(DocumentManager, object=): void $f
-     *
-     * @dataProvider provideParentAssociationsIsCleared
-     */
+    /** @param callable(DocumentManager, object=): void $f */
+    #[DataProvider('provideParentAssociationsIsCleared')]
     public function testParentAssociationsIsCleared(callable $f): void
     {
         $d         = new SplColDoc();
@@ -32,11 +30,8 @@ class SplObjectHashCollisionsTest extends BaseTestCase
         $this->expectCount('embeddedDocumentsRegistry', 0);
     }
 
-    /**
-     * @param callable(DocumentManager, object=): void $f
-     *
-     * @dataProvider provideParentAssociationsIsCleared
-     */
+    /** @param callable(DocumentManager, object=): void $f */
+    #[DataProvider('provideParentAssociationsIsCleared')]
     public function testParentAssociationsLeftover(callable $f, int $leftover): void
     {
         $d         = new SplColDoc();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TestTargetDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TestTargetDocument.php
@@ -6,10 +6,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 class TargetDocumentTest extends BaseTestCase
 {
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testMappedSuperClassAsTargetDocument(): void
     {
         $test            = new TargetDocumentTestDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
@@ -10,12 +10,13 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Exception;
 use MongoDB\BSON\ObjectId;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 use function array_merge;
 
 class GH1058Test extends BaseTestCase
 {
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testModifyingDuringOnFlushEventNewDocument(): void
     {
         $this->dm->getEventManager()->addEventListener([Events::onFlush], new GH1058Listener());
@@ -25,7 +26,7 @@ class GH1058Test extends BaseTestCase
         $this->dm->flush();
     }
 
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testModifyingDuringOnFlushEventNewDocumentWithId(): void
     {
         $this->dm->getEventManager()->addEventListener([Events::onFlush], new GH1058Listener());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 use function assert;
 use function count;
@@ -41,7 +42,7 @@ class GH1229Test extends BaseTestCase
         $this->secondParentId = $secondParent->id;
     }
 
-    /** @group m */
+    #[Group('m')]
     public function testMethodAWithoutClone(): void
     {
         $firstParent = $this->dm->find(GH1229Parent::CLASSNAME, $this->firstParentId);
@@ -87,7 +88,7 @@ class GH1229Test extends BaseTestCase
         self::assertInstanceOf(GH1229ChildTypeB::CLASSNAME, $children[1]);
     }
 
-    /** @group m */
+    #[Group('m')]
     public function testMethodAWithClone(): void
     {
         $firstParent = $this->dm->find(GH1229Parent::CLASSNAME, $this->firstParentId);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
@@ -10,12 +10,13 @@ use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 use function assert;
 
 class GH1232Test extends BaseTestCase
 {
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testRemoveDoesNotCauseErrors(): void
     {
         $post = new GH1232Post();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
@@ -10,6 +10,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function array_map;
 
@@ -145,7 +146,7 @@ class GH1275Test extends BaseTestCase
         ];
     }
 
-    /** @dataProvider getCollectionStrategies */
+    #[DataProvider('getCollectionStrategies')]
     public function testResortEmbedManyCollection(string $strategy): void
     {
         $getNameCallback = static fn (Element $element) => $element->name;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1346Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1346Test.php
@@ -8,10 +8,11 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class GH1346Test extends BaseTestCase
 {
-    /** @group GH1346Test */
+    #[Group('GH1346Test')]
     public function testPublicProperty(): void
     {
         $referenced1    = new GH1346ReferencedDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1428Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1428Test.php
@@ -6,10 +6,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 class GH1428Test extends BaseTestCase
 {
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testShortNameLossOnReplacingMiddleEmbeddedDocOfNestedEmbedding(): void
     {
         $owner          = new GH1428Document();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2002Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2002Test.php
@@ -7,16 +7,14 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function sprintf;
 
 class GH2002Test extends BaseTestCase
 {
-    /**
-     * @param array<string, mixed> $expectedReference
-     *
-     * @dataProvider getValidReferenceData
-     */
+    /** @param array<string, mixed> $expectedReference */
+    #[DataProvider('getValidReferenceData')]
     public function testBuildingReferenceCreatesCorrectStructure(array $expectedReference, object $document): void
     {
         $this->dm->persist($document);
@@ -59,7 +57,7 @@ class GH2002Test extends BaseTestCase
         ];
     }
 
-    /** @dataProvider getInvalidReferenceData */
+    #[DataProvider('getInvalidReferenceData')]
     public function testBuildingReferenceForUnlistedClassCausesException(string $expectedExceptionMessage, object $document): void
     {
         $this->dm->persist($document);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2251Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2251Test.php
@@ -7,13 +7,12 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\User;
 use MongoDB\BSON\ObjectId;
+use PHPUnit\Framework\Attributes\TestWith;
 
 class GH2251Test extends BaseTestCase
 {
-    /**
-     * @testWith ["groups"]
-     *           ["groupsSimple"]
-     */
+    #[TestWith(['groups'])]
+    #[TestWith(['groupsSimple'])]
     public function testElemMatchQuery(string $fieldName): void
     {
         $builder = $this->dm->createQueryBuilder(User::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
@@ -9,16 +9,14 @@ use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function get_class;
 
 class GH560Test extends BaseTestCase
 {
-    /**
-     * @param int|string $id
-     *
-     * @dataProvider provideDocumentIds
-     */
+    /** @param int|string $id */
+    #[DataProvider('provideDocumentIds')]
     public function testPersistListenersAreCalled($id): void
     {
         $listener = new GH560EventSubscriber([
@@ -41,11 +39,8 @@ class GH560Test extends BaseTestCase
         self::assertEquals($called, $listener->called);
     }
 
-    /**
-     * @param int|string $id
-     *
-     * @dataProvider provideDocumentIds
-     */
+    /** @param int|string $id */
+    #[DataProvider('provideDocumentIds')]
     public function testDocumentWithCustomIdStrategyIsSavedAndFoundFromDatabase($id): void
     {
         $doc = new GH560Document($id, 'test');
@@ -57,11 +52,8 @@ class GH560Test extends BaseTestCase
         self::assertEquals($id, $doc->id);
     }
 
-    /**
-     * @param int|string $id
-     *
-     * @dataProvider provideDocumentIds
-     */
+    /** @param int|string $id */
+    #[DataProvider('provideDocumentIds')]
     public function testUpdateListenersAreCalled($id): void
     {
         $listener = new GH560EventSubscriber([

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
@@ -12,11 +12,12 @@ use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\BSON\Binary;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ProxyManager\Proxy\GhostObjectInterface;
 
 class GH852Test extends BaseTestCase
 {
-    /** @dataProvider provideIdGenerators */
+    #[DataProvider('provideIdGenerators')]
     public function testA(Closure $idGenerator): void
     {
         $parent       = new GH852Document();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM160Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM160Test.php
@@ -6,10 +6,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Functional\Ticket\MODM160;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 class MODM160Test extends BaseTestCase
 {
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testEmbedManyInArrayMergeNew(): void
     {
         // create a test document
@@ -27,7 +28,7 @@ class MODM160Test extends BaseTestCase
         $this->dm->merge($test);
     }
 
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testEmbedManyInArrayCollectionMergeNew(): void
     {
         // create a test document
@@ -45,7 +46,7 @@ class MODM160Test extends BaseTestCase
         $this->dm->merge($test);
     }
 
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testEmbedOneMergeNew(): void
     {
         // create a test document

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractAnnotationDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractAnnotationDriverTestCase.php
@@ -11,6 +11,7 @@ use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Documents\CmsUser;
 use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 abstract class AbstractAnnotationDriverTestCase extends AbstractMappingDriverTestCase
@@ -152,7 +153,7 @@ abstract class AbstractAnnotationDriverTestCase extends AbstractMappingDriverTes
         self::assertNull($cm->writeConcern);
     }
 
-    /** @dataProvider provideClassCanBeMappedByOneAbstractDocument */
+    #[DataProvider('provideClassCanBeMappedByOneAbstractDocument')]
     public function testClassCanBeMappedByOneAbstractDocument(object $wrong, string $messageRegExp): void
     {
         $this->expectException(MappingException::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
@@ -23,6 +23,8 @@ use Documents\CustomCollection;
 use Documents\Suit;
 use Documents\UserTyped;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 use function key;
 use function sprintf;
@@ -38,11 +40,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
         return static::loadDriver();
     }
 
-    /**
-     * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @doesNotPerformAssertions
-     */
+    /** @return ClassMetadata<AbstractMappingDriverUser> */
+    #[DoesNotPerformAssertions]
     public function testLoadMapping(): ClassMetadata
     {
         return $this->dm->getClassMetadata(AbstractMappingDriverUser::class);
@@ -52,9 +51,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testLoadMapping
      */
+    #[Depends('testLoadMapping')]
     public function testDocumentCollectionNameAndInheritance(ClassMetadata $class): ClassMetadata
     {
         self::assertEquals('cms_users', $class->getCollection());
@@ -67,9 +65,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testLoadMapping
      */
+    #[Depends('testLoadMapping')]
     public function testDocumentMarkedAsReadOnly(ClassMetadata $class): ClassMetadata
     {
         self::assertTrue($class->isReadOnly);
@@ -81,9 +78,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testDocumentCollectionNameAndInheritance
      */
+    #[Depends('testDocumentCollectionNameAndInheritance')]
     public function testDocumentLevelReadPreference(ClassMetadata $class): ClassMetadata
     {
         self::assertEquals('primaryPreferred', $class->readPreference);
@@ -100,9 +96,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testDocumentCollectionNameAndInheritance
      */
+    #[Depends('testDocumentCollectionNameAndInheritance')]
     public function testDocumentLevelWriteConcern(ClassMetadata $class): ClassMetadata
     {
         self::assertEquals(1, $class->getWriteConcern());
@@ -114,9 +109,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testDocumentLevelWriteConcern
      */
+    #[Depends('testDocumentLevelWriteConcern')]
     public function testFieldMappings(ClassMetadata $class): ClassMetadata
     {
         self::assertCount(14, $class->fieldMappings);
@@ -130,11 +124,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
         return $class;
     }
 
-    /**
-     * @param ClassMetadata<AbstractMappingDriverUser> $class
-     *
-     * @depends testDocumentCollectionNameAndInheritance
-     */
+    /** @param ClassMetadata<AbstractMappingDriverUser> $class */
+    #[Depends('testDocumentCollectionNameAndInheritance')]
     public function testAssociationMappings(ClassMetadata $class): void
     {
         self::assertCount(6, $class->associationMappings);
@@ -146,11 +137,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
         self::assertTrue(isset($class->associationMappings['otherPhonenumbers']));
     }
 
-    /**
-     * @param ClassMetadata<AbstractMappingDriverUser> $class
-     *
-     * @depends testDocumentCollectionNameAndInheritance
-     */
+    /** @param ClassMetadata<AbstractMappingDriverUser> $class */
+    #[Depends('testDocumentCollectionNameAndInheritance')]
     public function testGetAssociationTargetClass(ClassMetadata $class): void
     {
         self::assertEquals(Address::class, $class->getAssociationTargetClass('address'));
@@ -161,11 +149,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
         self::assertNull($class->getAssociationTargetClass('otherPhonenumbers'));
     }
 
-    /**
-     * @param ClassMetadata<AbstractMappingDriverUser> $class
-     *
-     * @depends testDocumentCollectionNameAndInheritance
-     */
+    /** @param ClassMetadata<AbstractMappingDriverUser> $class */
+    #[Depends('testDocumentCollectionNameAndInheritance')]
     public function testGetAssociationTargetClassThrowsExceptionWhenEmpty(ClassMetadata $class): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -176,9 +161,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testDocumentCollectionNameAndInheritance
      */
+    #[Depends('testDocumentCollectionNameAndInheritance')]
     public function testStringFieldMappings(ClassMetadata $class): ClassMetadata
     {
         self::assertEquals('string', $class->fieldMappings['name']['type']);
@@ -190,9 +174,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testFieldMappings
      */
+    #[Depends('testFieldMappings')]
     public function testIdentifier(ClassMetadata $class): ClassMetadata
     {
         self::assertEquals('identifier', $class->identifier);
@@ -220,9 +203,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testFieldMappings
      */
+    #[Depends('testFieldMappings')]
     public function testVersionFieldMappings(ClassMetadata $class): ClassMetadata
     {
         self::assertEquals('int', $class->fieldMappings['version']['type']);
@@ -235,9 +217,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testFieldMappings
      */
+    #[Depends('testFieldMappings')]
     public function testLockFieldMappings(ClassMetadata $class): ClassMetadata
     {
         self::assertEquals('int', $class->fieldMappings['lock']['type']);
@@ -250,9 +231,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testIdentifier
      */
+    #[Depends('testIdentifier')]
     public function testAssocations(ClassMetadata $class): ClassMetadata
     {
         self::assertCount(14, $class->fieldMappings);
@@ -264,9 +244,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testAssocations
      */
+    #[Depends('testAssocations')]
     public function testOwningOneToOneAssociation(ClassMetadata $class): ClassMetadata
     {
         self::assertTrue(isset($class->fieldMappings['address']));
@@ -285,9 +264,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testOwningOneToOneAssociation
      */
+    #[Depends('testOwningOneToOneAssociation')]
     public function testLifecycleCallbacks(ClassMetadata $class): ClassMetadata
     {
         $expectedLifecycleCallbacks = [
@@ -304,9 +282,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testLifecycleCallbacks
      */
+    #[Depends('testLifecycleCallbacks')]
     public function testCustomFieldName(ClassMetadata $class): ClassMetadata
     {
         self::assertEquals('name', $class->fieldMappings['name']['fieldName']);
@@ -319,9 +296,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testCustomFieldName
      */
+    #[Depends('testCustomFieldName')]
     public function testCustomReferenceFieldName(ClassMetadata $class): ClassMetadata
     {
         self::assertEquals('morePhoneNumbers', $class->fieldMappings['morePhoneNumbers']['fieldName']);
@@ -334,9 +310,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testCustomReferenceFieldName
      */
+    #[Depends('testCustomReferenceFieldName')]
     public function testCustomEmbedFieldName(ClassMetadata $class): ClassMetadata
     {
         self::assertEquals('embeddedPhonenumber', $class->fieldMappings['embeddedPhonenumber']['fieldName']);
@@ -349,9 +324,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testCustomEmbedFieldName
      */
+    #[Depends('testCustomEmbedFieldName')]
     public function testDiscriminator(ClassMetadata $class): ClassMetadata
     {
         self::assertEquals('discr', $class->discriminatorField);
@@ -365,9 +339,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testDiscriminator
      */
+    #[Depends('testDiscriminator')]
     public function testEmbedDiscriminator(ClassMetadata $class): ClassMetadata
     {
         self::assertTrue(isset($class->fieldMappings['otherPhonenumbers']['discriminatorField']));
@@ -387,9 +360,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testEmbedDiscriminator
      */
+    #[Depends('testEmbedDiscriminator')]
     public function testReferenceDiscriminator(ClassMetadata $class): ClassMetadata
     {
         self::assertTrue(isset($class->fieldMappings['phonenumbers']['discriminatorField']));
@@ -409,9 +381,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
      * @param ClassMetadata<AbstractMappingDriverUser> $class
      *
      * @return ClassMetadata<AbstractMappingDriverUser>
-     *
-     * @depends testCustomFieldName
      */
+    #[Depends('testCustomFieldName')]
     public function testIndexes(ClassMetadata $class): ClassMetadata
     {
         $indexes = $class->indexes;
@@ -453,11 +424,8 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
         return $class;
     }
 
-    /**
-     * @param ClassMetadata<AbstractMappingDriverUser> $class
-     *
-     * @depends testIndexes
-     */
+    /** @param ClassMetadata<AbstractMappingDriverUser> $class */
+    #[Depends('testIndexes')]
     public function testShardKey(ClassMetadata $class): void
     {
         $shardKey = $class->getShardKey();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -35,6 +35,7 @@ use Documents\UserRepository;
 use Documents\UserTyped;
 use Generator;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ProxyManager\Proxy\GhostObjectInterface;
 use ReflectionClass;
 use ReflectionException;
@@ -382,11 +383,8 @@ class ClassMetadataTest extends BaseTestCase
         $cm->mapField(['fieldName' => 'namee', 'type' => 'string']);
     }
 
-    /**
-     * @param ClassMetadata<CmsUser> $cm
-     *
-     * @dataProvider dataProviderMetadataClasses
-     */
+    /** @param ClassMetadata<CmsUser> $cm */
+    #[DataProvider('dataProviderMetadataClasses')]
     public function testEmbeddedDocumentWithDiscriminator(ClassMetadata $cm): void
     {
         $cm->setDiscriminatorField('discriminator');
@@ -655,11 +653,8 @@ class ClassMetadataTest extends BaseTestCase
         ]);
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @dataProvider provideRepositoryMethodCanNotBeCombinedWithSkipLimitAndSort
-     */
+    /** @param mixed $value */
+    #[DataProvider('provideRepositoryMethodCanNotBeCombinedWithSkipLimitAndSort')]
     public function testRepositoryMethodCanNotBeCombinedWithSkipLimitAndSort(string $prop, $value): void
     {
         $cm = new ClassMetadata('stdClass');
@@ -738,11 +733,8 @@ class ClassMetadataTest extends BaseTestCase
         self::assertEquals(CollectionHelper::DEFAULT_STRATEGY, $mapping['strategy']);
     }
 
-    /**
-     * @param array<string, mixed> $config
-     *
-     * @dataProvider provideOwningAndInversedRefsNeedTargetDocument
-     */
+    /** @param array<string, mixed> $config */
+    #[DataProvider('provideOwningAndInversedRefsNeedTargetDocument')]
     public function testOwningAndInversedRefsNeedTargetDocument(array $config): void
     {
         $config = array_merge($config, [

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/AbstractDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/AbstractDriverTestCase.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Mapping\Symfony;
 
 use Doctrine\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\Persistence\Mapping\MappingException;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -16,7 +17,7 @@ use function sys_get_temp_dir;
 use function touch;
 use function unlink;
 
-/** @group DDC-1418 */
+#[Group('DDC-1418')]
 abstract class AbstractDriverTestCase extends TestCase
 {
     protected string $dir;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/XmlDriverTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Mapping\Symfony;
 
 use Doctrine\ODM\MongoDB\Mapping\Driver\SimplifiedXmlDriver;
+use PHPUnit\Framework\Attributes\Group;
 
 use function array_flip;
 
-/** @group DDC-1418 */
+#[Group('DDC-1418')]
 class XmlDriverTest extends AbstractDriverTestCase
 {
     protected function getFileExtension(): string

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/HydrationPerformanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/HydrationPerformanceTest.php
@@ -6,6 +6,8 @@ namespace Doctrine\Tests\ODM\MongoDB\Performance;
 
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsUser;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Group;
 
 use function gc_collect_cycles;
 use function memory_get_usage;
@@ -13,14 +15,13 @@ use function microtime;
 
 use const PHP_EOL;
 
-/** @group performance */
+#[Group('performance')]
 class HydrationPerformanceTest extends BaseTestCase
 {
     /**
      * [jwage: 10000 objects in ~6 seconds]
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testHydrationPerformance(): void
     {
         $s = microtime(true);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/InsertPerformanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/InsertPerformanceTest.php
@@ -6,6 +6,8 @@ namespace Doctrine\Tests\ODM\MongoDB\Performance;
 
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsUser;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Group;
 
 use function gc_collect_cycles;
 use function memory_get_usage;
@@ -13,14 +15,13 @@ use function microtime;
 
 use const PHP_EOL;
 
-/** @group performance */
+#[Group('performance')]
 class InsertPerformanceTest extends BaseTestCase
 {
     /**
      * [jwage: 10000 objects in ~4 seconds]
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testInsertPerformance(): void
     {
         $s = microtime(true);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/MemoryUsageTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/MemoryUsageTest.php
@@ -7,6 +7,8 @@ namespace Doctrine\ODM\MongoDB\Tests\Performance;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsPhonenumber;
 use Documents\CmsUser;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Group;
 
 use function current;
 use function end;
@@ -19,14 +21,13 @@ use function sprintf;
 
 use const PHP_EOL;
 
-/** @group performance */
+#[Group('performance')]
 class MemoryUsageTest extends BaseTestCase
 {
     /**
      * [jwage: Memory increased by 14.09 kb]
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testMemoryUsage(): void
     {
         $memoryUsage = [];

--- a/tests/Doctrine/ODM/MongoDB/Tests/Performance/UnitOfWorkPerformanceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Performance/UnitOfWorkPerformanceTest.php
@@ -6,20 +6,21 @@ namespace Doctrine\Tests\ODM\MongoDB\Performance;
 
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsUser;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Group;
 
 use function microtime;
 use function str_replace;
 
 use const PHP_EOL;
 
-/** @group performance */
+#[Group('performance')]
 class UnitOfWorkPerformanceTest extends BaseTestCase
 {
     /**
      * [jwage: compute changesets for 10000 objects in ~10 seconds]
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testComputeChanges(): void
     {
         $n     = 10000;

--- a/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/PersistentCollectionTest.php
@@ -12,6 +12,7 @@ use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\PersistentCollection;
 use Documents\User;
 use MongoDB\BSON\ObjectId;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 
@@ -135,9 +136,8 @@ class PersistentCollectionTest extends BaseTestCase
     /**
      * @param stdClass[] $expected
      * @param stdClass[] $snapshot
-     *
-     * @dataProvider dataGetDeletedDocuments
      */
+    #[DataProvider('dataGetDeletedDocuments')]
     public function testGetDeletedDocuments(array $expected, array $snapshot, Closure $callback): void
     {
         $collection = new PersistentCollection(new ArrayCollection(), $this->dm, $this->uow);
@@ -209,9 +209,8 @@ class PersistentCollectionTest extends BaseTestCase
     /**
      * @param stdClass[] $expected
      * @param stdClass[] $snapshot
-     *
-     * @dataProvider dataGetInsertedDocuments
      */
+    #[DataProvider('dataGetInsertedDocuments')]
     public function testGetInsertedDocuments(array $expected, array $snapshot, Closure $callback): void
     {
         $collection = new PersistentCollection(new ArrayCollection(), $this->dm, $this->uow);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/PersistenceBuilderTest.php
@@ -16,6 +16,7 @@ use Documents\Ecommerce\Order;
 use Documents\Functional\SameCollection1;
 use Documents\Functional\SameCollection2;
 use MongoDB\BSON\ObjectId;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function array_keys;
 
@@ -207,11 +208,8 @@ class PersistenceBuilderTest extends BaseTestCase
         self::assertEquals($expectedData, $this->pb->prepareUpsertData($comment));
     }
 
-    /**
-     * @param array<string, mixed> $expectedData
-     *
-     * @dataProvider getDocumentsAndExpectedData
-     */
+    /** @param array<string, mixed> $expectedData */
+    #[DataProvider('getDocumentsAndExpectedData')]
     public function testPrepareInsertData(object $document, array $expectedData): void
     {
         $this->dm->persist($document);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -23,6 +23,7 @@ use IteratorAggregate;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Regex;
 use MongoDB\Driver\ReadPreference;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionProperty;
 
@@ -187,11 +188,8 @@ class BuilderTest extends BaseTestCase
             ->getQuery();
     }
 
-    /**
-     * @param class-string $class
-     *
-     * @dataProvider provideArrayUpdateOperatorsOnReferenceMany
-     */
+    /** @param class-string $class */
+    #[DataProvider('provideArrayUpdateOperatorsOnReferenceMany')]
     public function testArrayUpdateOperatorsOnReferenceMany(string $class, string $field): void
     {
         $f = new Feature('Smarter references');
@@ -213,11 +211,8 @@ class BuilderTest extends BaseTestCase
         yield [ChildC::class, 'featurePartialMany'];
     }
 
-    /**
-     * @param class-string $class
-     *
-     * @dataProvider provideArrayUpdateOperatorsOnReferenceOne
-     */
+    /** @param class-string $class */
+    #[DataProvider('provideArrayUpdateOperatorsOnReferenceOne')]
     public function testArrayUpdateOperatorsOnReferenceOne(string $class, string $field): void
     {
         $f = new Feature('Smarter references');
@@ -473,7 +468,7 @@ class BuilderTest extends BaseTestCase
         self::assertCount(1, $qb->getQueryArray());
     }
 
-    /** @dataProvider provideProxiedExprMethods */
+    #[DataProvider('provideProxiedExprMethods')]
     public function testProxiedExprMethods(string $method, array $args = []): void
     {
         $expr = $this->getMockExpr();
@@ -564,11 +559,8 @@ class BuilderTest extends BaseTestCase
         ];
     }
 
-    /**
-     * @param string[] $args
-     *
-     * @dataProvider provideSelectProjections
-     */
+    /** @param string[] $args */
+    #[DataProvider('provideSelectProjections')]
     public function testSelect(array $args, array $expected): void
     {
         $qb = $this->getTestQueryBuilder();
@@ -582,11 +574,8 @@ class BuilderTest extends BaseTestCase
         return self::provideProjections(true);
     }
 
-    /**
-     * @param string[] $args
-     *
-     * @dataProvider provideExcludeProjections
-     */
+    /** @param string[] $args */
+    #[DataProvider('provideExcludeProjections')]
     public function testExclude(array $args, array $expected): void
     {
         $qb = $this->getTestQueryBuilder();
@@ -700,11 +689,8 @@ class BuilderTest extends BaseTestCase
         self::assertEquals(['foo' => 1], $qb->debug('sort'));
     }
 
-    /**
-     * @param string|int $order
-     *
-     * @dataProvider provideSortOrders
-     */
+    /** @param string|int $order */
+    #[DataProvider('provideSortOrders')]
     public function testSortWithFieldNameAndOrder($order, int $expectedOrder): void
     {
         $qb = $this->getTestQueryBuilder()
@@ -755,7 +741,7 @@ class BuilderTest extends BaseTestCase
         self::assertEquals(['score' => ['$meta' => 'textScore']], $qb->debug('sort'));
     }
 
-    /** @dataProvider provideCurrentDateOptions */
+    #[DataProvider('provideCurrentDateOptions')]
     public function testCurrentDateUpdateQuery(string $type): void
     {
         $qb = $this->getTestQueryBuilder()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/CriteriaMergerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/CriteriaMergerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Query;
 
 use Doctrine\ODM\MongoDB\Query\CriteriaMerger;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function call_user_func_array;
@@ -14,9 +15,8 @@ class CriteriaMergerTest extends TestCase
     /**
      * @param array<array<string, mixed>> $args
      * @param array<string, mixed>        $merged
-     *
-     * @dataProvider provideMerge
      */
+    #[DataProvider('provideMerge')]
     public function testMerge(array $args, array $merged): void
     {
         self::assertSame($merged, call_user_func_array([new CriteriaMerger(), 'merge'], $args));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/ExprTest.php
@@ -12,6 +12,7 @@ use Documents\User;
 use GeoJson\Geometry\Point;
 use GeoJson\Geometry\Polygon;
 use MongoDB\BSON\ObjectId;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ExprTest extends BaseTestCase
 {
@@ -411,9 +412,8 @@ class ExprTest extends BaseTestCase
     /**
      * @param Point|array<string, mixed> $point
      * @param array<string, mixed>       $expected
-     *
-     * @dataProvider provideGeoJsonPoint
      */
+    #[DataProvider('provideGeoJsonPoint')]
     public function testNearWithGeoJsonPoint($point, array $expected): void
     {
         $expr = $this->createExpr();
@@ -433,9 +433,8 @@ class ExprTest extends BaseTestCase
     /**
      * @param Point|array<string, mixed> $point
      * @param array<string, mixed>       $expected
-     *
-     * @dataProvider provideGeoJsonPoint
      */
+    #[DataProvider('provideGeoJsonPoint')]
     public function testNearSphereWithGeoJsonPoint($point, array $expected): void
     {
         $expr = $this->createExpr();
@@ -548,9 +547,8 @@ class ExprTest extends BaseTestCase
     /**
      * @param Polygon|array<string, array<string, mixed>> $geometry
      * @param array<string, mixed>                        $expected
-     *
-     * @dataProvider provideGeoJsonPolygon
      */
+    #[DataProvider('provideGeoJsonPolygon')]
     public function testGeoIntersects($geometry, array $expected): void
     {
         $expr = $this->createExpr();
@@ -579,9 +577,8 @@ class ExprTest extends BaseTestCase
     /**
      * @param Polygon|array<string, array<string, mixed>> $geometry
      * @param array<string, mixed>                        $expected
-     *
-     * @dataProvider provideGeoJsonPolygon
      */
+    #[DataProvider('provideGeoJsonPolygon')]
     public function testGeoWithin($geometry, array $expected): void
     {
         $expr = $this->createExpr();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/FilterCollectionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/FilterCollectionTest.php
@@ -8,6 +8,7 @@ use Doctrine\ODM\MongoDB\Query\Filter\BsonFilter;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\User;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Depends;
 
 class FilterCollectionTest extends BaseTestCase
 {
@@ -35,7 +36,7 @@ class FilterCollectionTest extends BaseTestCase
         self::assertFalse($filterCollection->has('fakeFilter'));
     }
 
-    /** @depends testEnable */
+    #[Depends('testEnable')]
     public function testIsEnabled(): void
     {
         $filterCollection = $this->dm->getFilterCollection();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/QueryExpressionVisitorTest.php
@@ -14,6 +14,7 @@ use Doctrine\ODM\MongoDB\Query\QueryExpressionVisitor;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Bars\Bar;
 use MongoDB\BSON\Regex;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 
 class QueryExpressionVisitorTest extends BaseTestCase
@@ -30,11 +31,8 @@ class QueryExpressionVisitorTest extends BaseTestCase
         $this->visitor      = new QueryExpressionVisitor($this->queryBuilder);
     }
 
-    /**
-     * @param array<string, mixed> $expectedQuery
-     *
-     * @dataProvider provideComparisons
-     */
+    /** @param array<string, mixed> $expectedQuery */
+    #[DataProvider('provideComparisons')]
     public function testWalkComparison(Comparison $comparison, array $expectedQuery): void
     {
         $expr = $this->visitor->dispatch($comparison);

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -21,6 +21,7 @@ use LogicException;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
 use MongoDB\Driver\ReadPreference;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Traversable;
 
@@ -423,11 +424,8 @@ class QueryTest extends BaseTestCase
         new Query($this->dm, new ClassMetadata(User::class), $this->getMockCollection(), ['type' => -1], []);
     }
 
-    /**
-     * @psalm-param Query::TYPE_* $type
-     *
-     * @dataProvider provideQueryTypesThatDoNotReturnAnIterator
-     */
+    /** @psalm-param Query::TYPE_* $type */
+    #[DataProvider('provideQueryTypesThatDoNotReturnAnIterator')]
     public function testGetIteratorShouldThrowExceptionWithoutExecutingForTypesThatDoNotReturnAnIterator(int $type, string $method): void
     {
         $collection = $this->getMockCollection();

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -31,6 +31,7 @@ use MongoDB\GridFS\Bucket;
 use MongoDB\Model\CollectionInfo;
 use MongoDB\Model\IndexInfo;
 use MongoDB\Model\IndexInfoIteratorIterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Constraint\ArrayHasKey;
 use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\Constraint\Constraint;
@@ -160,11 +161,8 @@ class SchemaManagerTest extends BaseTestCase
         ];
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getIndexCreationWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getIndexCreationWriteOptions')]
     public function testEnsureIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false): void
     {
         $indexedCollections = array_map(
@@ -209,11 +207,8 @@ class SchemaManagerTest extends BaseTestCase
         $this->schemaManager->ensureIndexes($maxTimeMs, $writeConcern, $background);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getIndexCreationWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getIndexCreationWriteOptions')]
     public function testEnsureDocumentIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false): void
     {
         $cmsArticleCollectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
@@ -231,11 +226,8 @@ class SchemaManagerTest extends BaseTestCase
         $this->schemaManager->ensureDocumentIndexes(CmsArticle::class, $maxTimeMs, $writeConcern, $background);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getIndexCreationWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getIndexCreationWriteOptions')]
     public function testEnsureDocumentIndexesForGridFSFile(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false): void
     {
         foreach ($this->documentCollections as $class => $collection) {
@@ -275,11 +267,8 @@ class SchemaManagerTest extends BaseTestCase
         $this->schemaManager->ensureDocumentIndexes(File::class, $maxTimeMs, $writeConcern, $background);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getIndexCreationWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getIndexCreationWriteOptions')]
     public function testEnsureDocumentIndexesWithTwoLevelInheritance(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern, bool $background = false): void
     {
         $collectionName = $this->dm->getClassMetadata(CmsProduct::class)->getCollection();
@@ -292,11 +281,8 @@ class SchemaManagerTest extends BaseTestCase
         $this->schemaManager->ensureDocumentIndexes(CmsProduct::class, $maxTimeMs, $writeConcern, $background);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testUpdateDocumentIndexesShouldCreateMappedIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $collectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
@@ -317,11 +303,8 @@ class SchemaManagerTest extends BaseTestCase
         $this->schemaManager->updateDocumentIndexes(CmsArticle::class, $maxTimeMs, $writeConcern);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testUpdateDocumentIndexesShouldDeleteUnmappedIndexesBeforeCreatingMappedIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $collectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
@@ -350,11 +333,8 @@ class SchemaManagerTest extends BaseTestCase
         $this->schemaManager->updateDocumentIndexes(CmsArticle::class, $maxTimeMs, $writeConcern);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testDeleteIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $views = array_map(
@@ -376,11 +356,8 @@ class SchemaManagerTest extends BaseTestCase
         $this->schemaManager->deleteIndexes($maxTimeMs, $writeConcern);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testDeleteDocumentIndexes(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $cmsArticleCollectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
@@ -419,11 +396,8 @@ class SchemaManagerTest extends BaseTestCase
         $this->schemaManager->updateValidators();
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testUpdateDocumentValidator(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $class                 = $this->dm->getClassMetadata(SchemaValidated::class);
@@ -470,11 +444,8 @@ EOT;
         $this->schemaManager->updateDocumentValidator($class->name);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testUpdateDocumentValidatorReset(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $class    = $this->dm->getClassMetadata(CmsArticle::class);
@@ -494,11 +465,8 @@ EOT;
         $this->schemaManager->updateDocumentValidator($class->name, $maxTimeMs, $writeConcern);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testCreateDocumentCollection(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $cm                   = $this->dm->getClassMetadata(CmsArticle::class);
@@ -523,11 +491,8 @@ EOT;
         $this->schemaManager->createDocumentCollection(CmsArticle::class, $maxTimeMs, $writeConcern);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testCreateDocumentCollectionForFile(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $database = $this->documentDatabases[$this->getDatabaseName($this->dm->getClassMetadata(File::class))];
@@ -539,11 +504,8 @@ EOT;
         $this->schemaManager->createDocumentCollection(File::class, $maxTimeMs, $writeConcern);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testCreateDocumentCollectionWithValidator(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $expectedValidatorJson = <<<'EOT'
@@ -584,11 +546,8 @@ EOT;
         $this->schemaManager->createDocumentCollection($cm->name, $maxTimeMs, $writeConcern);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testCreateView(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $cm = $this->dm->getClassMetadata(UserName::class);
@@ -623,11 +582,8 @@ EOT;
         $this->schemaManager->createDocumentCollection(UserName::class, $maxTimeMs, $writeConcern);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testCreateCollections(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $class = $this->dm->getClassMetadata(Tournament::class);
@@ -653,11 +609,8 @@ EOT;
         self::assertSame(1, array_count_values($createdCollections)['Tournament']);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testDropCollections(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         foreach ($this->documentCollections as $collection) {
@@ -669,11 +622,8 @@ EOT;
         $this->schemaManager->dropCollections($maxTimeMs, $writeConcern);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testDropDocumentCollection(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $cmsArticleCollectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
@@ -690,11 +640,8 @@ EOT;
         $this->schemaManager->dropDocumentCollection(CmsArticle::class, $maxTimeMs, $writeConcern);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testDropDocumentCollectionForGridFSFile(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         foreach ($this->documentCollections as $collection) {
@@ -727,11 +674,8 @@ EOT;
         $this->schemaManager->dropDocumentCollection(File::class, $maxTimeMs, $writeConcern);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testDropView(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $viewName = $this->dm->getClassMetadata(UserName::class)->getCollection();
@@ -748,11 +692,8 @@ EOT;
         $this->schemaManager->dropDocumentCollection(UserName::class, $maxTimeMs, $writeConcern);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testDropDocumentDatabase(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         $cmsArticleDatabaseName = $this->getDatabaseName($this->dm->getClassMetadata(CmsArticle::class));
@@ -770,11 +711,8 @@ EOT;
         $this->schemaManager->dropDocumentDatabase(CmsArticle::class, $maxTimeMs, $writeConcern);
     }
 
-    /**
-     * @psalm-param IndexOptions $expectedWriteOptions
-     *
-     * @dataProvider getWriteOptions
-     */
+    /** @psalm-param IndexOptions $expectedWriteOptions */
+    #[DataProvider('getWriteOptions')]
     public function testDropDatabases(array $expectedWriteOptions, ?int $maxTimeMs, ?WriteConcern $writeConcern): void
     {
         foreach ($this->documentDatabases as $database) {
@@ -790,9 +728,8 @@ EOT;
     /**
      * @param array<string, mixed> $mongoIndex
      * @psalm-param IndexMapping $documentIndex
-     *
-     * @dataProvider dataIsMongoIndexEquivalentToDocumentIndex
      */
+    #[DataProvider('dataIsMongoIndexEquivalentToDocumentIndex')]
     public function testIsMongoIndexEquivalentToDocumentIndex(bool $expected, array $mongoIndex, array $documentIndex): void
     {
         $defaultMongoIndex    = [
@@ -1003,9 +940,8 @@ EOT;
     /**
      * @param array<string, mixed> $mongoIndex
      * @psalm-param IndexMapping $documentIndex
-     *
-     * @dataProvider dataIsMongoTextIndexEquivalentToDocumentIndex
      */
+    #[DataProvider('dataIsMongoTextIndexEquivalentToDocumentIndex')]
     public function testIsMongoIndexEquivalentToDocumentIndexWithTextIndexes(bool $expected, array $mongoIndex, array $documentIndex): void
     {
         $defaultMongoIndex    = [

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/DateImmutableTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/DateImmutableTypeTest.php
@@ -11,6 +11,7 @@ use Doctrine\ODM\MongoDB\Types\DateImmutableType;
 use Doctrine\ODM\MongoDB\Types\Type;
 use InvalidArgumentException;
 use MongoDB\BSON\UTCDateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -75,11 +76,8 @@ class DateImmutableTypeTest extends TestCase
         self::assertEquals($type->convertToDatabaseValue($timestamp), $type->convertToDatabaseValue($date));
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @dataProvider provideInvalidDateValues
-     */
+    /** @param mixed $value */
+    #[DataProvider('provideInvalidDateValues')]
     public function testConvertToDatabaseValueWithInvalidValues($value): void
     {
         $type = Type::getType(Type::DATE_IMMUTABLE);
@@ -98,11 +96,8 @@ class DateImmutableTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @param mixed $input
-     *
-     * @dataProvider provideDatabaseToPHPValues
-     */
+    /** @param mixed $input */
+    #[DataProvider('provideDatabaseToPHPValues')]
     public function testConvertToPHPValue($input, DateTimeImmutable $output): void
     {
         $type   = Type::getType(Type::DATE_IMMUTABLE);
@@ -119,11 +114,8 @@ class DateImmutableTypeTest extends TestCase
         self::assertNull($type->convertToPHPValue(null));
     }
 
-    /**
-     * @param mixed $input
-     *
-     * @dataProvider provideDatabaseToPHPValues
-     */
+    /** @param mixed $input */
+    #[DataProvider('provideDatabaseToPHPValues')]
     public function testClosureToPHP($input, DateTimeImmutable $output): void
     {
         $type = Type::getType(Type::DATE_IMMUTABLE);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/DateTypeTest.php
@@ -11,6 +11,7 @@ use Doctrine\ODM\MongoDB\Types\DateType;
 use Doctrine\ODM\MongoDB\Types\Type;
 use InvalidArgumentException;
 use MongoDB\BSON\UTCDateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -75,11 +76,8 @@ class DateTypeTest extends TestCase
         self::assertEquals($type->convertToDatabaseValue($timestamp), $type->convertToDatabaseValue($date));
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @dataProvider provideInvalidDateValues
-     */
+    /** @param mixed $value */
+    #[DataProvider('provideInvalidDateValues')]
     public function testConvertToDatabaseValueWithInvalidValues($value): void
     {
         $type = Type::getType(Type::DATE);
@@ -98,11 +96,8 @@ class DateTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @param mixed $input
-     *
-     * @dataProvider provideDatabaseToPHPValues
-     */
+    /** @param mixed $input */
+    #[DataProvider('provideDatabaseToPHPValues')]
     public function testConvertToPHPValue($input, DateTime $output): void
     {
         $type   = Type::getType(Type::DATE);
@@ -119,11 +114,8 @@ class DateTypeTest extends TestCase
         self::assertNull($type->convertToPHPValue(null));
     }
 
-    /**
-     * @param mixed $input
-     *
-     * @dataProvider provideDatabaseToPHPValues
-     */
+    /** @param mixed $input */
+    #[DataProvider('provideDatabaseToPHPValues')]
     public function testClosureToPHP($input, DateTime $output): void
     {
         $type = Type::getType(Type::DATE);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/IdTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/IdTypeTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Types;
 
 use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\ObjectId;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class IdTypeTest extends TestCase
@@ -20,11 +21,8 @@ class IdTypeTest extends TestCase
         self::assertEquals($identifier, $type->convertToDatabaseValue((string) $identifier), 'ObjectId strings are converted to ObjectId objects');
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @dataProvider provideInvalidObjectIdConstructorArguments
-     */
+    /** @param mixed $value */
+    #[DataProvider('provideInvalidObjectIdConstructorArguments')]
     public function testConvertToDatabaseValueShouldGenerateObjectIds($value): void
     {
         $type = Type::getType('id');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
@@ -13,6 +13,7 @@ use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function md5;
 use function str_pad;
@@ -23,11 +24,8 @@ use const STR_PAD_LEFT;
 
 class TypeTest extends BaseTestCase
 {
-    /**
-     * @param mixed $test
-     *
-     * @dataProvider provideTypes
-     */
+    /** @param mixed $test */
+    #[DataProvider('provideTypes')]
     public function testConversion(Type $type, $test): void
     {
         self::assertEquals($test, $type->convertToPHPValue($type->convertToDatabaseValue($test)));
@@ -63,11 +61,8 @@ class TypeTest extends BaseTestCase
         ];
     }
 
-    /**
-     * @param mixed $test
-     *
-     * @dataProvider provideTypesForIdempotent
-     */
+    /** @param mixed $test */
+    #[DataProvider('provideTypesForIdempotent')]
     public function testConversionIsIdempotent(Type $type, $test): void
     {
         self::assertEquals($test, $type->convertToDatabaseValue($test));

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -24,6 +24,8 @@ use Documents\ForumUser;
 use Documents\Functional\NotSaved;
 use Documents\User;
 use MongoDB\BSON\ObjectId;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use ProxyManager\Proxy\GhostObjectInterface;
 use Throwable;
 
@@ -155,7 +157,7 @@ class UnitOfWorkTest extends BaseTestCase
         self::assertEquals([$mappingD, $c, 'b.c.d'], $this->uow->getParentAssociation($d));
     }
 
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testPreUpdateTriggeredWithEmptyChangeset(): void
     {
         $this->dm->getEventManager()->addEventSubscriber(
@@ -248,9 +250,8 @@ class UnitOfWorkTest extends BaseTestCase
     /**
      * @param array<string, mixed>|null $origData
      * @param array<string, mixed>|null $updateData
-     *
-     * @dataProvider getScheduleForUpdateWithArraysTests
      */
+    #[DataProvider('getScheduleForUpdateWithArraysTests')]
     public function testScheduleForUpdateWithArrays(?array $origData, ?array $updateData, bool $shouldInUpdate): void
     {
         $arrayTest = new ArrayTest($origData);


### PR DESCRIPTION
Closes https://github.com/doctrine/mongodb-odm/issues/2509

Since we are using PHP 8.1, we don't need PHPUnit 9 anymore, I've installed [rector](https://github.com/rectorphp/rector) locally and replaced annotations with attributes.