### PR TITLE
Refactor commit logic

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1161,9 +1161,8 @@ final class UnitOfWork implements PropertyChangedListener
     {
         $persister = $this->getDocumentPersister($class->name);
 
-        foreach ($documents as $oid => $document) {
+        foreach ($documents as $document) {
             $persister->addInsert($document);
-            unset($this->documentInsertions[$oid]);
         }
 
         $persister->executeInserts($options);
@@ -1186,9 +1185,8 @@ final class UnitOfWork implements PropertyChangedListener
     {
         $persister = $this->getDocumentPersister($class->name);
 
-        foreach ($documents as $oid => $document) {
+        foreach ($documents as $document) {
             $persister->addUpsert($document);
-            unset($this->documentUpserts[$oid]);
         }
 
         $persister->executeUpserts($options);
@@ -1223,8 +1221,6 @@ final class UnitOfWork implements PropertyChangedListener
                 $persister->update($document, $options);
             }
 
-            unset($this->documentUpdates[$oid]);
-
             $this->lifecycleEventManager->postUpdate($class, $document);
         }
     }
@@ -1248,7 +1244,6 @@ final class UnitOfWork implements PropertyChangedListener
             }
 
             unset(
-                $this->documentDeletions[$oid],
                 $this->documentIdentifiers[$oid],
                 $this->originalDocumentData[$oid],
             );
@@ -1267,10 +1262,6 @@ final class UnitOfWork implements PropertyChangedListener
 
                 $value->clearSnapshot();
             }
-
-            // Document with this $oid after deletion treated as NEW, even if the $oid
-            // is obtained by a new document because the old one went out of scope.
-            $this->documentStates[$oid] = self::STATE_NEW;
 
             $this->lifecycleEventManager->postRemove($class, $document);
         }

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
@@ -25,7 +25,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         parent::tearDown();
     }
 
-    public function testErrorDuringInsertKeepsFailingInsertions(): void
+    public function testInsertErrorKeepsFailingInsertions(): void
     {
         $firstUser           = new ForumUser();
         $firstUser->username = 'alcaeus';
@@ -69,7 +69,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         self::assertNotEquals([], $this->uow->getDocumentChangeSet($friendUser));
     }
 
-    public function testErrorDuringInsertKeepsFailingInsertionsForDocument(): void
+    public function testInsertErrorKeepsFailingInsertionsForDocumentClass(): void
     {
         // Create a unique index on the collection to let the second insert fail
         $collection = $this->dm->getDocumentCollection(ForumUser::class);
@@ -111,7 +111,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         self::assertNotEquals([], $this->uow->getDocumentChangeSet($thirdUser));
     }
 
-    public function testErrorDuringInsertWithEmbeddedDocumentKeepsInsertions(): void
+    public function testInsertErrorWithEmbeddedDocumentKeepsInsertions(): void
     {
         // Create a unique index on the collection to let the second insert fail
         $collection = $this->dm->getDocumentCollection(User::class);
@@ -155,7 +155,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         $this->assertNotEquals([], $this->uow->getDocumentChangeSet($secondAddress));
     }
 
-    public function testErrorDuringUpsertDropsFailingUpserts(): void
+    public function testUpsertErrorDropsFailingUpserts(): void
     {
         $user           = new ForumUser();
         $user->id       = new ObjectId(); // Specifying an identifier makes this an upsert
@@ -187,7 +187,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         self::assertNotEquals([], $this->uow->getDocumentChangeSet($user));
     }
 
-    public function testErrorDuringUpdateKeepsFailingUpdate(): void
+    public function testUpdateErrorKeepsFailingUpdate(): void
     {
         $user           = new ForumUser();
         $user->username = 'alcaeus';
@@ -222,7 +222,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         self::assertNotEquals([], $this->uow->getDocumentChangeSet($user));
     }
 
-    public function testErrorDuringUpdateWithNewEmbeddedDocumentKeepsFailingChangeset(): void
+    public function testUpdateErrorWithNewEmbeddedDocumentKeepsFailingChangeset(): void
     {
         $user = new User();
         $user->setUsername('alcaeus');
@@ -255,7 +255,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         $this->assertNotEquals([], $this->uow->getDocumentChangeSet($address));
     }
 
