### PR TITLE
Validate that targetDocument can be resolved

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -2318,6 +2318,14 @@ use const PHP_VERSION_ID;
             );
         }
 
+        if (isset($mapping['discriminatorMap'])) {
+            foreach ($mapping['discriminatorMap'] as $value => $class) {
+                if (! class_exists($class) && ! interface_exists($class)) {
+                    throw MappingException::invalidClassInReferenceDiscriminatorMap($class, $this->name, $mapping['fieldName']);
+                }
+            }
+        }
+
         if (isset($mapping['version'])) {
             $mapping['notSaved'] = true;
             $this->setVersionMapping($mapping);

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -42,6 +42,7 @@ use function enum_exists;
 use function extension_loaded;
 use function get_class;
 use function in_array;
+use function interface_exists;
 use function is_array;
 use function is_string;
 use function is_subclass_of;
@@ -2307,6 +2308,14 @@ use const PHP_VERSION_ID;
 
         if (isset($mapping['association']) && ! isset($mapping['targetDocument']) && ! isset($mapping['discriminatorField'])) {
             $mapping['discriminatorField'] = self::DEFAULT_DISCRIMINATOR_FIELD;
+        }
+
+        if (isset($mapping['targetDocument']) && ! class_exists($mapping['targetDocument']) && ! interface_exists($mapping['targetDocument'])) {
+            throw MappingException::invalidTargetDocument(
+                $mapping['targetDocument'],
+                $this->name,
+                $mapping['fieldName'],
+            );
         }
 
         if (isset($mapping['version'])) {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -87,6 +87,11 @@ final class MappingException extends BaseMappingException
         return new self(sprintf("Discriminator value '%s' used in the declaration of class '%s' does not exist.", $value, $owningClass));
     }
 
+    public static function invalidTargetDocument(string $targetDocument, string $owningClass, string $owningField): self
+    {
+        return new self(sprintf("Target document class '%s' used in field '%s' of class '%s' does not exist.", $targetDocument, $owningField, $owningClass));
+    }
+
     public static function missingFieldName(string $className): self
     {
         return new self(sprintf("The Document class '%s' field mapping misses the 'fieldName' attribute.", $className));

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -77,6 +77,11 @@ final class MappingException extends BaseMappingException
         return new self(sprintf("Document class '%s' used in the discriminator map of class '%s' does not exist.", $className, $owningClass));
     }
 
+    public static function invalidClassInReferenceDiscriminatorMap(string $className, string $owningClass, string $fieldName): self
+    {
+        return new self(sprintf("Document class '%s' used in the discriminator map of field '%s' in class '%s' does not exist.", $className, $fieldName, $owningClass));
+    }
+
     public static function unlistedClassInDiscriminatorMap(string $className): self
     {
         return new self(sprintf('Document class "%s" is unlisted in the discriminator map.', $className));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TargetDocumentTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TargetDocumentTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use stdClass;
 
@@ -22,7 +23,13 @@ class TargetDocumentTest extends BaseTestCase
 
     public function testTargetDocumentIsResolvable(): void
     {
-        self::expectExceptionMessage("Target document class 'Doctrine\ODM\MongoDB\Tests\Functional\SomeInvalidClass' used in field 'reference' of class 'Doctrine\ODM\MongoDB\Tests\Functional\InvalidTargetDocumentTestDocument' does not exist.");
+        self::expectExceptionObject(
+            MappingException::invalidTargetDocument(
+                SomeInvalidClass::class,
+                InvalidTargetDocumentTestDocument::class,
+                'reference',
+            ),
+        );
 
         $test            = new InvalidTargetDocumentTestDocument();
         $test->reference = new stdClass();
@@ -75,7 +82,7 @@ class InvalidTargetDocumentTestDocument
     public $id;
 
     /**
-     * @ODM\ReferenceOne(targetDocument=Doctrine\ODM\MongoDB\Tests\Functional\SomeInvalidClass::class)
+     * @ODM\ReferenceOne(targetDocument="Doctrine\ODM\MongoDB\Tests\Functional\SomeInvalidClass")
      *
      * @var object|null
      */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TargetDocumentTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TargetDocumentTest.php
@@ -35,6 +35,21 @@ class TargetDocumentTest extends BaseTestCase
         $test->reference = new stdClass();
         $this->dm->persist($test);
     }
+
+    public function testDiscriminatorTargetIsResolvable(): void
+    {
+        self::expectExceptionObject(
+            MappingException::invalidClassInReferenceDiscriminatorMap(
+                SomeInvalidClass::class,
+                InvalidDiscriminatorTargetsTestDocument::class,
+                'reference',
+            ),
+        );
+
+        $test            = new InvalidDiscriminatorTargetsTestDocument();
+        $test->reference = new stdClass();
+        $this->dm->persist($test);
+    }
 }
 
 /** @ODM\Document */
@@ -83,6 +98,25 @@ class InvalidTargetDocumentTestDocument
 
     /**
      * @ODM\ReferenceOne(targetDocument="Doctrine\ODM\MongoDB\Tests\Functional\SomeInvalidClass")
+     *
+     * @var object|null
+     */
+    public $reference;
+}
+
+
+/** @ODM\Document */
+class InvalidDiscriminatorTargetsTestDocument
+{
+    /**
+     * @ODM\Id
+     *
+     * @var string|null
+     */
+    public $id;
+
+    /**
+     * @ODM\ReferenceOne(discriminatorField="referencedClass", discriminatorMap={"Foo"="Doctrine\ODM\MongoDB\Tests\Functional\SomeInvalidClass"})
      *
      * @var object|null
      */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TargetDocumentTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TargetDocumentTest.php
@@ -25,8 +25,7 @@ class TargetDocumentTest extends BaseTestCase
     {
         self::expectExceptionObject(
             MappingException::invalidTargetDocument(
-                // @phpstan-ignore-next-line class.notFound
-                SomeInvalidClass::class,
+                'Doctrine\ODM\MongoDB\Tests\Functional\SomeInvalidClass',
                 InvalidTargetDocumentTestDocument::class,
                 'reference',
             ),
@@ -41,8 +40,7 @@ class TargetDocumentTest extends BaseTestCase
     {
         self::expectExceptionObject(
             MappingException::invalidClassInReferenceDiscriminatorMap(
-                // @phpstan-ignore-next-line class.notFound
-                SomeInvalidClass::class,
+                'Doctrine\ODM\MongoDB\Tests\Functional\SomeInvalidClass',
                 InvalidDiscriminatorTargetsTestDocument::class,
                 'reference',
             ),

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TargetDocumentTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TargetDocumentTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use stdClass;
 
 class TargetDocumentTest extends BaseTestCase
 {
@@ -17,6 +18,15 @@ class TargetDocumentTest extends BaseTestCase
         $this->dm->persist($test);
         $this->dm->persist($test->reference);
         $this->dm->flush();
+    }
+
+    public function testTargetDocumentIsResolvable(): void
+    {
+        self::expectExceptionMessage("Target document class 'Doctrine\ODM\MongoDB\Tests\Functional\SomeInvalidClass' used in field 'reference' of class 'Doctrine\ODM\MongoDB\Tests\Functional\InvalidTargetDocumentTestDocument' does not exist.");
+
+        $test            = new InvalidTargetDocumentTestDocument();
+        $test->reference = new stdClass();
+        $this->dm->persist($test);
     }
 }
 
@@ -52,4 +62,22 @@ abstract class AbstractTargetDocumentTestReference
 /** @ODM\Document */
 class TargetDocumentTestReference extends AbstractTargetDocumentTestReference
 {
+}
+
+/** @ODM\Document */
+class InvalidTargetDocumentTestDocument
+{
+    /**
+     * @ODM\Id
+     *
+     * @var string|null
+     */
+    public $id;
+
+    /**
+     * @ODM\ReferenceOne(targetDocument=Doctrine\ODM\MongoDB\Tests\Functional\SomeInvalidClass::class)
+     *
+     * @var object|null
+     */
+    public $reference;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TargetDocumentTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TargetDocumentTest.php
@@ -25,6 +25,7 @@ class TargetDocumentTest extends BaseTestCase
     {
         self::expectExceptionObject(
             MappingException::invalidTargetDocument(
+                // @phpstan-ignore-next-line class.notFound
                 SomeInvalidClass::class,
                 InvalidTargetDocumentTestDocument::class,
                 'reference',
@@ -40,6 +41,7 @@ class TargetDocumentTest extends BaseTestCase
     {
         self::expectExceptionObject(
             MappingException::invalidClassInReferenceDiscriminatorMap(
+                // @phpstan-ignore-next-line class.notFound
                 SomeInvalidClass::class,
                 InvalidDiscriminatorTargetsTestDocument::class,
                 'reference',


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | maybe
| Fixed issues | #2576 

#### Summary

Show an error when validating the `ClassMetadata`, if a `targetDocument` can neither be resolved to an existing interface or class.

```bash
$ bin/console doctrine:mongodb:mapping:info
[FAIL] InvalidTargetDocumentTestDocument
Target document class 'Doctrine\ODM\MongoDB\Tests\Functional\SomeInvalidClass' used in field 'reference' of class 'Doctrine\ODM\MongoDB\Tests\Functional\InvalidTargetDocumentTestDocument' does not exist.
```

BC breaks could occur, if current metadata contains undetected errors.