### PR TITLE
Fix phpstan errors

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -51,8 +51,6 @@ use function strtolower;
 use function strtoupper;
 use function trigger_deprecation;
 
-use const PHP_VERSION_ID;
-
 /**
  * A <tt>ClassMetadata</tt> instance holds all the object-document mapping metadata
  * of a document and it's references.
@@ -2616,16 +2614,16 @@ use const PHP_VERSION_ID;
             return $mapping;
         }
 
-        if (PHP_VERSION_ID >= 80100 && ! $type->isBuiltin() && enum_exists($type->getName())) {
+        if (! $type->isBuiltin() && enum_exists($type->getName())) {
             $reflection = new ReflectionEnum($type->getName());
-            $type       = $reflection->getBackingType();
 
-            if ($type === null) {
-                throw MappingException::nonBackedEnumMapped($this->name, $mapping['fieldName'], $mapping['enumType']);
+            if (! $reflection->isBacked()) {
+                throw MappingException::nonBackedEnumMapped($this->name, $mapping['fieldName'], $reflection->getName());
             }
 
+            $type = $reflection->getBackingType();
             assert($type instanceof ReflectionNamedType);
-            $mapping['enumType'] = $type->getName();
+            $mapping['enumType'] = $reflection->getName();
         }
 
         switch ($type->getName()) {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -2617,8 +2617,6 @@ use const PHP_VERSION_ID;
         }
 
         if (PHP_VERSION_ID >= 80100 && ! $type->isBuiltin() && enum_exists($type->getName())) {
-            $mapping['enumType'] = $type->getName();
-
             $reflection = new ReflectionEnum($type->getName());
             $type       = $reflection->getBackingType();
 
@@ -2627,6 +2625,7 @@ use const PHP_VERSION_ID;
             }
 
             assert($type instanceof ReflectionNamedType);
+            $mapping['enumType'] = $type->getName();
         }
 
         switch ($type->getName()) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -446,6 +446,11 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
 
 		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\:\\:validateAndCompleteTypedFieldMapping\\(\\) should return array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\} but returns array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+
+		-
 			message: "#^Parameter \\#2 \\$enumType of class Doctrine\\\\Persistence\\\\Reflection\\\\EnumReflectionProperty constructor expects class\\-string\\<BackedEnum\\>, class\\-string\\<UnitEnum\\> given\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -446,6 +446,11 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
 
 		-
+			message: "#^Parameter \\#2 \\$enumType of class Doctrine\\\\Persistence\\\\Reflection\\\\EnumReflectionProperty constructor expects class\\-string\\<BackedEnum\\>, class\\-string\\<UnitEnum\\> given\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+
+		-
 			message: "#^Parameter \\#2 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\Driver\\\\XmlDriver\\:\\:addFieldMapping\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\<string, non\\-empty\\-array\\<int, string\\>\\|bool\\|string\\> given\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
+<files psalm-version="5.17.0@c620f6e80d0abfca532b00bda366062aaedf6e5d">
   <file src="lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php">
     <MissingTemplateParam>
       <code>IteratorAggregate</code>
@@ -82,6 +82,7 @@
   <file src="lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php">
     <InvalidArgument>
       <code>$mapping</code>
+      <code>$options</code>
     </InvalidArgument>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php">


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| BC Break     | yes/no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

This fixes one error where the `enumType` mapping field gets rewritten to the `class-string<UnitEnum>` type because we don't ensure that the enum is backed before re-assigning `enumType`. The other issue in `mapField` is less obvious and I can't figure out where it takes the `class-string<UnitEnum>` type from, so I decided to ignore that for the time being. These issues started appearing with the latest phpstan release.