-    public function testSuccessfulUpdateWithNewEmbeddedDocumentClearsChangesets(): void
+    public function testUpdateWithNewEmbeddedDocumentClearsChangesets(): void
     {
         $user = new User();
         $user->setUsername('alcaeus');
@@ -275,7 +275,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         $this->assertEquals([], $this->uow->getDocumentChangeSet($address));
     }
 
-    public function testErrorDuringUpdateOfEmbeddedDocumentKeepsFailingChangeset(): void
+    public function testUpdateErrorWithEmbeddedDocumentKeepsFailingChangeset(): void
     {
         $address = new Address();
         $address->setCity('Olching');
@@ -310,7 +310,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         $this->assertNotEquals([], $this->uow->getDocumentChangeSet($address));
     }
 
-    public function testSuccessfulUpdateOfEmbeddedDocumentClearsChangesets(): void
+    public function testUpdateWithEmbeddedDocumentClearsChangesets(): void
     {
         $address = new Address();
         $address->setCity('Olching');
@@ -332,7 +332,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         $this->assertEquals([], $this->uow->getDocumentChangeSet($address));
     }
 
-    public function testErrorDuringUpdateWithRemovedEmbeddedDocumentKeepsFailingChangeset(): void
+    public function testUpdateErrorWithRemovedEmbeddedDocumentKeepsFailingChangeset(): void
     {
         $address = new Address();
         $address->setCity('Olching');
@@ -369,7 +369,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         $this->assertFalse($this->uow->isInIdentityMap($address));
     }
 
-    public function testSuccessfulUpdateWithRemovedEmbeddedDocumentClearsChangesets(): void
+    public function testUpdateWithRemovedEmbeddedDocumentClearsChangesets(): void
     {
         $address = new Address();
         $address->setCity('Olching');
@@ -391,7 +391,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         $this->assertFalse($this->uow->isInIdentityMap($address));
     }
 
-    public function testErrorDuringDeleteKeepsFailingDelete(): void
+    public function testDeleteErrorKeepsFailingDelete(): void
     {
         $user           = new ForumUser();
         $user->username = 'alcaeus';
@@ -425,7 +425,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         self::assertTrue($this->uow->isScheduledForDelete($user));
     }
 
-    public function testFailingDeleteWithEmbeddedDocumentKeepsChangeset(): void
+    public function testDeleteErrorWithEmbeddedDocumentKeepsChangeset(): void
     {
         $address = new Address();
         $address->setCity('Olching');
@@ -465,7 +465,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         self::assertTrue($this->uow->isScheduledForDelete($address));
     }
 
