### PR TITLE
Fix missing storeEmptyArray attribute for embed relationships in XML driver

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -393,6 +393,7 @@ class XmlDriver extends FileDriver
             'name'            => (string) $attributes['field'],
             'strategy'        => (string) ($attributes['strategy'] ?? $defaultStrategy),
             'nullable'        => isset($attributes['nullable']) ? ((string) $attributes['nullable'] === 'true') : false,
+            'storeEmptyArray'  => isset($attributes['store-empty-array']) ? ((string) $attributes['store-empty-array'] === 'true') : false,
         ];
         if (isset($attributes['field-name'])) {
             $mapping['fieldName'] = (string) $attributes['field-name'];

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
@@ -439,6 +439,17 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
         self::assertEquals(4096, $shardKey['options']['numInitialChunks'], 'Shard key option has wrong value');
     }
 
+    /** @param ClassMetadata<AbstractMappingDriverUser> $class */
+    #[Depends('testLoadMapping')]
+    public function testStoreEmptyArray(ClassMetadata $class): void
+    {
+        $referenceMapping = $class->getFieldMapping('phonenumbers');
+        $embeddedMapping  = $class->getFieldMapping('otherPhonenumbers');
+
+        self::assertFalse($referenceMapping['storeEmptyArray']);
+        self::assertFalse($embeddedMapping['storeEmptyArray']);
+    }
+
     public function testGridFSMapping(): void
     {
         $class = $this->dm->getClassMetadata(AbstractMappingDriverFile::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTestCase.php
@@ -125,6 +125,7 @@ abstract class AbstractDriverTestCase extends TestCase
             'isOwningSide' => true,
             'nullable' => false,
             'strategy' => ClassMetadata::STORAGE_STRATEGY_SET,
+            'storeEmptyArray' => false,
         ], $classMetadata->fieldMappings['address']);
 
         self::assertEquals([
@@ -144,6 +145,7 @@ abstract class AbstractDriverTestCase extends TestCase
             'isOwningSide' => true,
             'nullable' => false,
             'strategy' => ClassMetadata::STORAGE_STRATEGY_PUSH_ALL,
+            'storeEmptyArray' => false,
         ], $classMetadata->fieldMappings['phonenumbers']);
 
         self::assertEquals([
@@ -439,6 +441,7 @@ abstract class AbstractDriverTestCase extends TestCase
             'isOwningSide' => true,
             'nullable' => true,
             'strategy' => ClassMetadata::STORAGE_STRATEGY_SET,
+            'storeEmptyArray' => false,
         ], $classMetadata->fieldMappings['address']);
 
         self::assertEquals([
@@ -458,6 +461,7 @@ abstract class AbstractDriverTestCase extends TestCase
             'isOwningSide' => true,
             'nullable' => true,
             'strategy' => ClassMetadata::STORAGE_STRATEGY_PUSH_ALL,
+            'storeEmptyArray' => false,
         ], $classMetadata->fieldMappings['phonenumbers']);
 
         self::assertEquals([


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2588 

#### Summary

Fixes a missing default attribute for embedMany relationships. @frenchcomp please report back if this fixes your issue.