### PR TITLE
Update events to play nice with transactions

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/LifecycleEventArgs.php
@@ -6,6 +6,8 @@ namespace Doctrine\ODM\MongoDB\Event;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\Persistence\Event\LifecycleEventArgs as BaseLifecycleEventArgs;
+use Doctrine\Persistence\ObjectManager;
+use MongoDB\Driver\Session;
 
 /**
  * Lifecycle Events are triggered by the UnitOfWork during lifecycle transitions
@@ -15,6 +17,15 @@ use Doctrine\Persistence\Event\LifecycleEventArgs as BaseLifecycleEventArgs;
  */
 class LifecycleEventArgs extends BaseLifecycleEventArgs
 {
+    public function __construct(
+        object $object,
+        ObjectManager $objectManager,
+        public readonly bool $isInTransaction = false,
+        public readonly ?Session $session = null,
+    ) {
+        parent::__construct($object, $objectManager);
+    }
+
     public function getDocument(): object
     {
         return $this->getObject();

--- a/lib/Doctrine/ODM/MongoDB/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/LifecycleEventArgs.php
@@ -20,7 +20,6 @@ class LifecycleEventArgs extends BaseLifecycleEventArgs
     public function __construct(
         object $object,
         ObjectManager $objectManager,
-        public readonly bool $isInTransaction = false,
         public readonly ?Session $session = null,
     ) {
         parent::__construct($object, $objectManager);
@@ -34,5 +33,10 @@ class LifecycleEventArgs extends BaseLifecycleEventArgs
     public function getDocumentManager(): DocumentManager
     {
         return $this->getObjectManager();
+    }
+
+    public function isInTransaction(): bool
+    {
+        return $this->session?->isInTransaction() ?? false;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Event/PreLoadEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PreLoadEventArgs.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Event;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use MongoDB\Driver\Session;
 
 /**
  * Class that holds event arguments for a preLoad event.
@@ -15,9 +16,9 @@ final class PreLoadEventArgs extends LifecycleEventArgs
     private array $data;
 
     /** @param array<string, mixed> $data */
-    public function __construct(object $document, DocumentManager $dm, array &$data)
+    public function __construct(object $document, DocumentManager $dm, array &$data, bool $isInTransaction = false, ?Session $session = null)
     {
-        parent::__construct($document, $dm);
+        parent::__construct($document, $dm, $isInTransaction, $session);
 
         $this->data =& $data;
     }

--- a/lib/Doctrine/ODM/MongoDB/Event/PreLoadEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PreLoadEventArgs.php
@@ -12,19 +12,14 @@ use MongoDB\Driver\Session;
  */
 final class PreLoadEventArgs extends LifecycleEventArgs
 {
-    /** @var array<string, mixed> */
-    private array $data;
-
     /** @param array<string, mixed> $data */
     public function __construct(
         object $document,
         DocumentManager $dm,
-        array &$data,
+        private array &$data,
         ?Session $session = null,
     ) {
         parent::__construct($document, $dm, $session);
-
-        $this->data =& $data;
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Event/PreLoadEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PreLoadEventArgs.php
@@ -16,8 +16,12 @@ final class PreLoadEventArgs extends LifecycleEventArgs
     private array $data;
 
     /** @param array<string, mixed> $data */
-    public function __construct(object $document, DocumentManager $dm, array &$data, ?Session $session = null)
-    {
+    public function __construct(
+        object $document,
+        DocumentManager $dm,
+        array &$data,
+        ?Session $session = null,
+    ) {
         parent::__construct($document, $dm, $session);
 
         $this->data =& $data;

--- a/lib/Doctrine/ODM/MongoDB/Event/PreLoadEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PreLoadEventArgs.php
@@ -16,9 +16,9 @@ final class PreLoadEventArgs extends LifecycleEventArgs
     private array $data;
 
     /** @param array<string, mixed> $data */
-    public function __construct(object $document, DocumentManager $dm, array &$data, bool $isInTransaction = false, ?Session $session = null)
+    public function __construct(object $document, DocumentManager $dm, array &$data, ?Session $session = null)
     {
-        parent::__construct($document, $dm, $isInTransaction, $session);
+        parent::__construct($document, $dm, $session);
 
         $this->data =& $data;
     }

--- a/lib/Doctrine/ODM/MongoDB/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PreUpdateEventArgs.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Event;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use InvalidArgumentException;
+use MongoDB\Driver\Session;
 
 use function get_class;
 use function sprintf;
@@ -22,9 +23,9 @@ final class PreUpdateEventArgs extends LifecycleEventArgs
     private array $documentChangeSet;
 
     /** @psalm-param array<string, ChangeSet> $changeSet */
-    public function __construct(object $document, DocumentManager $dm, array $changeSet)
+    public function __construct(object $document, DocumentManager $dm, array $changeSet, bool $isInTransaction = false, ?Session $session = null)
     {
-        parent::__construct($document, $dm);
+        parent::__construct($document, $dm, $isInTransaction, $session);
 
         $this->documentChangeSet = $changeSet;
     }

--- a/lib/Doctrine/ODM/MongoDB/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PreUpdateEventArgs.php
@@ -19,30 +19,27 @@ use function sprintf;
  */
 final class PreUpdateEventArgs extends LifecycleEventArgs
 {
-    /** @psalm-var array<string, ChangeSet> */
-    private array $documentChangeSet;
-
     /** @psalm-param array<string, ChangeSet> $changeSet */
     public function __construct(
         object $document,
         DocumentManager $dm,
-        array $changeSet,
+        private array $changeSet,
         ?Session $session = null,
     ) {
         parent::__construct($document, $dm, $session);
 
-        $this->documentChangeSet = $changeSet;
+        $this->changeSet = $changeSet;
     }
 
     /** @return array<string, ChangeSet> */
     public function getDocumentChangeSet(): array
     {
-        return $this->documentChangeSet;
+        return $this->changeSet;
     }
 
     public function hasChangedField(string $field): bool
     {
-        return isset($this->documentChangeSet[$field]);
+        return isset($this->changeSet[$field]);
     }
 
     /**
@@ -54,7 +51,7 @@ final class PreUpdateEventArgs extends LifecycleEventArgs
     {
         $this->assertValidField($field);
 
-        return $this->documentChangeSet[$field][0];
+        return $this->changeSet[$field][0];
     }
 
     /**
@@ -66,7 +63,7 @@ final class PreUpdateEventArgs extends LifecycleEventArgs
     {
         $this->assertValidField($field);
 
-        return $this->documentChangeSet[$field][1];
+        return $this->changeSet[$field][1];
     }
 
     /**
@@ -78,8 +75,8 @@ final class PreUpdateEventArgs extends LifecycleEventArgs
     {
         $this->assertValidField($field);
 
-        $this->documentChangeSet[$field][1] = $value;
-        $this->getDocumentManager()->getUnitOfWork()->setDocumentChangeSet($this->getDocument(), $this->documentChangeSet);
+        $this->changeSet[$field][1] = $value;
+        $this->getDocumentManager()->getUnitOfWork()->setDocumentChangeSet($this->getDocument(), $this->changeSet);
     }
 
     /**
@@ -89,7 +86,7 @@ final class PreUpdateEventArgs extends LifecycleEventArgs
      */
     private function assertValidField(string $field): void
     {
-        if (! isset($this->documentChangeSet[$field])) {
+        if (! isset($this->changeSet[$field])) {
             throw new InvalidArgumentException(sprintf(
                 'Field "%s" is not a valid field of the document "%s" in PreUpdateEventArgs.',
                 $field,

--- a/lib/Doctrine/ODM/MongoDB/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PreUpdateEventArgs.php
@@ -23,8 +23,12 @@ final class PreUpdateEventArgs extends LifecycleEventArgs
     private array $documentChangeSet;
 
     /** @psalm-param array<string, ChangeSet> $changeSet */
-    public function __construct(object $document, DocumentManager $dm, array $changeSet, ?Session $session = null)
-    {
+    public function __construct(
+        object $document,
+        DocumentManager $dm,
+        array $changeSet,
+        ?Session $session = null,
+    ) {
         parent::__construct($document, $dm, $session);
 
         $this->documentChangeSet = $changeSet;

--- a/lib/Doctrine/ODM/MongoDB/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/PreUpdateEventArgs.php
@@ -23,9 +23,9 @@ final class PreUpdateEventArgs extends LifecycleEventArgs
     private array $documentChangeSet;
 
     /** @psalm-param array<string, ChangeSet> $changeSet */
-    public function __construct(object $document, DocumentManager $dm, array $changeSet, bool $isInTransaction = false, ?Session $session = null)
+    public function __construct(object $document, DocumentManager $dm, array $changeSet, ?Session $session = null)
     {
-        parent::__construct($document, $dm, $isInTransaction, $session);
+        parent::__construct($document, $dm, $session);
 
         $this->documentChangeSet = $changeSet;
     }

--- a/lib/Doctrine/ODM/MongoDB/MongoDBException.php
+++ b/lib/Doctrine/ODM/MongoDB/MongoDBException.php
@@ -155,4 +155,9 @@ class MongoDBException extends Exception
     {
         return new self(sprintf('Cannot create repository for class "%s".', $className));
     }
+
+    public static function transactionalSessionMismatch(): self
+    {
+        return new self('The transactional operation cannot be executed because it was started in a different session.');
+    }
 }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -74,7 +74,14 @@ use function trigger_deprecation;
  *
  * @template T of object
  *
- * @psalm-import-type CommitOptions from UnitOfWork
+ * @psalm-type CommitOptions array{
+ *      fsync?: bool,
+ *      safe?: int,
+ *      session?: ?Session,
+ *      w?: int,
+ *      withTransaction?: bool,
+ *      writeConcern?: WriteConcern
+ * }
  * @psalm-import-type Hints from UnitOfWork
  * @psalm-import-type FieldMapping from ClassMetadata
  * @psalm-import-type SortMeta from Sort

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1171,7 +1171,7 @@ final class UnitOfWork implements PropertyChangedListener
         $persister->executeInserts($options);
 
         foreach ($documents as $document) {
-            $this->lifecycleEventManager->postPersist($class, $document);
+            $this->lifecycleEventManager->postPersist($class, $document, $options['session'] ?? null);
         }
     }
 
@@ -1195,7 +1195,7 @@ final class UnitOfWork implements PropertyChangedListener
         $persister->executeUpserts($options);
 
         foreach ($documents as $document) {
-            $this->lifecycleEventManager->postPersist($class, $document);
+            $this->lifecycleEventManager->postPersist($class, $document, $options['session'] ?? null);
         }
     }
 
@@ -1218,13 +1218,13 @@ final class UnitOfWork implements PropertyChangedListener
         $persister = $this->getDocumentPersister($className);
 
         foreach ($documents as $oid => $document) {
-            $this->lifecycleEventManager->preUpdate($class, $document);
+            $this->lifecycleEventManager->preUpdate($class, $document, $options['session'] ?? null);
 
             if (! empty($this->documentChangeSets[$oid]) || $this->hasScheduledCollections($document)) {
                 $persister->update($document, $options);
             }
 
-            $this->lifecycleEventManager->postUpdate($class, $document);
+            $this->lifecycleEventManager->postUpdate($class, $document, $options['session'] ?? null);
         }
     }
 
@@ -1266,7 +1266,7 @@ final class UnitOfWork implements PropertyChangedListener
                 $value->clearSnapshot();
             }
 
-            $this->lifecycleEventManager->postRemove($class, $document);
+            $this->lifecycleEventManager->postRemove($class, $document, $options['session'] ?? null);
         }
     }
 

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -456,6 +456,8 @@ final class UnitOfWork implements PropertyChangedListener
             $this->evm->dispatchEvent(Events::onFlush, new Event\OnFlushEventArgs($this->dm));
 
             if ($this->useTransaction($options)) {
+                $this->lifecycleEventManager->enableTransactionalMode();
+
                 with_transaction(
                     $this->dm->getClient()->startSession(),
                     function (Session $session) use ($options): void {
@@ -484,6 +486,7 @@ final class UnitOfWork implements PropertyChangedListener
             $this->hasScheduledCollections      = [];
         } finally {
             $this->commitsInProgress--;
+            $this->lifecycleEventManager->clearTransactionalState();
         }
     }
 

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -456,10 +456,12 @@ final class UnitOfWork implements PropertyChangedListener
             $this->evm->dispatchEvent(Events::onFlush, new Event\OnFlushEventArgs($this->dm));
 
             if ($this->useTransaction($options)) {
-                $this->lifecycleEventManager->enableTransactionalMode();
+                $session = $this->dm->getClient()->startSession();
+
+                $this->lifecycleEventManager->enableTransactionalMode($session);
 
                 with_transaction(
-                    $this->dm->getClient()->startSession(),
+                    $session,
                     function (Session $session) use ($options): void {
                         $this->doCommit(['session' => $session] + $this->stripTransactionOptions($options));
                     },

--- a/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
+++ b/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
@@ -143,8 +143,10 @@ final class LifecycleEventManager
             return;
         }
 
-        $class->invokeLifecycleCallbacks(Events::prePersist, $document, [new LifecycleEventArgs($document, $this->dm)]);
-        $this->dispatchEvent($class, Events::prePersist, new LifecycleEventArgs($document, $this->dm));
+        $eventArgs = new LifecycleEventArgs($document, $this->dm);
+
+        $class->invokeLifecycleCallbacks(Events::prePersist, $document, [$eventArgs]);
+        $this->dispatchEvent($class, Events::prePersist, $eventArgs);
     }
 
     /**
@@ -161,8 +163,10 @@ final class LifecycleEventManager
             return;
         }
 
-        $class->invokeLifecycleCallbacks(Events::preRemove, $document, [new LifecycleEventArgs($document, $this->dm)]);
-        $this->dispatchEvent($class, Events::preRemove, new LifecycleEventArgs($document, $this->dm));
+        $eventArgs = new LifecycleEventArgs($document, $this->dm);
+
+        $class->invokeLifecycleCallbacks(Events::preRemove, $document, [$eventArgs]);
+        $this->dispatchEvent($class, Events::preRemove, $eventArgs);
     }
 
     /**
@@ -179,12 +183,17 @@ final class LifecycleEventManager
             return;
         }
 
+        $eventArgs = new PreUpdateEventArgs($document, $this->dm, $this->uow->getDocumentChangeSet($document), $session);
         if (! empty($class->lifecycleCallbacks[Events::preUpdate])) {
-            $class->invokeLifecycleCallbacks(Events::preUpdate, $document, [new PreUpdateEventArgs($document, $this->dm, $this->uow->getDocumentChangeSet($document), $session)]);
+            $class->invokeLifecycleCallbacks(Events::preUpdate, $document, [$eventArgs]);
             $this->uow->recomputeSingleDocumentChangeSet($class, $document);
         }
 
-        $this->dispatchEvent($class, Events::preUpdate, new PreUpdateEventArgs($document, $this->dm, $this->uow->getDocumentChangeSet($document), $session));
+        $this->dispatchEvent(
+            $class,
+            Events::preUpdate,
+            new PreUpdateEventArgs($document, $this->dm, $this->uow->getDocumentChangeSet($document), $session),
+        );
         $this->cascadePreUpdate($class, $document, $session);
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
+++ b/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
@@ -15,6 +15,7 @@ use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\UnitOfWork;
+use MongoDB\Driver\Session;
 
 /** @internal */
 final class LifecycleEventManager
@@ -55,11 +56,14 @@ final class LifecycleEventManager
      *
      * @template T of object
      */
-    public function postPersist(ClassMetadata $class, object $document): void
+    public function postPersist(ClassMetadata $class, object $document, ?Session $session = null): void
     {
-        $class->invokeLifecycleCallbacks(Events::postPersist, $document, [new LifecycleEventArgs($document, $this->dm)]);
-        $this->dispatchEvent($class, Events::postPersist, new LifecycleEventArgs($document, $this->dm));
-        $this->cascadePostPersist($class, $document);
+        $isInTransaction = $session ? $session->isInTransaction() : false;
+        $eventArgs       = new LifecycleEventArgs($document, $this->dm, $isInTransaction, $session);
+
+        $class->invokeLifecycleCallbacks(Events::postPersist, $document, [$eventArgs]);
+        $this->dispatchEvent($class, Events::postPersist, $eventArgs);
+        $this->cascadePostPersist($class, $document, $session);
     }
 
     /**
@@ -70,10 +74,13 @@ final class LifecycleEventManager
      *
      * @template T of object
      */
-    public function postRemove(ClassMetadata $class, object $document): void
+    public function postRemove(ClassMetadata $class, object $document, ?Session $session = null): void
     {
-        $class->invokeLifecycleCallbacks(Events::postRemove, $document, [new LifecycleEventArgs($document, $this->dm)]);
-        $this->dispatchEvent($class, Events::postRemove, new LifecycleEventArgs($document, $this->dm));
+        $isInTransaction = $session ? $session->isInTransaction() : false;
+        $eventArgs       = new LifecycleEventArgs($document, $this->dm, $isInTransaction, $session);
+
+        $class->invokeLifecycleCallbacks(Events::postRemove, $document, [$eventArgs]);
+        $this->dispatchEvent($class, Events::postRemove, $eventArgs);
     }
 
     /**
@@ -85,11 +92,14 @@ final class LifecycleEventManager
      *
      * @template T of object
      */
-    public function postUpdate(ClassMetadata $class, object $document): void
+    public function postUpdate(ClassMetadata $class, object $document, ?Session $session = null): void
     {
-        $class->invokeLifecycleCallbacks(Events::postUpdate, $document, [new LifecycleEventArgs($document, $this->dm)]);
-        $this->dispatchEvent($class, Events::postUpdate, new LifecycleEventArgs($document, $this->dm));
-        $this->cascadePostUpdate($class, $document);
+        $isInTransaction = $session ? $session->isInTransaction() : false;
+        $eventArgs       = new LifecycleEventArgs($document, $this->dm, $isInTransaction, $session);
+
+        $class->invokeLifecycleCallbacks(Events::postUpdate, $document, [$eventArgs]);
+        $this->dispatchEvent($class, Events::postUpdate, $eventArgs);
+        $this->cascadePostUpdate($class, $document, $session);
     }
 
     /**
@@ -128,15 +138,17 @@ final class LifecycleEventManager
      *
      * @template T of object
      */
-    public function preUpdate(ClassMetadata $class, object $document): void
+    public function preUpdate(ClassMetadata $class, object $document, ?Session $session = null): void
     {
+        $isInTransaction = $session ? $session->isInTransaction() : false;
+
         if (! empty($class->lifecycleCallbacks[Events::preUpdate])) {
-            $class->invokeLifecycleCallbacks(Events::preUpdate, $document, [new PreUpdateEventArgs($document, $this->dm, $this->uow->getDocumentChangeSet($document))]);
+            $class->invokeLifecycleCallbacks(Events::preUpdate, $document, [new PreUpdateEventArgs($document, $this->dm, $this->uow->getDocumentChangeSet($document), $isInTransaction, $session)]);
             $this->uow->recomputeSingleDocumentChangeSet($class, $document);
         }
 
-        $this->dispatchEvent($class, Events::preUpdate, new PreUpdateEventArgs($document, $this->dm, $this->uow->getDocumentChangeSet($document)));
-        $this->cascadePreUpdate($class, $document);
+        $this->dispatchEvent($class, Events::preUpdate, new PreUpdateEventArgs($document, $this->dm, $this->uow->getDocumentChangeSet($document), $isInTransaction, $session));
+        $this->cascadePreUpdate($class, $document, $session);
     }
 
     /**
@@ -147,7 +159,7 @@ final class LifecycleEventManager
      *
      * @template T of object
      */
-    private function cascadePreUpdate(ClassMetadata $class, object $document): void
+    private function cascadePreUpdate(ClassMetadata $class, object $document, ?Session $session = null): void
     {
         foreach ($class->getEmbeddedFieldsMappings() as $mapping) {
             $value = $class->reflFields[$mapping['fieldName']]->getValue($document);
@@ -162,7 +174,7 @@ final class LifecycleEventManager
                     continue;
                 }
 
-                $this->preUpdate($this->dm->getClassMetadata($entry::class), $entry);
+                $this->preUpdate($this->dm->getClassMetadata($entry::class), $entry, $session);
             }
         }
     }
@@ -175,8 +187,10 @@ final class LifecycleEventManager
      *
      * @template T of object
      */
-    private function cascadePostUpdate(ClassMetadata $class, object $document): void
+    private function cascadePostUpdate(ClassMetadata $class, object $document, ?Session $session = null): void
     {
+        $isInTransaction = $session ? $session->isInTransaction() : false;
+
         foreach ($class->getEmbeddedFieldsMappings() as $mapping) {
             $value = $class->reflFields[$mapping['fieldName']]->getValue($document);
             if ($value === null) {
@@ -192,8 +206,11 @@ final class LifecycleEventManager
 
                 $entryClass = $this->dm->getClassMetadata($entry::class);
                 $event      = $this->uow->isScheduledForInsert($entry) ? Events::postPersist : Events::postUpdate;
-                $entryClass->invokeLifecycleCallbacks($event, $entry, [new LifecycleEventArgs($entry, $this->dm)]);
-                $this->dispatchEvent($entryClass, $event, new LifecycleEventArgs($entry, $this->dm));
+
+                $eventArgs = new LifecycleEventArgs($entry, $this->dm, $isInTransaction, $session);
+
+                $entryClass->invokeLifecycleCallbacks($event, $entry, [$eventArgs]);
+                $this->dispatchEvent($entryClass, $event, $eventArgs);
 
                 $this->cascadePostUpdate($entryClass, $entry);
             }
@@ -208,7 +225,7 @@ final class LifecycleEventManager
      *
      * @template T of object
      */
-    private function cascadePostPersist(ClassMetadata $class, object $document): void
+    private function cascadePostPersist(ClassMetadata $class, object $document, ?Session $session = null): void
     {
         foreach ($class->getEmbeddedFieldsMappings() as $mapping) {
             $value = $class->reflFields[$mapping['fieldName']]->getValue($document);
@@ -218,7 +235,7 @@ final class LifecycleEventManager
 
             $values = $mapping['type'] === ClassMetadata::ONE ? [$value] : $value;
             foreach ($values as $embeddedDocument) {
-                $this->postPersist($this->dm->getClassMetadata($embeddedDocument::class), $embeddedDocument);
+                $this->postPersist($this->dm->getClassMetadata($embeddedDocument::class), $embeddedDocument, $session);
             }
         }
     }

--- a/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
+++ b/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
@@ -80,8 +80,7 @@ final class LifecycleEventManager
             return;
         }
 
-        $isInTransaction = $session ? $session->isInTransaction() : false;
-        $eventArgs       = new LifecycleEventArgs($document, $this->dm, $isInTransaction, $session);
+        $eventArgs = new LifecycleEventArgs($document, $this->dm, $session);
 
         $class->invokeLifecycleCallbacks(Events::postPersist, $document, [$eventArgs]);
         $this->dispatchEvent($class, Events::postPersist, $eventArgs);
@@ -102,8 +101,7 @@ final class LifecycleEventManager
             return;
         }
 
-        $isInTransaction = $session ? $session->isInTransaction() : false;
-        $eventArgs       = new LifecycleEventArgs($document, $this->dm, $isInTransaction, $session);
+        $eventArgs = new LifecycleEventArgs($document, $this->dm, $session);
 
         $class->invokeLifecycleCallbacks(Events::postRemove, $document, [$eventArgs]);
         $this->dispatchEvent($class, Events::postRemove, $eventArgs);
@@ -124,8 +122,7 @@ final class LifecycleEventManager
             return;
         }
 
-        $isInTransaction = $session ? $session->isInTransaction() : false;
-        $eventArgs       = new LifecycleEventArgs($document, $this->dm, $isInTransaction, $session);
+        $eventArgs = new LifecycleEventArgs($document, $this->dm, $session);
 
         $class->invokeLifecycleCallbacks(Events::postUpdate, $document, [$eventArgs]);
         $this->dispatchEvent($class, Events::postUpdate, $eventArgs);
@@ -182,14 +179,12 @@ final class LifecycleEventManager
             return;
         }
 
-        $isInTransaction = $session ? $session->isInTransaction() : false;
-
         if (! empty($class->lifecycleCallbacks[Events::preUpdate])) {
-            $class->invokeLifecycleCallbacks(Events::preUpdate, $document, [new PreUpdateEventArgs($document, $this->dm, $this->uow->getDocumentChangeSet($document), $isInTransaction, $session)]);
+            $class->invokeLifecycleCallbacks(Events::preUpdate, $document, [new PreUpdateEventArgs($document, $this->dm, $this->uow->getDocumentChangeSet($document), $session)]);
             $this->uow->recomputeSingleDocumentChangeSet($class, $document);
         }
 
-        $this->dispatchEvent($class, Events::preUpdate, new PreUpdateEventArgs($document, $this->dm, $this->uow->getDocumentChangeSet($document), $isInTransaction, $session));
+        $this->dispatchEvent($class, Events::preUpdate, new PreUpdateEventArgs($document, $this->dm, $this->uow->getDocumentChangeSet($document), $session));
         $this->cascadePreUpdate($class, $document, $session);
     }
 
@@ -231,8 +226,6 @@ final class LifecycleEventManager
      */
     private function cascadePostUpdate(ClassMetadata $class, object $document, ?Session $session = null): void
     {
-        $isInTransaction = $session ? $session->isInTransaction() : false;
-
         foreach ($class->getEmbeddedFieldsMappings() as $mapping) {
             $value = $class->reflFields[$mapping['fieldName']]->getValue($document);
             if ($value === null) {
@@ -253,7 +246,7 @@ final class LifecycleEventManager
                     continue;
                 }
 
-                $eventArgs = new LifecycleEventArgs($entry, $this->dm, $isInTransaction, $session);
+                $eventArgs = new LifecycleEventArgs($entry, $this->dm, $session);
 
                 $entryClass->invokeLifecycleCallbacks($event, $entry, [$eventArgs]);
                 $this->dispatchEvent($entryClass, $event, $eventArgs);

--- a/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
+++ b/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
@@ -305,16 +305,11 @@ final class LifecycleEventManager
         }
 
         // Check whether the event has already been dispatched.
-        $hasDispatched = isset($this->transactionalEvents[$this->getObjectId($document)][$eventName]);
+        $hasDispatched = isset($this->transactionalEvents[spl_object_hash($document)][$eventName]);
 
         // Mark the event as dispatched - no problem doing this if it already was dispatched
-        $this->transactionalEvents[$this->getObjectId($document)][$eventName] = true;
+        $this->transactionalEvents[spl_object_hash($document)][$eventName] = true;
 
         return ! $hasDispatched;
-    }
-
-    private function getObjectId(object $document): string
-    {
-        return spl_object_hash($document);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/TransactionalLifecycleEventsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/TransactionalLifecycleEventsTest.php
@@ -254,7 +254,7 @@ abstract class BaseEventDocument
 
     private function assertTransactionState(LifecycleEventArgs $e): void
     {
-        $this->test->assertTrue($e->isInTransaction);
+        $this->test->assertTrue($e->isInTransaction());
         $this->test->assertInstanceOf(Session::class, $e->session);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/TransactionalLifecycleEventsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/TransactionalLifecycleEventsTest.php
@@ -11,7 +11,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use MongoDB\Client;
 use MongoDB\Driver\Session;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
 class TransactionalLifecycleEventsTest extends BaseTestCase
 {
@@ -34,10 +34,10 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
 
     public function testPersistEvents(): void
     {
-        $root       = new RootEventDocument($this);
+        $root       = new RootEventDocument();
         $root->name = 'root';
 
-        $root->embedded       = new EmbeddedEventDocument($this);
+        $root->embedded       = new EmbeddedEventDocument();
         $root->embedded->name = 'embedded';
 
         $this->createFailPoint('insert');
@@ -51,10 +51,10 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
 
     public function testUpdateEvents(): void
     {
-        $root       = new RootEventDocument($this);
+        $root       = new RootEventDocument();
         $root->name = 'root';
 
-        $root->embedded       = new EmbeddedEventDocument($this);
+        $root->embedded       = new EmbeddedEventDocument();
         $root->embedded->name = 'embedded';
 
         $this->dm->persist($root);
@@ -75,10 +75,10 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
 
     public function testUpdateEventsRootOnly(): void
     {
-        $root       = new RootEventDocument($this);
+        $root       = new RootEventDocument();
         $root->name = 'root';
 
-        $root->embedded       = new EmbeddedEventDocument($this);
+        $root->embedded       = new EmbeddedEventDocument();
         $root->embedded->name = 'embedded';
 
         $this->dm->persist($root);
@@ -98,10 +98,10 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
 
     public function testUpdateEventsEmbeddedOnly(): void
     {
-        $root       = new RootEventDocument($this);
+        $root       = new RootEventDocument();
         $root->name = 'root';
 
-        $root->embedded       = new EmbeddedEventDocument($this);
+        $root->embedded       = new EmbeddedEventDocument();
         $root->embedded->name = 'embedded';
 
         $this->dm->persist($root);
@@ -122,13 +122,13 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
 
     public function testUpdateEventsWithNewEmbeddedDocument(): void
     {
-        $firstEmbedded       = new EmbeddedEventDocument($this);
+        $firstEmbedded       = new EmbeddedEventDocument();
         $firstEmbedded->name = 'embedded';
 
-        $secondEmbedded       = new EmbeddedEventDocument($this);
+        $secondEmbedded       = new EmbeddedEventDocument();
         $secondEmbedded->name = 'new';
 
-        $root           = new RootEventDocument($this);
+        $root           = new RootEventDocument();
         $root->name     = 'root';
         $root->embedded = $firstEmbedded;
 
@@ -158,10 +158,10 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
 
     public function testRemoveEvents(): void
     {
-        $root       = new RootEventDocument($this);
+        $root       = new RootEventDocument();
         $root->name = 'root';
 
-        $root->embedded       = new EmbeddedEventDocument($this);
+        $root->embedded       = new EmbeddedEventDocument();
         $root->embedded->name = 'embedded';
 
         $this->dm->persist($root);
@@ -205,7 +205,7 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
  */
 abstract class BaseEventDocument
 {
-    public function __construct(private TestCase $test)
+    public function __construct()
     {
     }
 
@@ -254,8 +254,8 @@ abstract class BaseEventDocument
 
     private function assertTransactionState(LifecycleEventArgs $e): void
     {
-        $this->test->assertTrue($e->isInTransaction());
-        $this->test->assertInstanceOf(Session::class, $e->session);
+        Assert::assertTrue($e->isInTransaction());
+        Assert::assertInstanceOf(Session::class, $e->session);
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/TransactionalLifecycleEventsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/TransactionalLifecycleEventsTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Events;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Event;
+use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use MongoDB\Client;
+use MongoDB\Driver\Session;
+use PHPUnit\Framework\TestCase;
+
+class TransactionalLifecycleEventsTest extends BaseTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skipTestIfTransactionalFlushDisabled();
+    }
+
+    public function tearDown(): void
+    {
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => 'off',
+        ]);
+
+        parent::tearDown();
+    }
+
+    public function testPersistEvents(): void
+    {
+        $root       = new RootEventDocument($this);
+        $root->name = 'root';
+
+        $root->embedded       = new EmbeddedEventDocument($this);
+        $root->embedded->name = 'embedded';
+
+        $this->createFailPoint('insert');
+
+        $this->dm->persist($root);
+        $this->dm->flush();
+
+        $this->assertSame(1, $root->postPersist);
+        $this->assertSame(1, $root->embedded->postPersist);
+    }
+
+    public function testUpdateEvents(): void
+    {
+        $root       = new RootEventDocument($this);
+        $root->name = 'root';
+
+        $root->embedded       = new EmbeddedEventDocument($this);
+        $root->embedded->name = 'embedded';
+
+        $this->dm->persist($root);
+        $this->dm->flush();
+
+        $this->createFailPoint('update');
+
+        $root->name           = 'updated';
+        $root->embedded->name = 'updated';
+
+        $this->dm->flush();
+
+        $this->assertSame(1, $root->preUpdate);
+        $this->assertSame(1, $root->postUpdate);
+        $this->assertSame(1, $root->embedded->preUpdate);
+        $this->assertSame(1, $root->embedded->postUpdate);
+    }
+
+    public function testUpdateEventsRootOnly(): void
+    {
+        $root       = new RootEventDocument($this);
+        $root->name = 'root';
+
+        $root->embedded       = new EmbeddedEventDocument($this);
+        $root->embedded->name = 'embedded';
+
+        $this->dm->persist($root);
+        $this->dm->flush();
+
+        $this->createFailPoint('update');
+
+        $root->name = 'updated';
+
+        $this->dm->flush();
+
+        $this->assertSame(1, $root->preUpdate);
+        $this->assertSame(1, $root->postUpdate);
+        $this->assertSame(0, $root->embedded->preUpdate);
+        $this->assertSame(0, $root->embedded->postUpdate);
+    }
+
+    public function testUpdateEventsEmbeddedOnly(): void
+    {
+        $root       = new RootEventDocument($this);
+        $root->name = 'root';
+
+        $root->embedded       = new EmbeddedEventDocument($this);
+        $root->embedded->name = 'embedded';
+
+        $this->dm->persist($root);
+        $this->dm->flush();
+
+        $this->createFailPoint('update');
+
+        $root->embedded->name = 'updated';
+
+        $this->dm->flush();
+
+        $this->assertSame(1, $root->preUpdate);
+        $this->assertSame(1, $root->postUpdate);
+
+        $this->assertSame(1, $root->embedded->preUpdate);
+        $this->assertSame(1, $root->embedded->postUpdate);
+    }
+
+    public function testUpdateEventsWithNewEmbeddedDocument(): void
+    {
+        $firstEmbedded       = new EmbeddedEventDocument($this);
+        $firstEmbedded->name = 'embedded';
+
+        $secondEmbedded       = new EmbeddedEventDocument($this);
+        $secondEmbedded->name = 'new';
+
+        $root           = new RootEventDocument($this);
+        $root->name     = 'root';
+        $root->embedded = $firstEmbedded;
+
+        $this->dm->persist($root);
+        $this->dm->flush();
+
+        $this->createFailPoint('update');
+
+        $root->name     = 'updated';
+        $root->embedded = $secondEmbedded;
+
+        $this->dm->flush();
+
+        $this->assertSame(1, $root->preUpdate);
+        $this->assertSame(1, $root->postUpdate);
+
+        // First embedded document was removed but not updated
+        $this->assertSame(1, $firstEmbedded->postRemove);
+        $this->assertSame(0, $firstEmbedded->preUpdate);
+        $this->assertSame(0, $firstEmbedded->postUpdate);
+
+        // Second embedded document was persisted but not updated
+        $this->assertSame(1, $secondEmbedded->postPersist);
+        $this->assertSame(0, $secondEmbedded->preUpdate);
+        $this->assertSame(0, $secondEmbedded->postUpdate);
+    }
+
+    public function testRemoveEvents(): void
+    {
+        $root       = new RootEventDocument($this);
+        $root->name = 'root';
+
+        $root->embedded       = new EmbeddedEventDocument($this);
+        $root->embedded->name = 'embedded';
+
+        $this->dm->persist($root);
+        $this->dm->flush();
+
+        $this->createFailPoint('delete');
+
+        $this->dm->remove($root);
+        $this->dm->flush();
+
+        $this->assertSame(1, $root->postRemove);
+        $this->assertSame(1, $root->embedded->postRemove);
+    }
+
+    /** Create a document manager with a single host to ensure failpoints target the correct server */
+    protected static function createTestDocumentManager(): DocumentManager
+    {
+        $config = static::getConfiguration();
+        $client = new Client(self::getUri(false), [], ['typeMap' => ['root' => 'array', 'document' => 'array']]);
+
+        return DocumentManager::create($client, $config);
+    }
+
+    private function createFailPoint(string $failCommand): void
+    {
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => ['times' => 1],
+            'data' => [
+                'errorCode' => 192, // FailPointEnabled
+                'errorLabels' => ['TransientTransactionError'],
+                'failCommands' => [$failCommand],
+            ],
+        ]);
+    }
+}
+
+/**
+ * @ODM\MappedSuperclass
+ * @ODM\HasLifecycleCallbacks
+ */
+abstract class BaseEventDocument
+{
+    public function __construct(private TestCase $test)
+    {
+    }
+
+    /**
+     * @ODM\Field(type="string")
+     *
+     * @var string|null
+     */
+    public $name;
+
+    public int $preUpdate = 0;
+
+    public int $postPersist = 0;
+
+    public int $postUpdate = 0;
+
+    public int $postRemove = 0;
+
+    /** @ODM\PreUpdate */
+    public function preUpdate(Event\PreUpdateEventArgs $e): void
+    {
+        $this->assertTransactionState($e);
+        $this->preUpdate++;
+    }
+
+    /** @ODM\PostPersist */
+    public function postPersist(Event\LifecycleEventArgs $e): void
+    {
+        $this->assertTransactionState($e);
+        $this->postPersist++;
+    }
+
+    /** @ODM\PostUpdate */
+    public function postUpdate(Event\LifecycleEventArgs $e): void
+    {
+        $this->assertTransactionState($e);
+        $this->postUpdate++;
+    }
+
+    /** @ODM\PostRemove */
+    public function postRemove(Event\LifecycleEventArgs $e): void
+    {
+        $this->assertTransactionState($e);
+        $this->postRemove++;
+    }
+
+    private function assertTransactionState(LifecycleEventArgs $e): void
+    {
+        $this->test->assertTrue($e->isInTransaction);
+        $this->test->assertInstanceOf(Session::class, $e->session);
+    }
+}
+
+/** @ODM\EmbeddedDocument */
+class EmbeddedEventDocument extends BaseEventDocument
+{
+}
+
+/** @ODM\Document  */
+class RootEventDocument extends BaseEventDocument
+{
+    /** @ODM\Id */
+    public string $id;
+
+    /** @ODM\EmbedOne(targetDocument=EmbeddedEventDocument::class) */
+    public ?EmbeddedEventDocument $embedded;
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

With transactional commit enabled, there's a chance that lifecycle events get dispatched more than once. This can be a problem for existing code that may assume that lifecycle events only get dispatched once, especially since this is also the behaviour when using transactions in ORM. Since a failing transaction may lead to retrying the entire commit operation, we need to make sure to only invoke lifecycle events once.

This is done by adding a transactional mode to the `LifecycleEventManager` class, which then tracks which events have been dispatched for each document. The `preUpdate`, `postPersist`, `postUpdate`, and `postRemove` events are then skipped if they have previously been dispatched for this document.

In addition to the above, the `LifecycleEventArgs` is now capable of telling event handlers whether the operation is part of a transaction. This and the `session` property in the event is necessary for any lifecycle event handlers that want to access the database. Since any changes already made to the database are only visible within the transaction, event handlers that want to read or write data need to pass the session option to ensure the write happens within the same transaction.