-    public function testSuccessfulDeleteWithEmbeddedDocumentClearsChangeset(): void
+    public function testDeleteWithEmbeddedDocumentClearsChangeset(): void
     {
         $address = new Address();
         $address->setCity('Olching');

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
@@ -1,0 +1,496 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests;
+
+use Documents\Address;
+use Documents\ForumUser;
+use Documents\FriendUser;
+use Documents\User;
+use MongoDB\BSON\ObjectId;
+use Throwable;
+
+class UnitOfWorkCommitConsistencyTest extends BaseTestCase
+{
+    public function tearDown(): void
+    {
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => 'off',
+        ]);
+
+        parent::tearDown();
+    }
+
+    public function testErrorDuringInsertKeepsFailingInsertions(): void
+    {
+        $firstUser           = new ForumUser();
+        $firstUser->username = 'alcaeus';
+        $this->uow->persist($firstUser);
+
+        $secondUser           = new ForumUser();
+        $secondUser->username = 'jmikola';
+        $this->uow->persist($secondUser);
+
+        $friendUser = new FriendUser('GromNaN');
+        $this->uow->persist($friendUser);
+
+        // Add failpoint to let the first insert command fail. This affects the ForumUser documents
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => ['times' => 1],
+            'data' => [
+                'errorCode' => 10107, // Not primary
+                'failCommands' => ['insert'],
+            ],
+        ]);
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        self::assertSame(
+            0,
+            $this->dm->getDocumentCollection(ForumUser::class)->countDocuments(),
+        );
+
+        // Wrong behaviour: the insertions should still be scheduled
+        self::assertFalse($this->uow->isScheduledForInsert($firstUser));
+        self::assertNotEquals([], $this->uow->getDocumentChangeSet($firstUser));
+
+        self::assertFalse($this->uow->isScheduledForInsert($secondUser));
+        self::assertNotEquals([], $this->uow->getDocumentChangeSet($secondUser));
+
+        self::assertTrue($this->uow->isScheduledForInsert($friendUser));
+        self::assertNotEquals([], $this->uow->getDocumentChangeSet($friendUser));
+    }
+
+    public function testErrorDuringInsertKeepsFailingInsertionsForDocument(): void
+    {
+        // Create a unique index on the collection to let the second insert fail
+        $collection = $this->dm->getDocumentCollection(ForumUser::class);
+        $collection->createIndex(['username' => 1], ['unique' => true]);
+
+        $firstUser           = new ForumUser();
+        $firstUser->username = 'alcaeus';
+        $this->uow->persist($firstUser);
+
+        $secondUser           = new ForumUser();
+        $secondUser->username = 'alcaeus';
+        $this->uow->persist($secondUser);
+
+        $thirdUser           = new ForumUser();
+        $thirdUser->username = 'jmikola';
+        $this->uow->persist($thirdUser);
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        // One user inserted, the second insert failed, the last was skipped
+        self::assertSame(
+            1,
+            $this->dm->getDocumentCollection(ForumUser::class)->countDocuments(),
+        );
+
+        // First user was inserted and changeset cleared
+        self::assertFalse($this->uow->isScheduledForInsert($firstUser));
+        // Wrong behaviour: changeset should be empty
+        self::assertNotEquals([], $this->uow->getDocumentChangeSet($firstUser));
+
+        // Wrong behaviour: user should still be scheduled for insertion
+        self::assertFalse($this->uow->isScheduledForInsert($secondUser));
+        self::assertNotEquals([], $this->uow->getDocumentChangeSet($secondUser));
+
+        // Wrong behaviour: user should still be scheduled for insertion
+        self::assertFalse($this->uow->isScheduledForInsert($thirdUser));
+        self::assertNotEquals([], $this->uow->getDocumentChangeSet($thirdUser));
+    }
+
+    public function testErrorDuringInsertWithEmbeddedDocumentKeepsInsertions(): void
+    {
+        // Create a unique index on the collection to let the second insert fail
+        $collection = $this->dm->getDocumentCollection(User::class);
+        $collection->createIndex(['username' => 1], ['unique' => true]);
+
+        $firstAddress = new Address();
+        $firstAddress->setCity('Olching');
+        $firstUser = new User();
+        $firstUser->setUsername('alcaeus');
+        $firstUser->setAddress($firstAddress);
+
+        $secondAddress = new Address();
+        $secondAddress->setCity('Olching');
+        $secondUser = new User();
+        $secondUser->setUsername('alcaeus');
+        $secondUser->setAddress($secondAddress);
+
+        $this->uow->persist($firstUser);
+        $this->uow->persist($secondUser);
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        // First document inserted, second failed due to index error
+        self::assertSame(1, $collection->countDocuments());
+
+        $this->assertFalse($this->uow->isScheduledForInsert($firstUser));
+        // Wrong behaviour: changeset should be cleared but isn't
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($firstUser));
+
+        // Wrong behaviour: document should no longer be scheduled for insertion and changeset cleared
+        $this->assertTrue($this->uow->isScheduledForInsert($firstAddress));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($firstAddress));
+
+        // Wrong behaviour: document should still be scheduled for insertion
+        $this->assertFalse($this->uow->isScheduledForInsert($secondUser));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($secondUser));
+        $this->assertTrue($this->uow->isScheduledForInsert($secondAddress));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($secondAddress));
+    }
+
+    public function testErrorDuringUpsertDropsFailingUpserts(): void
+    {
+        $user           = new ForumUser();
+        $user->id       = new ObjectId(); // Specifying an identifier makes this an upsert
+        $user->username = 'alcaeus';
+        $this->uow->persist($user);
+
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => ['times' => 1],
+            'data' => [
+                'errorCode' => 10107, // Not primary
+                'failCommands' => ['update'],
+            ],
+        ]);
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        // No document was inserted
+        self::assertSame(
+            0,
+            $this->dm->getDocumentCollection(ForumUser::class)->countDocuments(),
+        );
+
+        // Wrong behaviour: document should still be scheduled
+        self::assertFalse($this->uow->isScheduledForUpsert($user));
+        self::assertNotEquals([], $this->uow->getDocumentChangeSet($user));
+    }
+
+    public function testErrorDuringUpdateKeepsFailingUpdate(): void
+    {
+        $user           = new ForumUser();
+        $user->username = 'alcaeus';
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $user->username = 'jmikola';
+
+        // Make sure update command fails once
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => ['times' => 1],
+            'data' => [
+                'errorCode' => 10107, // Not primary
+                'failCommands' => ['update'],
+            ],
+        ]);
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        // The update is kept, user data is not changed
+        self::assertSame(
+            1,
+            $this->dm->getDocumentCollection(ForumUser::class)->countDocuments(['username' => 'alcaeus']),
+        );
+
+        self::assertTrue($this->uow->isScheduledForUpdate($user));
+        self::assertNotEquals([], $this->uow->getDocumentChangeSet($user));
+    }
+
+    public function testErrorDuringUpdateWithNewEmbeddedDocumentKeepsFailingChangeset(): void
+    {
+        $user = new User();
+        $user->setUsername('alcaeus');
+
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $address = new Address();
+        $address->setCity('Olching');
+        $user->setAddress($address);
+
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => ['times' => 1],
+            'data' => [
+                'errorCode' => 10107, // Not primary
+                'failCommands' => ['update'],
+            ],
+        ]);
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        $this->assertTrue($this->uow->isScheduledForUpdate($user));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($user));
+        $this->assertTrue($this->uow->isScheduledForInsert($address));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($address));
+    }
+
+    public function testSuccessfulUpdateWithNewEmbeddedDocumentClearsChangesets(): void
+    {
+        $user = new User();
+        $user->setUsername('alcaeus');
+
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $address = new Address();
+        $address->setCity('Olching');
+        $user->setAddress($address);
+
+        $this->uow->commit();
+
+        $this->assertFalse($this->uow->isScheduledForUpdate($user));
+        $this->assertEquals([], $this->uow->getDocumentChangeSet($user));
+        $this->assertFalse($this->uow->isScheduledForInsert($address));
+        $this->assertEquals([], $this->uow->getDocumentChangeSet($address));
+    }
+
+    public function testErrorDuringUpdateOfEmbeddedDocumentKeepsFailingChangeset(): void
+    {
+        $address = new Address();
+        $address->setCity('Olching');
+
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setAddress($address);
+
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $address->setCity('Munich');
+
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => ['times' => 1],
+            'data' => [
+                'errorCode' => 10107, // Not primary
+                'failCommands' => ['update'],
+            ],
+        ]);
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        $this->assertTrue($this->uow->isScheduledForUpdate($user));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($user));
+        $this->assertTrue($this->uow->isScheduledForUpdate($address));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($address));
+    }
+
+    public function testSuccessfulUpdateOfEmbeddedDocumentClearsChangesets(): void
+    {
+        $address = new Address();
+        $address->setCity('Olching');
+
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setAddress($address);
+
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $address->setCity('Munich');
+
+        $this->uow->commit();
+
+        $this->assertFalse($this->uow->isScheduledForUpdate($user));
+        $this->assertEquals([], $this->uow->getDocumentChangeSet($user));
+        $this->assertFalse($this->uow->isScheduledForUpdate($address));
+        $this->assertEquals([], $this->uow->getDocumentChangeSet($address));
+    }
+
+    public function testErrorDuringUpdateWithRemovedEmbeddedDocumentKeepsFailingChangeset(): void
+    {
+        $address = new Address();
+        $address->setCity('Olching');
+
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setAddress($address);
+
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $user->removeAddress();
+
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => ['times' => 1],
+            'data' => [
+                'errorCode' => 10107, // Not primary
+                'failCommands' => ['update'],
+            ],
+        ]);
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        $this->assertTrue($this->uow->isScheduledForUpdate($user));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($user));
+        $this->assertTrue($this->uow->isScheduledForDelete($address));
+
+        // As $address is orphaned after changeset computation, it is removed from the identity map
+        $this->assertFalse($this->uow->isInIdentityMap($address));
+    }
+
+    public function testSuccessfulUpdateWithRemovedEmbeddedDocumentClearsChangesets(): void
+    {
+        $address = new Address();
+        $address->setCity('Olching');
+
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setAddress($address);
+
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $user->removeAddress();
+
+        $this->uow->commit();
+
+        $this->assertFalse($this->uow->isScheduledForUpdate($user));
+        $this->assertEquals([], $this->uow->getDocumentChangeSet($user));
+        $this->assertFalse($this->uow->isScheduledForDelete($address));
+        $this->assertFalse($this->uow->isInIdentityMap($address));
+    }
+
+    public function testErrorDuringDeleteKeepsFailingDelete(): void
+    {
+        $user           = new ForumUser();
+        $user->username = 'alcaeus';
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $this->uow->remove($user);
+
+        // Make sure delete command fails once
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => ['times' => 1],
+            'data' => [
+                'errorCode' => 10107, // Not primary
+                'failCommands' => ['delete'],
+            ],
+        ]);
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        // The document still exists, the deletion is still scheduled
+        self::assertSame(
+            1,
+            $this->dm->getDocumentCollection(ForumUser::class)->countDocuments(['username' => 'alcaeus']),
+        );
+
+        self::assertTrue($this->uow->isScheduledForDelete($user));
+    }
+
+    public function testFailingDeleteWithEmbeddedDocumentKeepsChangeset(): void
+    {
+        $address = new Address();
+        $address->setCity('Olching');
+
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setAddress($address);
+
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $this->uow->remove($user);
+
+        // Make sure delete command fails once
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => ['times' => 1],
+            'data' => [
+                'errorCode' => 10107, // Not primary
+                'failCommands' => ['delete'],
+            ],
+        ]);
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        // The document still exists, the deletion is still scheduled
+        self::assertSame(
+            1,
+            $this->dm->getDocumentCollection(User::class)->countDocuments(['username' => 'alcaeus']),
+        );
+
+        self::assertTrue($this->uow->isScheduledForDelete($user));
+        // Wrong behaviour: embedded document should be scheduled for deletion
+        self::assertFalse($this->uow->isScheduledForDelete($address));
+    }
+
+    public function testSuccessfulDeleteWithEmbeddedDocumentClearsChangeset(): void
+    {
+        $address = new Address();
+        $address->setCity('Olching');
+
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setAddress($address);
+
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $this->uow->remove($user);
+
+        $this->uow->commit();
+
+        self::assertSame(
+            0,
+            $this->dm->getDocumentCollection(User::class)->countDocuments(['username' => 'alcaeus']),
+        );
+
+        self::assertFalse($this->uow->isScheduledForDelete($user));
+        self::assertFalse($this->uow->isScheduledForDelete($address));
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests;
 
+use Doctrine\ODM\MongoDB\DocumentManager;
 use Documents\Address;
 use Documents\ForumUser;
 use Documents\FriendUser;
 use Documents\User;
 use MongoDB\BSON\ObjectId;
+use MongoDB\Client;
 use Throwable;
 
 class UnitOfWorkCommitConsistencyTest extends BaseTestCase
@@ -486,5 +488,14 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
 
         self::assertFalse($this->uow->isScheduledForDelete($user));
         self::assertFalse($this->uow->isScheduledForDelete($address));
+    }
+
+    /** Create a document manager with a single host to ensure failpoints target the correct server */
+    protected static function createTestDocumentManager(): DocumentManager
+    {
+        $config = static::getConfiguration();
+        $client = new Client(self::getUri(false), [], ['typeMap' => ['root' => 'array', 'document' => 'array']]);
+
+        return DocumentManager::create($client, $config);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
@@ -102,11 +102,9 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         // Wrong behaviour: changeset should be empty
         self::assertNotEquals([], $this->uow->getDocumentChangeSet($firstUser));
 
-        // Wrong behaviour: user should still be scheduled for insertion
         self::assertTrue($this->uow->isScheduledForInsert($secondUser));
         self::assertNotEquals([], $this->uow->getDocumentChangeSet($secondUser));
 
-        // Wrong behaviour: user should still be scheduled for insertion
         self::assertTrue($this->uow->isScheduledForInsert($thirdUser));
         self::assertNotEquals([], $this->uow->getDocumentChangeSet($thirdUser));
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
@@ -41,7 +41,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
             'configureFailPoint' => 'failCommand',
             'mode' => ['times' => 1],
             'data' => [
-                'errorCode' => 10107, // Not primary
+                'errorCode' => 192, // FailPointEnabled
                 'failCommands' => ['insert'],
             ],
         ]);
