### PR TITLE
Deprecate legacy commit options

### DIFF
--- a/docs/en/reference/working-with-objects.rst
+++ b/docs/en/reference/working-with-objects.rst
@@ -133,8 +133,8 @@ Flush Options
 -------------
 
 When committing your documents you can specify an array of options to the
-``flush`` method. With it you can send options to the underlying database
-like ``safe``, ``fsync``, etc.
+``flush`` method. You can use this to pass a write options to the underlying
+operations, e.g. a custom write concern.
 
 Example:
 
@@ -145,7 +145,7 @@ Example:
     $user = $dm->getRepository(User::class)->find($userId);
     // ...
     $user->setPassword('changeme');
-    $dm->flush(null, ['safe' => true, 'fsync' => true]);
+    $dm->flush(['writeConcern' => new \MongoDB\Driver\WriteConcern(1)]);
 
 You can configure the default flush options on your ``Configuration`` object
 if you want to set them globally for all flushes.
@@ -157,15 +157,8 @@ Example:
     <?php
 
     $config->setDefaultCommitOptions(
-      [
-        'safe' => true,
-        'fsync' => true
-      ]
+      ['writeConcern' => new \MongoDB\Driver\WriteConcern(1)]
     );
-
-.. note::
-
-    Safe is set to true by default for all writes when using the ODM.
 
 Removing documents
 ------------------

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -32,6 +32,7 @@ use ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy;
 use Psr\Cache\CacheItemPoolInterface;
 use ReflectionClass;
 
+use function array_key_exists;
 use function interface_exists;
 use function trigger_deprecation;
 use function trim;
@@ -449,6 +450,19 @@ class Configuration
     /** @psalm-param CommitOptions $defaultCommitOptions */
     public function setDefaultCommitOptions(array $defaultCommitOptions): void
     {
+        foreach (UnitOfWork::DEPRECATED_WRITE_OPTIONS as $deprecatedOption) {
+            if (! array_key_exists($deprecatedOption, $defaultCommitOptions)) {
+                continue;
+            }
+
+            trigger_deprecation(
+                'doctrine/mongodb-odm',
+                '2.6',
+                'The "%s" commit option used in the configuration is deprecated.',
+                $deprecatedOption,
+            );
+        }
+
         $this->attributes['defaultCommitOptions'] = $defaultCommitOptions;
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -451,16 +451,14 @@ class Configuration
     public function setDefaultCommitOptions(array $defaultCommitOptions): void
     {
         foreach (UnitOfWork::DEPRECATED_WRITE_OPTIONS as $deprecatedOption) {
-            if (! array_key_exists($deprecatedOption, $defaultCommitOptions)) {
-                continue;
+            if (array_key_exists($deprecatedOption, $defaultCommitOptions)) {
+                trigger_deprecation(
+                    'doctrine/mongodb-odm',
+                    '2.6',
+                    'The "%s" commit option used in the configuration is deprecated.',
+                    $deprecatedOption,
+                );
             }
-
-            trigger_deprecation(
-                'doctrine/mongodb-odm',
-                '2.6',
-                'The "%s" commit option used in the configuration is deprecated.',
-                $deprecatedOption,
-            );
         }
 
         $this->attributes['defaultCommitOptions'] = $defaultCommitOptions;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -42,6 +42,12 @@
         <exclude name="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat.DisallowedShortNullable" />
     </rule>
 
+    <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit">
+        <properties>
+            <property name="ignoreStandaloneIfInScope" value="true"/>
+        </properties>
+    </rule>
+
     <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
         <exclude-pattern>tests/Doctrine/ODM/MongoDB/Tests/Mapping/Documents/GlobalNamespaceDocument.php</exclude-pattern>
     </rule>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

The `fsync`, `safe`, and `w` options can be deprecated, as they are all handled by the `writeConcern` commit option.