### PR TITLE
Transaction support

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - "*.x"
+      - "feature/*"
   push:
 
 jobs:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - "*.x"
+      - "feature/*"
   push:
 
 env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -45,7 +45,7 @@ jobs:
           # Test with highest dependencies
           - topology: "server"
             php-version: "8.2"
-            mongodb-version: "6.0"
+            mongodb-version: "7.0"
             driver-version: "stable"
             dependencies: "highest"
             symfony-version: "7"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,6 +22,7 @@ jobs:
           - "8.2"
           - "8.3"
         mongodb-version:
+          - "7.0"
           - "6.0"
           - "5.0"
           - "4.4"
@@ -34,24 +35,34 @@ jobs:
         symfony-version:
           - "stable"
         include:
+          # Test against lowest dependencies
           - dependencies: "lowest"
             php-version: "8.1"
             mongodb-version: "4.4"
             driver-version: "1.11.0"
             topology: "server"
             symfony-version: "stable"
-          - topology: "sharded_cluster"
-            php-version: "8.2"
-            mongodb-version: "4.4"
-            driver-version: "stable"
-            dependencies: "highest"
-            symfony-version: "stable"
+          # Test with highest dependencies
           - topology: "server"
             php-version: "8.2"
             mongodb-version: "6.0"
             driver-version: "stable"
             dependencies: "highest"
             symfony-version: "7"
+          # Test with a 4.4 replica set
+          - topology: "replica_set"
+            php-version: "8.2"
+            mongodb-version: "4.4"
+            driver-version: "stable"
+            dependencies: "highest"
+            symfony-version: "stable"
+          # Test with a 4.4 sharded cluster
+          - topology: "sharded_cluster"
+            php-version: "8.2"
+            mongodb-version: "4.4"
+            driver-version: "stable"
+            dependencies: "highest"
+            symfony-version: "stable"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - "*.x"
+      - "feature/*"
   push:
 
 jobs:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - "*.x"
+      - "feature/*"
   push:
 
 jobs:

--- a/docs/en/cookbook/validation-of-documents.rst
+++ b/docs/en/cookbook/validation-of-documents.rst
@@ -86,7 +86,7 @@ Now validation is performed whenever you call
 ``DocumentManager#persist($order)`` or when you call
 ``DocumentManager#flush()`` and an order is about to be updated. Any
 Exception that happens in the lifecycle callbacks will be cached by
-the DocumentManager and the current transaction is rolled back.
+the DocumentManager.
 
 Of course you can do any type of primitive checks, not null,
 email-validation, string size, integer and date ranges in your

--- a/docs/en/reference/architecture.rst
+++ b/docs/en/reference/architecture.rst
@@ -56,7 +56,7 @@ A document instance can be characterized as being NEW, MANAGED, DETACHED or REMO
    DocumentManager and a UnitOfWork.
 -  A REMOVED document instance is an instance with a persistent
    identity, associated with a DocumentManager, that will be removed
-   from the database upon transaction commit.
+   from the database upon UnitOfWork commit.
 
 Persistent fields
 ~~~~~~~~~~~~~~~~~
@@ -103,7 +103,7 @@ persistent objects.
 Transactional write-behind
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-An ``DocumentManager`` and the underlying ``UnitOfWork`` employ a
+The ``DocumentManager`` and the underlying ``UnitOfWork`` employ a
 strategy called "transactional write-behind" that delays the
 execution of query statements in order to execute them in the most
 efficient way and to execute them at the end of a transaction so

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -94,6 +94,7 @@ class Configuration
      *      defaultGridFSRepositoryClassName?: class-string<GridFSRepository<object>>,
      *      defaultDB?: string,
      *      documentNamespaces?: array<string, string>,