@@ -164,7 +164,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
             'configureFailPoint' => 'failCommand',
             'mode' => ['times' => 1],
             'data' => [
-                'errorCode' => 10107, // Not primary
+                'errorCode' => 192, // FailPointEnabled
                 'failCommands' => ['update'],
             ],
         ]);
@@ -199,7 +199,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
             'configureFailPoint' => 'failCommand',
             'mode' => ['times' => 1],
             'data' => [
-                'errorCode' => 10107, // Not primary
+                'errorCode' => 192, // FailPointEnabled
                 'failCommands' => ['update'],
             ],
         ]);
@@ -236,7 +236,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
             'configureFailPoint' => 'failCommand',
             'mode' => ['times' => 1],
             'data' => [
-                'errorCode' => 10107, // Not primary
+                'errorCode' => 192, // FailPointEnabled
                 'failCommands' => ['update'],
             ],
         ]);
@@ -291,7 +291,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
             'configureFailPoint' => 'failCommand',
             'mode' => ['times' => 1],
             'data' => [
-                'errorCode' => 10107, // Not primary
+                'errorCode' => 192, // FailPointEnabled
                 'failCommands' => ['update'],
             ],
         ]);
@@ -348,7 +348,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
             'configureFailPoint' => 'failCommand',
             'mode' => ['times' => 1],
             'data' => [
-                'errorCode' => 10107, // Not primary
+                'errorCode' => 192, // FailPointEnabled
                 'failCommands' => ['update'],
             ],
         ]);
