### PR TITLE
fix: Do not drop/re-create 2dsphere indexes

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -52,6 +52,7 @@ final class SchemaManager
         'language_override',
         'textIndexVersion',
         'name',
+        '2dsphereIndexVersion',
     ];
 
     protected DocumentManager $dm;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
@@ -239,6 +239,16 @@ class IndexesTest extends BaseTestCase
         self::assertSame(['counter' => ['$gt' => 5]], $indexes[0]['options']['partialFilterExpression']);
         self::assertTrue($indexes[0]['options']['unique']);
     }
+
+    public function testGeoIndexCreation(): void
+    {
+        $className = GeoIndexDocument::class;
+        $this->dm->getSchemaManager()->ensureDocumentIndexes(GeoIndexDocument::class);
+
+        $indexes = $this->dm->getSchemaManager()->getDocumentIndexes($className);
+        self::assertSame(['coordinatesWith2DIndex' => '2d'], $indexes[0]['keys']);
+        self::assertSame(['coordinatesWithSphereIndex' => '2dsphere'], $indexes[1]['keys']);
+    }
 }
 
 /** @ODM\Document */
@@ -656,4 +666,33 @@ class DocumentWithIndexInDiscriminatedEmbeds
      * @var EmbeddedDocumentWithIndexes|YetAnotherEmbeddedDocumentWithIndex|null
      */
     public $embedded;
+}
+
+/**
+ * @ODM\Document
+ * @ODM\Index(keys={"coordinatesWith2DIndex"="2d"})
+ * @ODM\Index(keys={"coordinatesWithSphereIndex"="2dsphere"})
+ */
+class GeoIndexDocument
+{
+    /**
+     * @ODM\Id
+     *
+     * @var string|null
+     */
+    public $id;
+
+    /**
+     * @ODM\Field(type="hash")
+     *
+     * @var array<float>
+     */
+    public $coordinatesWith2DIndex;
+
+    /**
+     * @ODM\Field(type="hash")
+     *
+     * @var array<float>
+     */
+    public $coordinatesWithSphereIndex;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -997,6 +997,12 @@ EOT;
                 'mongoIndex' => ['background' => true],
                 'documentIndex' => ['options' => ['background' => true]],
             ],
+            // 2dsphereIndexVersion index options
+            '2dsphereIndexVersionOptionsDifferent' => [
+                'expected' => true,
+                'mongoIndex' => ['2dsphereIndexVersion' => 3],
+                'documentIndex' => [],
+            ],
         ];
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fixes #2574

#### Summary

Indexes of tpye `2dsphere` are always re-created, because the server-side options contain a `2dsphereIndexVersion`, which causes a mismatch when comparing index options.