+     *      enableTransactionalFlush?: bool,
      *      filters?: array<string, array{
      *          class: class-string,
      *          parameters: array<string, mixed>
@@ -116,6 +117,8 @@ class Configuration
     private ProxyManagerConfiguration $proxyManagerConfiguration;
 
     private int $autoGenerateProxyClasses = self::AUTOGENERATE_EVAL;
+
+    private bool $useTransactionalFlush = false;
 
     public function __construct()
     {
@@ -595,6 +598,16 @@ class Configuration
     public function getProxyManagerConfiguration(): ProxyManagerConfiguration
     {
         return $this->proxyManagerConfiguration;
+    }
+
+    public function setUseTransactionalFlush(bool $useTransactionalFlush): void
+    {
+        $this->useTransactionalFlush = $useTransactionalFlush;
+    }
+
+    public function isTransactionalFlushEnabled(): bool
+    {
+        return $this->useTransactionalFlush;
     }
 }
 

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -94,7 +94,6 @@ class Configuration
      *      defaultGridFSRepositoryClassName?: class-string<GridFSRepository<object>>,
      *      defaultDB?: string,
      *      documentNamespaces?: array<string, string>,
-     *      enableTransactionalFlush?: bool,
      *      filters?: array<string, array{
      *          class: class-string,
      *          parameters: array<string, mixed>

--- a/lib/Doctrine/ODM/MongoDB/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/LifecycleEventArgs.php
@@ -6,6 +6,8 @@ namespace Doctrine\ODM\MongoDB\Event;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\Persistence\Event\LifecycleEventArgs as BaseLifecycleEventArgs;
+use Doctrine\Persistence\ObjectManager;
+use MongoDB\Driver\Session;
 
 /**
  * Lifecycle Events are triggered by the UnitOfWork during lifecycle transitions
@@ -15,6 +17,14 @@ use Doctrine\Persistence\Event\LifecycleEventArgs as BaseLifecycleEventArgs;
  */
 class LifecycleEventArgs extends BaseLifecycleEventArgs
 {
+    public function __construct(
+        object $object,
+        ObjectManager $objectManager,
+        public readonly ?Session $session = null,
+    ) {
+        parent::__construct($object, $objectManager);
+    }
+
     public function getDocument(): object
     {
         return $this->getObject();
@@ -23,5 +33,10 @@ class LifecycleEventArgs extends BaseLifecycleEventArgs
     public function getDocumentManager(): DocumentManager
     {
         return $this->getObjectManager();
+    }
+
+    public function isInTransaction(): bool
+    {
+        return $this->session?->isInTransaction() ?? false;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Event/PreLoadEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PreLoadEventArgs.php
@@ -5,21 +5,21 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Event;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use MongoDB\Driver\Session;
 
 /**
  * Class that holds event arguments for a preLoad event.
  */
 final class PreLoadEventArgs extends LifecycleEventArgs
 {
-    /** @var array<string, mixed> */
-    private array $data;
-
     /** @param array<string, mixed> $data */
-    public function __construct(object $document, DocumentManager $dm, array &$data)
-    {
-        parent::__construct($document, $dm);
-
-        $this->data =& $data;
+    public function __construct(
+        object $document,
+        DocumentManager $dm,
+        private array &$data,
+        ?Session $session = null,
+    ) {
+        parent::__construct($document, $dm, $session);
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PreUpdateEventArgs.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Event;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use InvalidArgumentException;
+use MongoDB\Driver\Session;
 
 use function get_class;
 use function sprintf;
@@ -18,26 +19,27 @@ use function sprintf;
  */
 final class PreUpdateEventArgs extends LifecycleEventArgs
 {
-    /** @psalm-var array<string, ChangeSet> */
-    private array $documentChangeSet;
-
     /** @psalm-param array<string, ChangeSet> $changeSet */
-    public function __construct(object $document, DocumentManager $dm, array $changeSet)
-    {
-        parent::__construct($document, $dm);
+    public function __construct(
+        object $document,
+        DocumentManager $dm,
+        private array $changeSet,
+        ?Session $session = null,
+    ) {
+        parent::__construct($document, $dm, $session);
 
-        $this->documentChangeSet = $changeSet;
+        $this->changeSet = $changeSet;
     }
 
     /** @return array<string, ChangeSet> */
     public function getDocumentChangeSet(): array
     {
-        return $this->documentChangeSet;
+        return $this->changeSet;
     }
 
     public function hasChangedField(string $field): bool
     {
-        return isset($this->documentChangeSet[$field]);
+        return isset($this->changeSet[$field]);
     }
 
     /**
@@ -49,7 +51,7 @@ final class PreUpdateEventArgs extends LifecycleEventArgs
     {
         $this->assertValidField($field);
 
-        return $this->documentChangeSet[$field][0];
+        return $this->changeSet[$field][0];
     }
 
     /**
@@ -61,7 +63,7 @@ final class PreUpdateEventArgs extends LifecycleEventArgs
     {
         $this->assertValidField($field);
 
-        return $this->documentChangeSet[$field][1];
+        return $this->changeSet[$field][1];
     }
 
     /**
@@ -73,8 +75,8 @@ final class PreUpdateEventArgs extends LifecycleEventArgs
     {
         $this->assertValidField($field);
 
-        $this->documentChangeSet[$field][1] = $value;
-        $this->getDocumentManager()->getUnitOfWork()->setDocumentChangeSet($this->getDocument(), $this->documentChangeSet);
+        $this->changeSet[$field][1] = $value;
+        $this->getDocumentManager()->getUnitOfWork()->setDocumentChangeSet($this->getDocument(), $this->changeSet);
     }
 
     /**
@@ -84,7 +86,7 @@ final class PreUpdateEventArgs extends LifecycleEventArgs
      */
     private function assertValidField(string $field): void
     {
-        if (! isset($this->documentChangeSet[$field])) {
+        if (! isset($this->changeSet[$field])) {
             throw new InvalidArgumentException(sprintf(
                 'Field "%s" is not a valid field of the document "%s" in PreUpdateEventArgs.',
                 $field,

--- a/lib/Doctrine/ODM/MongoDB/MongoDBException.php
+++ b/lib/Doctrine/ODM/MongoDB/MongoDBException.php
@@ -155,4 +155,9 @@ class MongoDBException extends Exception
     {
         return new self(sprintf('Cannot create repository for class "%s".', $className));
     }
+
+    public static function transactionalSessionMismatch(): self
+    {
+        return new self('The transactional operation cannot be executed because it was started in a different session.');
+    }
 }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -74,7 +74,14 @@ use function trigger_deprecation;
  *
  * @template T of object
  *
- * @psalm-import-type CommitOptions from UnitOfWork
+ * @psalm-type CommitOptions array{
+ *      fsync?: bool,
+ *      safe?: int,
+ *      session?: ?Session,
+ *      w?: int,
+ *      withTransaction?: bool,
+ *      writeConcern?: WriteConcern
+ * }
  * @psalm-import-type Hints from UnitOfWork
  * @psalm-import-type FieldMapping from ClassMetadata
  * @psalm-import-type SortMeta from Sort

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -3183,6 +3183,9 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * This following method was taken from the MongoDB Library and adapted to not use the default 120 seconds timeout.
      * The code within this method is licensed under the Apache License. Copyright belongs to MongoDB, Inc.
+     *
+     * @see https://github.com/mongodb/mongo-php-library/blob/1.17.0/src/Operation/WithTransaction.php
+     * @see https://github.com/mongodb/specifications/blob/master/source/transactions-convenient-api/transactions-convenient-api.rst#pseudo-code
      */
     private function withTransaction(Session $session, callable $callback, array $transactionOptions = []): void
     {

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -162,42 +162,42 @@ final class UnitOfWork implements PropertyChangedListener
      *
      * @var array<string, object>
      */
-    private array $documentInsertions = [];
+    private array $scheduledDocumentInsertions = [];
 
     /**
      * A list of all pending document updates.
      *
      * @var array<string, object>
      */
-    private array $documentUpdates = [];
+    private array $scheduledDocumentUpdates = [];
 
     /**
      * A list of all pending document upserts.
      *
      * @var array<string, object>
      */
-    private array $documentUpserts = [];
+    private array $scheduledDocumentUpserts = [];
 
     /**
      * A list of all pending document deletions.
      *
      * @var array<string, object>
      */
-    private array $documentDeletions = [];
+    private array $scheduledDocumentDeletions = [];
 
     /**
      * All pending collection deletions.
      *
      * @psalm-var array<string, PersistentCollectionInterface<array-key, object>>
      */
-    private array $collectionDeletions = [];
+    private array $scheduledCollectionDeletions = [];
 
     /**
      * All pending collection updates.
      *
      * @psalm-var array<string, PersistentCollectionInterface<array-key, object>>
      */
-    private array $collectionUpdates = [];
+    private array $scheduledCollectionUpdates = [];
 
     /**
      * A list of documents related to collections scheduled for update or deletion
@@ -418,12 +418,12 @@ final class UnitOfWork implements PropertyChangedListener
         $this->computeChangeSets();
 
         if (
-            ! ($this->documentInsertions ||
-            $this->documentUpserts ||
-            $this->documentDeletions ||
-            $this->documentUpdates ||
-            $this->collectionUpdates ||
-            $this->collectionDeletions ||
+            ! ($this->scheduledDocumentInsertions ||
+            $this->scheduledDocumentUpserts ||
+            $this->scheduledDocumentDeletions ||
+            $this->scheduledDocumentUpdates ||
+            $this->scheduledCollectionUpdates ||
+            $this->scheduledCollectionDeletions ||
             $this->orphanRemovals)
         ) {
             return; // Nothing to do.
@@ -444,22 +444,22 @@ final class UnitOfWork implements PropertyChangedListener
             // Raise onFlush
             $this->evm->dispatchEvent(Events::onFlush, new Event\OnFlushEventArgs($this->dm));
 
-            foreach ($this->getClassesForCommitAction($this->documentUpserts) as $classAndDocuments) {
+            foreach ($this->getClassesForCommitAction($this->scheduledDocumentUpserts) as $classAndDocuments) {
                 [$class, $documents] = $classAndDocuments;
                 $this->executeUpserts($class, $documents, $options);
             }
 
-            foreach ($this->getClassesForCommitAction($this->documentInsertions) as $classAndDocuments) {
+            foreach ($this->getClassesForCommitAction($this->scheduledDocumentInsertions) as $classAndDocuments) {
                 [$class, $documents] = $classAndDocuments;
                 $this->executeInserts($class, $documents, $options);
             }
 
-            foreach ($this->getClassesForCommitAction($this->documentUpdates) as $classAndDocuments) {
+            foreach ($this->getClassesForCommitAction($this->scheduledDocumentUpdates) as $classAndDocuments) {
                 [$class, $documents] = $classAndDocuments;
                 $this->executeUpdates($class, $documents, $options);
             }
 
-            foreach ($this->getClassesForCommitAction($this->documentDeletions, true) as $classAndDocuments) {
+            foreach ($this->getClassesForCommitAction($this->scheduledDocumentDeletions, true) as $classAndDocuments) {
                 [$class, $documents] = $classAndDocuments;
                 $this->executeDeletions($class, $documents, $options);
             }
@@ -468,17 +468,17 @@ final class UnitOfWork implements PropertyChangedListener
             $this->evm->dispatchEvent(Events::postFlush, new Event\PostFlushEventArgs($this->dm));
 
             // Clear up
-            $this->documentInsertions          =
-            $this->documentUpserts             =
-            $this->documentUpdates             =
-            $this->documentDeletions           =
-            $this->documentChangeSets          =
-            $this->collectionUpdates           =
-            $this->collectionDeletions         =
-            $this->visitedCollections          =
-            $this->scheduledForSynchronization =
-            $this->orphanRemovals              =
-            $this->hasScheduledCollections     = [];
+            $this->scheduledDocumentInsertions  =
+            $this->scheduledDocumentUpserts     =
+            $this->scheduledDocumentUpdates     =
+            $this->scheduledDocumentDeletions   =
+            $this->documentChangeSets           =
+            $this->scheduledCollectionUpdates   =
+            $this->scheduledCollectionDeletions =
+            $this->visitedCollections           =
+            $this->scheduledForSynchronization  =
+            $this->orphanRemovals               =
+            $this->hasScheduledCollections      = [];
         } finally {
             $this->commitsInProgress--;
         }
@@ -537,7 +537,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     private function computeScheduleInsertsChangeSets(): void
     {
-        foreach ($this->documentInsertions as $document) {
+        foreach ($this->scheduledDocumentInsertions as $document) {
             $class = $this->dm->getClassMetadata($document::class);
             if ($class->isEmbeddedDocument || $class->isView()) {
                 continue;
@@ -554,7 +554,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     private function computeScheduleUpsertsChangeSets(): void
     {
-        foreach ($this->documentUpserts as $document) {
+        foreach ($this->scheduledDocumentUpserts as $document) {
             $class = $this->dm->getClassMetadata($document::class);
             if ($class->isEmbeddedDocument || $class->isView()) {
                 continue;
@@ -647,7 +647,7 @@ final class UnitOfWork implements PropertyChangedListener
      * entry is the new value of the property. Changesets are used by persisters
      * to INSERT/UPDATE the persistent document state.
      *
-     * {@link documentUpdates}
+     * {@link scheduledDocumentUpdates}
      * If the document is already fully MANAGED (has been fetched from the database before)
      * and any changes to its properties are detected, then a reference to the document is stored
      * there to mark it for an update.
@@ -930,9 +930,9 @@ final class UnitOfWork implements PropertyChangedListener
                 // Only MANAGED documents that are NOT SCHEDULED FOR INSERTION, UPSERT OR DELETION are processed here.
                 $oid = spl_object_hash($document);
                 if (
-                    isset($this->documentInsertions[$oid])
-                    || isset($this->documentUpserts[$oid])
-                    || isset($this->documentDeletions[$oid])
+                    isset($this->scheduledDocumentInsertions[$oid])
+                    || isset($this->scheduledDocumentUpserts[$oid])
+                    || isset($this->scheduledDocumentDeletions[$oid])
                     || ! isset($this->documentStates[$oid])
                 ) {
                     continue;
@@ -953,7 +953,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     private function computeAssociationChanges(object $parentDocument, array $assoc, $value): void
     {
-        $isNewParentDocument   = isset($this->documentInsertions[spl_object_hash($parentDocument)]);
+        $isNewParentDocument   = isset($this->scheduledDocumentInsertions[spl_object_hash($parentDocument)]);
         $class                 = $this->dm->getClassMetadata($parentDocument::class);
         $topOrExistingDocument = ( ! $isNewParentDocument || ! $class->isEmbeddedDocument);
 
@@ -1161,9 +1161,8 @@ final class UnitOfWork implements PropertyChangedListener
     {
         $persister = $this->getDocumentPersister($class->name);
 
-        foreach ($documents as $oid => $document) {
+        foreach ($documents as $document) {
             $persister->addInsert($document);
-            unset($this->documentInsertions[$oid]);
         }
 
         $persister->executeInserts($options);
@@ -1186,9 +1185,8 @@ final class UnitOfWork implements PropertyChangedListener
     {
         $persister = $this->getDocumentPersister($class->name);
 
-        foreach ($documents as $oid => $document) {
+        foreach ($documents as $document) {
             $persister->addUpsert($document);
-            unset($this->documentUpserts[$oid]);
         }
 
         $persister->executeUpserts($options);
@@ -1223,8 +1221,6 @@ final class UnitOfWork implements PropertyChangedListener
                 $persister->update($document, $options);
             }
 
-            unset($this->documentUpdates[$oid]);
-
             $this->lifecycleEventManager->postUpdate($class, $document);
         }
     }
@@ -1248,7 +1244,6 @@ final class UnitOfWork implements PropertyChangedListener
             }
 
             unset(
-                $this->documentDeletions[$oid],
                 $this->documentIdentifiers[$oid],
                 $this->originalDocumentData[$oid],
             );
@@ -1267,10 +1262,6 @@ final class UnitOfWork implements PropertyChangedListener
 
                 $value->clearSnapshot();
             }
-
-            // Document with this $oid after deletion treated as NEW, even if the $oid
-            // is obtained by a new document because the old one went out of scope.
-            $this->documentStates[$oid] = self::STATE_NEW;
 
             $this->lifecycleEventManager->postRemove($class, $document);
         }
@@ -1294,19 +1285,19 @@ final class UnitOfWork implements PropertyChangedListener
     {
         $oid = spl_object_hash($document);
 
-        if (isset($this->documentUpdates[$oid])) {
+        if (isset($this->scheduledDocumentUpdates[$oid])) {
             throw new InvalidArgumentException('Dirty document can not be scheduled for insertion.');
         }
 
-        if (isset($this->documentDeletions[$oid])) {
+        if (isset($this->scheduledDocumentDeletions[$oid])) {
             throw new InvalidArgumentException('Removed document can not be scheduled for insertion.');
         }
 
-        if (isset($this->documentInsertions[$oid])) {
+        if (isset($this->scheduledDocumentInsertions[$oid])) {
             throw new InvalidArgumentException('Document can not be scheduled for insertion twice.');
         }
 
-        $this->documentInsertions[$oid] = $document;
+        $this->scheduledDocumentInsertions[$oid] = $document;
 
         if (! isset($this->documentIdentifiers[$oid])) {
             return;
@@ -1336,20 +1327,20 @@ final class UnitOfWork implements PropertyChangedListener
             throw new InvalidArgumentException('Embedded document can not be scheduled for upsert.');
         }
 
-        if (isset($this->documentUpdates[$oid])) {
+        if (isset($this->scheduledDocumentUpdates[$oid])) {
             throw new InvalidArgumentException('Dirty document can not be scheduled for upsert.');
         }
 
-        if (isset($this->documentDeletions[$oid])) {
+        if (isset($this->scheduledDocumentDeletions[$oid])) {
             throw new InvalidArgumentException('Removed document can not be scheduled for upsert.');
         }
 
-        if (isset($this->documentUpserts[$oid])) {
+        if (isset($this->scheduledDocumentUpserts[$oid])) {
             throw new InvalidArgumentException('Document can not be scheduled for upsert twice.');
         }
 
-        $this->documentUpserts[$oid]     = $document;
-        $this->documentIdentifiers[$oid] = $class->getIdentifierValue($document);
+        $this->scheduledDocumentUpserts[$oid] = $document;
+        $this->documentIdentifiers[$oid]      = $class->getIdentifierValue($document);
         $this->addToIdentityMap($document);
     }
 
@@ -1358,7 +1349,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function isScheduledForInsert(object $document): bool
     {
-        return isset($this->documentInsertions[spl_object_hash($document)]);
+        return isset($this->scheduledDocumentInsertions[spl_object_hash($document)]);
     }
 
     /**
@@ -1366,7 +1357,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function isScheduledForUpsert(object $document): bool
     {
-        return isset($this->documentUpserts[spl_object_hash($document)]);
+        return isset($this->scheduledDocumentUpserts[spl_object_hash($document)]);
     }
 
     /**
@@ -1383,19 +1374,19 @@ final class UnitOfWork implements PropertyChangedListener
             throw new InvalidArgumentException('Document has no identity.');
         }
 
-        if (isset($this->documentDeletions[$oid])) {
+        if (isset($this->scheduledDocumentDeletions[$oid])) {
             throw new InvalidArgumentException('Document is removed.');
         }
 
         if (
-            isset($this->documentUpdates[$oid])
-            || isset($this->documentInsertions[$oid])
-            || isset($this->documentUpserts[$oid])
+            isset($this->scheduledDocumentUpdates[$oid])
+            || isset($this->scheduledDocumentInsertions[$oid])
+            || isset($this->scheduledDocumentUpserts[$oid])
         ) {
             return;
         }
 
-        $this->documentUpdates[$oid] = $document;
+        $this->scheduledDocumentUpdates[$oid] = $document;
     }
 
     /**
@@ -1405,7 +1396,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function isScheduledForUpdate(object $document): bool
     {
-        return isset($this->documentUpdates[spl_object_hash($document)]);
+        return isset($this->scheduledDocumentUpdates[spl_object_hash($document)]);
     }
 
     /**
@@ -1427,12 +1418,12 @@ final class UnitOfWork implements PropertyChangedListener
     {
         $oid = spl_object_hash($document);
 
-        if (isset($this->documentInsertions[$oid])) {
+        if (isset($this->scheduledDocumentInsertions[$oid])) {
             if ($this->isInIdentityMap($document)) {
                 $this->removeFromIdentityMap($document);
             }
 
-            unset($this->documentInsertions[$oid]);
+            unset($this->scheduledDocumentInsertions[$oid]);
 
             return; // document has not been persisted yet, so nothing more to do.
         }
@@ -1444,15 +1435,15 @@ final class UnitOfWork implements PropertyChangedListener
         $this->removeFromIdentityMap($document);
         $this->documentStates[$oid] = self::STATE_REMOVED;
 
-        if (isset($this->documentUpdates[$oid])) {
-            unset($this->documentUpdates[$oid]);
+        if (isset($this->scheduledDocumentUpdates[$oid])) {
+            unset($this->scheduledDocumentUpdates[$oid]);
         }
 
-        if (isset($this->documentUpserts[$oid])) {
-            unset($this->documentUpserts[$oid]);
+        if (isset($this->scheduledDocumentUpserts[$oid])) {
+            unset($this->scheduledDocumentUpserts[$oid]);
         }
 
-        if (isset($this->documentDeletions[$oid])) {
+        if (isset($this->scheduledDocumentDeletions[$oid])) {
             return;
         }
 
@@ -1460,7 +1451,7 @@ final class UnitOfWork implements PropertyChangedListener
             return;
         }
 
-        $this->documentDeletions[$oid] = $document;
+        $this->scheduledDocumentDeletions[$oid] = $document;
     }
 
     /**
@@ -1469,7 +1460,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function isScheduledForDelete(object $document): bool
     {
-        return isset($this->documentDeletions[spl_object_hash($document)]);
+        return isset($this->scheduledDocumentDeletions[spl_object_hash($document)]);
     }
 
     /**
@@ -1481,10 +1472,10 @@ final class UnitOfWork implements PropertyChangedListener
     {
         $oid = spl_object_hash($document);
 
-        return isset($this->documentInsertions[$oid]) ||
-            isset($this->documentUpserts[$oid]) ||
-            isset($this->documentUpdates[$oid]) ||
-            isset($this->documentDeletions[$oid]);
+        return isset($this->scheduledDocumentInsertions[$oid]) ||
+            isset($this->scheduledDocumentUpserts[$oid]) ||
+            isset($this->scheduledDocumentUpdates[$oid]) ||
+            isset($this->scheduledDocumentDeletions[$oid]);
     }
 
     /**
@@ -1781,7 +1772,7 @@ final class UnitOfWork implements PropertyChangedListener
 
             case self::STATE_REMOVED:
                 // Document becomes managed again
-                unset($this->documentDeletions[$oid]);
+                unset($this->scheduledDocumentDeletions[$oid]);
 
                 $this->documentStates[$oid] = self::STATE_MANAGED;
                 break;
@@ -2094,14 +2085,14 @@ final class UnitOfWork implements PropertyChangedListener
             case self::STATE_MANAGED:
                 $this->removeFromIdentityMap($document);
                 unset(
-                    $this->documentInsertions[$oid],
-                    $this->documentUpdates[$oid],
-                    $this->documentDeletions[$oid],
+                    $this->scheduledDocumentInsertions[$oid],
+                    $this->scheduledDocumentUpdates[$oid],
+                    $this->scheduledDocumentDeletions[$oid],
                     $this->documentIdentifiers[$oid],
                     $this->documentStates[$oid],
                     $this->originalDocumentData[$oid],
                     $this->parentAssociations[$oid],
-                    $this->documentUpserts[$oid],
+                    $this->scheduledDocumentUpserts[$oid],
                     $this->hasScheduledCollections[$oid],
                     $this->embeddedDocumentsRegistry[$oid],
                 );
@@ -2392,22 +2383,22 @@ final class UnitOfWork implements PropertyChangedListener
     public function clear(?string $documentName = null): void
     {
         if ($documentName === null) {
-            $this->identityMap                 =
-            $this->documentIdentifiers         =
-            $this->originalDocumentData        =
-            $this->documentChangeSets          =
-            $this->documentStates              =
-            $this->scheduledForSynchronization =
-            $this->documentInsertions          =
-            $this->documentUpserts             =
-            $this->documentUpdates             =
-            $this->documentDeletions           =
-            $this->collectionUpdates           =
-            $this->collectionDeletions         =
-            $this->parentAssociations          =
-            $this->embeddedDocumentsRegistry   =
-            $this->orphanRemovals              =
-            $this->hasScheduledCollections     = [];
+            $this->identityMap                  =
+            $this->documentIdentifiers          =
+            $this->originalDocumentData         =
+            $this->documentChangeSets           =
+            $this->documentStates               =
+            $this->scheduledForSynchronization  =
+            $this->scheduledDocumentInsertions  =
+            $this->scheduledDocumentUpserts     =
+            $this->scheduledDocumentUpdates     =
+            $this->scheduledDocumentDeletions   =
+            $this->scheduledCollectionUpdates   =
+            $this->scheduledCollectionDeletions =
+            $this->parentAssociations           =
+            $this->embeddedDocumentsRegistry    =
+            $this->orphanRemovals               =
+            $this->hasScheduledCollections      = [];
 
             $event = new Event\OnClearEventArgs($this->dm);
         } else {
@@ -2497,12 +2488,12 @@ final class UnitOfWork implements PropertyChangedListener
     public function scheduleCollectionDeletion(PersistentCollectionInterface $coll): void
     {
         $oid = spl_object_hash($coll);
-        unset($this->collectionUpdates[$oid]);
-        if (isset($this->collectionDeletions[$oid])) {
+        unset($this->scheduledCollectionUpdates[$oid]);
+        if (isset($this->scheduledCollectionDeletions[$oid])) {
             return;
         }
 
-        $this->collectionDeletions[$oid] = $coll;
+        $this->scheduledCollectionDeletions[$oid] = $coll;
         $this->scheduleCollectionOwner($coll);
     }
 
@@ -2515,7 +2506,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function isCollectionScheduledForDeletion(PersistentCollectionInterface $coll): bool
     {
-        return isset($this->collectionDeletions[spl_object_hash($coll)]);
+        return isset($this->scheduledCollectionDeletions[spl_object_hash($coll)]);
     }
 
     /**
@@ -2532,12 +2523,12 @@ final class UnitOfWork implements PropertyChangedListener
         }
 
         $oid = spl_object_hash($coll);
-        if (! isset($this->collectionDeletions[$oid])) {
+        if (! isset($this->scheduledCollectionDeletions[$oid])) {
             return;
         }
 
         $topmostOwner = $this->getOwningDocument($coll->getOwner());
-        unset($this->collectionDeletions[$oid]);
+        unset($this->scheduledCollectionDeletions[$oid]);
         unset($this->hasScheduledCollections[spl_object_hash($topmostOwner)][$oid]);
     }
 
@@ -2559,11 +2550,11 @@ final class UnitOfWork implements PropertyChangedListener
         }
 
         $oid = spl_object_hash($coll);
-        if (isset($this->collectionUpdates[$oid])) {
+        if (isset($this->scheduledCollectionUpdates[$oid])) {
             return;
         }
 
-        $this->collectionUpdates[$oid] = $coll;
+        $this->scheduledCollectionUpdates[$oid] = $coll;
         $this->scheduleCollectionOwner($coll);
     }
 
@@ -2581,12 +2572,12 @@ final class UnitOfWork implements PropertyChangedListener
         }
 
         $oid = spl_object_hash($coll);
-        if (! isset($this->collectionUpdates[$oid])) {
+        if (! isset($this->scheduledCollectionUpdates[$oid])) {
             return;
         }
 
         $topmostOwner = $this->getOwningDocument($coll->getOwner());
-        unset($this->collectionUpdates[$oid]);
+        unset($this->scheduledCollectionUpdates[$oid]);
         unset($this->hasScheduledCollections[spl_object_hash($topmostOwner)][$oid]);
     }
 
@@ -2599,7 +2590,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function isCollectionScheduledForUpdate(PersistentCollectionInterface $coll): bool
     {
-        return isset($this->collectionUpdates[spl_object_hash($coll)]);
+        return isset($this->scheduledCollectionUpdates[spl_object_hash($coll)]);
     }
 
     /**
@@ -2939,7 +2930,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function hasPendingInsertions(): bool
     {
-        return ! empty($this->documentInsertions);
+        return ! empty($this->scheduledDocumentInsertions);
     }
 
     /**
@@ -3034,7 +3025,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function getScheduledDocumentInsertions(): array
     {
-        return $this->documentInsertions;
+        return $this->scheduledDocumentInsertions;
     }
 
     /**
@@ -3044,7 +3035,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function getScheduledDocumentUpserts(): array
     {
-        return $this->documentUpserts;
+        return $this->scheduledDocumentUpserts;
     }
 
     /**
@@ -3054,7 +3045,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function getScheduledDocumentUpdates(): array
     {
-        return $this->documentUpdates;
+        return $this->scheduledDocumentUpdates;
     }
 
     /**
@@ -3064,7 +3055,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function getScheduledDocumentDeletions(): array
     {
-        return $this->documentDeletions;
+        return $this->scheduledDocumentDeletions;
     }
 
     /**
@@ -3076,7 +3067,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function getScheduledCollectionDeletions(): array
     {
-        return $this->collectionDeletions;
+        return $this->scheduledCollectionDeletions;
     }
 
     /**
@@ -3088,7 +3079,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function getScheduledCollectionUpdates(): array
     {
-        return $this->collectionUpdates;
+        return $this->scheduledCollectionUpdates;
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -25,10 +25,12 @@ use Doctrine\Persistence\NotifyPropertyChanged;
 use Doctrine\Persistence\PropertyChangedListener;
 use InvalidArgumentException;
 use MongoDB\BSON\UTCDateTime;
+use MongoDB\Driver\Exception\RuntimeException;
 use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
 use ProxyManager\Proxy\GhostObjectInterface;
 use ReflectionProperty;
+use Throwable;
 use UnexpectedValueException;
 
 use function array_diff_key;
@@ -37,13 +39,13 @@ use function array_intersect_key;
 use function array_key_exists;
 use function array_merge;
 use function assert;
+use function call_user_func;
 use function count;
 use function get_class;
 use function in_array;
 use function is_array;
 use function is_object;
 use function method_exists;
-use function MongoDB\with_transaction;
 use function preg_match;
 use function serialize;
 use function spl_object_hash;
@@ -460,7 +462,7 @@ final class UnitOfWork implements PropertyChangedListener
 
                 $this->lifecycleEventManager->enableTransactionalMode($session);
 
-                with_transaction(
+                $this->withTransaction(
                     $session,
                     function (Session $session) use ($options): void {
                         $this->doCommit(['session' => $session] + $this->stripTransactionOptions($options));
@@ -3176,5 +3178,78 @@ final class UnitOfWork implements PropertyChangedListener
             ),
             self::TRANSACTION_OPTIONS,
         );
+    }
+
+    /**
+     * This following method was taken from the MongoDB Library and adapted to not use the default 120 seconds timeout.
+     * The code within this method is licensed under the Apache License. Copyright belongs to MongoDB, Inc.
+     */
+    private function withTransaction(Session $session, callable $callback, array $transactionOptions = []): void
+    {
+        $numAttempts = 0;
+
+        while (true) {
+            $session->startTransaction($transactionOptions);
+
+            try {
+                $numAttempts++;
+                call_user_func($callback, $session);
+            } catch (Throwable $e) {
+                if ($session->isInTransaction()) {
+                    $session->abortTransaction();
+                }
+
+                if (
+                    $e instanceof RuntimeException &&
+                    $e->hasErrorLabel('TransientTransactionError') &&
+                    ! $this->shouldAbortWithTransaction($numAttempts)
+                ) {
+                    continue;
+                }
+
+                throw $e;
+            }
+
+            if (! $session->isInTransaction()) {
+                // Assume callback intentionally ended the transaction
+                return;
+            }
+
+            while (true) {
+                try {
+                    $session->commitTransaction();
+                } catch (RuntimeException $e) {
+                    if (
+                        $e->getCode() !== 50 /* MaxTimeMSExpired */ &&
+                        $e->hasErrorLabel('UnknownTransactionCommitResult') &&
+                        ! $this->shouldAbortWithTransaction($numAttempts)
+                    ) {
+                        // Retry committing the transaction
+                        continue;
+                    }
+
+                    if (
+                        $e->hasErrorLabel('TransientTransactionError') &&
+                        ! $this->shouldAbortWithTransaction($numAttempts)
+                    ) {
+                        // Restart the transaction, invoking the callback again
+                        continue 2;
+                    }
+
+                    throw $e;
+                }
+
+                // Commit was successful
+                break;
+            }
+
+            // Transaction was successful
+            break;
+        }
+    }
+
+    private function shouldAbortWithTransaction(int $numAttempts): bool
+    {
+        return $numAttempts >= 2;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
+++ b/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
@@ -188,8 +188,8 @@ final class LifecycleEventManager
             return;
         }
 
-        $eventArgs = new PreUpdateEventArgs($document, $this->dm, $this->uow->getDocumentChangeSet($document), $session);
         if (! empty($class->lifecycleCallbacks[Events::preUpdate])) {
+            $eventArgs = new PreUpdateEventArgs($document, $this->dm, $this->uow->getDocumentChangeSet($document), $session);
             $class->invokeLifecycleCallbacks(Events::preUpdate, $document, [$eventArgs]);
             $this->uow->recomputeSingleDocumentChangeSet($class, $document);
         }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -621,6 +621,11 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/UnitOfWork.php
 
 		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\UnitOfWork\\:\\:withTransaction\\(\\) has parameter \\$transactionOptions with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+
+		-
 			message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getClassMetadata\\(\\)$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/UnitOfWork.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -546,6 +546,11 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
 		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Persisters\\\\DocumentPersister\\:\\:isInTransaction\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+
+		-
 			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Proxy\\\\Factory\\\\StaticProxyFactory\\:\\:createInitializer\\(\\) should return Closure\\(ProxyManager\\\\Proxy\\\\GhostObjectInterface\\<TDocument\\>&TDocument\\=, string\\=, array\\<string, mixed\\>\\=, Closure\\|null\\=, array\\<string, mixed\\>\\=\\)\\: bool but returns Closure\\(ProxyManager\\\\Proxy\\\\GhostObjectInterface, string, array, mixed, array\\)\\: true\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Proxy/Factory/StaticProxyFactory.php
@@ -599,6 +604,21 @@ parameters:
 			message: "#^Unsafe call to private method Doctrine\\\\ODM\\\\MongoDB\\\\Types\\\\DateType\\:\\:craftDateTime\\(\\) through static\\:\\:\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Types/DateType.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\UnitOfWork\\:\\:getTransactionOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\UnitOfWork\\:\\:stripTransactionOptions\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\UnitOfWork\\:\\:stripTransactionOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/UnitOfWork.php
 
 		-
 			message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getClassMetadata\\(\\)$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.18.0@b113f3ed0259fd6e212d87c3df80eec95a6abf19">
+<files psalm-version="5.20.0@3f284e96c9d9be6fe6b15c79416e1d1903dcfef4">
   <file src="lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php">
     <MissingTemplateParam>
       <code>IteratorAggregate</code>
@@ -301,6 +301,9 @@
     <NullableReturnStatement>
       <code><![CDATA[$mapping['targetDocument']]]></code>
     </NullableReturnStatement>
+    <TypeDoesNotContainType>
+      <code><![CDATA[empty($divided[$class->name])]]></code>
+    </TypeDoesNotContainType>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/OperatorTest.php">
     <InternalClass>
@@ -489,6 +492,9 @@
     <InvalidArgument>
       <code>$options + $expectedWriteOptions</code>
     </InvalidArgument>
+    <TypeDoesNotContainType>
+      <code>empty($dbCommands[$databaseName])</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Types/DateImmutableTypeTest.php">
     <TypeDoesNotContainType>

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
@@ -16,10 +16,17 @@ use PHPUnit\Framework\TestCase;
 
 use function array_key_exists;
 use function array_map;
+use function count;
+use function explode;
 use function getenv;
+use function implode;
 use function in_array;
 use function iterator_to_array;
+use function parse_url;
 use function preg_match;
+use function strlen;
+use function strpos;
+use function substr_replace;
 use function version_compare;
 
 use const DOCTRINE_MONGODB_DATABASE;
@@ -108,7 +115,7 @@ abstract class BaseTestCase extends TestCase
     protected static function createTestDocumentManager(): DocumentManager
     {
         $config = static::getConfiguration();
-        $client = new Client(getenv('DOCTRINE_MONGODB_SERVER') ?: DOCTRINE_MONGODB_SERVER);
+        $client = new Client(self::getUri());
 
         return DocumentManager::create($client, $config);
     }
@@ -161,5 +168,44 @@ abstract class BaseTestCase extends TestCase
     protected function requireMongoDB42(string $message): void
     {
         $this->requireVersion($this->getServerVersion(), '4.2.0', '<', $message);
+    }
+
+    protected static function getUri(bool $useMultipleMongoses = true): string
+    {
+        $uri = getenv('DOCTRINE_MONGODB_SERVER') ?: DOCTRINE_MONGODB_SERVER;
+
+        return $useMultipleMongoses ? $uri : self::removeMultipleHosts($uri);
+    }
+
+    /**
+     * Removes any hosts beyond the first in a URI. This function should only be
+     * used with a sharded cluster URI, but that is not enforced.
+     */
+    protected static function removeMultipleHosts(string $uri): string
+    {
+        $parts = parse_url($uri);
+
+        self::assertIsArray($parts);
+
+        $hosts = explode(',', $parts['host']);
+
+        // Nothing to do if the URI already has a single mongos host
+        if (count($hosts) === 1) {
+            return $uri;
+        }
+
+        // Re-append port to last host
+        if (isset($parts['port'])) {
+            $hosts[count($hosts) - 1] .= ':' . $parts['port'];
+        }
+
+        $singleHost    = $hosts[0];
+        $multipleHosts = implode(',', $hosts);
+
+        $pos = strpos($uri, $multipleHosts);
+
+        self::assertNotFalse($pos);
+
+        return substr_replace($uri, $singleHost, $pos, strlen($multipleHosts));
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
@@ -27,4 +27,17 @@ class ConfigurationTest extends BaseTestCase
         self::assertInstanceOf(PersistentCollectionGenerator::class, $generator);
         self::assertSame($generator, $c->getPersistentCollectionGenerator());
     }
+
+    public function testEnableTransactionalFlush(): void
+    {
+        $c = new Configuration();
+
+        self::assertFalse($c->isTransactionalFlushEnabled(), 'Transactional flush is disabled by default');
+
+        $c->setUseTransactionalFlush(true);
+        self::assertTrue($c->isTransactionalFlushEnabled(), 'Transactional flush is enabled after setTransactionalFlush(true)');
+
+        $c->setUseTransactionalFlush(false);
+        self::assertFalse($c->isTransactionalFlushEnabled(), 'Transactional flush is disabled after setTransactionalFlush(false)');
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/TransactionalLifecycleEventsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/TransactionalLifecycleEventsTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Events;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Event;
+use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use MongoDB\Client;
+use MongoDB\Driver\Session;
+use PHPUnit\Framework\Assert;
+
+class TransactionalLifecycleEventsTest extends BaseTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skipTestIfTransactionalFlushDisabled();
+    }
+
+    public function tearDown(): void
+    {
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => 'off',
+        ]);
+
+        parent::tearDown();
+    }
+
+    public function testPersistEvents(): void
+    {
+        $root       = new RootEventDocument();
+        $root->name = 'root';
+
+        $root->embedded       = new EmbeddedEventDocument();
+        $root->embedded->name = 'embedded';
+
+        $this->createFailPoint('insert');
+
+        $this->dm->persist($root);
+        $this->dm->flush();
+
+        $this->assertSame(1, $root->postPersist);
+        $this->assertSame(1, $root->embedded->postPersist);
+    }
+
+    public function testUpdateEvents(): void
+    {
+        $root       = new RootEventDocument();
+        $root->name = 'root';
+
+        $root->embedded       = new EmbeddedEventDocument();
+        $root->embedded->name = 'embedded';
+
+        $this->dm->persist($root);
+        $this->dm->flush();
+
+        $this->createFailPoint('update');
+
+        $root->name           = 'updated';
+        $root->embedded->name = 'updated';
+
+        $this->dm->flush();
+
+        $this->assertSame(1, $root->preUpdate);
+        $this->assertSame(1, $root->postUpdate);
+        $this->assertSame(1, $root->embedded->preUpdate);
+        $this->assertSame(1, $root->embedded->postUpdate);
+    }
+
+    public function testUpdateEventsRootOnly(): void
+    {
+        $root       = new RootEventDocument();
+        $root->name = 'root';
+
+        $root->embedded       = new EmbeddedEventDocument();
+        $root->embedded->name = 'embedded';
+
+        $this->dm->persist($root);
+        $this->dm->flush();
+
+        $this->createFailPoint('update');
+
+        $root->name = 'updated';
+
+        $this->dm->flush();
+
+        $this->assertSame(1, $root->preUpdate);
+        $this->assertSame(1, $root->postUpdate);
+        $this->assertSame(0, $root->embedded->preUpdate);
+        $this->assertSame(0, $root->embedded->postUpdate);
+    }
+
+    public function testUpdateEventsEmbeddedOnly(): void
+    {
+        $root       = new RootEventDocument();
+        $root->name = 'root';
+
+        $root->embedded       = new EmbeddedEventDocument();
+        $root->embedded->name = 'embedded';
+
+        $this->dm->persist($root);
+        $this->dm->flush();
+
+        $this->createFailPoint('update');
+
+        $root->embedded->name = 'updated';
+
+        $this->dm->flush();
+
+        $this->assertSame(1, $root->preUpdate);
+        $this->assertSame(1, $root->postUpdate);
+
+        $this->assertSame(1, $root->embedded->preUpdate);
+        $this->assertSame(1, $root->embedded->postUpdate);
+    }
+
+    public function testUpdateEventsWithNewEmbeddedDocument(): void
+    {
+        $firstEmbedded       = new EmbeddedEventDocument();
+        $firstEmbedded->name = 'embedded';
+
+        $secondEmbedded       = new EmbeddedEventDocument();
+        $secondEmbedded->name = 'new';
+
+        $root           = new RootEventDocument();
+        $root->name     = 'root';
+        $root->embedded = $firstEmbedded;
+
+        $this->dm->persist($root);
+        $this->dm->flush();
+
+        $this->createFailPoint('update');
+
+        $root->name     = 'updated';
+        $root->embedded = $secondEmbedded;
+
+        $this->dm->flush();
+
+        $this->assertSame(1, $root->preUpdate);
+        $this->assertSame(1, $root->postUpdate);
+
+        // First embedded document was removed but not updated
+        $this->assertSame(1, $firstEmbedded->postRemove);
+        $this->assertSame(0, $firstEmbedded->preUpdate);
+        $this->assertSame(0, $firstEmbedded->postUpdate);
+
+        // Second embedded document was persisted but not updated
+        $this->assertSame(1, $secondEmbedded->postPersist);
+        $this->assertSame(0, $secondEmbedded->preUpdate);
+        $this->assertSame(0, $secondEmbedded->postUpdate);
+    }
+
+    public function testRemoveEvents(): void
+    {
+        $root       = new RootEventDocument();
+        $root->name = 'root';
+
+        $root->embedded       = new EmbeddedEventDocument();
+        $root->embedded->name = 'embedded';
+
+        $this->dm->persist($root);
+        $this->dm->flush();
+
+        $this->createFailPoint('delete');
+
+        $this->dm->remove($root);
+        $this->dm->flush();
+
+        $this->assertSame(1, $root->postRemove);
+        $this->assertSame(1, $root->embedded->postRemove);
+    }
+
+    /** Create a document manager with a single host to ensure failpoints target the correct server */
+    protected static function createTestDocumentManager(): DocumentManager
+    {
+        $config = static::getConfiguration();
+        $client = new Client(self::getUri(false), [], ['typeMap' => ['root' => 'array', 'document' => 'array']]);
+
+        return DocumentManager::create($client, $config);
+    }
+
+    private function createFailPoint(string $failCommand): void
+    {
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => ['times' => 1],
+            'data' => [
+                'errorCode' => 192, // FailPointEnabled
+                'errorLabels' => ['TransientTransactionError'],
+                'failCommands' => [$failCommand],
+            ],
+        ]);
+    }
+}
+
+/**
+ * @ODM\MappedSuperclass
+ * @ODM\HasLifecycleCallbacks
+ */
+abstract class BaseEventDocument
+{
+    public function __construct()
+    {
+    }
+
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @var string|null
+     */
+    public $name;
+
+    public int $preUpdate = 0;
+
+    public int $postPersist = 0;
+
+    public int $postUpdate = 0;
+
+    public int $postRemove = 0;
+
+    /** @ODM\PreUpdate */
+    public function preUpdate(Event\PreUpdateEventArgs $e): void
+    {
+        $this->assertTransactionState($e);
+        $this->preUpdate++;
+    }
+
+    /** @ODM\PostPersist */
+    public function postPersist(Event\LifecycleEventArgs $e): void
+    {
+        $this->assertTransactionState($e);
+        $this->postPersist++;
+    }
+
+    /** @ODM\PostUpdate */
+    public function postUpdate(Event\LifecycleEventArgs $e): void
+    {
+        $this->assertTransactionState($e);
+        $this->postUpdate++;
+    }
+
+    /** @ODM\PostRemove */
+    public function postRemove(Event\LifecycleEventArgs $e): void
+    {
+        $this->assertTransactionState($e);
+        $this->postRemove++;
+    }
+
+    private function assertTransactionState(LifecycleEventArgs $e): void
+    {
+        Assert::assertTrue($e->isInTransaction());
+        Assert::assertInstanceOf(Session::class, $e->session);
+    }
+}
+
+/** @ODM\EmbeddedDocument */
+class EmbeddedEventDocument extends BaseEventDocument
+{
+}
+
+/** @ODM\Document  */
+class RootEventDocument extends BaseEventDocument
+{
+    /** @ODM\Id */
+    public string $id;
+
+    /** @ODM\EmbedOne(targetDocument=EmbeddedEventDocument::class) */
+    public ?EmbeddedEventDocument $embedded;
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
@@ -25,6 +25,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
  */
 class AtomicSetTest extends BaseTestCase
 {
+    // This test counts executed commands and thus doesn't work with transactions
+    protected static bool $allowsTransactions = false;
+
     private CommandLogger $logger;
 
     public function setUp(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -15,6 +15,9 @@ use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 class CollectionPersisterTest extends BaseTestCase
 {
+    // This test counts executed commands and thus doesn't work with transactions
+    protected static bool $allowsTransactions = false;
+
     private CommandLogger $logger;
 
     public function setUp(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CommitImprovementTest.php
@@ -18,6 +18,9 @@ use Documents\VersionedUser;
 
 class CommitImprovementTest extends BaseTestCase
 {
+    // This test counts executed commands and thus doesn't work with transactions
+    protected static bool $allowsTransactions = false;
+
     private CommandLogger $logger;
 
     public function setUp(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
@@ -389,7 +389,9 @@ class ReferencePrimerTest extends BaseTestCase
             $invokedArgs[] = func_get_args();
         };
 
-        $readPreference = new ReadPreference(ReadPreference::RP_SECONDARY_PREFERRED);
+        // Note: using a secondary read preference here can cause issues when using transactions
+        // Using a primaryPreferred works just as well to check if the hint is passed on to the primer
+        $readPreference = new ReadPreference(ReadPreference::RP_PRIMARY_PREFERRED);
         $this->dm->createQueryBuilder(User::class)
             ->field('account')->prime($primer)
             ->field('groups')->prime($primer)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1138Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1138Test.php
@@ -12,6 +12,9 @@ use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
 class GH1138Test extends BaseTestCase
 {
+    // This test counts executed commands and thus doesn't work with transactions
+    protected static bool $allowsTransactions = false;
+
     private CommandLogger $logger;
 
     public function setUp(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
@@ -1,0 +1,458 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Documents\Address;
+use Documents\ForumUser;
+use Documents\FriendUser;
+use Documents\User;
+use MongoDB\BSON\ObjectId;
+use MongoDB\Client;
+use Throwable;
+
+class UnitOfWorkCommitConsistencyTest extends BaseTestCase
+{
+    public function tearDown(): void
+    {
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => 'off',
+        ]);
+
+        parent::tearDown();
+    }
+
+    public function testInsertErrorKeepsFailingInsertions(): void
+    {
+        $firstUser           = new ForumUser();
+        $firstUser->username = 'alcaeus';
+        $this->uow->persist($firstUser);
+
+        $secondUser           = new ForumUser();
+        $secondUser->username = 'jmikola';
+        $this->uow->persist($secondUser);
+
+        $friendUser = new FriendUser('GromNaN');
+        $this->uow->persist($friendUser);
+
+        // Add failpoint to let the first insert command fail. This affects the ForumUser documents
+        $this->createFailpoint('insert');
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        self::assertSame(
+            0,
+            $this->dm->getDocumentCollection(ForumUser::class)->countDocuments(),
+        );
+
+        self::assertTrue($this->uow->isScheduledForInsert($firstUser));
+        self::assertNotEquals([], $this->uow->getDocumentChangeSet($firstUser));
+
+        self::assertTrue($this->uow->isScheduledForInsert($secondUser));
+        self::assertNotEquals([], $this->uow->getDocumentChangeSet($secondUser));
+
+        self::assertTrue($this->uow->isScheduledForInsert($friendUser));
+        self::assertNotEquals([], $this->uow->getDocumentChangeSet($friendUser));
+    }
+
+    public function testInsertErrorKeepsFailingInsertionsForDocumentClass(): void
+    {
+        // Create a unique index on the collection to let the second document fail, as using a fail point would also
+        // affect the first document.
+        $collection = $this->dm->getDocumentCollection(ForumUser::class);
+        $collection->createIndex(['username' => 1], ['unique' => true]);
+
+        $firstUser           = new ForumUser();
+        $firstUser->username = 'alcaeus';
+        $this->uow->persist($firstUser);
+
+        $secondUser           = new ForumUser();
+        $secondUser->username = 'alcaeus';
+        $this->uow->persist($secondUser);
+
+        $thirdUser           = new ForumUser();
+        $thirdUser->username = 'jmikola';
+        $this->uow->persist($thirdUser);
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        // One user inserted, the second insert failed, the last was skipped
+        self::assertSame(
+            1,
+            $this->dm->getDocumentCollection(ForumUser::class)->countDocuments(),
+        );
+
+        // Wrong behaviour: user was saved and should no longer be scheduled for insertion
+        self::assertTrue($this->uow->isScheduledForInsert($firstUser));
+        // Wrong behaviour: changeset should be empty
+        self::assertNotEquals([], $this->uow->getDocumentChangeSet($firstUser));
+
+        self::assertTrue($this->uow->isScheduledForInsert($secondUser));
+        self::assertNotEquals([], $this->uow->getDocumentChangeSet($secondUser));
+
+        self::assertTrue($this->uow->isScheduledForInsert($thirdUser));
+        self::assertNotEquals([], $this->uow->getDocumentChangeSet($thirdUser));
+    }
+
+    public function testInsertErrorWithEmbeddedDocumentKeepsInsertions(): void
+    {
+        // Create a unique index on the collection to let the second insert fail
+        $collection = $this->dm->getDocumentCollection(User::class);
+        $collection->createIndex(['username' => 1], ['unique' => true]);
+
+        $firstAddress = new Address();
+        $firstAddress->setCity('Olching');
+        $firstUser = new User();
+        $firstUser->setUsername('alcaeus');
+        $firstUser->setAddress($firstAddress);
+
+        $secondAddress = new Address();
+        $secondAddress->setCity('Olching');
+        $secondUser = new User();
+        $secondUser->setUsername('alcaeus');
+        $secondUser->setAddress($secondAddress);
+
+        $this->uow->persist($firstUser);
+        $this->uow->persist($secondUser);
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        // First document inserted, second failed due to index error
+        self::assertSame(1, $collection->countDocuments());
+
+        // Wrong behaviour: document should no longer be scheduled and changeset should be cleared
+        $this->assertTrue($this->uow->isScheduledForInsert($firstUser));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($firstUser));
+
+        // Wrong behaviour: document should no longer be scheduled for insertion and changeset cleared
+        $this->assertTrue($this->uow->isScheduledForInsert($firstAddress));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($firstAddress));
+
+        $this->assertTrue($this->uow->isScheduledForInsert($secondUser));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($secondUser));
+        $this->assertTrue($this->uow->isScheduledForInsert($secondAddress));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($secondAddress));
+    }
+
+    public function testUpsertErrorDropsFailingUpserts(): void
+    {
+        $user           = new ForumUser();
+        $user->id       = new ObjectId(); // Specifying an identifier makes this an upsert
+        $user->username = 'alcaeus';
+        $this->uow->persist($user);
+
+        $this->createFailpoint('update');
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        // No document was inserted
+        self::assertSame(
+            0,
+            $this->dm->getDocumentCollection(ForumUser::class)->countDocuments(),
+        );
+
+        self::assertTrue($this->uow->isScheduledForUpsert($user));
+        self::assertNotEquals([], $this->uow->getDocumentChangeSet($user));
+    }
+
+    public function testUpdateErrorKeepsFailingUpdate(): void
+    {
+        $user           = new ForumUser();
+        $user->username = 'alcaeus';
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $user->username = 'jmikola';
+
+        // Make sure update command fails once
+        $this->createFailpoint('update');
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        // The update is kept, user data is not changed
+        self::assertSame(
+            1,
+            $this->dm->getDocumentCollection(ForumUser::class)->countDocuments(['username' => 'alcaeus']),
+        );
+
+        self::assertTrue($this->uow->isScheduledForUpdate($user));
+        self::assertNotEquals([], $this->uow->getDocumentChangeSet($user));
+    }
+
+    public function testUpdateErrorWithNewEmbeddedDocumentKeepsFailingChangeset(): void
+    {
+        $user = new User();
+        $user->setUsername('alcaeus');
+
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $address = new Address();
+        $address->setCity('Olching');
+        $user->setAddress($address);
+
+        $this->createFailpoint('update');
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        $this->assertTrue($this->uow->isScheduledForUpdate($user));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($user));
+        $this->assertTrue($this->uow->isScheduledForInsert($address));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($address));
+    }
+
+    public function testUpdateWithNewEmbeddedDocumentClearsChangesets(): void
+    {
+        $user = new User();
+        $user->setUsername('alcaeus');
+
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $address = new Address();
+        $address->setCity('Olching');
+        $user->setAddress($address);
+
+        $this->uow->commit();
+
+        $this->assertFalse($this->uow->isScheduledForUpdate($user));
+        $this->assertEquals([], $this->uow->getDocumentChangeSet($user));
+        $this->assertFalse($this->uow->isScheduledForInsert($address));
+        $this->assertEquals([], $this->uow->getDocumentChangeSet($address));
+    }
+
+    public function testUpdateErrorWithEmbeddedDocumentKeepsFailingChangeset(): void
+    {
+        $address = new Address();
+        $address->setCity('Olching');
+
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setAddress($address);
+
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $address->setCity('Munich');
+
+        $this->createFailpoint('update');
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        $this->assertTrue($this->uow->isScheduledForUpdate($user));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($user));
+        $this->assertTrue($this->uow->isScheduledForUpdate($address));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($address));
+    }
+
+    public function testUpdateWithEmbeddedDocumentClearsChangesets(): void
+    {
+        $address = new Address();
+        $address->setCity('Olching');
+
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setAddress($address);
+
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $address->setCity('Munich');
+
+        $this->uow->commit();
+
+        $this->assertFalse($this->uow->isScheduledForUpdate($user));
+        $this->assertEquals([], $this->uow->getDocumentChangeSet($user));
+        $this->assertFalse($this->uow->isScheduledForUpdate($address));
+        $this->assertEquals([], $this->uow->getDocumentChangeSet($address));
+    }
+
+    public function testUpdateErrorWithRemovedEmbeddedDocumentKeepsFailingChangeset(): void
+    {
+        $address = new Address();
+        $address->setCity('Olching');
+
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setAddress($address);
+
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $user->removeAddress();
+
+        $this->createFailpoint('update');
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        $this->assertTrue($this->uow->isScheduledForUpdate($user));
+        $this->assertNotEquals([], $this->uow->getDocumentChangeSet($user));
+        $this->assertTrue($this->uow->isScheduledForDelete($address));
+
+        // As $address is orphaned after changeset computation, it is removed from the identity map
+        $this->assertFalse($this->uow->isInIdentityMap($address));
+    }
+
+    public function testUpdateWithRemovedEmbeddedDocumentClearsChangesets(): void
+    {
+        $address = new Address();
+        $address->setCity('Olching');
+
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setAddress($address);
+
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $user->removeAddress();
+
+        $this->uow->commit();
+
+        $this->assertFalse($this->uow->isScheduledForUpdate($user));
+        $this->assertEquals([], $this->uow->getDocumentChangeSet($user));
+        $this->assertFalse($this->uow->isScheduledForDelete($address));
+        $this->assertFalse($this->uow->isInIdentityMap($address));
+    }
+
+    public function testDeleteErrorKeepsFailingDelete(): void
+    {
+        $user           = new ForumUser();
+        $user->username = 'alcaeus';
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $this->uow->remove($user);
+
+        // Make sure delete command fails once
+        $this->createFailpoint('delete');
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        // The document still exists, the deletion is still scheduled
+        self::assertSame(
+            1,
+            $this->dm->getDocumentCollection(ForumUser::class)->countDocuments(['username' => 'alcaeus']),
+        );
+
+        self::assertTrue($this->uow->isScheduledForDelete($user));
+    }
+
+    public function testDeleteErrorWithEmbeddedDocumentKeepsChangeset(): void
+    {
+        $address = new Address();
+        $address->setCity('Olching');
+
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setAddress($address);
+
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $this->uow->remove($user);
+
+        // Make sure delete command fails once
+        $this->createFailpoint('delete');
+
+        try {
+            $this->uow->commit();
+            self::fail('Expected exception when committing');
+        } catch (Throwable) {
+        }
+
+        // The document still exists, the deletion is still scheduled
+        self::assertSame(
+            1,
+            $this->dm->getDocumentCollection(User::class)->countDocuments(['username' => 'alcaeus']),
+        );
+
+        self::assertTrue($this->uow->isScheduledForDelete($user));
+        self::assertTrue($this->uow->isScheduledForDelete($address));
+    }
+
+    public function testDeleteWithEmbeddedDocumentClearsChangeset(): void
+    {
+        $address = new Address();
+        $address->setCity('Olching');
+
+        $user = new User();
+        $user->setUsername('alcaeus');
+        $user->setAddress($address);
+
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $this->uow->remove($user);
+
+        $this->uow->commit();
+
+        self::assertSame(
+            0,
+            $this->dm->getDocumentCollection(User::class)->countDocuments(['username' => 'alcaeus']),
+        );
+
+        self::assertFalse($this->uow->isScheduledForDelete($user));
+        self::assertFalse($this->uow->isScheduledForDelete($address));
+    }
+
+    /** Create a document manager with a single host to ensure failpoints target the correct server */
+    protected static function createTestDocumentManager(): DocumentManager
+    {
+        $config = static::getConfiguration();
+        $client = new Client(self::getUri(false), [], ['typeMap' => ['root' => 'array', 'document' => 'array']]);
+
+        return DocumentManager::create($client, $config);
+    }
+
+    private function createFailpoint(string $commandName): void
+    {
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => ['times' => 1],
+            'data' => [
+                'errorCode' => 192, // FailPointEnabled
+                'failCommands' => [$commandName],
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

This pull request introduces support for transactions. When calling `DocumentManager::commit`, a transaction will be used depending on a configuration setting. Alternatively, transaction usage can also be changed using a commit option.

#### Usage

A new `useTransactionalFlush` configuration option can be enabled when running on the following deployments:
* Replica sets starting with MongoDB 4.0
* Sharded clusters starting with MongoDB 4.2
* Serverless deployments on MongoDB Atlas
* Loadbalanced deployments on MongoDB Atlas

To enable this feature globally, enable transactional flushes in the configuration:
```php
$config = new Configuration();
$config->setUseTransactionalFlush(true);
// Other configuration

$dm = DocumentManager::create(null, $config);
```

Alternatively, the `withTransaction` commit option can be specified to override this default value and selectively enable or disable transactions:
```php
// To explicitly enable transaction for this write
$dm->flush(['withTransaction' => true]);

// To disable transaction usage for a write, regardless of the ``useTransactionalFlush`` config:
$dm->flush(['withTransaction' => false]);
```

This pull request has been reviewed in smaller chunks in the following pull requests:
* #2580
* #2587
* #2589
* #2594
* #2604
* #2606

This PR is also accompanied by a [pull request in the Symfony Bundle](https://github.com/doctrine/DoctrineMongoDBBundle/pull/814) to expose the transactional flush setting in the bundle configuration.