@@ -403,7 +403,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
             'configureFailPoint' => 'failCommand',
             'mode' => ['times' => 1],
             'data' => [
-                'errorCode' => 10107, // Not primary
+                'errorCode' => 192, // FailPointEnabled
                 'failCommands' => ['delete'],
             ],
         ]);
@@ -442,7 +442,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
             'configureFailPoint' => 'failCommand',
             'mode' => ['times' => 1],
             'data' => [
-                'errorCode' => 10107, // Not primary
+                'errorCode' => 192, // FailPointEnabled
                 'failCommands' => ['delete'],
             ],
         ]);

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
@@ -71,7 +71,8 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
 
     public function testInsertErrorKeepsFailingInsertionsForDocumentClass(): void
     {
-        // Create a unique index on the collection to let the second insert fail
+        // Create a unique index on the collection to let the second document fail, as using a fail point would also
+        // affect the first document.
         $collection = $this->dm->getDocumentCollection(ForumUser::class);
         $collection->createIndex(['username' => 1], ['unique' => true]);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
@@ -57,11 +57,10 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
             $this->dm->getDocumentCollection(ForumUser::class)->countDocuments(),
         );
 
-        // Wrong behaviour: the insertions should still be scheduled
-        self::assertFalse($this->uow->isScheduledForInsert($firstUser));
+        self::assertTrue($this->uow->isScheduledForInsert($firstUser));
         self::assertNotEquals([], $this->uow->getDocumentChangeSet($firstUser));
 
