### PR TITLE
fix: Don't process subclass indexes with SingleCollection inheritance

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -139,7 +139,11 @@ final class ClassMetadataFactory extends AbstractClassMetadataFactory implements
             $class->setIdGeneratorType($parent->generatorType);
             $this->addInheritedFields($class, $parent);
             $this->addInheritedRelations($class, $parent);
-            $this->addInheritedIndexes($class, $parent);
+            if ($parent->isMappedSuperclass) {
+                // only inherit indexes if parent won't apply them itself
+                $this->addInheritedIndexes($class, $parent);
+            }
+
             $this->setInheritedShardKey($class, $parent);
             $class->setIdentifier($parent->identifier);
             $class->setVersioned($parent->isVersioned);

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -16,6 +16,7 @@ use Documents\CmsComment;
 use Documents\CmsProduct;
 use Documents\Comment;
 use Documents\File;
+use Documents\Project;
 use Documents\SchemaValidated;
 use Documents\Sharded\ShardedOne;
 use Documents\Sharded\ShardedOneWithDifferentKey;
@@ -41,6 +42,7 @@ use function array_count_values;
 use function array_map;
 use function assert;
 use function in_array;
+use function key;
 use function MongoDB\BSON\fromJSON;
 use function MongoDB\BSON\toPHP;
 
@@ -60,6 +62,7 @@ class SchemaManagerTest extends BaseTestCase
         SimpleReferenceUser::class,
         ShardedOne::class,
         ShardedOneWithDifferentKey::class,
+        Project::class,
     ];
 
     /** @psalm-var list<class-string> */
@@ -285,7 +288,7 @@ class SchemaManagerTest extends BaseTestCase
         $collectionName = $this->dm->getClassMetadata(CmsProduct::class)->getCollection();
         $collection     = $this->documentCollections[$collectionName];
         $collection
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('createIndex')
             ->with($this->anything(), $this->writeOptions($expectedWriteOptions));
 
@@ -315,6 +318,50 @@ class SchemaManagerTest extends BaseTestCase
             ->with($this->writeOptions($expectedWriteOptions));
 
         $this->schemaManager->updateDocumentIndexes(CmsArticle::class, $maxTimeMs, $writeConcern);
+    }
+
+    public function testUpdateDocumentIndexesShouldCreateIndexesFromMappedSuperclass(): void
+    {
+        $collectionName = $this->dm->getClassMetadata(CmsProduct::class)->getCollection();
+        $collection     = $this->documentCollections[$collectionName];
+        $collection
+            ->expects($this->once())
+            ->method('listIndexes')
+            ->willReturn(new IndexInfoIteratorIterator(new ArrayIterator([])));
+        $collection
+            ->expects($this->exactly(2))
+            ->method('createIndex')
+            ->with($this->anything(), $this->anything());
+        $collection
+            ->expects($this->never())
+            ->method('dropIndex')
+            ->with($this->anything());
+
+        $this->schemaManager->updateDocumentIndexes(CmsProduct::class);
+    }
+
+    public function testUpdateDocumentIndexesShouldCreateIndexFromSubclasses(): void
+    {
+        $collectionName = $this->dm->getClassMetadata(Project::class)->getCollection();
+        $collection     = $this->documentCollections[$collectionName];
+        $collection
+            ->expects($this->once())
+            ->method('listIndexes')
+            ->willReturn(new IndexInfoIteratorIterator(new ArrayIterator([])));
+
+        $matcher = $this->exactly(2);
+        $collection
+            ->expects($matcher)
+            ->method('createIndex')
+            ->willReturnCallback(static function ($key, $value) use ($matcher) {
+                self::assertSame(['name', 'externalId'][$matcher->numberOfInvocations() - 1], key($key));
+            });
+        $collection
+            ->expects($this->never())
+            ->method('dropIndex')
+            ->with($this->anything());
+
+        $this->schemaManager->updateDocumentIndexes(Project::class);
     }
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -353,8 +353,11 @@ class SchemaManagerTest extends BaseTestCase
         $collection
             ->expects($matcher)
             ->method('createIndex')
-            ->willReturnCallback(static function ($key, $value) use ($matcher) {
-                self::assertSame(['name', 'externalId'][$matcher->numberOfInvocations() - 1], key($key));
+            ->willReturnCallback(static function ($key, $value) {
+                static $counter = 0;
+
+                self::assertSame(['name', 'externalId'][$counter], key($key));
+                ++$counter;
             });
         $collection
             ->expects($this->never())

--- a/tests/Documents/CmsProduct.php
+++ b/tests/Documents/CmsProduct.php
@@ -15,4 +15,12 @@ class CmsProduct extends CmsContent
      * @var string|null
      */
     public $name;
+
+    /**
+     * @ODM\Field(type="string")
+     * @ODM\Index
+     *
+     * @var string|null
+     */
+    public $productId;
 }

--- a/tests/Documents/Project.php
+++ b/tests/Documents/Project.php
@@ -25,6 +25,7 @@ class Project
 
     /**
      * @ODM\Field(type="string")
+     * @ODM\UniqueIndex
      *
      * @var string|null
      */

--- a/tests/Documents/SubProject.php
+++ b/tests/Documents/SubProject.php
@@ -11,6 +11,14 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 class SubProject extends Project
 {
     /**
+     * @ODM\Field(type="string")
+     * @ODM\Index
+     *
+     * @var string|null
+     */
+    private $externalId;
+
+    /**
      * @ODM\EmbedMany(targetDocument=Issue::class)
      *
      * @var Collection<int, Issue>


### PR DESCRIPTION

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | https://github.com/doctrine/mongodb-odm/issues/2561

#### Summary

When using single collection inheritance, all sub classes are processed as well and indexes get dropped or re-created, depending on class order.

With this PR only the parent classes are processed and will ensure the indexes of all subclasses.