-        self::assertFalse($this->uow->isScheduledForInsert($secondUser));
+        self::assertTrue($this->uow->isScheduledForInsert($secondUser));
         self::assertNotEquals([], $this->uow->getDocumentChangeSet($secondUser));
 
         self::assertTrue($this->uow->isScheduledForInsert($friendUser));
@@ -98,17 +97,17 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
             $this->dm->getDocumentCollection(ForumUser::class)->countDocuments(),
         );
 
-        // First user was inserted and changeset cleared
-        self::assertFalse($this->uow->isScheduledForInsert($firstUser));
+        // Wrong behaviour: user was saved and should no longer be scheduled for insertion
+        self::assertTrue($this->uow->isScheduledForInsert($firstUser));
         // Wrong behaviour: changeset should be empty
         self::assertNotEquals([], $this->uow->getDocumentChangeSet($firstUser));
 
         // Wrong behaviour: user should still be scheduled for insertion
-        self::assertFalse($this->uow->isScheduledForInsert($secondUser));
+        self::assertTrue($this->uow->isScheduledForInsert($secondUser));
         self::assertNotEquals([], $this->uow->getDocumentChangeSet($secondUser));
 
         // Wrong behaviour: user should still be scheduled for insertion
-        self::assertFalse($this->uow->isScheduledForInsert($thirdUser));
+        self::assertTrue($this->uow->isScheduledForInsert($thirdUser));
         self::assertNotEquals([], $this->uow->getDocumentChangeSet($thirdUser));
     }
 
@@ -142,16 +141,15 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         // First document inserted, second failed due to index error
         self::assertSame(1, $collection->countDocuments());
 
-        $this->assertFalse($this->uow->isScheduledForInsert($firstUser));
-        // Wrong behaviour: changeset should be cleared but isn't
+        // Wrong behaviour: document should no longer be scheduled and changeset should be cleared
+        $this->assertTrue($this->uow->isScheduledForInsert($firstUser));
         $this->assertNotEquals([], $this->uow->getDocumentChangeSet($firstUser));
 
         // Wrong behaviour: document should no longer be scheduled for insertion and changeset cleared
         $this->assertTrue($this->uow->isScheduledForInsert($firstAddress));
         $this->assertNotEquals([], $this->uow->getDocumentChangeSet($firstAddress));
 
-        // Wrong behaviour: document should still be scheduled for insertion
-        $this->assertFalse($this->uow->isScheduledForInsert($secondUser));
+        $this->assertTrue($this->uow->isScheduledForInsert($secondUser));
         $this->assertNotEquals([], $this->uow->getDocumentChangeSet($secondUser));
         $this->assertTrue($this->uow->isScheduledForInsert($secondAddress));
         $this->assertNotEquals([], $this->uow->getDocumentChangeSet($secondAddress));
@@ -185,8 +183,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
             $this->dm->getDocumentCollection(ForumUser::class)->countDocuments(),
         );
 
-        // Wrong behaviour: document should still be scheduled
-        self::assertFalse($this->uow->isScheduledForUpsert($user));
+        self::assertTrue($this->uow->isScheduledForUpsert($user));
         self::assertNotEquals([], $this->uow->getDocumentChangeSet($user));
     }
 
@@ -465,8 +462,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         );
 
         self::assertTrue($this->uow->isScheduledForDelete($user));
-        // Wrong behaviour: embedded document should be scheduled for deletion
-        self::assertFalse($this->uow->isScheduledForDelete($address));
+        self::assertTrue($this->uow->isScheduledForDelete($address));
     }
 
     public function testSuccessfulDeleteWithEmbeddedDocumentClearsChangeset(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
@@ -39,14 +39,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         $this->uow->persist($friendUser);
 
         // Add failpoint to let the first insert command fail. This affects the ForumUser documents
-        $this->dm->getClient()->selectDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => ['times' => 1],
-            'data' => [
-                'errorCode' => 192, // FailPointEnabled
-                'failCommands' => ['insert'],
-            ],
-        ]);
+        $this->createFailpoint('insert');
 
         try {
             $this->uow->commit();
@@ -163,14 +156,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         $user->username = 'alcaeus';
         $this->uow->persist($user);
 
-        $this->dm->getClient()->selectDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => ['times' => 1],
-            'data' => [
-                'errorCode' => 192, // FailPointEnabled
-                'failCommands' => ['update'],
-            ],
-        ]);
+        $this->createFailpoint('update');
 
         try {
             $this->uow->commit();
@@ -198,14 +184,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         $user->username = 'jmikola';
 
         // Make sure update command fails once
-        $this->dm->getClient()->selectDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => ['times' => 1],
-            'data' => [
-                'errorCode' => 192, // FailPointEnabled
-                'failCommands' => ['update'],
-            ],
-        ]);
+        $this->createFailpoint('update');
 
         try {
             $this->uow->commit();
@@ -235,14 +214,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         $address->setCity('Olching');
         $user->setAddress($address);
 
-        $this->dm->getClient()->selectDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => ['times' => 1],
-            'data' => [
-                'errorCode' => 192, // FailPointEnabled
-                'failCommands' => ['update'],
-            ],
-        ]);
+        $this->createFailpoint('update');
 
         try {
             $this->uow->commit();
@@ -290,14 +262,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
 
         $address->setCity('Munich');
 
-        $this->dm->getClient()->selectDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => ['times' => 1],
-            'data' => [
-                'errorCode' => 192, // FailPointEnabled
-                'failCommands' => ['update'],
-            ],
-        ]);
+        $this->createFailpoint('update');
 
         try {
             $this->uow->commit();
@@ -347,14 +312,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
 
         $user->removeAddress();
 
-        $this->dm->getClient()->selectDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => ['times' => 1],
-            'data' => [
-                'errorCode' => 192, // FailPointEnabled
-                'failCommands' => ['update'],
-            ],
-        ]);
+        $this->createFailpoint('update');
 
         try {
             $this->uow->commit();
@@ -402,14 +360,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         $this->uow->remove($user);
 
         // Make sure delete command fails once
-        $this->dm->getClient()->selectDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => ['times' => 1],
-            'data' => [
-                'errorCode' => 192, // FailPointEnabled
-                'failCommands' => ['delete'],
-            ],
-        ]);
+        $this->createFailpoint('delete');
 
         try {
             $this->uow->commit();
@@ -441,14 +392,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         $this->uow->remove($user);
 
         // Make sure delete command fails once
-        $this->dm->getClient()->selectDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => ['times' => 1],
-            'data' => [
-                'errorCode' => 192, // FailPointEnabled
-                'failCommands' => ['delete'],
-            ],
-        ]);
+        $this->createFailpoint('delete');
 
         try {
             $this->uow->commit();
@@ -498,5 +442,17 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         $client = new Client(self::getUri(false), [], ['typeMap' => ['root' => 'array', 'document' => 'array']]);
 
         return DocumentManager::create($client, $config);
+    }
+
+    private function createFailpoint(string $commandName): void
+    {
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => ['times' => 1],
+            'data' => [
+                'errorCode' => 192, // FailPointEnabled
+                'failCommands' => [$commandName],
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

[PHPORM-112](https://jira.mongodb.org/browse/PHPORM-112)

(This PR currently targets 2.6.x, but will be held back until we work on 2.7.x)

As is, failures during a `commit` operation in `UnitOfWork` result in an inconsistent state. While updates and deletions mostly handle errors during the operation gracefully, errors during an insert or upset result in the UnitOfWork having a broken state.

This PR changes the timing of when we mark changes as done and remove changesets. All of these are now handled after all commit operations have concluded, which is a change made in preparation for transaction support (which requires us to keep changesets around until we successfully commit the transaction or give up). As a side effect, this will eventually allow fixing the inconsistencies mentioned above. A new test class keeps track of these inconsistencies so they can be addressed in the future.