### PR TITLE
Use attributes in tests

### DIFF
--- a/benchmark/BaseBench.php
+++ b/benchmark/BaseBench.php
@@ -6,7 +6,7 @@ namespace Doctrine\ODM\MongoDB\Benchmark;
 
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use MongoDB\Client;
 use MongoDB\Model\DatabaseInfo;
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
@@ -80,8 +80,8 @@ abstract class BaseBench
         }
     }
 
-    protected static function createMetadataDriverImpl(): AnnotationDriver
+    protected static function createMetadataDriverImpl(): AttributeDriver
     {
-        return AnnotationDriver::create(__DIR__ . '/../tests/Documents');
+        return AttributeDriver::create(__DIR__ . '/../tests/Documents');
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -791,6 +791,16 @@ parameters:
 			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
 
 		-
+			message: "#^Parameter \\$discriminatorMap of attribute class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\Annotations\\\\ReferenceOne constructor expects array\\<string, class\\-string\\>\\|null, array\\<string, string\\> given\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/TargetDocumentTest.php
+
+		-
+			message: "#^Parameter \\$targetDocument of attribute class Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\Annotations\\\\ReferenceOne constructor expects class\\-string\\|null, string given\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/TargetDocumentTest.php
+
+		-
 			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\Ticket\\\\GH1058PersistDocument\\:\\:\\$id is never written, only read\\.$#"
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -391,6 +391,11 @@
       <code><![CDATA[['upsert' => true]]]></code>
     </InvalidArgument>
   </file>
+  <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/TargetDocumentTest.php">
+    <UndefinedClass>
+      <code><![CDATA[['Foo' => 'Doctrine\ODM\MongoDB\Tests\Functional\SomeInvalidClass']]]></code>
+    </UndefinedClass>
+  </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php">
     <InvalidArgument>
       <code><![CDATA[$doc->embeds]]></code>

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
@@ -6,7 +6,7 @@ namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use Doctrine\ODM\MongoDB\Tests\Query\Filter\Filter;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
@@ -116,7 +116,7 @@ abstract class BaseTestCase extends TestCase
 
     protected static function createMetadataDriverImpl(): MappingDriver
     {
-        return AnnotationDriver::create(__DIR__ . '/../../../../Documents');
+        return AttributeDriver::create(__DIR__ . '/../../../../Documents');
     }
 
     protected static function createTestDocumentManager(): DocumentManager

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -231,59 +231,38 @@ class DocumentManagerTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class WrongSimpleRefDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Documents\Tournament\Participant::class, storeAs="id")
-     *
-     * @var Participant|null
-     */
+    /** @var Participant|null */
+    #[ODM\ReferenceOne(targetDocument: Participant::class, storeAs: 'id')]
     public $ref;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class ReferenceStoreAsDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=User::class, storeAs="id")
-     *
-     * @var User|null
-     */
+    /** @var User|null */
+    #[ODM\ReferenceOne(targetDocument: User::class, storeAs: 'id')]
     public $ref1;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=User::class, storeAs="dbRef")
-     *
-     * @var Collection<int, User>
-     */
+    /** @var Collection<int, User> */
+    #[ODM\ReferenceOne(targetDocument: User::class, storeAs: 'dbRef')]
     public $ref2;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=User::class, storeAs="dbRefWithDb")
-     *
-     * @var Collection<int, User>
-     */
+    /** @var Collection<int, User> */
+    #[ODM\ReferenceOne(targetDocument: User::class, storeAs: 'dbRefWithDb')]
     public $ref3;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=User::class, storeAs="ref")
-     *
-     * @var Collection<int, User>
-     */
+    /** @var Collection<int, User> */
+    #[ODM\ReferenceOne(targetDocument: User::class, storeAs: 'ref')]
     public $ref4;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleCallbacksTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleCallbacksTest.php
@@ -246,110 +246,72 @@ class LifecycleCallbacksTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class User extends BaseDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Profile::class)
-     *
-     * @var Profile|null
-     */
+    /** @var Profile|null */
+    #[ODM\EmbedOne(targetDocument: Profile::class)]
     public $profile;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Profile::class)
-     *
-     * @var Collection<int, Profile>|array<Profile>
-     */
+    /** @var Collection<int, Profile>|array<Profile> */
+    #[ODM\EmbedMany(targetDocument: Profile::class)]
     public $profiles = [];
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=User::class)
-     *
-     * @var Collection<int, User>|array<User>
-     */
+    /** @var Collection<int, User>|array<User> */
+    #[ODM\ReferenceMany(targetDocument: self::class)]
     public $friends = [];
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class Cart extends BaseDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Customer::class, inversedBy="cart")
-     *
-     * @var Customer|null
-     */
+    /** @var Customer|null */
+    #[ODM\ReferenceOne(targetDocument: Customer::class, inversedBy: 'cart')]
     public $customer;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class Customer extends BaseDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Cart::class, mappedBy="customer")
-     *
-     * @var Cart|null
-     */
+    /** @var Cart|null */
+    #[ODM\ReferenceOne(targetDocument: Cart::class, mappedBy: 'customer')]
     public $cart;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Profile extends BaseDocument
 {
-    /**
-     * @ODM\EmbedOne(targetDocument=Profile::class)
-     *
-     * @var Profile|null
-     */
+    /** @var Profile|null */
+    #[ODM\EmbedOne(targetDocument: self::class)]
     public $profile;
 }
 
-/**
- * @ODM\MappedSuperclass
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\MappedSuperclass]
+#[ODM\HasLifecycleCallbacks]
 abstract class BaseDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\Field(type="date")
-     *
-     * @var DateTime
-     */
+    /** @var DateTime */
+    #[ODM\Field(type: 'date')]
     public $createdAt;
 
-    /**
-     * @ODM\Field(type="date")
-     *
-     * @var DateTime|null
-     */
+    /** @var DateTime|null */
+    #[ODM\Field(type: 'date')]
     public $updatedAt;
 
     /** @var bool */
@@ -379,57 +341,57 @@ abstract class BaseDocument
     /** @var bool */
     public $preFlush = false;
 
-    /** @ODM\PrePersist */
+    #[ODM\PrePersist]
     public function prePersist(Event\LifecycleEventArgs $e): void
     {
         $this->prePersist = true;
         $this->createdAt  = new DateTime();
     }
 
-    /** @ODM\PostPersist */
+    #[ODM\PostPersist]
     public function postPersist(Event\LifecycleEventArgs $e): void
     {
         $this->postPersist = true;
     }
 
-    /** @ODM\PreUpdate */
+    #[ODM\PreUpdate]
     public function preUpdate(Event\PreUpdateEventArgs $e): void
     {
         $this->preUpdate = true;
         $this->updatedAt = new DateTime();
     }
 
-    /** @ODM\PostUpdate */
+    #[ODM\PostUpdate]
     public function postUpdate(Event\LifecycleEventArgs $e): void
     {
         $this->postUpdate = true;
     }
 
-    /** @ODM\PreRemove */
+    #[ODM\PreRemove]
     public function preRemove(Event\LifecycleEventArgs $e): void
     {
         $this->preRemove = true;
     }
 
-    /** @ODM\PostRemove */
+    #[ODM\PostRemove]
     public function postRemove(Event\LifecycleEventArgs $e): void
     {
         $this->postRemove = true;
     }
 
-    /** @ODM\PreLoad */
+    #[ODM\PreLoad]
     public function preLoad(Event\PreLoadEventArgs $e): void
     {
         $this->preLoad = true;
     }
 
-    /** @ODM\PostLoad */
+    #[ODM\PostLoad]
     public function postLoad(Event\LifecycleEventArgs $e): void
     {
         $this->postLoad = true;
     }
 
-    /** @ODM\PreFlush */
+    #[ODM\PreFlush]
     public function preFlush(Event\PreFlushEventArgs $e): void
     {
         $this->preFlush = true;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleListenersTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/LifecycleListenersTest.php
@@ -257,60 +257,39 @@ class PostCollectionLoadEventListener
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class TestDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=TestEmbeddedDocument::class)
-     *
-     * @var Collection<int, TestEmbeddedDocument>
-     */
+    /** @var Collection<int, TestEmbeddedDocument> */
+    #[ODM\EmbedMany(targetDocument: TestEmbeddedDocument::class)]
     public $embedded;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Image::class)
-     *
-     * @var Image|null
-     */
+    /** @var Image|null */
+    #[ODM\EmbedOne(targetDocument: Image::class)]
     public $image;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=TestProfile::class)
-     *
-     * @var Collection<int, TestProfile>|array<TestProfile>
-     */
+    /** @var Collection<int, TestProfile>|array<TestProfile> */
+    #[ODM\ReferenceMany(targetDocument: TestProfile::class)]
     public $profiles;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=TestProfile::class)
-     *
-     * @var TestProfile|null
-     */
+    /** @var TestProfile|null */
+    #[ODM\ReferenceOne(targetDocument: TestProfile::class)]
     public $profile;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class TestEmbeddedDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name = '')
@@ -320,46 +299,31 @@ class TestEmbeddedDocument
 }
 
 
-/** @ODM\Document */
+#[ODM\Document]
 class TestProfile
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Image::class)
-     *
-     * @var Image|null
-     */
+    /** @var Image|null */
+    #[ODM\EmbedOne(targetDocument: Image::class)]
     public $image;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Image
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Thumbnail::class)
-     *
-     * @var Collection<int, Thumbnail>|array<Thumbnail>
-     */
+    /** @var Collection<int, Thumbnail>|array<Thumbnail> */
+    #[ODM\EmbedMany(targetDocument: Thumbnail::class)]
     public $thumbnails = [];
 
     public function __construct(string $name)
@@ -368,14 +332,11 @@ class Image
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Thumbnail
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/TransactionalLifecycleEventsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/TransactionalLifecycleEventsTest.php
@@ -9,6 +9,7 @@ use Doctrine\ODM\MongoDB\Event;
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\Client;
 use MongoDB\Driver\Session;
 use PHPUnit\Framework\Assert;
@@ -199,22 +200,16 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
     }
 }
 
-/**
- * @ODM\MappedSuperclass
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\MappedSuperclass]
+#[ODM\HasLifecycleCallbacks]
 abstract class BaseEventDocument
 {
     public function __construct()
     {
     }
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
-    public $name;
+    #[ODM\Field(type: Type::STRING)]
+    public ?string $name = null;
 
     public int $preUpdate = 0;
 
@@ -225,27 +220,28 @@ abstract class BaseEventDocument
     public int $postRemove = 0;
 
     /** @ODM\PreUpdate */
+    #[ODM\PreUpdate]
     public function preUpdate(Event\PreUpdateEventArgs $e): void
     {
         $this->assertTransactionState($e);
         $this->preUpdate++;
     }
 
-    /** @ODM\PostPersist */
+    #[ODM\PostPersist]
     public function postPersist(Event\LifecycleEventArgs $e): void
     {
         $this->assertTransactionState($e);
         $this->postPersist++;
     }
 
-    /** @ODM\PostUpdate */
+    #[ODM\PostUpdate]
     public function postUpdate(Event\LifecycleEventArgs $e): void
     {
         $this->assertTransactionState($e);
         $this->postUpdate++;
     }
 
-    /** @ODM\PostRemove */
+    #[ODM\PostRemove]
     public function postRemove(Event\LifecycleEventArgs $e): void
     {
         $this->assertTransactionState($e);
@@ -259,17 +255,17 @@ abstract class BaseEventDocument
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbeddedEventDocument extends BaseEventDocument
 {
 }
 
-/** @ODM\Document  */
+#[ODM\Document]
 class RootEventDocument extends BaseEventDocument
 {
-    /** @ODM\Id */
+    #[ODM\Id]
     public string $id;
 
-    /** @ODM\EmbedOne(targetDocument=EmbeddedEventDocument::class) */
+    #[ODM\EmbedOne(targetDocument: EmbeddedEventDocument::class)]
     public ?EmbeddedEventDocument $embedded;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AlsoLoadTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AlsoLoadTest.php
@@ -211,151 +211,106 @@ class AlsoLoadTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class AlsoLoadDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     * @ODM\AlsoLoad({"bar", "zip"})
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
+    #[ODM\AlsoLoad(['bar', 'zip'])]
     public $foo;
 
-    /**
-     * @ODM\Field(notSaved=true)
-     * @ODM\AlsoLoad({"zip", "bar"})
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(notSaved: true)]
+    #[ODM\AlsoLoad(['zip', 'bar'])]
     public $baz;
 
-    /**
-     * @ODM\Field(notSaved=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(notSaved: true)]
     public $bar;
 
-    /**
-     * @ODM\Field(notSaved=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(notSaved: true)]
     public $zip;
 
-    /**
-     * @ODM\Field(type="string")
-     * @ODM\AlsoLoad("zip")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
+    #[ODM\AlsoLoad('zip')]
     public $zap = 'zap';
 
-    /**
-     * @ODM\Field(notSaved=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(notSaved: true)]
     public $name;
 
-    /**
-     * @ODM\Field(notSaved=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(notSaved: true)]
     public $fullName;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $firstName;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $lastName;
 
-    /**
-     * @ODM\Field(type="string")
-     * @ODM\AlsoLoad("testNew")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
+    #[ODM\AlsoLoad('testNew')]
     public $test = 'test';
 
-    /**
-     * @ODM\Field(notSaved=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(notSaved: true)]
     public $testNew;
 
-    /**
-     * @ODM\Field(notSaved=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(notSaved: true)]
     public $testOld;
 
-    /**
-     * @ODM\Field(notSaved=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(notSaved: true)]
     public $testOlder;
 
-    /** @ODM\AlsoLoad({"name", "fullName"}) */
+    #[ODM\AlsoLoad(['name', 'fullName'])]
     public function populateFirstAndLastName(string $name): void
     {
         [$this->firstName, $this->lastName] = explode(' ', $name);
     }
 
-    /** @ODM\AlsoLoad ({"testOld", "testOlder"}) */
+    #[ODM\AlsoLoad(['testOld', 'testOlder'])]
     public function populateTest(?string $test): void
     {
         $this->test = $test;
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class AlsoLoadChild extends AlsoLoadDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $fizz;
 
-    /** @ODM\AlsoLoad("buzz") */
+    #[ODM\AlsoLoad('buzz')]
     public function populateFizz(string $fizz): void
     {
         $this->fizz = $fizz;
     }
 
-    /** @ODM\AlsoLoad ("testOldest") */
+    #[ODM\AlsoLoad('testOldest')]
     public function populateTest(?string $test): void
     {
         $this->test = $test;
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class AlsoLoadGrandchild extends AlsoLoadChild
 {
-    /** @ODM\AlsoLoad ("testReallyOldest") */
+    #[ODM\AlsoLoad('testReallyOldest')]
     public function populateTest(?string $test): void
     {
         $this->test = $test;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtomicSetTest.php
@@ -547,71 +547,44 @@ class AtomicSetTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class AtomicSetUser
 {
-    /**
-     * @ODM\Id
-     *
-     * @var ObjectId|null
-     */
+    /** @var ObjectId|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\Field(type="int")
-     * @ODM\Version
-     *
-     * @var int
-     */
+    /** @var int */
+    #[ODM\Field(type: 'int')]
+    #[ODM\Version]
     public $version = 1;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $surname;
 
-    /**
-     * @ODM\EmbedMany(strategy="atomicSet", targetDocument=Documents\Phonenumber::class)
-     *
-     * @var Collection<int, Phonenumber>
-     */
+    /** @var Collection<int, Phonenumber> */
+    #[ODM\EmbedMany(strategy: 'atomicSet', targetDocument: Phonenumber::class)]
     public $phonenumbers;
 
-    /**
-     * @ODM\EmbedMany(strategy="atomicSetArray", targetDocument=Documents\Phonenumber::class)
-     *
-     * @var Collection<int, Phonenumber>
-     */
+    /** @var Collection<int, Phonenumber> */
+    #[ODM\EmbedMany(strategy: 'atomicSetArray', targetDocument: Phonenumber::class)]
     public $phonenumbersArray;
 
-    /**
-     * @ODM\EmbedMany(strategy="atomicSet", targetDocument=Documents\Phonebook::class)
-     *
-     * @var Collection<int, Phonebook>
-     */
+    /** @var Collection<int, Phonebook> */
+    #[ODM\EmbedMany(strategy: 'atomicSet', targetDocument: Phonebook::class)]
     public $phonebooks;
 
-    /**
-     * @ODM\EmbedMany(strategy="atomicSet", targetDocument=AtomicSetInception::class)
-     *
-     * @var Collection<int, AtomicSetInception>
-     */
+    /** @var Collection<int, AtomicSetInception> */
+    #[ODM\EmbedMany(strategy: 'atomicSet', targetDocument: AtomicSetInception::class)]
     public $inception;
 
-    /**
-     * @ODM\ReferenceMany(strategy="atomicSetArray", targetDocument=AtomicSetUser::class)
-     *
-     * @var Collection<int, AtomicSetUser>|array<AtomicSetUser>
-     */
+    /** @var Collection<int, AtomicSetUser>|array<AtomicSetUser> */
+    #[ODM\ReferenceMany(strategy: 'atomicSetArray', targetDocument: self::class)]
     public $friends;
 
     public function __construct(string $name)
@@ -624,28 +597,19 @@ class AtomicSetUser
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class AtomicSetInception
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $value;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=AtomicSetInception::class)
-     *
-     * @var AtomicSetInception|null
-     */
+    /** @var AtomicSetInception|null */
+    #[ODM\EmbedOne(targetDocument: self::class)]
     public $one;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=AtomicSetInception::class)
-     *
-     * @var Collection<int, AtomicSetInception>
-     */
+    /** @var Collection<int, AtomicSetInception> */
+    #[ODM\EmbedMany(targetDocument: self::class)]
     public $many;
 
     public function __construct(string $value)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/BinDataTest.php
@@ -39,62 +39,38 @@ class BinDataTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class BinDataTestUser
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="bin")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'bin')]
     public $bin;
 
-    /**
-     * @ODM\Field(type="bin_func")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'bin_func')]
     public $binFunc;
 
-    /**
-     * @ODM\Field(type="bin_bytearray")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'bin_bytearray')]
     public $binByteArray;
 
-    /**
-     * @ODM\Field(type="bin_uuid")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'bin_uuid')]
     public $binUUID;
 
-    /**
-     * @ODM\Field(type="bin_uuid_rfc4122")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'bin_uuid_rfc4122')]
     public $binUUIDRFC4122;
 
-    /**
-     * @ODM\Field(type="bin_md5")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'bin_md5')]
     public $binMD5;
 
-    /**
-     * @ODM\Field(type="bin_custom")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'bin_custom')]
     public $binCustom;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionPersisterTest.php
@@ -589,67 +589,43 @@ class CollectionPersisterTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document(collection="user_collection_persister_test") */
+#[ODM\Document(collection: 'user_collection_persister_test')]
 class CollectionPersisterUser
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $username;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterCategory::class)
-     *
-     * @var Collection<int, CollectionPersisterCategory>|array<CollectionPersisterCategory>
-     */
+    /** @var Collection<int, CollectionPersisterCategory>|array<CollectionPersisterCategory> */
+    #[ODM\EmbedMany(targetDocument: CollectionPersisterCategory::class)]
     public $categories = [];
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterGroup::class, storeEmptyArray=true)
-     *
-     * @var Collection<int, CollectionPersisterGroup>|array<CollectionPersisterGroup>
-     */
+    /** @var Collection<int, CollectionPersisterGroup>|array<CollectionPersisterGroup> */
+    #[ODM\EmbedMany(targetDocument: CollectionPersisterGroup::class, storeEmptyArray: true)]
     public $groups = [];
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=CollectionPersisterPhonenumber::class, cascade={"persist"})
-     *
-     * @var Collection<int, CollectionPersisterPhonenumber>|array<CollectionPersisterPhonenumber>
-     */
+    /** @var Collection<int, CollectionPersisterPhonenumber>|array<CollectionPersisterPhonenumber> */
+    #[ODM\ReferenceMany(targetDocument: CollectionPersisterPhonenumber::class, cascade: ['persist'])]
     public $phonenumbers = [];
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=CollectionPersisterRole::class, cascade={"persist"}, storeEmptyArray=true)
-     *
-     * @var Collection<int, CollectionPersisterRole>|array<CollectionPersisterRole>
-     */
+    /** @var Collection<int, CollectionPersisterRole>|array<CollectionPersisterRole> */
+    #[ODM\ReferenceMany(targetDocument: CollectionPersisterRole::class, cascade: ['persist'], storeEmptyArray: true)]
     public $roles = [];
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class CollectionPersisterCategory
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterCategory::class)
-     *
-     * @var Collection<int, CollectionPersisterCategory>|array<CollectionPersisterCategory>
-     */
+    /** @var Collection<int, CollectionPersisterCategory>|array<CollectionPersisterCategory> */
+    #[ODM\EmbedMany(targetDocument: self::class)]
     public $children = [];
 
     public function __construct(string $name)
@@ -658,21 +634,15 @@ class CollectionPersisterCategory
     }
 }
 
-/** @ODM\Document(collection="phonenumber_collection_persister_test") */
+#[ODM\Document(collection: 'phonenumber_collection_persister_test')]
 class CollectionPersisterPhonenumber
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $phonenumber;
 
     public function __construct(string $phonenumber)
@@ -681,21 +651,15 @@ class CollectionPersisterPhonenumber
     }
 }
 
-/** @ODM\Document(collection="role_collection_persister_test") */
+#[ODM\Document(collection: 'role_collection_persister_test')]
 class CollectionPersisterRole
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $role;
 
     public function __construct(string $role)
@@ -704,21 +668,15 @@ class CollectionPersisterRole
     }
 }
 
-/** @ODM\Document(collection="group_collection_persister_test") */
+#[ODM\Document(collection: 'group_collection_persister_test')]
 class CollectionPersisterGroup
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $group;
 
     public function __construct(string $group)
@@ -727,28 +685,19 @@ class CollectionPersisterGroup
     }
 }
 
-/** @ODM\Document(collection="post_collection_persister_test") */
+#[ODM\Document(collection: 'post_collection_persister_test')]
 class CollectionPersisterPost
 {
-  /**
-   * @ODM\Id
-   *
-   * @var string|null
-   */
+  /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-  /**
-   * @ODM\Field(type="string")
-   *
-   * @var string
-   */
+  /** @var string */
+    #[ODM\Field(type: 'string')]
     public $post;
 
-  /**
-   * @ODM\EmbedMany(targetDocument=CollectionPersisterComment::class, strategy="set")
-   *
-   * @var Collection<array-key, CollectionPersisterComment>|array<CollectionPersisterComment>
-   */
+  /** @var Collection<array-key, CollectionPersisterComment>|array<CollectionPersisterComment> */
+    #[ODM\EmbedMany(targetDocument: CollectionPersisterComment::class, strategy: 'set')]
     public $comments = [];
 
     public function __construct(string $post)
@@ -758,35 +707,23 @@ class CollectionPersisterPost
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class CollectionPersisterComment
 {
-  /**
-   * @ODM\Id
-   *
-   * @var string|null
-   */
+  /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-  /**
-   * @ODM\Field(type="string")
-   *
-   * @var string
-   */
+  /** @var string */
+    #[ODM\Field(type: 'string')]
     public $comment;
 
-  /**
-   * @ODM\Field(type="string")
-   *
-   * @var string
-   */
+  /** @var string */
+    #[ODM\Field(type: 'string')]
     public $by;
 
-  /**
-   * @ODM\EmbedMany(targetDocument=CollectionPersisterComment::class, strategy="set")
-   *
-   * @var Collection<array-key, CollectionPersisterComment>|array<CollectionPersisterComment>
-   */
+  /** @var Collection<array-key, CollectionPersisterComment>|array<CollectionPersisterComment> */
+    #[ODM\EmbedMany(targetDocument: self::class, strategy: 'set')]
     public $comments = [];
 
     public function __construct(string $comment, string $by)
@@ -797,70 +734,43 @@ class CollectionPersisterComment
     }
 }
 
-/** @ODM\Document(collection="structure_collection_persister_test") */
+#[ODM\Document(collection: 'structure_collection_persister_test')]
 class CollectionPersisterStructure
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="addToSet")
-     *
-     * @var Collection<int, CollectionPersisterNestedStructure>
-     */
+    /** @var Collection<int, CollectionPersisterNestedStructure> */
+    #[ODM\EmbedMany(targetDocument: CollectionPersisterNestedStructure::class, strategy: 'addToSet')]
     public $addToSet;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="addToSet")
-     *
-     * @var Collection<int, CollectionPersisterNestedStructure>
-     */
+    /** @var Collection<int, CollectionPersisterNestedStructure> */
+    #[ODM\EmbedMany(targetDocument: CollectionPersisterNestedStructure::class, strategy: 'addToSet')]
     public $addToSet2;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="set")
-     *
-     * @var Collection<int, CollectionPersisterNestedStructure>
-     */
+    /** @var Collection<int, CollectionPersisterNestedStructure> */
+    #[ODM\EmbedMany(targetDocument: CollectionPersisterNestedStructure::class, strategy: 'set')]
     public $set;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="set")
-     *
-     * @var Collection<int, CollectionPersisterNestedStructure>
-     */
+    /** @var Collection<int, CollectionPersisterNestedStructure> */
+    #[ODM\EmbedMany(targetDocument: CollectionPersisterNestedStructure::class, strategy: 'set')]
     public $set2;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="setArray")
-     *
-     * @var Collection<int, CollectionPersisterNestedStructure>
-     */
+    /** @var Collection<int, CollectionPersisterNestedStructure> */
+    #[ODM\EmbedMany(targetDocument: CollectionPersisterNestedStructure::class, strategy: 'setArray')]
     public $setArray;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="setArray")
-     *
-     * @var Collection<int, CollectionPersisterNestedStructure>
-     */
+    /** @var Collection<int, CollectionPersisterNestedStructure> */
+    #[ODM\EmbedMany(targetDocument: CollectionPersisterNestedStructure::class, strategy: 'setArray')]
     public $setArray2;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="pushAll")
-     *
-     * @var Collection<int, CollectionPersisterNestedStructure>
-     */
+    /** @var Collection<int, CollectionPersisterNestedStructure> */
+    #[ODM\EmbedMany(targetDocument: CollectionPersisterNestedStructure::class, strategy: 'pushAll')]
     public $pushAll;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="pushAll")
-     *
-     * @var Collection<int, CollectionPersisterNestedStructure>
-     */
+    /** @var Collection<int, CollectionPersisterNestedStructure> */
+    #[ODM\EmbedMany(targetDocument: CollectionPersisterNestedStructure::class, strategy: 'pushAll')]
     public $pushAll2;
 
     public function __construct()
@@ -875,77 +785,47 @@ class CollectionPersisterStructure
         $this->pushAll2  = new ArrayCollection();
     }
 }
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class CollectionPersisterNestedStructure
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $field;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="addToSet")
-     *
-     * @var Collection<int, CollectionPersisterNestedStructure>
-     */
+    /** @var Collection<int, CollectionPersisterNestedStructure> */
+    #[ODM\EmbedMany(targetDocument: self::class, strategy: 'addToSet')]
     public $addToSet;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="addToSet")
-     *
-     * @var Collection<int, CollectionPersisterNestedStructure>
-     */
+    /** @var Collection<int, CollectionPersisterNestedStructure> */
+    #[ODM\EmbedMany(targetDocument: self::class, strategy: 'addToSet')]
     public $addToSet2;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="set")
-     *
-     * @var Collection<int, CollectionPersisterNestedStructure>
-     */
+    /** @var Collection<int, CollectionPersisterNestedStructure> */
+    #[ODM\EmbedMany(targetDocument: self::class, strategy: 'set')]
     public $set;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="set")
-     *
-     * @var Collection<int, CollectionPersisterNestedStructure>
-     */
+    /** @var Collection<int, CollectionPersisterNestedStructure> */
+    #[ODM\EmbedMany(targetDocument: self::class, strategy: 'set')]
     public $set2;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="setArray")
-     *
-     * @var Collection<int, CollectionPersisterNestedStructure>
-     */
+    /** @var Collection<int, CollectionPersisterNestedStructure> */
+    #[ODM\EmbedMany(targetDocument: self::class, strategy: 'setArray')]
     public $setArray;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="setArray")
-     *
-     * @var Collection<int, CollectionPersisterNestedStructure>
-     */
+    /** @var Collection<int, CollectionPersisterNestedStructure> */
+    #[ODM\EmbedMany(targetDocument: self::class, strategy: 'setArray')]
     public $setArray2;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="pushAll")
-     *
-     * @var Collection<int, CollectionPersisterNestedStructure>
-     */
+    /** @var Collection<int, CollectionPersisterNestedStructure> */
+    #[ODM\EmbedMany(targetDocument: self::class, strategy: 'pushAll')]
     public $pushAll;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=CollectionPersisterNestedStructure::class, strategy="pushAll")
-     *
-     * @var Collection<int, CollectionPersisterNestedStructure>
-     */
+    /** @var Collection<int, CollectionPersisterNestedStructure> */
+    #[ODM\EmbedMany(targetDocument: self::class, strategy: 'pushAll')]
     public $pushAll2;
 
     public function __construct(string $field)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CollectionsTest.php
@@ -116,45 +116,26 @@ class CollectionsTest extends BaseTestCase
     }
 }
 
-/**
- * @ODM\Document(collection={
- *   "name"="CollectionTestCapped",
- *   "capped"=true,
- *   "size"=1000,
- *   "max"=1
- * })
- */
+#[ODM\Document(collection: ['name' => 'CollectionTestCapped', 'capped' => true, 'size' => 1000, 'max' => 1])]
 class CollectionTestCapped
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $username;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class CollectionTestBasic
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $username;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomCollectionsTest.php
@@ -185,55 +185,27 @@ class CustomCollectionsTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class DocumentWithCustomCollection
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedMany(
-     *   collectionClass=MyEmbedsCollection::class,
-     *   targetDocument=EmbeddedDocumentInCustomCollection::class
-     * )
-     *
-     * @var MyEmbedsCollection<int, EmbeddedDocumentInCustomCollection>
-     */
+    /** @var MyEmbedsCollection<int, EmbeddedDocumentInCustomCollection> */
+    #[ODM\EmbedMany(collectionClass: MyEmbedsCollection::class, targetDocument: EmbeddedDocumentInCustomCollection::class)]
     public $coll;
 
-    /**
-     * @ODM\EmbedMany(
-     *   targetDocument=EmbeddedDocumentInCustomCollection::class
-     * )
-     *
-     * @var Collection<int, EmbeddedDocumentInCustomCollection>
-     */
+    /** @var Collection<int, EmbeddedDocumentInCustomCollection> */
+    #[ODM\EmbedMany(targetDocument: EmbeddedDocumentInCustomCollection::class)]
     public $boring;
 
-    /**
-     * @ODM\ReferenceMany(
-     *   collectionClass=MyDocumentsCollection::class,
-     *   orphanRemoval=true,
-     *   targetDocument=DocumentWithCustomCollection::class
-     * )
-     *
-     * @var MyDocumentsCollection<int, DocumentWithCustomCollection>
-     */
+    /** @var MyDocumentsCollection<int, DocumentWithCustomCollection> */
+    #[ODM\ReferenceMany(collectionClass: MyDocumentsCollection::class, orphanRemoval: true, targetDocument: self::class)]
     public $refMany;
 
-    /**
-     * @ODM\ReferenceMany(
-     *   collectionClass="\Doctrine\ODM\MongoDB\Tests\Functional\MyDocumentsCollection",
-     *   mappedBy="refMany",
-     *   targetDocument=DocumentWithCustomCollection::class
-     * )
-     *
-     * @var MyDocumentsCollection<int, DocumentWithCustomCollection>
-     */
+    /** @var MyDocumentsCollection<int, DocumentWithCustomCollection> */
+    #[ODM\ReferenceMany(collectionClass: '\Doctrine\ODM\MongoDB\Tests\Functional\MyDocumentsCollection', mappedBy: 'refMany', targetDocument: self::class)]
     public $inverseRefMany;
 
     public function __construct()
@@ -245,21 +217,15 @@ class DocumentWithCustomCollection
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbeddedDocumentInCustomCollection
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\Field(type="bool")
-     *
-     * @var bool
-     */
+    /** @var bool */
+    #[ODM\Field(type: 'bool')]
     public $enabled;
 
     public function __construct(string $name, bool $enabled)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomFieldNameTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomFieldNameTest.php
@@ -100,20 +100,14 @@ class CustomFieldNameTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class CustomFieldName
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(name="login", type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(name: 'login', type: 'string')]
     public $username;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/CustomTypeTest.php
@@ -103,20 +103,14 @@ class CustomTypeException extends Exception
 {
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class Country
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="date_collection")
-     *
-     * @var DateTime[]|DateTime|null
-     */
+    /** @var DateTime[]|DateTime|null */
+    #[ODM\Field(type: 'date_collection')]
     public $nationalHolidays;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DatabasesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DatabasesTest.php
@@ -30,24 +30,18 @@ class DatabasesTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document(db="test_custom") */
+#[ODM\Document(db: 'test_custom')]
 class CustomDatabaseTest
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 }
 
-/** @ODM\Document() */
+#[ODM\Document]
 class DefaultDatabaseTest
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DiscriminatorsDefaultValueTest.php
@@ -80,14 +80,11 @@ class DiscriminatorsDefaultValueTest extends BaseTestCase
 }
 
 // Unmapped superclasses
-/** @ODM\Document(collection="discriminator_parent") */
+#[ODM\Document(collection: 'discriminator_parent')]
 abstract class ParentDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
     /** @var ChildDocument */
@@ -139,21 +136,15 @@ abstract class ParentDocument
     }
 }
 
-/** @ODM\Document(collection="discriminator_child") */
+#[ODM\Document(collection: 'discriminator_child')]
 abstract class ChildDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     protected $type;
 
     public function __construct(string $type)
@@ -173,100 +164,71 @@ abstract class ChildDocument
 }
 
 // Documents without discriminators - used to create "legacy" data
-/** @ODM\Document(collection="discriminator_parent") */
+#[ODM\Document(collection: 'discriminator_parent')]
 class ParentDocumentWithoutDiscriminator extends ParentDocument
 {
-    /**
-     * @ODM\ReferenceOne(targetDocument=ChildDocumentWithoutDiscriminator::class)
-     *
-     * @var ChildDocumentWithDiscriminator
-     */
+    /** @var ChildDocumentWithDiscriminator */
+    #[ODM\ReferenceOne(targetDocument: ChildDocumentWithoutDiscriminator::class)]
     protected $referencedChild;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=ChildDocumentWithoutDiscriminator::class)
-     *
-     * @var Collection<int, ChildDocumentWithDiscriminator>|array<ChildDocumentWithDiscriminator>
-     */
+    /** @var Collection<int, ChildDocumentWithDiscriminator>|array<ChildDocumentWithDiscriminator> */
+    #[ODM\ReferenceMany(targetDocument: ChildDocumentWithoutDiscriminator::class)]
     protected $referencedChildren;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=ChildDocumentWithoutDiscriminator::class)
-     *
-     * @var ChildDocumentWithoutDiscriminator
-     */
+    /** @var ChildDocumentWithoutDiscriminator */
+    #[ODM\EmbedOne(targetDocument: ChildDocumentWithoutDiscriminator::class)]
     protected $embeddedChild;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=ChildDocumentWithoutDiscriminator::class)
-     *
-     * @var Collection<int, ChildDocumentWithDiscriminator>|array<ChildDocumentWithDiscriminator>
-     */
+    /** @var Collection<int, ChildDocumentWithDiscriminator>|array<ChildDocumentWithDiscriminator> */
+    #[ODM\EmbedMany(targetDocument: ChildDocumentWithoutDiscriminator::class)]
     protected $embeddedChildren;
 }
 
-/** @ODM\Document(collection="discriminator_child") */
+#[ODM\Document(collection: 'discriminator_child')]
 class ChildDocumentWithoutDiscriminator extends ChildDocument
 {
 }
 
 // Documents with discriminators - these represent a "refactored" document structure
-/** @ODM\Document(collection="discriminator_parent") */
+#[ODM\Document(collection: 'discriminator_parent')]
 class ParentDocumentWithDiscriminator extends ParentDocument
 {
-    /**
-     * @ODM\ReferenceOne(targetDocument=ChildDocumentWithDiscriminator::class)
-     *
-     * @var ChildDocumentWithDiscriminator
-     */
+    /** @var ChildDocumentWithDiscriminator */
+    #[ODM\ReferenceOne(targetDocument: ChildDocumentWithDiscriminator::class)]
     protected $referencedChild;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=ChildDocumentWithDiscriminator::class)
-     *
-     * @var Collection<int, ChildDocumentWithDiscriminator>|array<ChildDocumentWithDiscriminator>
-     */
+    /** @var Collection<int, ChildDocumentWithDiscriminator>|array<ChildDocumentWithDiscriminator> */
+    #[ODM\ReferenceMany(targetDocument: ChildDocumentWithDiscriminator::class)]
     protected $referencedChildren;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=ChildDocumentWithDiscriminator::class)
-     *
-     * @var ChildDocumentWithDiscriminator
-     */
+    /** @var ChildDocumentWithDiscriminator */
+    #[ODM\EmbedOne(targetDocument: ChildDocumentWithDiscriminator::class)]
     protected $embeddedChild;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=ChildDocumentWithDiscriminator::class)
-     *
-     * @var Collection<int, ChildDocumentWithDiscriminator>
-     */
+    /** @var Collection<int, ChildDocumentWithDiscriminator> */
+    #[ODM\EmbedMany(targetDocument: ChildDocumentWithDiscriminator::class)]
     protected $embeddedChildren;
 }
 
-/**
- * @ODM\Document(collection="discriminator_child")
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("discriminator")
- * @ODM\DiscriminatorMap({"simple"=ChildDocumentWithDiscriminatorSimple::class, "complex"=ChildDocumentWithDiscriminatorComplex::class})
- * @ODM\DefaultDiscriminatorValue("simple")
- */
+#[ODM\Document(collection: 'discriminator_child')]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('discriminator')]
+#[ODM\DiscriminatorMap(['simple' => ChildDocumentWithDiscriminatorSimple::class, 'complex' => ChildDocumentWithDiscriminatorComplex::class])]
+#[ODM\DefaultDiscriminatorValue('simple')]
 class ChildDocumentWithDiscriminator extends ChildDocument
 {
 }
 
-/** @ODM\Document(collection="discriminator_child") */
+#[ODM\Document(collection: 'discriminator_child')]
 class ChildDocumentWithDiscriminatorSimple extends ChildDocumentWithDiscriminator
 {
 }
 
-/** @ODM\Document(collection="discriminator_child") */
+#[ODM\Document(collection: 'discriminator_child')]
 class ChildDocumentWithDiscriminatorComplex extends ChildDocumentWithDiscriminatorSimple
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     protected $value;
 
     public function __construct(string $type, string $value)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -873,231 +873,143 @@ class DocumentPersisterTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class DocumentPersisterTestDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var ObjectId|null
-     */
+    /** @var ObjectId|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(name="dbName", type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(name: 'dbName', type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedOne(
-     *     targetDocument=Doctrine\ODM\MongoDB\Tests\Functional\AbstractDocumentPersisterTestDocumentAssociation::class,
-     *     discriminatorField="type",
-     *     name="associationName"
-     * )
-     *
-     * @var AbstractDocumentPersisterTestDocumentAssociation|null
-     */
+    /** @var AbstractDocumentPersisterTestDocumentAssociation|null */
+    #[ODM\EmbedOne(targetDocument: AbstractDocumentPersisterTestDocumentAssociation::class, discriminatorField: 'type', name: 'associationName')]
     public $association;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=DocumentPersisterTestHashIdDocument::class, storeAs="id")
-     *
-     * @var DocumentPersisterTestHashIdDocument|null
-     */
+    /** @var DocumentPersisterTestHashIdDocument|null */
+    #[ODM\ReferenceOne(targetDocument: DocumentPersisterTestHashIdDocument::class, storeAs: 'id')]
     public $simpleRef;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=DocumentPersisterTestHashIdDocument::class, storeAs="dbRef")
-     *
-     * @var DocumentPersisterTestHashIdDocument|null
-     */
+    /** @var DocumentPersisterTestHashIdDocument|null */
+    #[ODM\ReferenceOne(targetDocument: DocumentPersisterTestHashIdDocument::class, storeAs: 'dbRef')]
     public $semiComplexRef;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=DocumentPersisterTestHashIdDocument::class, storeAs="dbRefWithDb")
-     *
-     * @var DocumentPersisterTestHashIdDocument|null
-     */
+    /** @var DocumentPersisterTestHashIdDocument|null */
+    #[ODM\ReferenceOne(targetDocument: DocumentPersisterTestHashIdDocument::class, storeAs: 'dbRefWithDb')]
     public $complexRef;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=DocumentPersisterTestHashIdDocument::class, storeAs="ref")
-     *
-     * @var DocumentPersisterTestHashIdDocument|null
-     */
+    /** @var DocumentPersisterTestHashIdDocument|null */
+    #[ODM\ReferenceOne(targetDocument: DocumentPersisterTestHashIdDocument::class, storeAs: 'ref')]
     public $embeddedRef;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class DocumentPersisterTestDocumentWithVersion
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(name="dbName", type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(name: 'dbName', type: 'string')]
     public $name;
 
-    /**
-     * @ODM\Version
-     * @ODM\Field(type="int")
-     *
-     * @var int
-     */
+    /** @var int */
+    #[ODM\Version]
+    #[ODM\Field(type: 'int')]
     public $revision = 1;
 }
 
-/**
- * @ODM\EmbeddedDocument
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({
- *     "reference"="Doctrine\ODM\MongoDB\Tests\Functional\DocumentPersisterTestDocumentReference",
- *     "embed"="Doctrine\ODM\MongoDB\Tests\Functional\DocumentPersisterTestDocumentEmbed"
- * })
- */
+#[ODM\EmbeddedDocument]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('type')]
+#[ODM\DiscriminatorMap(['reference' => DocumentPersisterTestDocumentReference::class, 'embed' => DocumentPersisterTestDocumentEmbed::class])]
 abstract class AbstractDocumentPersisterTestDocumentAssociation
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(name="nestedName")
-     *
-     * @var object|null
-     */
+    /** @var object|null */
+    #[ODM\EmbedOne(name: 'nestedName')]
     public $nested;
 
-    /**
-     * @ODM\EmbedOne(
-     *     targetDocument=Doctrine\ODM\MongoDB\Tests\Functional\AbstractDocumentPersisterTestDocumentAssociation::class,
-     *     discriminatorField="type",
-     *     name="associationName"
-     * )
-     *
-     * @var AbstractDocumentPersisterTestDocumentAssociation|null
-     */
+    /** @var AbstractDocumentPersisterTestDocumentAssociation|null */
+    #[ODM\EmbedOne(targetDocument: self::class, discriminatorField: 'type', name: 'associationName')]
     public $association;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class DocumentPersisterTestDocumentReference extends AbstractDocumentPersisterTestDocumentAssociation
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(name="nestedName")
-     *
-     * @var object|null
-     */
+    /** @var object|null */
+    #[ODM\ReferenceOne(name: 'nestedName')]
     public $nested;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class DocumentPersisterTestDocumentEmbed extends AbstractDocumentPersisterTestDocumentAssociation
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(name="nestedName")
-     *
-     * @var object|null
-     */
+    /** @var object|null */
+    #[ODM\EmbedOne(name: 'nestedName')]
     public $nested;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class DocumentPersisterTestHashIdDocument
 {
-    /**
-     * @ODM\Id(strategy="none", options={"type"="hash"})
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id(strategy: 'none', options: ['type' => 'hash'])]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=DocumentPersisterTestDocument::class, storeAs="id")
-     *
-     * @var DocumentPersisterTestDocument|null
-     */
+    /** @var DocumentPersisterTestDocument|null */
+    #[ODM\ReferenceOne(targetDocument: DocumentPersisterTestDocument::class, storeAs: 'id')]
     public $simpleRef;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=DocumentPersisterTestDocument::class, storeAs="dbRef")
-     *
-     * @var DocumentPersisterTestDocument|null
-     */
+    /** @var DocumentPersisterTestDocument|null */
+    #[ODM\ReferenceOne(targetDocument: DocumentPersisterTestDocument::class, storeAs: 'dbRef')]
     public $semiComplexRef;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=DocumentPersisterTestDocument::class, storeAs="dbRefWithDb")
-     *
-     * @var DocumentPersisterTestDocument|null
-     */
+    /** @var DocumentPersisterTestDocument|null */
+    #[ODM\ReferenceOne(targetDocument: DocumentPersisterTestDocument::class, storeAs: 'dbRefWithDb')]
     public $complexRef;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=DocumentPersisterTestDocument::class, storeAs="ref")
-     *
-     * @var DocumentPersisterTestDocument|null
-     */
+    /** @var DocumentPersisterTestDocument|null */
+    #[ODM\ReferenceOne(targetDocument: DocumentPersisterTestDocument::class, storeAs: 'ref')]
     public $embeddedRef;
 }
 
-/** @ODM\Document(writeConcern="majority") */
+#[ODM\Document(writeConcern: 'majority')]
 class DocumentPersisterWriteConcernMajority
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }
 
-/** @ODM\Document(writeConcern=0) */
+#[ODM\Document(writeConcern: 0)]
 class DocumentPersisterWriteConcernUnacknowledged
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }
 
-/** @ODM\Document(writeConcern=1) */
+#[ODM\Document(writeConcern: 1)]
 class DocumentPersisterWriteConcernAcknowledged
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }
 
@@ -1171,14 +1083,11 @@ final class DocumentPersisterCustomIdType extends Type
     }
 }
 
-/** @ODM\Document() */
+#[ODM\Document]
 class DocumentPersisterTestDocumentWithCustomId
 {
-    /**
-     * @ODM\Id(strategy="NONE", type="DocumentPersisterCustomId")
-     *
-     * @var DocumentPersisterCustomTypedId
-     */
+    /** @var DocumentPersisterCustomTypedId */
+    #[ODM\Id(strategy: 'NONE', type: 'DocumentPersisterCustomId')]
     private $id;
 
     public function __construct(DocumentPersisterCustomTypedId $id)
@@ -1192,21 +1101,15 @@ class DocumentPersisterTestDocumentWithCustomId
     }
 }
 
-/** @ODM\Document() */
+#[ODM\Document]
 class DocumentPersisterTestDocumentWithReferenceToDocumentWithCustomId
 {
-    /**
-     * @ODM\Id()
-     *
-     * @var DocumentPersisterCustomTypedId
-     */
+    /** @var DocumentPersisterCustomTypedId */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=DocumentPersisterTestDocumentWithCustomId::class, storeAs="id")
-     *
-     * @var DocumentPersisterTestDocumentWithCustomId
-     */
+    /** @var DocumentPersisterTestDocumentWithCustomId */
+    #[ODM\ReferenceOne(targetDocument: DocumentPersisterTestDocumentWithCustomId::class, storeAs: 'id')]
     private $documentWithCustomId;
 
     public function __construct(DocumentPersisterTestDocumentWithCustomId $documentWithCustomId)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedIdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedIdTest.php
@@ -59,74 +59,50 @@ class EmbeddedIdTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class EmbeddedIdTestUser
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=DefaultIdEmbeddedDocument::class)
-     *
-     * @var DefaultIdEmbeddedDocument|null
-     */
+    /** @var DefaultIdEmbeddedDocument|null */
+    #[ODM\EmbedOne(targetDocument: DefaultIdEmbeddedDocument::class)]
     public $embedOne;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=DefaultIdEmbeddedDocument::class)
-     *
-     * @var Collection<int, DefaultIdEmbeddedDocument>|array<DefaultIdEmbeddedDocument>
-     */
+    /** @var Collection<int, DefaultIdEmbeddedDocument>|array<DefaultIdEmbeddedDocument> */
+    #[ODM\EmbedMany(targetDocument: DefaultIdEmbeddedDocument::class)]
     public $embedMany = [];
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class EmbeddedStrategyNoneIdTestUser
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=DefaultIdStrategyNoneEmbeddedDocument::class)
-     *
-     * @var DefaultIdStrategyNoneEmbeddedDocument|null
-     */
+    /** @var DefaultIdStrategyNoneEmbeddedDocument|null */
+    #[ODM\EmbedOne(targetDocument: DefaultIdStrategyNoneEmbeddedDocument::class)]
     public $embedOne;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=DefaultIdStrategyNoneEmbeddedDocument::class)
-     *
-     * @var Collection<int, DefaultIdStrategyNoneEmbeddedDocument>|array<DefaultIdStrategyNoneEmbeddedDocument>
-     */
+    /** @var Collection<int, DefaultIdStrategyNoneEmbeddedDocument>|array<DefaultIdStrategyNoneEmbeddedDocument> */
+    #[ODM\EmbedMany(targetDocument: DefaultIdStrategyNoneEmbeddedDocument::class)]
     public $embedMany = [];
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class DefaultIdEmbeddedDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class DefaultIdStrategyNoneEmbeddedDocument
 {
-    /**
-     * @ODM\Id(strategy="none")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id(strategy: 'none')]
     public $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedReferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedReferenceTest.php
@@ -58,28 +58,19 @@ class EmbeddedReferenceTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class Offer
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Link::class)
-     *
-     * @var Collection<int, Link>
-     */
+    /** @var Collection<int, Link> */
+    #[ODM\EmbedMany(targetDocument: Link::class)]
     public $links;
 
     public function __construct(string $name)
@@ -89,28 +80,19 @@ class Offer
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Link
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $url;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=ReferencedDocument::class)
-     *
-     * @var Collection<int, ReferencedDocument>
-     */
+    /** @var Collection<int, ReferencedDocument> */
+    #[ODM\ReferenceMany(targetDocument: ReferencedDocument::class)]
     public $referencedDocuments;
 
     public function __construct(string $url)
@@ -120,21 +102,15 @@ class Link
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class ReferencedDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EmbeddedTest.php
@@ -637,28 +637,19 @@ class EmbeddedTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class ChangeEmbeddedIdTest
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithId::class)
-     *
-     * @var EmbeddedDocumentWithId|null
-     */
+    /** @var EmbeddedDocumentWithId|null */
+    #[ODM\EmbedOne(targetDocument: EmbeddedDocumentWithId::class)]
     public $embed;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=EmbeddedDocumentWithId::class)
-     *
-     * @var Collection<int, EmbeddedDocumentWithId>|array<EmbeddedDocumentWithId>
-     */
+    /** @var Collection<int, EmbeddedDocumentWithId>|array<EmbeddedDocumentWithId> */
+    #[ODM\EmbedMany(targetDocument: EmbeddedDocumentWithId::class)]
     public $embedMany;
 
     public function __construct()
@@ -667,49 +658,34 @@ class ChangeEmbeddedIdTest
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbeddedDocumentWithId
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class ChangeEmbeddedWithNameAnnotationTest
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithAnotherEmbedded::class)
-     *
-     * @var EmbeddedDocumentWithAnotherEmbedded|null
-     */
+    /** @var EmbeddedDocumentWithAnotherEmbedded|null */
+    #[ODM\EmbedOne(targetDocument: EmbeddedDocumentWithAnotherEmbedded::class)]
     public $embedOne;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithAnotherEmbedded::class)
-     *
-     * @var EmbeddedDocumentWithAnotherEmbedded|null
-     */
+    /** @var EmbeddedDocumentWithAnotherEmbedded|null */
+    #[ODM\EmbedOne(targetDocument: EmbeddedDocumentWithAnotherEmbedded::class)]
     public $embedTwo;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbeddedDocumentWithAnotherEmbedded
 {
-    /**
-     * @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithId::class, name="m_id")
-     *
-     * @var EmbeddedDocumentWithId|null
-     */
+    /** @var EmbeddedDocumentWithId|null */
+    #[ODM\EmbedOne(targetDocument: EmbeddedDocumentWithId::class, name: 'm_id')]
     public $embed;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FunctionalTest.php
@@ -928,27 +928,18 @@ class FunctionalTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class ParentAssociationTestA
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedOne
-     *
-     * @var object|null
-     */
+    /** @var object|null */
+    #[ODM\EmbedOne]
     public $child;
 
     public function __construct(string $name)
@@ -957,20 +948,14 @@ class ParentAssociationTestA
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class ParentAssociationTestB
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
-    /**
-     * @ODM\EmbedMany
-     *
-     * @var Collection<int, object>|array<object>
-     */
+    /** @var Collection<int, object>|array<object> */
+    #[ODM\EmbedMany]
     public $children = [];
 
     public function __construct(string $name)
@@ -979,14 +964,11 @@ class ParentAssociationTestB
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class ParentAssociationTestC
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/HasLifecycleCallbacksTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/HasLifecycleCallbacksTest.php
@@ -107,115 +107,99 @@ class HasLifecycleCallbacksTest extends BaseTestCase
     }
 }
 
-/** @ODM\MappedSuperclass */
+#[ODM\MappedSuperclass]
 abstract class HasLifecycleCallbacksSuper
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
     /** @var string[] */
     public $invoked = [];
 
-    /** @ODM\PrePersist */
+    #[ODM\PrePersist]
     public function prePersist(): void
     {
         $this->invoked[] = 'super';
     }
 }
 
-/**
- * @ODM\MappedSuperclass
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\MappedSuperclass]
+#[ODM\HasLifecycleCallbacks]
 abstract class HasLifecycleCallbacksSuperAnnotated
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
     /** @var string[] */
     public $invoked = [];
 
-    /** @ODM\PrePersist */
+    #[ODM\PrePersist]
     public function prePersist(): void
     {
         $this->invoked[] = 'super';
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class HasLifecycleCallbacksSubExtendsSuper extends HasLifecycleCallbacksSuper
 {
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class HasLifecycleCallbacksSubExtendsSuperAnnotated extends HasLifecycleCallbacksSuperAnnotated
 {
 }
 
-/**
- * @ODM\Document
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\Document]
+#[ODM\HasLifecycleCallbacks]
 class HasLifecycleCallbacksSubAnnotatedExtendsSuper extends HasLifecycleCallbacksSuper
 {
 }
 
-/**
- * @ODM\Document
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\Document]
+#[ODM\HasLifecycleCallbacks]
 class HasLifecycleCallbacksSubAnnotatedExtendsSuperAnnotated extends HasLifecycleCallbacksSuperAnnotated
 {
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class HasLifecycleCallbacksSubOverrideExtendsSuper extends HasLifecycleCallbacksSuper
 {
-    /** @ODM\PrePersist */
+    #[ODM\PrePersist]
     public function prePersist(): void
     {
         $this->invoked[] = 'sub';
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class HasLifecycleCallbacksSubOverrideExtendsSuperAnnotated extends HasLifecycleCallbacksSuperAnnotated
 {
-    /** @ODM\PrePersist */
+    #[ODM\PrePersist]
     public function prePersist(): void
     {
         $this->invoked[] = 'sub';
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\Document]
+#[ODM\HasLifecycleCallbacks]
 class HasLifecycleCallbacksSubOverrideAnnotatedExtendsSuper extends HasLifecycleCallbacksSuper
 {
-    /** @ODM\PrePersist */
+    #[ODM\PrePersist]
     public function prePersist(): void
     {
         $this->invoked[] = 'sub';
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\Document]
+#[ODM\HasLifecycleCallbacks]
 class HasLifecycleCallbacksSubOverrideAnnotatedExtendsSuperAnnotated extends HasLifecycleCallbacksSuperAnnotated
 {
-    /** @ODM\PrePersist */
+    #[ODM\PrePersist]
     public function prePersist(): void
     {
         $this->invoked[] = 'sub';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IdTest.php
@@ -368,13 +368,13 @@ class IdTest extends BaseTestCase
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @Doctrine\ODM\MongoDB\Mapping\Annotations\Document */
+#[ODM\Document]
 class %s
 {
-    /** @Doctrine\ODM\MongoDB\Mapping\Annotations\Id(strategy="%s", options={"type"="%s"}) **/
+    #[ODM\Id(strategy: "%s", options: ["type" => "%s"])]
     public $id;
 
-    /** @Doctrine\ODM\MongoDB\Mapping\Annotations\Field("type=string") **/
+    #[ODM\Field(type: "string")]
     public $test = "test";
 }',
                 $shortClassName,
@@ -389,21 +389,15 @@ class %s
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class UuidUser
 {
-    /**
-     * @ODM\Id(strategy="uuid", options={"salt"="test"})
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id(strategy: 'uuid', options: ['salt' => 'test'])]
     public $id;
 
-    /**
-     * @ODM\Field(name="t", type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(name: 't', type: 'string')]
     public $name;
 
     public function __construct(string $name)
@@ -412,35 +406,23 @@ class UuidUser
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class CollectionIdUser
 {
-    /**
-     * @ODM\Id(strategy="increment")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Id(strategy: 'increment')]
     public $id;
 
-    /**
-     * @ODM\Field(name="t", type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(name: 't', type: 'string')]
     public $name;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=ReferencedCollectionId::class, cascade={"persist"})
-     *
-     * @var ReferencedCollectionId|null
-     */
+    /** @var ReferencedCollectionId|null */
+    #[ODM\ReferenceOne(targetDocument: ReferencedCollectionId::class, cascade: ['persist'])]
     public $reference;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=EmbeddedCollectionId::class)
-     *
-     * @var Collection<int, EmbeddedCollectionId>|array<EmbeddedCollectionId>
-     */
+    /** @var Collection<int, EmbeddedCollectionId>|array<EmbeddedCollectionId> */
+    #[ODM\EmbedMany(targetDocument: EmbeddedCollectionId::class)]
     public $embedded = [];
 
     public function __construct(string $name)
@@ -449,35 +431,23 @@ class CollectionIdUser
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class CollectionIdUserWithStartingId
 {
-    /**
-     * @ODM\Id(strategy="increment", options={"startingId"=10})
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Id(strategy: 'increment', options: ['startingId' => 10])]
     public $id;
 
-    /**
-     * @ODM\Field(name="t", type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(name: 't', type: 'string')]
     public $name;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=ReferencedCollectionId::class, cascade={"persist"})
-     *
-     * @var ReferencedCollectionId|null
-     */
+    /** @var ReferencedCollectionId|null */
+    #[ODM\ReferenceOne(targetDocument: ReferencedCollectionId::class, cascade: ['persist'])]
     public $reference;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=EmbeddedCollectionId::class)
-     *
-     * @var Collection<int, EmbeddedCollectionId>|array<EmbeddedCollectionId>
-     */
+    /** @var Collection<int, EmbeddedCollectionId>|array<EmbeddedCollectionId> */
+    #[ODM\EmbedMany(targetDocument: EmbeddedCollectionId::class)]
     public $embedded = [];
 
     public function __construct(string $name)
@@ -486,21 +456,15 @@ class CollectionIdUserWithStartingId
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class ReferencedCollectionId
 {
-    /**
-     * @ODM\Id(strategy="increment")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Id(strategy: 'increment')]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name)
@@ -514,21 +478,15 @@ class ReferencedCollectionId
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbeddedCollectionId
 {
-    /**
-     * @ODM\Id(strategy="increment")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Id(strategy: 'increment')]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name)
@@ -542,21 +500,15 @@ class EmbeddedCollectionId
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class AlnumCharsUser
 {
-    /**
-     * @ODM\Id(strategy="alnum", options={"chars"="zyxwvutsrqponmlkjihgfedcba"})
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id(strategy: 'alnum', options: ['chars' => 'zyxwvutsrqponmlkjihgfedcba'])]
     public $id;
 
-    /**
-     * @ODM\Field(name="t", type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(name: 't', type: 'string')]
     public $name;
 
     public function __construct(string $name)
@@ -565,21 +517,15 @@ class AlnumCharsUser
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class CustomIdUser
 {
-    /**
-     * @ODM\Id(strategy="none", nullable=true)
-     *
-     * @var int|string|null
-     */
+    /** @var int|string|null */
+    #[ODM\Id(strategy: 'none', nullable: true)]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name)
@@ -588,13 +534,10 @@ class CustomIdUser
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class TestIdTypesIdAutoUser
 {
-    /**
-     * @ODM\Id(strategy="auto", options={"type"="id"})
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Id(strategy: 'auto', options: ['type' => 'id'])]
     public $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/IndexesTest.php
@@ -251,448 +251,283 @@ class IndexesTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class UniqueOnFieldTest
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     * @ODM\UniqueIndex()
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
+    #[ODM\UniqueIndex]
     public $username;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $email;
 }
 
-/**
- * @ODM\Document
- * @ODM\UniqueIndex(keys={"username"="asc"})
- */
+#[ODM\Document]
+#[ODM\UniqueIndex(keys: ['username' => 'asc'])]
 class UniqueOnDocumentTest
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $username;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $email;
 }
 
-/**
- * @ODM\Document
- * @ODM\Indexes(@ODM\UniqueIndex(keys={"username"="asc"}))
- */
+#[ODM\Document]
+#[ODM\UniqueIndex(keys: ['username' => 'asc'])]
 class IndexesOnDocumentTest
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $username;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $email;
 }
 
-/**
- * @ODM\Document
- * @ODM\Indexes(@ODM\UniqueIndex(keys={"username"="asc"},partialFilterExpression={"counter"={"$gt"=5}}))
- */
+#[ODM\Document]
+#[ODM\UniqueIndex(keys: ['username' => 'asc'], partialFilterExpression: ['counter' => ['$gt' => 5]])]
 class PartialIndexOnDocumentTest
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $username;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $email;
 
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Field(type: 'int')]
     public $counter;
 }
 
-/**
- * @ODM\Document
- * @ODM\UniqueIndex(keys={"username"="asc", "email"="asc"})
- */
+#[ODM\Document]
+#[ODM\UniqueIndex(keys: ['username' => 'asc', 'email' => 'asc'])]
 class MultipleFieldsUniqueIndexTest
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $username;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $email;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class UniqueSparseOnFieldTest
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     * @ODM\UniqueIndex(sparse=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
+    #[ODM\UniqueIndex(sparse: true)]
     public $username;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $email;
 }
 
-/**
- * @ODM\Document
- * @ODM\UniqueIndex(keys={"username"="asc"}, options={"sparse"=true})
- */
+#[ODM\Document]
+#[ODM\UniqueIndex(keys: ['username' => 'asc'], options: ['sparse' => true])]
 class UniqueSparseOnDocumentTest
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $username;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $email;
 }
 
-/**
- * @ODM\Document
- * @ODM\Indexes(@ODM\UniqueIndex(keys={"username"="asc"}, options={"sparse"=true}))
- */
+#[ODM\Document]
+#[ODM\UniqueIndex(keys: ['username' => 'asc'], options: ['sparse' => true])]
 class SparseIndexesOnDocumentTest
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $username;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $email;
 }
 
-/**
- * @ODM\Document
- * @ODM\UniqueIndex(keys={"username"="asc", "email"="asc"}, options={"sparse"=true})
- */
+#[ODM\Document]
+#[ODM\UniqueIndex(keys: ['username' => 'asc', 'email' => 'asc'], options: ['sparse' => true])]
 class MultipleFieldsUniqueSparseIndexTest
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $username;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $email;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MultipleFieldIndexes
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     * @ODM\UniqueIndex(name="test")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
+    #[ODM\UniqueIndex(name: 'test')]
     public $username;
 
-    /**
-     * @ODM\Field(type="string")
-     * @ODM\Index(unique=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
+    #[ODM\Index(unique: true)]
     public $email;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class DocumentWithEmbeddedIndexes
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithIndexes::class)
-     *
-     * @var EmbeddedDocumentWithIndexes|null
-     */
+    /** @var EmbeddedDocumentWithIndexes|null */
+    #[ODM\EmbedOne(targetDocument: EmbeddedDocumentWithIndexes::class)]
     public $embedded;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithIndexes::class)
-     *
-     * @var EmbeddedDocumentWithIndexes|null
-     */
+    /** @var EmbeddedDocumentWithIndexes|null */
+    #[ODM\EmbedOne(targetDocument: EmbeddedDocumentWithIndexes::class)]
     public $embeddedSecondary;
 }
 
-/**
- * @ODM\Document
- * @ODM\DiscriminatorField("type")
- * @ODM\Index(keys={"type"="asc"})
- */
+#[ODM\Document]
+#[ODM\DiscriminatorField('type')]
+#[ODM\Index(keys: ['type' => 'asc'])]
 class DocumentWithDiscriminatorIndex
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }
 
-/**
- * @ODM\Document
- * @ODM\Index(keys={"name"="asc"})
- * @ODM\Index(keys={"name"="desc"})
- * @ODM\UniqueIndex(keys={"name"="asc"}, options={"sparse"=true})
- */
+#[ODM\Document]
+#[ODM\Index(keys: ['name' => 'asc'])]
+#[ODM\Index(keys: ['name' => 'desc'])]
+#[ODM\UniqueIndex(keys: ['name' => 'asc'], options: ['sparse' => true])]
 class DocumentWithMultipleIndexAnnotations
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbeddedDocumentWithIndexes
 {
-    /**
-     * @ODM\Field(type="string")
-     * @ODM\Index
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
+    #[ODM\Index]
     public $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=EmbeddedManyDocumentWithIndexes::class)
-     *
-     * @var Collection<int, EmbeddedManyDocumentWithIndexes>
-     */
+    /** @var Collection<int, EmbeddedManyDocumentWithIndexes> */
+    #[ODM\EmbedMany(targetDocument: EmbeddedManyDocumentWithIndexes::class)]
     public $embeddedMany;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbeddedManyDocumentWithIndexes
 {
-    /**
-     * @ODM\Field(type="string")
-     * @ODM\Index
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
+    #[ODM\Index]
     public $name;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class YetAnotherEmbeddedDocumentWithIndex
 {
-    /**
-     * @ODM\Field(type="string")
-     * @ODM\Index
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
+    #[ODM\Index]
     public $value;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class DocumentWithIndexInDiscriminatedEmbeds
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(
-     *  discriminatorMap={
-     *   "d1"=EmbeddedDocumentWithIndexes::class,
-     *   "d2"=YetAnotherEmbeddedDocumentWithIndex::class,
-     * })
-     *
-     * @var EmbeddedDocumentWithIndexes|YetAnotherEmbeddedDocumentWithIndex|null
-     */
+    /** @var EmbeddedDocumentWithIndexes|YetAnotherEmbeddedDocumentWithIndex|null */
+    #[ODM\EmbedOne(discriminatorMap: ['d1' => EmbeddedDocumentWithIndexes::class, 'd2' => YetAnotherEmbeddedDocumentWithIndex::class])]
     public $embedded;
 }
 
-/**
- * @ODM\Document
- * @ODM\Index(keys={"coordinatesWith2DIndex"="2d"})
- * @ODM\Index(keys={"coordinatesWithSphereIndex"="2dsphere"})
- */
+#[ODM\Document]
+#[ODM\Index(keys: ['coordinatesWith2DIndex' => '2d'])]
+#[ODM\Index(keys: ['coordinatesWithSphereIndex' => '2dsphere'])]
 class GeoIndexDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="hash")
-     *
-     * @var array<float>
-     */
+    /** @var array<float> */
+    #[ODM\Field(type: 'hash')]
     public $coordinatesWith2DIndex;
 
-    /**
-     * @ODM\Field(type="hash")
-     *
-     * @var array<float>
-     */
+    /** @var array<float> */
+    #[ODM\Field(type: 'hash')]
     public $coordinatesWithSphereIndex;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LifecycleTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LifecycleTest.php
@@ -52,38 +52,24 @@ class LifecycleTest extends BaseTestCase
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\Document]
+#[ODM\HasLifecycleCallbacks]
 class ParentObject
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=ChildObject::class, cascade="all")
-     *
-     * @var Collection<int, ChildObject>|array<ChildObject>
-     */
+    /** @var Collection<int, ChildObject>|array<ChildObject> */
+    #[ODM\ReferenceMany(targetDocument: ChildObject::class, cascade: 'all')]
     private $children;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     private $name;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=ChildEmbeddedObject::class)
-     *
-     * @var ChildEmbeddedObject
-     */
+    /** @var ChildEmbeddedObject */
+    #[ODM\EmbedOne(targetDocument: ChildEmbeddedObject::class)]
     private $childEmbedded;
 
     /** @var ChildObject */
@@ -106,16 +92,14 @@ class ParentObject
         return $this->name;
     }
 
-    /**
-     * @ODM\PrePersist
-     * @ODM\PreUpdate
-     */
+    #[ODM\PrePersist]
+    #[ODM\PreUpdate]
     public function prePersistPreUpdate(): void
     {
         $this->children = [$this->child];
     }
 
-    /** @ODM\PreUpdate */
+    #[ODM\PreUpdate]
     public function preUpdate(): void
     {
         $this->childEmbedded->setName('changed');
@@ -138,21 +122,15 @@ class ParentObject
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class ChildObject
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     private $name;
 
     public function __construct(string $name)
@@ -171,14 +149,11 @@ class ChildObject
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class ChildEmbeddedObject
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     private $name;
 
     public function __construct(string $name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/LockTest.php
@@ -559,36 +559,24 @@ class LockTest extends BaseTestCase
     }
 }
 
-/** @ODM\MappedSuperclass */
+#[ODM\MappedSuperclass]
 abstract class AbstractVersionBase
 {
-    /**
-     * @ODM\Id
-     *
-     * @var ObjectId|string|null
-     */
+    /** @var ObjectId|string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $title;
 
-    /**
-     * @ODM\Lock
-     * @ODM\Field(type="int")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Lock]
+    #[ODM\Field(type: 'int')]
     public $locked;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Issue::class)
-     *
-     * @var Collection<int, Issue>
-     */
+    /** @var Collection<int, Issue> */
+    #[ODM\EmbedMany(targetDocument: Issue::class)]
     public $issues;
 
     /** @var int|string|DateTime|DateTimeImmutable|null */
@@ -618,88 +606,64 @@ abstract class AbstractVersionBase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class LockInt extends AbstractVersionBase
 {
-    /**
-     * @ODM\Version
-     * @ODM\Field(type="int")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Version]
+    #[ODM\Field(type: 'int')]
     public $version;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class LockDate extends AbstractVersionBase
 {
-    /**
-     * @ODM\Version
-     * @ODM\Field(type="date")
-     *
-     * @var DateTime|null
-     */
+    /** @var DateTime|null */
+    #[ODM\Version]
+    #[ODM\Field(type: 'date')]
     public $version;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class LockDateImmutable extends AbstractVersionBase
 {
-    /**
-     * @ODM\Version
-     * @ODM\Field(type="date_immutable")
-     *
-     * @var DateTimeImmutable|null
-     */
+    /** @var DateTimeImmutable|null */
+    #[ODM\Version]
+    #[ODM\Field(type: 'date_immutable')]
     public $version;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class LockDecimal128 extends AbstractVersionBase
 {
-    /**
-     * @ODM\Version
-     * @ODM\Field(type="decimal128")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Version]
+    #[ODM\Field(type: 'decimal128')]
     public $version;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class InvalidLockDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Lock
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Lock]
+    #[ODM\Field(type: 'string')]
     public $lock;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class InvalidVersionDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Version
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Version]
+    #[ODM\Field(type: 'string')]
     public $version;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/MappedSuperclassTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/MappedSuperclassTest.php
@@ -38,28 +38,19 @@ class MappedSuperclassTest extends BaseTestCase
     }
 }
 
-/** @ODM\MappedSuperclass */
+#[ODM\MappedSuperclass]
 class MappedSuperclassBase
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var int|string|null
-     */
+    /** @var int|string|null */
+    #[ODM\Field(type: 'string')]
     private $mapped1;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $mapped2;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=MappedSuperclassRelated1::class)
-     *
-     * @var MappedSuperclassRelated1|null
-     */
+    /** @var MappedSuperclassRelated1|null */
+    #[ODM\ReferenceOne(targetDocument: MappedSuperclassRelated1::class)]
     private $mappedRelated1;
 
     /** @param int|string $val */
@@ -95,21 +86,15 @@ class MappedSuperclassBase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MappedSuperclassRelated1
 {
-    /**
-     * @ODM\Id(strategy="none")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Id(strategy: 'none')]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $name;
 
     public function setName(string $name): void
@@ -133,21 +118,15 @@ class MappedSuperclassRelated1
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class DocumentSubClass extends MappedSuperclassBase
 {
-    /**
-     * @ODM\Id(strategy="none")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Id(strategy: 'none')]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $name;
 
     public function setName(string $name): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedCollectionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedCollectionsTest.php
@@ -77,55 +77,34 @@ class NestedCollectionsTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class DocWithNestedCollections
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedMany(strategy="atomicSet", targetDocument=Documents\Phonebook::class)
-     *
-     * @var Collection<int, Phonebook>
-     */
+    /** @var Collection<int, Phonebook> */
+    #[ODM\EmbedMany(strategy: 'atomicSet', targetDocument: Phonebook::class)]
     public $atomicSet;
 
-    /**
-     * @ODM\EmbedMany(strategy="atomicSetArray", targetDocument=Documents\Phonebook::class)
-     *
-     * @var Collection<int, Phonebook>
-     */
+    /** @var Collection<int, Phonebook> */
+    #[ODM\EmbedMany(strategy: 'atomicSetArray', targetDocument: Phonebook::class)]
     public $atomicSetArray;
 
-    /**
-     * @ODM\EmbedMany(strategy="set", targetDocument=Documents\Phonebook::class)
-     *
-     * @var Collection<int, Phonebook>
-     */
+    /** @var Collection<int, Phonebook> */
+    #[ODM\EmbedMany(strategy: 'set', targetDocument: Phonebook::class)]
     public $set;
 
-    /**
-     * @ODM\EmbedMany(strategy="setArray", targetDocument=Documents\Phonebook::class)
-     *
-     * @var Collection<int, Phonebook>
-     */
+    /** @var Collection<int, Phonebook> */
+    #[ODM\EmbedMany(strategy: 'setArray', targetDocument: Phonebook::class)]
     public $setArray;
 
-    /**
-     * @ODM\EmbedMany(strategy="pushAll", targetDocument=Documents\Phonebook::class)
-     *
-     * @var Collection<int, Phonebook>
-     */
+    /** @var Collection<int, Phonebook> */
+    #[ODM\EmbedMany(strategy: 'pushAll', targetDocument: Phonebook::class)]
     public $pushAll;
 
-    /**
-     * @ODM\EmbedMany(strategy="addToSet", targetDocument=Documents\Phonebook::class)
-     *
-     * @var Collection<int, Phonebook>
-     */
+    /** @var Collection<int, Phonebook> */
+    #[ODM\EmbedMany(strategy: 'addToSet', targetDocument: Phonebook::class)]
     public $addToSet;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/NestedDocumentsTest.php
@@ -140,28 +140,19 @@ class NestedDocumentsTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class Hierarchy
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     private $name;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Hierarchy::class)
-     *
-     * @var Collection<int, Hierarchy>|array<Hierarchy>
-     */
+    /** @var Collection<int, Hierarchy>|array<Hierarchy> */
+    #[ODM\ReferenceMany(targetDocument: self::class)]
     private $children = [];
 
     public function __construct(string $name)
@@ -227,21 +218,15 @@ class Hierarchy
     }
 }
 
-/** @ODM\MappedSuperclass */
+#[ODM\MappedSuperclass]
 class BaseCategory
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     protected $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=ChildCategory::class)
-     *
-     * @var Collection<int, ChildCategory>
-     */
+    /** @var Collection<int, ChildCategory> */
+    #[ODM\EmbedMany(targetDocument: ChildCategory::class)]
     protected $children;
 
     public function __construct(string $name)
@@ -303,14 +288,11 @@ class BaseCategory
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class Category extends BaseCategory
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
     public function getId(): ?string
@@ -319,55 +301,40 @@ class Category extends BaseCategory
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class ChildCategory extends BaseCategory
 {
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class Order
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $title;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=ProductBackup::class)
-     *
-     * @var ProductBackup|null
-     */
+    /** @var ProductBackup|null */
+    #[ODM\EmbedOne(targetDocument: ProductBackup::class)]
     public $product;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class Product
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $title;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class ProductBackup extends Product
 {
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalEmbedTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalEmbedTest.php
@@ -162,77 +162,50 @@ class OrphanRemovalEmbedTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class OrphanRemovalCascadeUser
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=OrphanRemovalCascadeProfile::class)
-     *
-     * @var OrphanRemovalCascadeProfile|null
-     */
+    /** @var OrphanRemovalCascadeProfile|null */
+    #[ODM\EmbedOne(targetDocument: OrphanRemovalCascadeProfile::class)]
     public $profile;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=OrphanRemovalCascadeProfile::class)
-     *
-     * @var Collection<int, OrphanRemovalCascadeProfile>|array<OrphanRemovalCascadeProfile>
-     */
+    /** @var Collection<int, OrphanRemovalCascadeProfile>|array<OrphanRemovalCascadeProfile> */
+    #[ODM\EmbedMany(targetDocument: OrphanRemovalCascadeProfile::class)]
     public $profileMany = [];
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class OrphanRemovalCascadeProfile
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=OrphanRemovalCascadeAddress::class, orphanRemoval=true, cascade={"all"})
-     *
-     * @var OrphanRemovalCascadeAddress|null
-     */
+    /** @var OrphanRemovalCascadeAddress|null */
+    #[ODM\ReferenceOne(targetDocument: OrphanRemovalCascadeAddress::class, orphanRemoval: true, cascade: ['all'])]
     public $address;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=OrphanRemovalCascadeAddress::class, orphanRemoval=true, cascade={"all"})
-     *
-     * @var Collection<int, OrphanRemovalCascadeAddress>
-     */
+    /** @var Collection<int, OrphanRemovalCascadeAddress> */
+    #[ODM\ReferenceMany(targetDocument: OrphanRemovalCascadeAddress::class, orphanRemoval: true, cascade: ['all'])]
     public $addressMany;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class OrphanRemovalCascadeAddress
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/OrphanRemovalTest.php
@@ -303,59 +303,38 @@ class OrphanRemovalTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class OrphanRemovalUser
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=OrphanRemovalProfile::class, orphanRemoval=true)
-     *
-     * @var OrphanRemovalProfile|null
-     */
+    /** @var OrphanRemovalProfile|null */
+    #[ODM\ReferenceOne(targetDocument: OrphanRemovalProfile::class, orphanRemoval: true)]
     public $profile;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=OrphanRemovalProfile::class, orphanRemoval=false)
-     *
-     * @var OrphanRemovalProfile|null
-     */
+    /** @var OrphanRemovalProfile|null */
+    #[ODM\ReferenceOne(targetDocument: OrphanRemovalProfile::class, orphanRemoval: false)]
     public $profileNoOrphanRemoval;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=OrphanRemovalProfile::class, orphanRemoval=true)
-     *
-     * @var Collection<int, OrphanRemovalProfile>|array<OrphanRemovalProfile>
-     */
+    /** @var Collection<int, OrphanRemovalProfile>|array<OrphanRemovalProfile> */
+    #[ODM\ReferenceMany(targetDocument: OrphanRemovalProfile::class, orphanRemoval: true)]
     public $profileMany = [];
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=OrphanRemovalProfile::class, orphanRemoval=false)
-     *
-     * @var Collection<int, OrphanRemovalProfile>|array<OrphanRemovalProfile>
-     */
+    /** @var Collection<int, OrphanRemovalProfile>|array<OrphanRemovalProfile> */
+    #[ODM\ReferenceMany(targetDocument: OrphanRemovalProfile::class, orphanRemoval: false)]
     public $profileManyNoOrphanRemoval = [];
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class OrphanRemovalProfile
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/PrePersistTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/PrePersistTest.php
@@ -28,10 +28,8 @@ class PrePersistTest extends BaseTestCase
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\Document]
+#[ODM\HasLifecycleCallbacks]
 class PrePersistTestDocument
 {
     /** @var int */
@@ -40,27 +38,21 @@ class PrePersistTestDocument
     /** @var int */
     public $preUpdate;
 
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $field;
 
-    /** @ODM\PrePersist */
+    #[ODM\PrePersist]
     public function prePersist(): void
     {
         $this->prePersist++;
     }
 
-    /** @ODM\PreUpdate */
+    #[ODM\PreUpdate]
     public function preUpdate(): void
     {
         $this->preUpdate++;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/RawTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/RawTypeTest.php
@@ -41,20 +41,14 @@ class RawTypeTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class RawType
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="raw")
-     *
-     * @var mixed
-     */
+    /** @var mixed */
+    #[ODM\Field(type: 'raw')]
     public $raw;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadOnlyDocumentTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadOnlyDocumentTest.php
@@ -78,21 +78,15 @@ class ReadOnlyDocumentTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document(readOnly=true) */
+#[ODM\Document(readOnly: true)]
 class ReadOnlyDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var ObjectId|null
-     */
+    /** @var ObjectId|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $value;
 
     public function __construct(string $value)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
@@ -110,16 +110,11 @@ class ReadPreferenceTest extends BaseTestCase
     }
 }
 
-/**
- * @ODM\Document()
- * @ODM\ReadPreference("nearest", tags={ { "dc"="east" } })
- */
+#[ODM\Document]
+#[ODM\ReadPreference('nearest', tags: [['dc' => 'east']])]
 class DocumentWithReadPreference
 {
-    /**
-     * @ODM\Id()
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferenceDiscriminatorsTest.php
@@ -91,26 +91,18 @@ class ReferenceDiscriminatorsTest extends BaseTestCase
     }
 }
 
-/**
- * @ODM\Document(collection="rdt_action")
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("discriminator")
- * @ODM\DiscriminatorMap({"action"=Action::class, "commentable_action"=CommentableAction::class})
- */
+#[ODM\Document(collection: 'rdt_action')]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('discriminator')]
+#[ODM\DiscriminatorMap(['action' => Action::class, 'commentable_action' => CommentableAction::class])]
 class Action
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     protected $type;
 
     public function __construct(string $type)
@@ -129,14 +121,11 @@ class Action
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class CommentableAction extends Action
 {
-    /**
-     * @ODM\Field(type="collection") *
-     *
-     * @var string[]
-     */
+    /** @var string[] */
+    #[ODM\Field(type: 'collection')]
     protected $comments = [];
 
     /** @param string[] $comments */
@@ -154,21 +143,15 @@ class CommentableAction extends Action
     }
 }
 
-/** @ODM\MappedSuperclass */
+#[ODM\MappedSuperclass]
 abstract class ActivityStreamItem
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Action::class)
-     *
-     * @var Action
-     */
+    /** @var Action */
+    #[ODM\ReferenceOne(targetDocument: Action::class)]
     protected $action;
 
     public function __construct(Action $action)
@@ -187,17 +170,12 @@ abstract class ActivityStreamItem
     }
 }
 
-/**
- * @ODM\MappedSuperclass
- * @ODM\UniqueIndex(keys={"groupId"="asc", "action.$id"="asc"}, options={"unique"=true})
- */
+#[ODM\MappedSuperclass]
+#[ODM\UniqueIndex(keys: ['groupId' => 'asc', 'action.$id' => 'asc'], options: ['unique' => true])]
 abstract class GroupActivityStreamItem extends ActivityStreamItem
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     protected $groupId;
 
     public function __construct(Action $action, string $groupId)
@@ -213,27 +191,22 @@ abstract class GroupActivityStreamItem extends ActivityStreamItem
     }
 }
 
-/** @ODM\Document(collection="rdt_group_main_activity_stream_item") */
+#[ODM\Document(collection: 'rdt_group_main_activity_stream_item')]
 class GroupMainActivityStreamItem extends GroupActivityStreamItem
 {
 }
 
-/** @ODM\Document(collection="rdt_group_members_activity_stream_item") */
+#[ODM\Document(collection: 'rdt_group_members_activity_stream_item')]
 class GroupMembersActivityStreamItem extends GroupActivityStreamItem
 {
 }
 
-/**
- * @ODM\MappedSuperclass
- * @ODM\UniqueIndex(keys={"userId"="asc", "action.$id"="asc"}, options={"unique"=true})
- */
+#[ODM\MappedSuperclass]
+#[ODM\UniqueIndex(keys: ['userId' => 'asc', 'action.$id' => 'asc'], options: ['unique' => true])]
 abstract class UserActivityStreamItem extends ActivityStreamItem
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     protected $userId;
 
     public function __construct(Action $action, string $userId)
@@ -249,12 +222,12 @@ abstract class UserActivityStreamItem extends ActivityStreamItem
     }
 }
 
-/** @ODM\Document(collection="rdt_user_dashboard_activity_stream_item") */
+#[ODM\Document(collection: 'rdt_user_dashboard_activity_stream_item')]
 class UserDashboardActivityStreamItem extends UserActivityStreamItem
 {
 }
 
-/** @ODM\Document(collection="rdt_user_profile_activity_stream_item") */
+#[ODM\Document(collection: 'rdt_user_profile_activity_stream_item')]
 class UserProfileActivityStreamItem extends UserActivityStreamItem
 {
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencesTest.php
@@ -507,62 +507,44 @@ class ReferencesTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class DocumentWithArrayReference
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=DocumentWithArrayId::class)
-     *
-     * @var DocumentWithArrayId|null
-     */
+    /** @var DocumentWithArrayId|null */
+    #[ODM\ReferenceOne(targetDocument: DocumentWithArrayId::class)]
     public $referenceOne;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class DocumentWithArrayId
 {
-    /**
-     * @ODM\Id(strategy="none", options={"type"="hash"})
-     *
-     * @var array<string, int>
-     */
+    /** @var array<string, int> */
+    #[ODM\Id(strategy: 'none', options: ['type' => 'hash'])]
     public $id;
 }
 
 
-/** @ODM\Document */
+#[ODM\Document]
 class DocumentWithMongoBinDataReference
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=DocumentWithMongoBinDataId::class)
-     *
-     * @var DocumentWithMongoBinDataId|null
-     */
+    /** @var DocumentWithMongoBinDataId|null */
+    #[ODM\ReferenceOne(targetDocument: DocumentWithMongoBinDataId::class)]
     public $referenceOne;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class DocumentWithMongoBinDataId
 {
-    /**
-     * @ODM\Id(strategy="none", options={"type"="bin"})
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id(strategy: 'none', options: ['type' => 'bin'])]
     public $id;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
@@ -82,46 +82,31 @@ class SplObjectHashCollisionsTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class SplColDoc
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedOne
-     *
-     * @var object|null
-     */
+    /** @var object|null */
+    #[ODM\EmbedOne]
     public $one;
 
-    /**
-     * @ODM\EmbedMany
-     *
-     * @var Collection<int, object>|array<object>
-     */
+    /** @var Collection<int, object>|array<object> */
+    #[ODM\EmbedMany]
     public $many = [];
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class SplColEmbed
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TargetDocumentTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TargetDocumentTest.php
@@ -52,73 +52,52 @@ class TargetDocumentTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class TargetDocumentTestDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Doctrine\ODM\MongoDB\Tests\Functional\TargetDocumentTestReference::class)
-     *
-     * @var TargetDocumentTestReference|null
-     */
+    /** @var TargetDocumentTestReference|null */
+    #[ODM\ReferenceOne(targetDocument: TargetDocumentTestReference::class)]
     public $reference;
 }
 
-/** @ODM\MappedSuperclass */
+#[ODM\MappedSuperclass]
 abstract class AbstractTargetDocumentTestReference
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class TargetDocumentTestReference extends AbstractTargetDocumentTestReference
 {
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class InvalidTargetDocumentTestDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument="Doctrine\ODM\MongoDB\Tests\Functional\SomeInvalidClass")
-     *
-     * @var object|null
-     */
+    /** @var object|null */
+    #[ODM\ReferenceOne(targetDocument: 'Doctrine\ODM\MongoDB\Tests\Functional\SomeInvalidClass')]
     public $reference;
 }
 
 
-/** @ODM\Document */
+#[ODM\Document]
 class InvalidDiscriminatorTargetsTestDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(discriminatorField="referencedClass", discriminatorMap={"Foo"="Doctrine\ODM\MongoDB\Tests\Functional\SomeInvalidClass"})
-     *
-     * @var object|null
-     */
+    /** @var object|null */
+    #[ODM\ReferenceOne(discriminatorField: 'referencedClass', discriminatorMap: ['Foo' => 'Doctrine\ODM\MongoDB\Tests\Functional\SomeInvalidClass'])]
     public $reference;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1011Test.php
@@ -43,21 +43,15 @@ class GH1011Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1011Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=GH1011Embedded::class, strategy="set")
-     *
-     * @var Collection<int, GH1011Embedded>
-     */
+    /** @var Collection<int, GH1011Embedded> */
+    #[ODM\EmbedMany(targetDocument: GH1011Embedded::class, strategy: 'set')]
     public $embeds;
 
     public function __construct()
@@ -66,14 +60,11 @@ class GH1011Document
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH1011Embedded
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1017Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1017Test.php
@@ -51,25 +51,19 @@ class GH1017Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1017Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=GH1017EmbeddedDocument::class)
-     *
-     * @var GH1017EmbeddedDocument|null
-     */
+    /** @var GH1017EmbeddedDocument|null */
+    #[ODM\EmbedOne(targetDocument: GH1017EmbeddedDocument::class)]
     public $embedded;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH1017EmbeddedDocument
 {
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1058Test.php
@@ -57,21 +57,15 @@ class GH1058Listener
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1058PersistDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $value;
 
     public function getId(): ?string
@@ -85,21 +79,15 @@ class GH1058PersistDocument
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1058UpsertDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $value;
 
     public function getId(): ?string

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1107Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1107Test.php
@@ -19,34 +19,23 @@ class GH1107Test extends BaseTestCase
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- */
+#[ODM\Document]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
 class GH1107ParentClass
 {
-    /**
-     * @ODM\Id(strategy="NONE")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id(strategy: 'NONE')]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1107ChildClass extends GH1107ParentClass
 {
-    /**
-     * @ODM\Id(strategy="AUTO")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id(strategy: 'AUTO')]
     public $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1117Test.php
@@ -31,21 +31,15 @@ class GH1117Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1117Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedMany(strategy="set", targetDocument=GH1117EmbeddedDocument::class)
-     *
-     * @var Collection<int, GH1117EmbeddedDocument>
-     */
+    /** @var Collection<int, GH1117EmbeddedDocument> */
+    #[ODM\EmbedMany(strategy: 'set', targetDocument: GH1117EmbeddedDocument::class)]
     public $embeds;
 
     public function __construct()
@@ -54,14 +48,11 @@ class GH1117Document
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH1117EmbeddedDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $value;
 
     public function __construct(string $value)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1138Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1138Test.php
@@ -50,21 +50,15 @@ class GH1138Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1138Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1152Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1152Test.php
@@ -35,31 +35,22 @@ class GH1152Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1152Parent
 {
     public const CLASSNAME = self::class;
 
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=GH1152Child::class)
-     *
-     * @var GH1152Child|null
-     */
+    /** @var GH1152Child|null */
+    #[ODM\EmbedOne(targetDocument: GH1152Child::class)]
     public $child;
 }
 
-/**
- * @ODM\EmbeddedDocument
- *
- * @psalm-import-type AssociationFieldMapping from ClassMetadata
- */
+/** @psalm-import-type AssociationFieldMapping from ClassMetadata */
+#[ODM\EmbeddedDocument]
 class GH1152Child
 {
     /** @psalm-var array{0: AssociationFieldMapping, 1: object|null, 2: string}|null */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1225Test.php
@@ -31,24 +31,16 @@ class GH1225Test extends BaseTestCase
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\Document]
+#[ODM\HasLifecycleCallbacks]
 class GH1225Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedMany(strategy="atomicSet", targetDocument=GH1225EmbeddedDocument::class)
-     *
-     * @var Collection<int, GH1225EmbeddedDocument>
-     */
+    /** @var Collection<int, GH1225EmbeddedDocument> */
+    #[ODM\EmbedMany(strategy: 'atomicSet', targetDocument: GH1225EmbeddedDocument::class)]
     public $embeds;
 
     public function __construct()
@@ -56,20 +48,17 @@ class GH1225Document
         $this->embeds = new ArrayCollection();
     }
 
-    /** @ODM\PreUpdate */
+    #[ODM\PreUpdate]
     public function exampleHook(): void
     {
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH1225EmbeddedDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $value;
 
     public function __construct(string $value)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
@@ -129,23 +129,17 @@ class GH1229Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1229Parent
 {
     public const CLASSNAME = self::class;
 
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedMany(discriminatorField="_class")
-     *
-     * @var Collection<int, GH1229Child>
-     */
+    /** @var Collection<int, GH1229Child> */
+    #[ODM\EmbedMany(discriminatorField: '_class')]
     protected $children;
 
     public function __construct()
@@ -183,23 +177,17 @@ class GH1229Parent
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH1229Child
 {
     public const CLASSNAME = self::class;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int
-     */
+    /** @var int */
+    #[ODM\Field(type: 'int')]
     public $order = 0;
 
     public function __construct(string $name)
@@ -221,7 +209,7 @@ class GH1229Child
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH1229ChildTypeB extends GH1229Child
 {
     public const CLASSNAME = self::class;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1232Test.php
@@ -35,34 +35,21 @@ class GH1232Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1232Post
 {
     public const CLASSNAME = self::class;
 
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH1232Comment::class, mappedBy="post", cascade={"remove"})
-     *
-     * @var Collection<int, GH1232Comment>
-     */
+    /** @var Collection<int, GH1232Comment> */
+    #[ODM\ReferenceMany(targetDocument: GH1232Comment::class, mappedBy: 'post', cascade: ['remove'])]
     protected $comments;
 
-    /**
-     * @ODM\ReferenceMany(
-     *     targetDocument=GH1232Comment::class,
-     *     mappedBy="post",
-     *     repositoryMethod="getLongComments",
-     * )
-     *
-     * @var Collection<int, GH1232Comment>
-     */
+    /** @var Collection<int, GH1232Comment> */
+    #[ODM\ReferenceMany(targetDocument: GH1232Comment::class, mappedBy: 'post', repositoryMethod: 'getLongComments')]
     protected $longComments;
 
     public function __construct()
@@ -71,21 +58,15 @@ class GH1232Post
     }
 }
 
-/** @ODM\Document(repositoryClass="GH1232CommentRepository") */
+#[ODM\Document(repositoryClass: 'GH1232CommentRepository')]
 class GH1232Comment
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=GH1232Post::class)
-     *
-     * @var GH1232Post|null
-     */
+    /** @var GH1232Post|null */
+    #[ODM\ReferenceOne(targetDocument: GH1232Post::class)]
     public $post;
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1275Test.php
@@ -181,21 +181,15 @@ class GH1275Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document(collection="item") */
+#[ODM\Document(collection: 'item')]
 class Item
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     /** @var Container */
@@ -208,21 +202,15 @@ class Item
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Element
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name)
@@ -231,95 +219,43 @@ class Element
     }
 }
 
-/** @ODM\Document(collection="container") */
+#[ODM\Document(collection: 'container')]
 class Container
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /** @ODM\ReferenceMany(
-     *     targetDocument=Item::class,
-     *     cascade={"refresh","persist"},
-     *     orphanRemoval="true",
-     *     strategy="atomicSet"
-     * )
-     *
-     * @var Collection<int, Item>
-     */
+    /** @var Collection<int, Item> */
+    #[ODM\ReferenceMany(targetDocument: Item::class, cascade: ['refresh', 'persist'], orphanRemoval: true, strategy: 'atomicSet')]
     public $items;
 
-    /**
-     * @ODM\ReferenceOne(
-     *     targetDocument=Item::class,
-     *     cascade={"refresh"}
-     * )
-     *
-     * @var Item
-     */
+    /** @var Item */
+    #[ODM\ReferenceOne(targetDocument: Item::class, cascade: ['refresh'])]
     public $firstItem;
 
-    /**
-     * @ODM\EmbedMany(
-     *     targetDocument=Element::class,
-     *     strategy="addToSet"
-     * )
-     *
-     * @var Collection<int, Element>
-     */
+    /** @var Collection<int, Element> */
+    #[ODM\EmbedMany(targetDocument: Element::class, strategy: 'addToSet')]
     public $addToSet;
 
-    /**
-     * @ODM\EmbedMany(
-     *     targetDocument=Element::class,
-     *     strategy="set"
-     * )
-     *
-     * @var Collection<int, Element>
-     */
+    /** @var Collection<int, Element> */
+    #[ODM\EmbedMany(targetDocument: Element::class, strategy: 'set')]
     public $set;
 
-    /**
-     * @ODM\EmbedMany(
-     *     targetDocument=Element::class,
-     *     strategy="setArray"
-     * )
-     *
-     * @var Collection<int, Element>
-     */
+    /** @var Collection<int, Element> */
+    #[ODM\EmbedMany(targetDocument: Element::class, strategy: 'setArray')]
     public $setArray;
 
-    /**
-     * @ODM\EmbedMany(
-     *     targetDocument=Element::class,
-     *     strategy="pushAll"
-     * )
-     *
-     * @var Collection<int, Element>
-     */
+    /** @var Collection<int, Element> */
+    #[ODM\EmbedMany(targetDocument: Element::class, strategy: 'pushAll')]
     public $pushAll;
 
-    /**
-     * @ODM\EmbedMany(
-     *     targetDocument=Element::class,
-     *     strategy="atomicSet"
-     * )
-     *
-     * @var Collection<int, Element>
-     */
+    /** @var Collection<int, Element> */
+    #[ODM\EmbedMany(targetDocument: Element::class, strategy: 'atomicSet')]
     public $atomicSet;
 
-    /**
-     * @ODM\EmbedMany(
-     *     targetDocument=Element::class,
-     *     strategy="atomicSetArray"
-     * )
-     *
-     * @var Collection<int, Element>
-     */
+    /** @var Collection<int, Element> */
+    #[ODM\EmbedMany(targetDocument: Element::class, strategy: 'atomicSetArray')]
     public $atomicSetArray;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1294Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1294Test.php
@@ -37,21 +37,15 @@ class GH1294Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1294User
 {
-    /**
-     * @ODM\Id(strategy="UUID", type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id(strategy: 'UUID', type: 'string')]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name = '';
 
     public function getId(): ?string

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1344Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1344Test.php
@@ -46,94 +46,61 @@ class GH1344Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1344Main
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=GH1344Embedded::class)
-     *
-     * @var GH1344Embedded|null
-     */
+    /** @var GH1344Embedded|null */
+    #[ODM\EmbedOne(targetDocument: GH1344Embedded::class)]
     public $embedded1;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=GH1344Embedded::class)
-     *
-     * @var GH1344Embedded|null
-     */
+    /** @var GH1344Embedded|null */
+    #[ODM\EmbedOne(targetDocument: GH1344Embedded::class)]
     public $embedded2;
 }
 
-/**
- * @ODM\EmbeddedDocument
- * @ODM\Index(keys={"property"="asc"}, name="embedded")
- */
+#[ODM\EmbeddedDocument]
+#[ODM\Index(keys: ['property' => 'asc'], name: 'embedded')]
 class GH1344Embedded
 {
-    /**
-     * @ODM\Field
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field]
     public $property;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=GH1344EmbeddedNested::class)
-     *
-     * @var GH1344EmbeddedNested|null
-     */
+    /** @var GH1344EmbeddedNested|null */
+    #[ODM\EmbedOne(targetDocument: GH1344EmbeddedNested::class)]
     public $embedded;
 }
 
-/**
- * @ODM\EmbeddedDocument
- * @ODM\Index(keys={"property"="asc"}, name="nested")
- */
+#[ODM\EmbeddedDocument]
+#[ODM\Index(keys: ['property' => 'asc'], name: 'nested')]
 class GH1344EmbeddedNested
 {
-    /**
-     * @ODM\Field
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field]
     public $property;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1344LongIndexName
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=GH1344LongIndexNameEmbedded::class)
-     *
-     * @var GH1344LongIndexNameEmbedded|null
-     */
+    /** @var GH1344LongIndexNameEmbedded|null */
+    #[ODM\EmbedOne(targetDocument: GH1344LongIndexNameEmbedded::class)]
     public $embedded1;
 }
 
-/**
- * @ODM\EmbeddedDocument
- * @ODM\Index(keys={"property"="asc"}, name="this_is_a_really_long_name_that_will_cause_problems_for_whoever_tries_to_use_it_whether_in_an_embedded_field_or_not")
- */
+#[ODM\EmbeddedDocument]
+#[ODM\Index(keys: ['property' => 'asc'], name: 'this_is_a_really_long_name_that_will_cause_problems_for_whoever_tries_to_use_it_whether_in_an_embedded_field_or_not')]
 class GH1344LongIndexNameEmbedded
 {
-    /**
-     * @ODM\Field
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field]
     public $property;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1346Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1346Test.php
@@ -41,21 +41,15 @@ class GH1346Test extends BaseTestCase
 }
 
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1346Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH1346ReferencedDocument::class)
-     *
-     * @var Collection<int, GH1346ReferencedDocument>
-     */
+    /** @var Collection<int, GH1346ReferencedDocument> */
+    #[ODM\ReferenceMany(targetDocument: GH1346ReferencedDocument::class)]
     protected $references;
 
     public function __construct()
@@ -80,21 +74,15 @@ class GH1346Document
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1346ReferencedDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $test;
 
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
     public function setTest(string $test): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1418Test.php
@@ -102,46 +102,31 @@ class GH1418Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1418Document
 {
-    /**
-     * @ODM\Id(strategy="none")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Id(strategy: 'none')]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=GH1418Embedded::class)
-     *
-     * @var GH1418Embedded|null
-     */
+    /** @var GH1418Embedded|null */
+    #[ODM\EmbedOne(targetDocument: GH1418Embedded::class)]
     public $embedOne;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=GH1418Embedded::class)
-     *
-     * @var Collection<int, GH1418Embedded>
-     */
+    /** @var Collection<int, GH1418Embedded> */
+    #[ODM\EmbedMany(targetDocument: GH1418Embedded::class)]
     public $embedMany;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH1418Embedded
 {
-    /**
-     * @ODM\Id(strategy="none", type="int")
-     * @ODM\AlsoLoad("sourceId")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Id(strategy: 'none', type: 'int')]
+    #[ODM\AlsoLoad('sourceId')]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1428Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1428Test.php
@@ -29,36 +29,27 @@ class GH1428Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1428Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=GH1428EmbeddedDocument::class)
-     *
-     * @var GH1428EmbeddedDocument|null
-     */
+    /** @var GH1428EmbeddedDocument|null */
+    #[ODM\EmbedOne(targetDocument: GH1428EmbeddedDocument::class)]
     public $embedded;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH1428EmbeddedDocument
 {
-    /**
-     * @ODM\EmbedOne(targetDocument=GH1428NestedEmbeddedDocument::class, name="shortNameThatDoesntExist")
-     *
-     * @var GH1428NestedEmbeddedDocument|null
-     */
+    /** @var GH1428NestedEmbeddedDocument|null */
+    #[ODM\EmbedOne(targetDocument: GH1428NestedEmbeddedDocument::class, name: 'shortNameThatDoesntExist')]
     public $nestedEmbedded;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH1428NestedEmbeddedDocument
 {
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1435Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1435Test.php
@@ -67,38 +67,26 @@ class GH1435Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document() */
+#[ODM\Document]
 class GH1435Document
 {
-    /**
-     * @ODM\Id()
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string", nullable=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string', nullable: true)]
     public $name;
 }
 
-/** @ODM\Document() */
+#[ODM\Document]
 class GH1435DocumentIncrement
 {
-    /**
-     * @ODM\Id(strategy="increment")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Id(strategy: 'increment')]
     public $id;
 
-    /**
-     * @ODM\Field(type="string", nullable=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string', nullable: true)]
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1525Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1525Test.php
@@ -95,35 +95,23 @@ class GH1525Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document(collection="document_test") */
+#[ODM\Document(collection: 'document_test')]
 class GH1525Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=GH1525Embedded::class)
-     *
-     * @var GH1525Embedded|null
-     */
+    /** @var GH1525Embedded|null */
+    #[ODM\EmbedOne(targetDocument: GH1525Embedded::class)]
     public $embedded;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=GH1525Embedded::class)
-     *
-     * @var Collection<int, GH1525Embedded>
-     */
+    /** @var Collection<int, GH1525Embedded> */
+    #[ODM\EmbedMany(targetDocument: GH1525Embedded::class)]
     public $embedMany;
 
     public function __construct(string $name)
@@ -133,28 +121,19 @@ class GH1525Document
     }
 }
 
-/** @ODM\Document(collection="document_test_with_auto_ids") */
+#[ODM\Document(collection: 'document_test_with_auto_ids')]
 class GH1525DocumentIdStrategyNone
 {
-    /**
-     * @ODM\Id(strategy="NONE")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Id(strategy: 'NONE')]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=GH1525Embedded::class)
-     *
-     * @var GH1525Embedded|null
-     */
+    /** @var GH1525Embedded|null */
+    #[ODM\EmbedOne(targetDocument: GH1525Embedded::class)]
     public $embedded;
 
     public function __construct(string $id, string $name)
@@ -164,14 +143,11 @@ class GH1525DocumentIdStrategyNone
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH1525Embedded
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1572Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1572Test.php
@@ -43,53 +43,35 @@ class GH1572Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1572Blog
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH1572Post::class, mappedBy="blog")
-     *
-     * @var Collection<int, GH1572Post>|array<GH1572Post>
-     */
+    /** @var Collection<int, GH1572Post>|array<GH1572Post> */
+    #[ODM\ReferenceMany(targetDocument: GH1572Post::class, mappedBy: 'blog')]
     public $allPosts = [];
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH1572Post::class, mappedBy="blog", sort={"id"="asc"}, limit=2)
-     *
-     * @var Collection<int, GH1572Post>|array<GH1572Post>
-     */
+    /** @var Collection<int, GH1572Post>|array<GH1572Post> */
+    #[ODM\ReferenceMany(targetDocument: GH1572Post::class, mappedBy: 'blog', sort: ['id' => 'asc'], limit: 2)]
     public $latestPosts = [];
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH1572Post::class, repositoryMethod="getPostsForBlog")
-     *
-     * @var Collection<int, GH1572Post>|array<GH1572Post>
-     */
+    /** @var Collection<int, GH1572Post>|array<GH1572Post> */
+    #[ODM\ReferenceMany(targetDocument: GH1572Post::class, repositoryMethod: 'getPostsForBlog')]
     public $latestPostsRepositoryMethod = [];
 }
 
-/** @ODM\Document(repositoryClass=GH1572PostRepository::class) */
+#[ODM\Document(repositoryClass: GH1572PostRepository::class)]
 class GH1572Post
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=GH1572Blog::class)
-     *
-     * @var GH1572Blog
-     */
+    /** @var GH1572Blog */
+    #[ODM\ReferenceOne(targetDocument: GH1572Blog::class)]
     public $blog;
 
     public function __construct(GH1572Blog $blog)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1674Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1674Test.php
@@ -34,21 +34,15 @@ class GH1674Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1674Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var ObjectId|null
-     */
+    /** @var ObjectId|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=GH1674Embedded::class)
-     *
-     * @var Collection<int, GH1674Embedded>
-     */
+    /** @var Collection<int, GH1674Embedded> */
+    #[ODM\EmbedMany(targetDocument: GH1674Embedded::class)]
     protected $embedded;
 
     public function __construct()
@@ -58,13 +52,10 @@ class GH1674Document
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH1674Embedded
 {
-    /**
-     * @ODM\Field
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field]
     public $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1775Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1775Test.php
@@ -58,32 +58,23 @@ class GH1775Test extends BaseTestCase
     }
 }
 
-/** @ODM\MappedSuperclass */
+#[ODM\MappedSuperclass]
 class GH1775MetaDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int
-     */
+    /** @var int */
+    #[ODM\Field(type: 'int')]
     public $version = 5;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1775Image
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
     public function __construct()
@@ -91,39 +82,27 @@ class GH1775Image
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1775Blog
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH1775Post::class, inversedBy="blogs")
-     *
-     * @var Collection<int, GH1775Post>|array<GH1775Post>
-     */
+    /** @var Collection<int, GH1775Post>|array<GH1775Post> */
+    #[ODM\ReferenceMany(targetDocument: GH1775Post::class, inversedBy: 'blogs')]
     public $posts = [];
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1775Post extends GH1775MetaDocument
 {
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH1775Image::class, storeAs=ClassMetadata::REFERENCE_STORE_AS_ID)
-     *
-     * @var Collection<int, GH1775Image>
-     */
+    /** @var Collection<int, GH1775Image> */
+    #[ODM\ReferenceMany(targetDocument: GH1775Image::class, storeAs: ClassMetadata::REFERENCE_STORE_AS_ID)]
     protected $images;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH1775Blog::class, mappedBy="posts")
-     *
-     * @var Collection<int, GH1775Blog>
-     */
+    /** @var Collection<int, GH1775Blog> */
+    #[ODM\ReferenceMany(targetDocument: GH1775Blog::class, mappedBy: 'posts')]
     protected $blogs;
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1962Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1962Test.php
@@ -65,85 +65,64 @@ class GH1962Test extends BaseTestCase
     }
 }
 
-/**
- * @ODM\MappedSuperclass()
- * @ODM\DiscriminatorField("type")
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorMap({
- *     "foo"=GH1962FooDocument::class,
- *     "bar"=GH1962BarDocument::class,
- *     "baz"=GH1962BazDocument::class
- * })
- */
+#[ODM\MappedSuperclass]
+#[ODM\DiscriminatorField('type')]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorMap(['foo' => GH1962FooDocument::class, 'bar' => GH1962BarDocument::class, 'baz' => GH1962BazDocument::class])]
 class GH1962Superclass
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1962FooDocument extends GH1962Superclass
 {
 }
 
-/**
- * @ODM\MappedSuperclass()
- * @ODM\DiscriminatorMap({
- *     "bar"=GH1962BarDocument::class,
- *     "baz"=GH1962BazDocument::class
- * })
- */
+#[ODM\MappedSuperclass]
+#[ODM\DiscriminatorMap(['bar' => GH1962BarDocument::class, 'baz' => GH1962BazDocument::class])]
 class GH1962BarSuperclass extends GH1962Superclass
 {
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1962BarDocument extends GH1962BarSuperclass
 {
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1962BazDocument extends GH1962BarSuperclass
 {
 }
-/**
- * @ODM\MappedSuperclass()
- * @ODM\DiscriminatorField("type")
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- */
+#[ODM\MappedSuperclass]
+#[ODM\DiscriminatorField('type')]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
 class GH1962SuperclassWithoutDiscriminatorMap
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1962FooDocumentWithoutDiscriminatorMap extends GH1962SuperclassWithoutDiscriminatorMap
 {
 }
 
-/** @ODM\MappedSuperclass() */
+#[ODM\MappedSuperclass]
 class GH1962BarSuperclassWithoutDiscriminatorMap extends GH1962SuperclassWithoutDiscriminatorMap
 {
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1962BarDocumentWithoutDiscriminatorMap extends GH1962BarSuperclassWithoutDiscriminatorMap
 {
 }
 
-/**
- * @ODM\Document
- * @ODM\DiscriminatorValue(GH1962BazDocumentWithoutDiscriminatorMap::class)
- */
+#[ODM\Document]
+#[ODM\DiscriminatorValue(GH1962BazDocumentWithoutDiscriminatorMap::class)]
 class GH1962BazDocumentWithoutDiscriminatorMap extends GH1962BarSuperclassWithoutDiscriminatorMap
 {
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1964Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1964Test.php
@@ -24,13 +24,10 @@ class GH1964Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1964Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1990Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1990Test.php
@@ -30,21 +30,15 @@ class GH1990Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH1990Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=GH1990Document::class)
-     *
-     * @var GH1990Document|null
-     */
+    /** @var GH1990Document|null */
+    #[ODM\ReferenceOne(targetDocument: self::class)]
     private $parent;
 
     public function __construct(?GH1990Document $parent)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2002Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2002Test.php
@@ -85,25 +85,17 @@ class GH2002Test extends BaseTestCase
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("class")
- */
+#[ODM\Document]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('class')]
 class GH2002DocumentA
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=GH2002DocumentA::class, cascade="all")
-     *
-     * @var GH2002DocumentA
-     */
+    /** @var GH2002DocumentA */
+    #[ODM\ReferenceOne(targetDocument: self::class, cascade: 'all')]
     public $parentDocument;
 
     public function __construct(?GH2002DocumentA $parentDocument = null)
@@ -112,26 +104,20 @@ class GH2002DocumentA
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH2002DocumentB extends GH2002DocumentA
 {
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH2002ReferenceWithoutTargetDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(cascade="all")
-     *
-     * @var GH2002DocumentA
-     */
+    /** @var GH2002DocumentA */
+    #[ODM\ReferenceOne(cascade: 'all')]
     public $parentDocument;
 
     public function __construct(?GH2002DocumentA $parentDocument = null)
@@ -140,21 +126,15 @@ class GH2002ReferenceWithoutTargetDocument
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH2002ReferenceWithoutTargetDocumentWithDiscriminatorField
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(discriminatorField="referencedClass", cascade="all")
-     *
-     * @var GH2002DocumentA
-     */
+    /** @var GH2002DocumentA */
+    #[ODM\ReferenceOne(discriminatorField: 'referencedClass', cascade: 'all')]
     public $parentDocument;
 
     public function __construct(?GH2002DocumentA $parentDocument = null)
@@ -163,21 +143,15 @@ class GH2002ReferenceWithoutTargetDocumentWithDiscriminatorField
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH2002ReferenceWithDiscriminatorField
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=GH2002DocumentA::class, discriminatorField="referencedClass", cascade="all")
-     *
-     * @var GH2002DocumentA
-     */
+    /** @var GH2002DocumentA */
+    #[ODM\ReferenceOne(targetDocument: GH2002DocumentA::class, discriminatorField: 'referencedClass', cascade: 'all')]
     public $parentDocument;
 
     public function __construct(?GH2002DocumentA $parentDocument = null)
@@ -186,21 +160,15 @@ class GH2002ReferenceWithDiscriminatorField
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH2002ReferenceWithPartialDiscriminatorMap
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(discriminatorField="referencedClass", discriminatorMap={"B"=GH2002DocumentB::class}, cascade="all")
-     *
-     * @var GH2002DocumentA
-     */
+    /** @var GH2002DocumentA */
+    #[ODM\ReferenceOne(discriminatorField: 'referencedClass', discriminatorMap: ['B' => GH2002DocumentB::class], cascade: 'all')]
     public $parentDocument;
 
     public function __construct(?GH2002DocumentA $parentDocument = null)
@@ -209,26 +177,18 @@ class GH2002ReferenceWithPartialDiscriminatorMap
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"A"=GH2002DocumentWithDiscriminatorMapA::class})
- */
+#[ODM\Document]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('type')]
+#[ODM\DiscriminatorMap(['A' => GH2002DocumentWithDiscriminatorMapA::class])]
 class GH2002DocumentWithDiscriminatorMapA
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=GH2002DocumentWithDiscriminatorMapA::class, cascade="all")
-     *
-     * @var GH2002DocumentWithDiscriminatorMapA
-     */
+    /** @var GH2002DocumentWithDiscriminatorMapA */
+    #[ODM\ReferenceOne(targetDocument: self::class, cascade: 'all')]
     public $parentDocument;
 
     public function __construct(?GH2002DocumentWithDiscriminatorMapA $parentDocument = null)
@@ -237,7 +197,7 @@ class GH2002DocumentWithDiscriminatorMapA
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH2002DocumentWithDiscriminatorMapB extends GH2002DocumentWithDiscriminatorMapA
 {
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2157Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2157Test.php
@@ -38,28 +38,23 @@ class GH2157Test extends BaseTestCase
     }
 }
 
-/**
- * @ODM\Document(collection="documents")
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"firsttype"=GH2157FirstType::class, "secondtype"=GH2157SecondType::class})
- */
+#[ODM\Document(collection: 'documents')]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('type')]
+#[ODM\DiscriminatorMap(['firsttype' => GH2157FirstType::class, 'secondtype' => GH2157SecondType::class])]
 abstract class GH2157Abstract
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Id]
     protected $id;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH2157FirstType extends GH2157Abstract
 {
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH2157SecondType extends GH2157Abstract
 {
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH232Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH232Test.php
@@ -38,35 +38,23 @@ class GH232Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class Product
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Price::class)
-     *
-     * @var Collection<int, Price>|array<Price>
-     */
+    /** @var Collection<int, Price>|array<Price> */
+    #[ODM\EmbedMany(targetDocument: Price::class)]
     public $prices = [];
 
-    /**
-     * @ODM\EmbedMany(targetDocument=SubProduct::class)
-     *
-     * @var Collection<int, SubProduct>|array<SubProduct>
-     */
+    /** @var Collection<int, SubProduct>|array<SubProduct> */
+    #[ODM\EmbedMany(targetDocument: SubProduct::class)]
     public $subproducts = [];
 
     public function __construct(string $name)
@@ -76,14 +64,11 @@ class Product
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class SubProduct
 {
-    /**
-     * @ODM\EmbedMany(targetDocument=Price::class)
-     *
-     * @var Collection<int, Price>|array<Price>
-     */
+    /** @var Collection<int, Price>|array<Price> */
+    #[ODM\EmbedMany(targetDocument: Price::class)]
     public $prices = [];
 
     public function __construct()
@@ -92,13 +77,10 @@ class SubProduct
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Price
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $price;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH245Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH245Test.php
@@ -31,31 +31,22 @@ class GH245Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH245Order
 {
-    /**
-     * @ODM\Id(strategy="NONE")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Id(strategy: 'NONE')]
     public $id;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH245OrderLog
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=GH245Order::class)
-     *
-     * @var GH245Order|null
-     */
+    /** @var GH245Order|null */
+    #[ODM\ReferenceOne(targetDocument: GH245Order::class)]
     public $order;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH267Test.php
@@ -61,28 +61,19 @@ class GH267Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document(collection="users") */
+#[ODM\Document(collection: 'users')]
 class GH267User
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     protected $name;
 
-    /**
-     * @ODM\ReferenceOne(name="company", targetDocument=GH267Company::class, inversedBy="users")
-     *
-     * @var GH267Company|null
-     */
+    /** @var GH267Company|null */
+    #[ODM\ReferenceOne(name: 'company', targetDocument: GH267Company::class, inversedBy: 'users')]
     protected $company;
 
     public function __construct(string $name)
@@ -121,26 +112,18 @@ class GH267User
     }
 }
 
-/**
- * @ODM\Document(collection="companies")
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"seller"=GH267SellerCompany::class, "buyer"=GH267BuyerCompany::class})
- */
+#[ODM\Document(collection: 'companies')]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('type')]
+#[ODM\DiscriminatorMap(['seller' => GH267SellerCompany::class, 'buyer' => GH267BuyerCompany::class])]
 class GH267Company
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH267User::class, mappedBy="company")
-     *
-     * @var Collection<int, GH267User>
-     */
+    /** @var Collection<int, GH267User> */
+    #[ODM\ReferenceMany(targetDocument: GH267User::class, mappedBy: 'company')]
     protected $users;
 
     public function setId(string $id): void
@@ -166,12 +149,12 @@ class GH267Company
     }
 }
 
-/** @ODM\Document(collection="companies") */
+#[ODM\Document(collection: 'companies')]
 class GH267BuyerCompany extends GH267Company
 {
 }
 
-/** @ODM\Document(collection="companies") */
+#[ODM\Document(collection: 'companies')]
 class GH267SellerCompany extends GH267Company
 {
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH389Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH389Test.php
@@ -31,21 +31,15 @@ class GH389Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class RootDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=EmptyMappedSuperClass::class)
-     *
-     * @var EmptyEmbeddedDocument
-     */
+    /** @var EmptyEmbeddedDocument */
+    #[ODM\EmbedOne(targetDocument: EmptyMappedSuperClass::class)]
     protected $emptyEmbeddedDocument;
 
     public function __construct()
@@ -64,18 +58,14 @@ class RootDocument
     }
 }
 
-/**
- * @ODM\MappedSuperClass
- * @ODM\DiscriminatorField("foobar")
- * @ODM\DiscriminatorMap({
- *     "empty"=EmptyEmbeddedDocument::class
- * })
- */
+#[ODM\MappedSuperclass]
+#[ODM\DiscriminatorField('foobar')]
+#[ODM\DiscriminatorMap(['empty' => EmptyEmbeddedDocument::class])]
 class EmptyMappedSuperClass
 {
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmptyEmbeddedDocument extends EmptyMappedSuperClass
 {
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH426Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH426Test.php
@@ -30,53 +30,35 @@ class GH426Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH426Form
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH426Field::class, mappedBy="form", cascade={"all"})
-     *
-     * @var Collection<int, GH426Field>|array<GH426Field>
-     */
+    /** @var Collection<int, GH426Field>|array<GH426Field> */
+    #[ODM\ReferenceMany(targetDocument: GH426Field::class, mappedBy: 'form', cascade: ['all'])]
     public $fields = [];
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=GH426Field::class, mappedBy="form", sort={"_id":1})
-     *
-     * @var GH426Field|null
-     */
+    /** @var GH426Field|null */
+    #[ODM\ReferenceOne(targetDocument: GH426Field::class, mappedBy: 'form', sort: ['_id' => 1])]
     public $firstField;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=GH426Field::class, mappedBy="form", sort={"_id":-1})
-     *
-     * @var GH426Field|null
-     */
+    /** @var GH426Field|null */
+    #[ODM\ReferenceOne(targetDocument: GH426Field::class, mappedBy: 'form', sort: ['_id' => -1])]
     public $lastField;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH426Field
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(inversedBy="fields", discriminatorMap={"f":GH426Form::class}, discriminatorField="type", cascade={"all"})
-     *
-     * @var GH426Form
-     */
+    /** @var GH426Form */
+    #[ODM\ReferenceOne(inversedBy: 'fields', discriminatorMap: ['f' => GH426Form::class], discriminatorField: 'type', cascade: ['all'])]
     public $form;
 
     public function __construct(GH426Form $form)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH435Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH435Test.php
@@ -24,31 +24,22 @@ class GH435Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH435Parent
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int|string|null
-     */
+    /** @var int|string|null */
+    #[ODM\Field(type: 'int')]
     protected $test;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH435Child extends GH435Parent
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     protected $test;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH453Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH453Test.php
@@ -300,112 +300,70 @@ class GH453Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH453Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="hash")
-     *
-     * @var array<string>
-     */
+    /** @var array<string> */
+    #[ODM\Field(type: 'hash')]
     public $hash;
 
-    /**
-     * @ODM\Field(type="collection")
-     *
-     * @var string[]
-     */
+    /** @var string[] */
+    #[ODM\Field(type: 'collection')]
     public $colPush;
 
-    /**
-     * @ODM\Field(type="collection")
-     *
-     * @var string[]
-     */
+    /** @var string[] */
+    #[ODM\Field(type: 'collection')]
     public $colSet;
 
-    /**
-     * @ODM\EmbedMany(strategy="pushAll"))
-     *
-     * @var Collection<int, GH453EmbeddedDocument>
-     */
+    /** @var Collection<int, GH453EmbeddedDocument> */
+    #[ODM\EmbedMany(strategy: 'pushAll')]
     public $embedManyPush;
 
-    /**
-     * @ODM\EmbedMany(strategy="set")
-     *
-     * @var Collection<int, GH453EmbeddedDocument>
-     */
+    /** @var Collection<int, GH453EmbeddedDocument> */
+    #[ODM\EmbedMany(strategy: 'set')]
     public $embedManySet;
 
-    /**
-     * @ODM\EmbedMany(strategy="setArray")
-     *
-     * @var Collection<int, GH453EmbeddedDocument>
-     */
+    /** @var Collection<int, GH453EmbeddedDocument> */
+    #[ODM\EmbedMany(strategy: 'setArray')]
     public $embedManySetArray;
 
-    /**
-     * @ODM\EmbedMany(strategy="addToSet")
-     *
-     * @var Collection<int, GH453EmbeddedDocument>
-     */
+    /** @var Collection<int, GH453EmbeddedDocument> */
+    #[ODM\EmbedMany(strategy: 'addToSet')]
     public $embedManyAddToSet;
 
-    /**
-     * @ODM\ReferenceMany(strategy="pushAll"))
-     *
-     * @var Collection<int, GH453ReferencedDocument>
-     */
+    /** @var Collection<int, GH453ReferencedDocument> */
+    #[ODM\ReferenceMany(strategy: 'pushAll')]
     public $referenceManyPush;
 
-    /**
-     * @ODM\ReferenceMany(strategy="set")
-     *
-     * @var Collection<int, GH453ReferencedDocument>
-     */
+    /** @var Collection<int, GH453ReferencedDocument> */
+    #[ODM\ReferenceMany(strategy: 'set')]
     public $referenceManySet;
 
-    /**
-     * @ODM\ReferenceMany(strategy="setArray")
-     *
-     * @var Collection<int, GH453ReferencedDocument>
-     */
+    /** @var Collection<int, GH453ReferencedDocument> */
+    #[ODM\ReferenceMany(strategy: 'setArray')]
     public $referenceManySetArray;
 
-    /**
-     * @ODM\ReferenceMany(strategy="addToSet")
-     *
-     * @var Collection<int, GH453ReferencedDocument>
-     */
+    /** @var Collection<int, GH453ReferencedDocument> */
+    #[ODM\ReferenceMany(strategy: 'addToSet')]
     public $referenceManyAddToSet;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH453EmbeddedDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH453ReferencedDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH467Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH467Test.php
@@ -29,56 +29,38 @@ class GH467Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH467Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="collection")
-     *
-     * @var mixed[]
-     */
+    /** @var mixed[] */
+    #[ODM\Field(type: 'collection')]
     public $col;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=GH467EmbeddedDocument::class)
-     *
-     * @var Collection<int, GH467EmbeddedDocument>
-     */
+    /** @var Collection<int, GH467EmbeddedDocument> */
+    #[ODM\EmbedMany(targetDocument: GH467EmbeddedDocument::class)]
     public $embedMany;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH467EmbeddedDocument::class)
-     *
-     * @var Collection<int, GH467EmbeddedDocument>
-     */
+    /** @var Collection<int, GH467EmbeddedDocument> */
+    #[ODM\ReferenceMany(targetDocument: GH467EmbeddedDocument::class)]
     public $refMany;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH467EmbeddedDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH467ReferencedDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH499Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH499Test.php
@@ -36,21 +36,15 @@ class GH499Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH499Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH499Document::class, storeAs="id", strategy="set")
-     *
-     * @var Collection<array-key, GH499Document>
-     */
+    /** @var Collection<array-key, GH499Document> */
+    #[ODM\ReferenceMany(targetDocument: self::class, storeAs: 'id', strategy: 'set')]
     protected $refMany;
 
     public function __construct(?ObjectId $id = null)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH520Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH520Test.php
@@ -64,20 +64,14 @@ class GH520Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH520Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=GH520Document::class, cascade={"persist"})
-     *
-     * @var GH520Document|null
-     */
+    /** @var GH520Document|null */
+    #[ODM\ReferenceOne(targetDocument: self::class, cascade: ['persist'])]
     public $ref;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH529Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH529Test.php
@@ -75,35 +75,26 @@ class GH529Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH529AutoIdDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var ObjectId|null
-     */
+    /** @var ObjectId|null */
+    #[ODM\Id]
     public $id;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH529CustomIdDocument
 {
-    /**
-     * @ODM\Id(strategy="none", type="custom_id")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id(strategy: 'none', type: 'custom_id')]
     public $id;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH529IntIdDocument
 {
-    /**
-     * @ODM\Id(strategy="none", type="int")
-     *
-     * @var float|int|null
-     */
+    /** @var float|int|null */
+    #[ODM\Id(strategy: 'none', type: 'int')]
     public $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH560Test.php
@@ -114,21 +114,15 @@ class GH560EventSubscriber implements EventSubscriber
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH560Document
 {
-    /**
-     * @ODM\Id(strategy="NONE")
-     *
-     * @var int|string|null
-     */
+    /** @var int|string|null */
+    #[ODM\Id(strategy: 'NONE')]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     /** @param int|string $id */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH561Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH561Test.php
@@ -37,21 +37,15 @@ class GH561Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH561Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=GH561EmbeddedDocument::class, strategy="set")
-     *
-     * @var Collection<int, GH561EmbeddedDocument>
-     */
+    /** @var Collection<int, GH561EmbeddedDocument> */
+    #[ODM\EmbedMany(targetDocument: GH561EmbeddedDocument::class, strategy: 'set')]
     public $embeddedDocuments;
 
     public function __construct()
@@ -60,14 +54,11 @@ class GH561Document
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH561EmbeddedDocument
 {
-    /**
-     * @ODM\EmbedMany(targetDocument=GH561AnotherEmbeddedDocument::class, strategy="set")
-     *
-     * @var Collection<int, GH561AnotherEmbeddedDocument>
-     */
+    /** @var Collection<int, GH561AnotherEmbeddedDocument> */
+    #[ODM\EmbedMany(targetDocument: GH561AnotherEmbeddedDocument::class, strategy: 'set')]
     public $embeddedDocuments;
 
     public function __construct()
@@ -76,14 +67,11 @@ class GH561EmbeddedDocument
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH561AnotherEmbeddedDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH566Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH566Test.php
@@ -71,40 +71,23 @@ class GH566Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH566Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=GH566EmbeddedDocument::class)
-     *
-     * @var GH566EmbeddedDocument|null
-     */
+    /** @var GH566EmbeddedDocument|null */
+    #[ODM\EmbedOne(targetDocument: GH566EmbeddedDocument::class)]
     public $version;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=GH566EmbeddedDocument::class)
-     *
-     * @var Collection<int, GH566EmbeddedDocument>
-     */
+    /** @var Collection<int, GH566EmbeddedDocument> */
+    #[ODM\EmbedMany(targetDocument: GH566EmbeddedDocument::class)]
     public $versions;
 
-    /**
-     * @ODM\ReferenceMany(
-     *      targetDocument=GH566Document::class,
-     *      cascade={"all"},
-     *      mappedBy="version.parent",
-     *      sort={"version.sequence"="asc"}
-     * )
-     *
-     * @var Collection<int, GH566Document>
-     */
+    /** @var Collection<int, GH566Document> */
+    #[ODM\ReferenceMany(targetDocument: self::class, cascade: ['all'], mappedBy: 'version.parent', sort: ['version.sequence' => 'asc'])]
     public $children;
 
     public function __construct()
@@ -114,20 +97,14 @@ class GH566Document
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH566EmbeddedDocument
 {
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Field(type: 'int')]
     public $sequence = 0;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=GH566Document::class, cascade={"all"}, inversedBy="children")
-     *
-     * @var GH566Document|null
-     */
+    /** @var GH566Document|null */
+    #[ODM\ReferenceOne(targetDocument: GH566Document::class, cascade: ['all'], inversedBy: 'children')]
     public $parent;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
@@ -62,21 +62,15 @@ class GH580Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH580Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     * @ODM\Index(unique=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
+    #[ODM\Index(unique: true)]
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH593Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH593Test.php
@@ -100,35 +100,23 @@ class GH593Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH593User
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(name="d", type="bool")
-     *
-     * @var bool
-     */
+    /** @var bool */
+    #[ODM\Field(name: 'd', type: 'bool')]
     public $deleted = false;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH593User::class, inversedBy="followedBy", storeAs="id")
-     *
-     * @var Collection<int, GH593User>
-     */
+    /** @var Collection<int, GH593User> */
+    #[ODM\ReferenceMany(targetDocument: self::class, inversedBy: 'followedBy', storeAs: 'id')]
     public $following;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH593User::class, mappedBy="following")
-     *
-     * @var Collection<int, GH593User>
-     */
+    /** @var Collection<int, GH593User> */
+    #[ODM\ReferenceMany(targetDocument: self::class, mappedBy: 'following')]
     public $followedBy;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH596Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH596Test.php
@@ -48,27 +48,18 @@ class GH596Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH596Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\Field(type="bool")
-     *
-     * @var bool|null
-     */
+    /** @var bool|null */
+    #[ODM\Field(type: 'bool')]
     public $deleted = false;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH597Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH597Test.php
@@ -120,28 +120,19 @@ class GH597Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document() */
+#[ODM\Document]
 class GH597Post
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=GH597Comment::class)
-     *
-     * @var Collection<int, GH597Comment>
-     */
+    /** @var Collection<int, GH597Comment> */
+    #[ODM\EmbedMany(targetDocument: GH597Comment::class)]
     public $comments;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH597ReferenceMany::class, storeAs="id")
-     *
-     * @var Collection<int, GH597ReferenceMany>
-     */
+    /** @var Collection<int, GH597ReferenceMany> */
+    #[ODM\ReferenceMany(targetDocument: GH597ReferenceMany::class, storeAs: 'id')]
     public $referenceMany;
 
     public function __construct()
@@ -168,14 +159,11 @@ class GH597Post
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH597Comment
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $comment;
 
     public function __construct(string $comment)
@@ -185,21 +173,15 @@ class GH597Comment
 }
 
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH597ReferenceMany
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $field;
 
     public function __construct(string $field)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH602Test.php
@@ -103,28 +103,19 @@ class GH602Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH602User
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(name="user_deleted", type="bool")
-     *
-     * @var bool
-     */
+    /** @var bool */
+    #[ODM\Field(name: 'user_deleted', type: 'bool')]
     public $deleted = false;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH602Thing::class, inversedBy="likedBy", storeAs="id")
-     *
-     * @var Collection<int, GH602Thing>
-     */
+    /** @var Collection<int, GH602Thing> */
+    #[ODM\ReferenceMany(targetDocument: GH602Thing::class, inversedBy: 'likedBy', storeAs: 'id')]
     public $likes;
 
     public function __construct()
@@ -139,28 +130,19 @@ class GH602User
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH602Thing
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(name="thing_deleted", type="bool")
-     *
-     * @var bool
-     */
+    /** @var bool */
+    #[ODM\Field(name: 'thing_deleted', type: 'bool')]
     public $deleted = false;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH602User::class, mappedBy="likes")
-     *
-     * @var Collection<int, GH602User>
-     */
+    /** @var Collection<int, GH602User> */
+    #[ODM\ReferenceMany(targetDocument: GH602User::class, mappedBy: 'likes')]
     public $likedBy;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH611Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH611Test.php
@@ -119,39 +119,27 @@ class GH611Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH611Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=GH611EmbeddedDocument::class)
-     *
-     * @var GH611EmbeddedDocument|null
-     */
+    /** @var GH611EmbeddedDocument|null */
+    #[ODM\EmbedOne(targetDocument: GH611EmbeddedDocument::class)]
     public $embedded;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH611EmbeddedDocument
 {
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int
-     */
+    /** @var int */
+    #[ODM\Field(type: 'int')]
     public $id;
 
-    /**
-     * @ODM\Field(name="n", type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(name: 'n', type: 'string')]
     public $name;
 
     public function __construct(int $id, string $name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH628Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH628Test.php
@@ -22,20 +22,14 @@ class GH628Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH628Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(name="f", type="raw")
-     *
-     * @var mixed
-     */
+    /** @var mixed */
+    #[ODM\Field(name: 'f', type: 'raw')]
     public $foo;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH665Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH665Test.php
@@ -47,28 +47,19 @@ class GH665Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH665Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=GH665Embedded::class, strategy="pushAll")
-     *
-     * @var Collection<int, GH665Embedded>
-     */
+    /** @var Collection<int, GH665Embedded> */
+    #[ODM\EmbedMany(targetDocument: GH665Embedded::class, strategy: 'pushAll')]
     public $embeddedPushAll;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=GH665Embedded::class, strategy="addToSet")
-     *
-     * @var Collection<int, GH665Embedded>
-     */
+    /** @var Collection<int, GH665Embedded> */
+    #[ODM\EmbedMany(targetDocument: GH665Embedded::class, strategy: 'addToSet')]
     public $embeddedAddToSet;
 
     public function __construct()
@@ -78,14 +69,11 @@ class GH665Document
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH665Embedded
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH788Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH788Test.php
@@ -240,120 +240,59 @@ class GH788Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH788Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=GH788ExternEmbedListed::class)
-     *
-     * @var Collection<int, GH788ExternEmbedListed>
-     */
+    /** @var Collection<int, GH788ExternEmbedListed> */
+    #[ODM\EmbedMany(targetDocument: GH788ExternEmbedListed::class)]
     public $externEmbedMany;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=GH788ExternEmbedListed::class)
-     *
-     * @var GH788ExternEmbedListed|null
-     */
+    /** @var GH788ExternEmbedListed|null */
+    #[ODM\EmbedOne(targetDocument: GH788ExternEmbedListed::class)]
     public $externEmbedOne;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH788ExternRefListed::class, cascade="all")
-     *
-     * @var Collection<int, GH788ExternRefListed>
-     */
+    /** @var Collection<int, GH788ExternRefListed> */
+    #[ODM\ReferenceMany(targetDocument: GH788ExternRefListed::class, cascade: 'all')]
     public $externRefMany;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=GH788ExternRefListed::class, cascade="all")
-     *
-     * @var GH788ExternRefListed
-     */
+    /** @var GH788ExternRefListed */
+    #[ODM\ReferenceOne(targetDocument: GH788ExternRefListed::class, cascade: 'all')]
     public $externRefOne;
 
-    /**
-     * @ODM\EmbedMany(
-     *   discriminatorField="type",
-     *   discriminatorMap={
-     *     "b"=GH788InlineEmbedListed::class
-     *   }
-     * )
-     *
-     * @var Collection<int, GH788InlineEmbedListed>
-     */
+    /** @var Collection<int, GH788InlineEmbedListed> */
+    #[ODM\EmbedMany(discriminatorField: 'type', discriminatorMap: ['b' => GH788InlineEmbedListed::class])]
     public $inlineEmbedMany;
 
-    /**
-     * @ODM\EmbedOne(
-     *   discriminatorField="type",
-     *   discriminatorMap={
-     *     "b"=GH788InlineEmbedListed::class
-     *   }
-     * )
-     *
-     * @var GH788InlineEmbedListed|null
-     */
+    /** @var GH788InlineEmbedListed|null */
+    #[ODM\EmbedOne(discriminatorField: 'type', discriminatorMap: ['b' => GH788InlineEmbedListed::class])]
     public $inlineEmbedOne;
 
-    /**
-     * @ODM\ReferenceMany(
-     *   discriminatorField="type",
-     *   discriminatorMap={
-     *     "c"=GH788InlineRefListed::class
-     *   },
-     *   cascade="all"
-     * )
-     *
-     * @var Collection<int, GH788InlineRefListed>
-     */
+    /** @var Collection<int, GH788InlineRefListed> */
+    #[ODM\ReferenceMany(discriminatorField: 'type', discriminatorMap: ['c' => GH788InlineRefListed::class], cascade: 'all')]
     public $inlineRefMany;
 
-    /**
-     * @ODM\ReferenceOne(
-     *   discriminatorField="type",
-     *   discriminatorMap={
-     *     "c"=GH788InlineRefListed::class
-     *   },
-     *   cascade="all"
-     * )
-     *
-     * @var GH788InlineRefListed|null
-     */
+    /** @var GH788InlineRefListed|null */
+    #[ODM\ReferenceOne(discriminatorField: 'type', discriminatorMap: ['c' => GH788InlineRefListed::class], cascade: 'all')]
     public $inlineRefOne;
 
-    /**
-     * @ODM\EmbedMany
-     *
-     * @var Collection<int, object>
-     */
+    /** @var Collection<int, object> */
+    #[ODM\EmbedMany]
     public $noTargetEmbedMany;
 
-    /**
-     * @ODM\EmbedOne
-     *
-     * @var object|null
-     */
+    /** @var object|null */
+    #[ODM\EmbedOne]
     public $noTargetEmbedOne;
 
-    /**
-     * @ODM\ReferenceMany(cascade="all")
-     *
-     * @var Collection<int, object>
-     */
+    /** @var Collection<int, object> */
+    #[ODM\ReferenceMany(cascade: 'all')]
     public $noTargetRefMany;
 
-    /**
-     * @ODM\ReferenceOne(cascade="all")
-     *
-     * @var object|null
-     */
+    /** @var object|null */
+    #[ODM\ReferenceOne(cascade: 'all')]
     public $noTargetRefOne;
 
     public function __construct()
@@ -367,124 +306,91 @@ class GH788Document
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"a"=GH788DocumentListed::class})
- */
+#[ODM\Document]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('type')]
+#[ODM\DiscriminatorMap(['a' => GH788DocumentListed::class])]
 class GH788DocumentListed extends GH788Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH788DocumentUnlisted extends GH788DocumentListed
 {
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH788InlineEmbedListed
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH788InlineEmbedUnlisted extends GH788InlineEmbedListed
 {
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH788InlineRefListed
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH788InlineRefUnlisted extends GH788InlineRefListed
 {
 }
 
-/**
- * @ODM\EmbeddedDocument
- * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"d"=GH788ExternEmbedListed::class})
- */
+#[ODM\EmbeddedDocument]
+#[ODM\DiscriminatorField('type')]
+#[ODM\DiscriminatorMap(['d' => GH788ExternEmbedListed::class])]
 class GH788ExternEmbedListed
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH788ExternEmbedUnlisted extends GH788ExternEmbedListed
 {
 }
 
-/**
- * @ODM\Document
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"e"=GH788ExternRefListed::class})
- */
+#[ODM\Document]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('type')]
+#[ODM\DiscriminatorMap(['e' => GH788ExternRefListed::class])]
 class GH788ExternRefListed
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH788ExternRefUnlisted extends GH788ExternRefListed
 {
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH816Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH816Test.php
@@ -33,20 +33,14 @@ class GH816Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH816Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var ObjectId|null
-     */
+    /** @var ObjectId|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $title;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH850Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH850Test.php
@@ -22,20 +22,14 @@ class GH850Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH850Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne
-     *
-     * @var object|string
-     */
+    /** @var object|string */
+    #[ODM\ReferenceOne]
     public $refs = '';
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH852Test.php
@@ -110,35 +110,23 @@ class GH852Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH852Document
 {
-    /**
-     * @ODM\Id(strategy="NONE", type="custom_id")
-     *
-     * @var Binary|array<string, mixed>
-     */
+    /** @var Binary|array<string, mixed> */
+    #[ODM\Id(strategy: 'NONE', type: 'custom_id')]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=GH852Document::class, cascade="all")
-     *
-     * @var GH852Document
-     */
+    /** @var GH852Document */
+    #[ODM\ReferenceOne(targetDocument: self::class, cascade: 'all')]
     public $refOne;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH852Document::class, cascade="all")
-     *
-     * @var Collection<int, GH852Document>
-     */
+    /** @var Collection<int, GH852Document> */
+    #[ODM\ReferenceMany(targetDocument: self::class, cascade: 'all')]
     public $refMany;
 
     public function __construct()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH878Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH878Test.php
@@ -53,42 +53,30 @@ class GH878Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH878Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=GH878SubDocument::class)
-     *
-     * @var GH878SubDocument|null
-     */
+    /** @var GH878SubDocument|null */
+    #[ODM\EmbedOne(targetDocument: GH878SubDocument::class)]
     public $embeddedField;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH878SubDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $some = '2';
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH878OtherDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH880Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH880Test.php
@@ -40,28 +40,19 @@ class GH880Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH880Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $status;
 
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int
-     */
+    /** @var int */
+    #[ODM\Field(type: 'int')]
     public $category;
 
     public function __construct(string $status = '', int $category = 0)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH897Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH897Test.php
@@ -40,55 +40,38 @@ class GH897Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH897A
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }
 
-/**
- * @ODM\Document
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\Document]
+#[ODM\HasLifecycleCallbacks]
 class GH897B
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=GH897A::class)
-     *
-     * @var GH897A|null
-     */
+    /** @var GH897A|null */
+    #[ODM\ReferenceOne(targetDocument: GH897A::class)]
     public $refOne;
 
     /** @var DocumentManager|null */
     public $dm;
 
-    /** @ODM\PreFlush */
+    #[ODM\PreFlush]
     public function preFlush(): void
     {
         if (! $this->refOne instanceof GH897A) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH921Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH921Test.php
@@ -66,28 +66,19 @@ class GH921Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH921User
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $name;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=GH921Post::class)
-     *
-     * @var Collection<int, GH921Post>
-     */
+    /** @var Collection<int, GH921Post> */
+    #[ODM\ReferenceMany(targetDocument: GH921Post::class)]
     private $posts;
 
     public function __construct()
@@ -122,21 +113,15 @@ class GH921User
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH921Post
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $name;
 
     public function getId(): ?string

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH927Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH927Test.php
@@ -19,36 +19,27 @@ class GH927Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH927Parent
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Doctrine\ODM\MongoDB\Tests\Functional\Ticket\GH927Reference::class)
-     *
-     * @var GH927Reference|null
-     */
+    /** @var GH927Reference|null */
+    #[ODM\ReferenceOne(targetDocument: GH927Reference::class)]
     protected $reference;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH927Child extends GH927Parent
 {
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH927Reference
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH928Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH928Test.php
@@ -33,13 +33,10 @@ class GH928Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH928Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH936Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH936Test.php
@@ -39,21 +39,15 @@ class GH936Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH936Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=GH936Document::class, cascade={"persist","remove"})
-     *
-     * @var GH936Document|null
-     */
+    /** @var GH936Document|null */
+    #[ODM\ReferenceOne(targetDocument: self::class, cascade: ['persist', 'remove'])]
     public $ref;
 
     public function __construct(?GH936Document $ref = null)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH942Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH942Test.php
@@ -52,56 +52,40 @@ class GH942Test extends BaseTestCase
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("type")
- */
+#[ODM\Document]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('type')]
 class GH942Document
 {
     public const CLASSNAME = self::class;
 
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }
 
-/**
- * @ODM\Document
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"p"=GH942DocumentParent::class})
- */
+#[ODM\Document]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('type')]
+#[ODM\DiscriminatorMap(['p' => GH942DocumentParent::class])]
 class GH942DocumentParent
 {
     public const CLASSNAME = self::class;
 
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH942DocumentChild extends GH942DocumentParent
 {
     public const CLASSNAME = self::class;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH944Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH944Test.php
@@ -38,21 +38,15 @@ class GH944Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH944Document
 {
-    /**
-     * @ODM\Id(strategy="auto")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id(strategy: 'auto')]
     public $id;
 
-    /**
-     * @ODM\EmbedMany
-     *
-     * @var Collection<int, GH944Embedded>
-     */
+    /** @var Collection<int, GH944Embedded> */
+    #[ODM\EmbedMany]
     public $data;
 
     public function __construct()
@@ -72,14 +66,11 @@ class GH944Document
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH944Embedded
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $text;
 
     public function __construct(string $text)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH971Test.php
@@ -71,47 +71,36 @@ class GH971Test extends BaseTestCase
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"car"=Car::class, "bicycle"=Bicycle::class, "tandem"=Tandem::class})
- */
+#[ODM\Document]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('type')]
+#[ODM\DiscriminatorMap(['car' => Car::class, 'bicycle' => Bicycle::class, 'tandem' => Tandem::class])]
 class Vehicle
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedMany
-     *
-     * @var Collection<int, object>
-     */
+    /** @var Collection<int, object> */
+    #[ODM\EmbedMany]
     public $features;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class Car extends Vehicle
 {
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class Bicycle extends Vehicle
 {
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class Tandem extends Bicycle
 {
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH977Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH977Test.php
@@ -53,27 +53,18 @@ class GH977Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class GH977TestDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $value1;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $value2;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH999Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH999Test.php
@@ -41,24 +41,16 @@ class GH999Listener
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\Document]
+#[ODM\HasLifecycleCallbacks]
 class GH999Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     private $name;
 
     public function __construct(string $name)
@@ -81,7 +73,7 @@ class GH999Document
         $this->name = $name;
     }
 
-    /** @ODM\PostUpdate */
+    #[ODM\PostUpdate]
     public function postUpdate(): void
     {
         throw new Exception('Did not expect postUpdate to be called when persisting a new document');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM116Test.php
@@ -39,31 +39,20 @@ class MODM116Test extends BaseTestCase
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\InheritanceType("COLLECTION_PER_CLASS") *
- */
+#[ODM\Document]
+#[ODM\InheritanceType('COLLECTION_PER_CLASS')]
 class MODM116Parent
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $name;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=MODM116Child::class) *
-     *
-     * @var MODM116Child|null
-     */
+    /** @var MODM116Child|null */
+    #[ODM\ReferenceOne(targetDocument: MODM116Child::class)]
     private $child;
 
     public function getId(): ?string
@@ -92,7 +81,7 @@ class MODM116Parent
     }
 }
 
-/** @ODM\Document **/
+#[ODM\Document]
 class MODM116Child extends MODM116Parent
 {
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM140Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM140Test.php
@@ -122,28 +122,19 @@ class MODM140Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class Category
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Post::class)
-     *
-     * @var Collection<int, Post>
-     */
+    /** @var Collection<int, Post> */
+    #[ODM\EmbedMany(targetDocument: Post::class)]
     public $posts;
 
     public function __construct()
@@ -152,21 +143,15 @@ class Category
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Post
 {
-    /**
-     * @ODM\EmbedMany(targetDocument=PostVersion::class)
-     *
-     * @var Collection<int, PostVersion>
-     */
+    /** @var Collection<int, PostVersion> */
+    #[ODM\EmbedMany(targetDocument: PostVersion::class)]
     public $versions;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Comment::class)
-     *
-     * @var Collection<int, Comment>
-     */
+    /** @var Collection<int, Comment> */
+    #[ODM\ReferenceMany(targetDocument: Comment::class)]
     public $comments;
 
     public function __construct()
@@ -176,14 +161,11 @@ class Post
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class PostVersion
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name)
@@ -192,20 +174,14 @@ class PostVersion
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class Comment
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $content;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM29Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM29Test.php
@@ -55,21 +55,15 @@ class MODM29Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM29Doc
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=MODM29Embedded::class, strategy="set")
-     *
-     * @var Collection<int, MODM29Embedded>
-     */
+    /** @var Collection<int, MODM29Embedded> */
+    #[ODM\EmbedMany(targetDocument: MODM29Embedded::class, strategy: 'set')]
     protected $collection;
 
     /** @param Collection<int, MODM29Embedded> $c */
@@ -91,14 +85,11 @@ class MODM29Doc
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM29Embedded
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     protected $val;
 
     public function __construct(string $val)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM43Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM43Test.php
@@ -26,34 +26,23 @@ class MODM43Test extends BaseTestCase
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\Document]
+#[ODM\HasLifecycleCallbacks]
 class Person
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $firstName;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $lastName;
 
-    /** @ODM\PreLoad */
+    #[ODM\PreLoad]
     public function preLoad(PreLoadEventArgs $e): void
     {
         $data =& $e->getData();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM45Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM45Test.php
@@ -24,21 +24,15 @@ class MODM45Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document(collection="modm45_test") */
+#[ODM\Document(collection: 'modm45_test')]
 class MODM45A
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=MODM45B::class)
-     *
-     * @var MODM45B|null
-     */
+    /** @var MODM45B|null */
+    #[ODM\EmbedOne(targetDocument: MODM45B::class)]
     protected $b;
 
     public function getId(): ?string
@@ -57,14 +51,11 @@ class MODM45A
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM45B
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     protected $val;
 
     public function setVal(string $val): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM46Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM46Test.php
@@ -25,32 +25,23 @@ class MODM46Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM46A
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=MODM46AB::class)
-     * @ODM\AlsoLoad("c")
-     *
-     * @var MODM46AB|null
-     */
+    /** @var MODM46AB|null */
+    #[ODM\EmbedOne(targetDocument: MODM46AB::class)]
+    #[ODM\AlsoLoad('c')]
     public $b;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM46AB
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $value;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM47Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM47Test.php
@@ -23,24 +23,18 @@ class MODM47Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM47A
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $b = 'tmp';
 
-    /** @ODM\AlsoLoad("c") */
+    #[ODM\AlsoLoad('c')]
     public function renameC(string $c): void
     {
         $this->b = $c;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM48Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM48Test.php
@@ -30,21 +30,15 @@ class MODM48Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM48A
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=MODM48B::class)
-     *
-     * @var MODM48B|null
-     */
+    /** @var MODM48B|null */
+    #[ODM\EmbedOne(targetDocument: MODM48B::class)]
     public $b;
 
     public function getId(): ?string
@@ -63,14 +57,11 @@ class MODM48A
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM48B
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $val;
 
     public function setVal(string $val): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM52Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM52Test.php
@@ -39,18 +39,12 @@ class MODM52Test extends BaseTestCase
 /** @ODM\MappedSuperClass */
 class MODM52Container
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $value;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=MODM52Embedded::class, strategy="set")
-     *
-     * @var Collection<int, MODM52Embedded>|array<MODM52Embedded>
-     */
+    /** @var Collection<int, MODM52Embedded>|array<MODM52Embedded> */
+    #[ODM\EmbedMany(targetDocument: MODM52Embedded::class, strategy: 'set')]
     public $items = [];
 
     /** @param array<MODM52Embedded>|null $items */
@@ -80,18 +74,15 @@ class MODM52Container
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM52Embedded extends MODM52Container
 {
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM52Doc extends MODM52Container
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM56Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM56Test.php
@@ -35,38 +35,24 @@ class MODM56Test extends BaseTestCase
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\Document]
+#[ODM\HasLifecycleCallbacks]
 class MODM56Parent
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\Field(type="date")
-     *
-     * @var DateTime|null
-     */
+    /** @var DateTime|null */
+    #[ODM\Field(type: 'date')]
     public $updatedAt;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=MODM56Child::class)
-     *
-     * @var Collection<int, MODM56Child>|array<MODM56Child>
-     */
+    /** @var Collection<int, MODM56Child>|array<MODM56Child> */
+    #[ODM\EmbedMany(targetDocument: MODM56Child::class)]
     public $children = [];
 
     public function __construct(string $name)
@@ -74,28 +60,22 @@ class MODM56Parent
         $this->name = $name;
     }
 
-    /** @ODM\PreUpdate */
+    #[ODM\PreUpdate]
     public function preUpdate(): void
     {
         $this->updatedAt = new DateTime();
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM56Child
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM62Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM62Test.php
@@ -25,21 +25,15 @@ class MODM62Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document(collection="modm62_users") */
+#[ODM\Document(collection: 'modm62_users')]
 class MODM62Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="collection")
-     *
-     * @var string[]
-     */
+    /** @var string[] */
+    #[ODM\Field(type: 'collection')]
     public $b = ['ok'];
 
     /** @param string[] $b */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM65Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM65Test.php
@@ -29,42 +29,24 @@ class MODM65Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document(collection="modm65_users") */
+#[ODM\Document(collection: 'modm65_users')]
 class MODM65User
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
-    /**
-     * @ODM\EmbedOne(
-     *  discriminatorField="php",
-     *  discriminatorMap={
-     *      "fbu"=Doctrine\ODM\MongoDB\Tests\Functional\Ticket\MODM65SocialNetworkUser::class
-     *  },
-     *  name="snu"
-     * )
-     *
-     * @var MODM65SocialNetworkUser|null
-     */
+    /** @var MODM65SocialNetworkUser|null */
+    #[ODM\EmbedOne(discriminatorField: 'php', discriminatorMap: ['fbu' => MODM65SocialNetworkUser::class], name: 'snu')]
     public $socialNetworkUser;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM65SocialNetworkUser
 {
-    /**
-     * @ODM\Field(name="fN", type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(name: 'fN', type: 'string')]
     public $firstName;
-    /**
-     * @ODM\Field(name="lN", type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(name: 'lN', type: 'string')]
     public $lastName;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM66Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM66Test.php
@@ -62,21 +62,15 @@ class MODM66Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM52A
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=MODM52B::class, cascade="all")
-     *
-     * @var Collection<int, MODM52B>
-     */
+    /** @var Collection<int, MODM52B> */
+    #[ODM\ReferenceMany(targetDocument: MODM52B::class, cascade: 'all')]
     protected $b;
 
     /** @param array<MODM52B> $b */
@@ -92,21 +86,15 @@ class MODM52A
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM52B
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     protected $value;
 
     public function __construct(string $v)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM67Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM67Test.php
@@ -107,59 +107,38 @@ class MODM67TestEventListener
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM67DerivedClass
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=MODM67EmbeddedObject::class)
-     *
-     * @var MODM67EmbeddedObject|null
-     */
+    /** @var MODM67EmbeddedObject|null */
+    #[ODM\EmbedOne(targetDocument: MODM67EmbeddedObject::class)]
     public $embedOne;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM67EmbeddedObject
 {
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Field(type: 'int')]
     public $numAccesses = 0;
 
-    /**
-     * @ODM\Field(type="bool")
-     *
-     * @var bool|null
-     */
+    /** @var bool|null */
+    #[ODM\Field(type: 'bool')]
     public $prePersist = false;
 
-    /**
-     * @ODM\Field(type="bool")
-     *
-     * @var bool|null
-     */
+    /** @var bool|null */
+    #[ODM\Field(type: 'bool')]
     public $postPersist = false;
 
-    /**
-     * @ODM\Field(type="bool")
-     *
-     * @var bool|null
-     */
+    /** @var bool|null */
+    #[ODM\Field(type: 'bool')]
     public $preUpdate = false;
 
-    /**
-     * @ODM\Field(type="bool")
-     *
-     * @var bool|null
-     */
+    /** @var bool|null */
+    #[ODM\Field(type: 'bool')]
     public $postUpdate = false;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM70Test.php
@@ -31,38 +31,23 @@ class MODM70Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class Avatar
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(name="na", type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(name: 'na', type: 'string')]
     protected $name;
 
-    /**
-     * @ODM\Field(name="sex", type="int")
-     *
-     * @var int
-     */
+    /** @var int */
+    #[ODM\Field(name: 'sex', type: 'int')]
     protected $sex;
 
-    /**
-     * @ODM\EmbedMany(
-     *  targetDocument=AvatarPart::class,
-     *  name="aP"
-     * )
-     *
-     * @var Collection<int, AvatarPart>|array<AvatarPart>
-     */
+    /** @var Collection<int, AvatarPart>|array<AvatarPart> */
+    #[ODM\EmbedMany(targetDocument: AvatarPart::class, name: 'aP')]
     protected $avatarParts;
 
     /** @param AvatarPart[] $avatarParts */
@@ -126,14 +111,11 @@ class Avatar
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class AvatarPart
 {
-    /**
-     * @ODM\Field(name="col", type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(name: 'col', type: 'string')]
     protected $color;
 
     public function __construct(string $color)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM72Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM72Test.php
@@ -16,20 +16,14 @@ class MODM72Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM72User
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string", options={"test"="test"})
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string', options: ['test' => 'test'])]
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM76Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM76Test.php
@@ -29,35 +29,23 @@ class MODM76Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM76A
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     protected $test = 'test';
 
-    /**
-     * @ODM\EmbedMany(targetDocument=MODM76B::class)
-     *
-     * @var Collection<int, MODM76B>
-     */
+    /** @var Collection<int, MODM76B> */
+    #[ODM\EmbedMany(targetDocument: MODM76B::class)]
     protected $b;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=MODM76C::class)
-     *
-     * @var Collection<int, MODM76C>
-     */
+    /** @var Collection<int, MODM76C> */
+    #[ODM\ReferenceMany(targetDocument: MODM76C::class)]
     protected $c;
 
     /**
@@ -88,14 +76,11 @@ class MODM76A
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM76B
 {
-    /**
-     * @ODM\ReferenceOne(targetDocument=MODM76C::class)
-     *
-     * @var MODM76C
-     */
+    /** @var MODM76C */
+    #[ODM\ReferenceOne(targetDocument: MODM76C::class)]
     protected $c;
 
     public function __construct(MODM76C $c)
@@ -109,13 +94,10 @@ class MODM76B
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM76C
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM81Test.php
@@ -60,28 +60,19 @@ class MODM81Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM81TestDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     protected $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=MODM81TestEmbeddedDocument::class)
-     *
-     * @var Collection<int, MODM81TestEmbeddedDocument>
-     */
+    /** @var Collection<int, MODM81TestEmbeddedDocument> */
+    #[ODM\EmbedMany(targetDocument: MODM81TestEmbeddedDocument::class)]
     protected $embeddedDocuments;
 
     public function getId(): ?string
@@ -112,28 +103,19 @@ class MODM81TestDocument
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM81TestEmbeddedDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $message;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=MODM81TestDocument::class)
-     *
-     * @var MODM81TestDocument
-     */
+    /** @var MODM81TestDocument */
+    #[ODM\ReferenceOne(targetDocument: MODM81TestDocument::class)]
     public $refTodocument1;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=MODM81TestDocument::class)
-     *
-     * @var MODM81TestDocument
-     */
+    /** @var MODM81TestDocument */
+    #[ODM\ReferenceOne(targetDocument: MODM81TestDocument::class)]
     public $refTodocument2;
 
     public function __construct(MODM81TestDocument $document1, MODM81TestDocument $document2, string $message)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM83Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM83Test.php
@@ -70,56 +70,38 @@ class MODM83EventListener
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM83TestDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=MODM83TestEmbeddedDocument::class)
-     *
-     * @var MODM83TestEmbeddedDocument|null
-     */
+    /** @var MODM83TestEmbeddedDocument|null */
+    #[ODM\EmbedOne(targetDocument: MODM83TestEmbeddedDocument::class)]
     public $embedded;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM83TestEmbeddedDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM83OtherDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM90Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM90Test.php
@@ -87,63 +87,41 @@ class MODM90EventListener
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM90TestDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedOne
-     * (
-     *   discriminatorField="type",
-     *   discriminatorMap={
-     *     "test"=MODM90TestEmbeddedDocument::class,
-     *     "test2"=MODM90Test2EmbeddedDocument::class
-     *   }
-     *  )
-     *
-     * @var MODM90TestEmbeddedDocument|MODM90Test2EmbeddedDocument|null
-     */
+    /** @var MODM90TestEmbeddedDocument|MODM90Test2EmbeddedDocument|null */
+    #[ODM\EmbedOne(discriminatorField: 'type', discriminatorMap: [
+        'test' => MODM90TestEmbeddedDocument::class,
+        'test2' => MODM90Test2EmbeddedDocument::class,
+    ])]
     public $embedded;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM90TestEmbeddedDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM90Test2EmbeddedDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\Field(type="string") The discriminator field is a real property
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $type;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM91Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM91Test.php
@@ -62,38 +62,26 @@ class MODM91EventListener
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM91TestDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=MODM91TestEmbeddedDocument::class)
-     *
-     * @var MODM91TestEmbeddedDocument|null
-     */
+    /** @var MODM91TestEmbeddedDocument|null */
+    #[ODM\EmbedOne(targetDocument: MODM91TestEmbeddedDocument::class)]
     public $embedded;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM91TestEmbeddedDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM92Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM92Test.php
@@ -40,22 +40,16 @@ class MODM92Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM92TestDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
     // Note: Test case fails with default "pushAll" strategy, but "set" works
-    /**
-     * @ODM\EmbedMany(targetDocument=MODM92TestEmbeddedDocument::class)
-     *
-     * @var Collection<int, MODM92TestEmbeddedDocument>
-     */
+    /** @var Collection<int, MODM92TestEmbeddedDocument> */
+    #[ODM\EmbedMany(targetDocument: MODM92TestEmbeddedDocument::class)]
     public $embeddedDocuments;
 
     public function __construct()
@@ -88,14 +82,11 @@ class MODM92TestDocument
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM92TestEmbeddedDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM95Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/MODM95Test.php
@@ -43,22 +43,16 @@ class MODM95Test extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class MODM95TestDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
     // Note: Test case fails with default "pushAll" strategy, but "set" works
-    /**
-     * @ODM\EmbedMany(targetDocument=MODM95TestEmbeddedDocument::class)
-     *
-     * @var Collection<int, MODM95TestEmbeddedDocument>
-     */
+    /** @var Collection<int, MODM95TestEmbeddedDocument> */
+    #[ODM\EmbedMany(targetDocument: MODM95TestEmbeddedDocument::class)]
     public $embeddedDocuments;
 
     public function __construct()
@@ -77,14 +71,11 @@ class MODM95TestDocument
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM95TestEmbeddedDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/UpsertTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/UpsertTest.php
@@ -87,42 +87,27 @@ class UpsertTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class UpsertTestUser
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(nullable=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(nullable: true)]
     public $nullableField;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=UpsertTestUserEmbedded::class, nullable=true)
-     *
-     * @var UpsertTestUserEmbedded|null
-     */
+    /** @var UpsertTestUserEmbedded|null */
+    #[ODM\EmbedOne(targetDocument: UpsertTestUserEmbedded::class, nullable: true)]
     public $nullableEmbedOne;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=UpsertTestUser::class, cascade="persist", nullable=true)
-     *
-     * @var UpsertTestUser|null
-     */
+    /** @var UpsertTestUser|null */
+    #[ODM\ReferenceOne(targetDocument: self::class, cascade: 'persist', nullable: true)]
     public $nullableReferenceOne;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=UpsertTestUserEmbedded::class)
-     *
-     * @var Collection<int, UpsertTestUserEmbedded>
-     */
+    /** @var Collection<int, UpsertTestUserEmbedded> */
+    #[ODM\EmbedMany(targetDocument: UpsertTestUserEmbedded::class)]
     public $embedMany;
 
     public function __construct()
@@ -131,13 +116,10 @@ class UpsertTestUser
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class UpsertTestUserEmbedded
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $test;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ValidationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ValidationTest.php
@@ -89,7 +89,7 @@ EOT;
     }
 }
 
-/** @ODM\Document(collection="SchemaValidated") */
+#[ODM\Document(collection: 'SchemaValidated')]
 class SchemaValidatedUpdate extends SchemaValidated
 {
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/VersionTest.php
@@ -44,36 +44,24 @@ class VersionTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class VersionedDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="int", name="_version")
-     * @ODM\Version
-     *
-     * @var int
-     */
+    /** @var int */
+    #[ODM\Field(type: 'int', name: '_version')]
+    #[ODM\Version]
     public $version = 1;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=VersionedEmbeddedDocument::class)
-     *
-     * @var Collection<int, VersionedEmbeddedDocument>|array<VersionedEmbeddedDocument>|null
-     */
+    /** @var Collection<int, VersionedEmbeddedDocument>|array<VersionedEmbeddedDocument>|null */
+    #[ODM\EmbedMany(targetDocument: VersionedEmbeddedDocument::class)]
     public $embedMany = [];
 
     public function __construct()
@@ -82,21 +70,15 @@ class VersionedDocument
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class VersionedEmbeddedDocument
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $value;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=VersionedEmbeddedDocument::class)
-     *
-     * @var Collection<int, VersionedEmbeddedDocument>
-     */
+    /** @var Collection<int, VersionedEmbeddedDocument> */
+    #[ODM\EmbedMany(targetDocument: self::class)]
     public $embedMany;
 
     public function __construct(string $value)

--- a/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/HydratorTest.php
@@ -179,120 +179,78 @@ class HydratorTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class HydrationClosureUser
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string", nullable=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string', nullable: true)]
     public $title = 'Mr.';
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\Field(type="date")
-     *
-     * @var DateTime|null
-     */
+    /** @var DateTime|null */
+    #[ODM\Field(type: 'date')]
     public $birthdate;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=HydrationClosureReferenceOne::class)
-     *
-     * @var HydrationClosureReferenceOne|null
-     */
+    /** @var HydrationClosureReferenceOne|null */
+    #[ODM\ReferenceOne(targetDocument: HydrationClosureReferenceOne::class)]
     public $referenceOne;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=HydrationClosureReferenceMany::class)
-     *
-     * @var Collection<int, HydrationClosureReferenceMany>|array<HydrationClosureReferenceMany>
-     */
+    /** @var Collection<int, HydrationClosureReferenceMany>|array<HydrationClosureReferenceMany> */
+    #[ODM\ReferenceMany(targetDocument: HydrationClosureReferenceMany::class)]
     public $referenceMany = [];
 
-    /**
-     * @ODM\EmbedOne(targetDocument=HydrationClosureEmbedOne::class)
-     *
-     * @var HydrationClosureEmbedOne|null
-     */
+    /** @var HydrationClosureEmbedOne|null */
+    #[ODM\EmbedOne(targetDocument: HydrationClosureEmbedOne::class)]
     public $embedOne;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=HydrationClosureEmbedMany::class)
-     *
-     * @var Collection<int, HydrationClosureEmbedMany>|array<HydrationClosureReferenceMany>
-     */
+    /** @var Collection<int, HydrationClosureEmbedMany>|array<HydrationClosureReferenceMany> */
+    #[ODM\EmbedMany(targetDocument: HydrationClosureEmbedMany::class)]
     public $embedMany = [];
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class HydrationClosureReferenceOne
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class HydrationClosureReferenceMany
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class HydrationClosureEmbedMany
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class HydrationClosureEmbedOne
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
@@ -100,94 +100,63 @@ class TransientBaseClass
     private $transient2;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class DocumentSubClass extends TransientBaseClass
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $name;
 }
 
-/**
- * @ODM\MappedSuperclass
- * @ODM\ReadPreference("secondary", tags={ { "dc"="east" } })
- */
+#[ODM\MappedSuperclass]
+#[ODM\ReadPreference('secondary', tags: [['dc' => 'east']])]
 class MappedSuperclassBase
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $mapped1;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $mapped2;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=MappedSuperclassRelated1::class)
-     *
-     * @var MappedSuperclassRelated1|null
-     */
+    /** @var MappedSuperclassRelated1|null */
+    #[ODM\ReferenceOne(targetDocument: MappedSuperclassRelated1::class)]
     private $mappedRelated1;
 
     /** @var mixed */
     private $transient;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class DocumentSubClass2 extends MappedSuperclassBase
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $name;
 }
 
-/**
- * @ODM\File(bucketName="myFile", chunkSizeBytes=112)
- * @ODM\DiscriminatorField("type")
- */
+#[ODM\File(bucketName: 'myFile', chunkSizeBytes: 112)]
+#[ODM\DiscriminatorField('type')]
 class GridFSParentClass
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 }
 
-/** @ODM\File */
+#[ODM\File]
 class GridFSChildClass extends GridFSParentClass
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
@@ -35,21 +35,15 @@ class ClassMetadataLoadEventTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class LoadEventTestDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $name;
 
     /** @var mixed */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -982,27 +982,18 @@ class EmbedWithCascadeTest
     public $address;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class EmbeddedAssociationsCascadeTest
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Documents\Address::class)
-     *
-     * @var Address|null
-     */
+    /** @var Address|null */
+    #[ODM\EmbedOne(targetDocument: Address::class)]
     public $address;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Documents\Address::class)
-     *
-     * @var Address|null
-     */
+    /** @var Address|null */
+    #[ODM\EmbedOne(targetDocument: Address::class)]
     public $addresses;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ShardKeyInheritanceMappingTest.php
@@ -62,83 +62,61 @@ class ShardKeyInheritanceMappingTest extends BaseTestCase
 }
 
 
-/**
- * @ODM\MappedSuperclass
- * @ODM\ShardKey(keys={"_id"="asc"})
- */
+#[ODM\MappedSuperclass]
+#[ODM\ShardKey(keys: ['_id' => 'asc'])]
 class ShardedSuperclass
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $name;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class ShardedSubclass extends ShardedSuperclass
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 }
 
-/**
- * @ODM\Document
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\ShardKey(keys={"_id"="asc"})
- */
+#[ODM\Document]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\ShardKey(keys: ['_id' => 'asc'])]
 class ShardedSingleCollInheritance1
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class ShardedSingleCollInheritance2 extends ShardedSingleCollInheritance1
 {
 }
 
-/**
- * @ODM\Document
- * @ODM\ShardKey(keys={"_id"="hashed"})
- */
+#[ODM\Document]
+#[ODM\ShardKey(keys: ['_id' => 'hashed'])]
 class ShardedSingleCollInheritance3 extends ShardedSingleCollInheritance1
 {
 }
 
-/**
- * @ODM\Document
- * @ODM\InheritanceType("COLLECTION_PER_CLASS")
- * @ODM\ShardKey(keys={"_id"="asc"})
- */
+#[ODM\Document]
+#[ODM\InheritanceType('COLLECTION_PER_CLASS')]
+#[ODM\ShardKey(keys: ['_id' => 'asc'])]
 class ShardedCollectionPerClass1
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class ShardedCollectionPerClass2 extends ShardedCollectionPerClass1
 {
 }
 
-/**
- * @ODM\Document
- * @ODM\ShardKey(keys={"_id"="hashed"})
- */
+#[ODM\Document]
+#[ODM\ShardKey(keys: ['_id' => 'hashed'])]
 class ShardedCollectionPerClass3 extends ShardedCollectionPerClass1
 {
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
@@ -96,114 +96,70 @@ class DocumentPersisterGetShardKeyQueryTest extends BaseTestCase
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\ShardKey(keys={"int"="asc","string"="asc","bool"="asc","float"="asc"})
- */
+#[ODM\Document]
+#[ODM\ShardKey(keys: ['int' => 'asc', 'string' => 'asc', 'bool' => 'asc', 'float' => 'asc'])]
 class ShardedByScalars
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int
-     */
+    /** @var int */
+    #[ODM\Field(type: 'int')]
     public $int;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $string;
 
-    /**
-     * @ODM\Field(type="bool")
-     *
-     * @var bool|null
-     */
+    /** @var bool|null */
+    #[ODM\Field(type: 'bool')]
     public $bool;
 
-    /**
-     * @ODM\Field(type="float")
-     *
-     * @var float|null
-     */
+    /** @var float|null */
+    #[ODM\Field(type: 'float')]
     public $float;
 }
 
-/**
- * @ODM\Document
- * @ODM\ShardKey(keys={"oid"="asc","bin"="asc","date"="asc"})
- */
+#[ODM\Document]
+#[ODM\ShardKey(keys: ['oid' => 'asc', 'bin' => 'asc', 'date' => 'asc'])]
 class ShardedByObjects
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="object_id")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'object_id')]
     public $oid;
 
-    /**
-     * @ODM\Field(type="bin")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'bin')]
     public $bin;
 
-    /**
-     * @ODM\Field(type="date")
-     *
-     * @var DateTime|null
-     */
+    /** @var DateTime|null */
+    #[ODM\Field(type: 'date')]
     public $date;
 }
 
-/**
- * @ODM\Document
- * @ODM\ShardKey(keys={"_id"="asc"})
- */
+#[ODM\Document]
+#[ODM\ShardKey(keys: ['_id' => 'asc'])]
 class ShardedById
 {
-    /**
-     * @ODM\Id
-     *
-     * @var ObjectId|null
-     */
+    /** @var ObjectId|null */
+    #[ODM\Id]
     public $identifier;
 }
 
-/**
- * @ODM\Document
- * @ODM\ShardKey(keys={"reference"="asc"})
- */
+#[ODM\Document]
+#[ODM\ShardKey(keys: ['reference' => 'asc'])]
 class ShardedByReferenceOne
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=User::class)
-     *
-     * @var User|null
-     */
+    /** @var User|null */
+    #[ODM\ReferenceOne(targetDocument: User::class)]
     public $reference;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -862,100 +862,65 @@ class BuilderTest extends BaseTestCase
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"ca"=ChildA::class, "cb"=ChildB::class, "cc"=ChildC::class})
- */
+#[ODM\Document]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('type')]
+#[ODM\DiscriminatorMap(['ca' => ChildA::class, 'cb' => ChildB::class, 'cc' => ChildC::class])]
 class ParentClass
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class ChildA extends ParentClass
 {
-    /**
-     * @ODM\ReferenceOne(targetDocument=Documents\Feature::class)
-     *
-     * @var Feature|null
-     */
+    /** @var Feature|null */
+    #[ODM\ReferenceOne(targetDocument: Feature::class)]
     public $featureFull;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Documents\Feature::class)
-     *
-     * @var Collection<int, Feature>
-     */
+    /** @var Collection<int, Feature> */
+    #[ODM\ReferenceMany(targetDocument: Feature::class)]
     public $featureFullMany;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Documents\Feature::class)
-     *
-     * @var Feature|null
-     */
+    /** @var Feature|null */
+    #[ODM\ReferenceOne(targetDocument: Feature::class)]
     public $conflict;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Documents\Feature::class)
-     *
-     * @var Collection<int, Feature>
-     */
+    /** @var Collection<int, Feature> */
+    #[ODM\ReferenceMany(targetDocument: Feature::class)]
     public $conflictMany;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class ChildB extends ParentClass
 {
-    /**
-     * @ODM\ReferenceOne(targetDocument=Documents\Feature::class, storeAs="id")
-     *
-     * @var Feature|null
-     */
+    /** @var Feature|null */
+    #[ODM\ReferenceOne(targetDocument: Feature::class, storeAs: 'id')]
     public $featureSimple;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Documents\Feature::class, storeAs="id")
-     *
-     * @var Collection<int, Feature>
-     */
+    /** @var Collection<int, Feature> */
+    #[ODM\ReferenceMany(targetDocument: Feature::class, storeAs: 'id')]
     public $featureSimpleMany;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Documents\Feature::class, storeAs="id")
-     *
-     * @var Feature|null
-     */
+    /** @var Feature|null */
+    #[ODM\ReferenceOne(targetDocument: Feature::class, storeAs: 'id')]
     public $conflict;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Documents\Feature::class, storeAs="id")
-     *
-     * @var Collection<int, Feature>
-     */
+    /** @var Collection<int, Feature> */
+    #[ODM\ReferenceMany(targetDocument: Feature::class, storeAs: 'id')]
     public $conflictMany;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class ChildC extends ParentClass
 {
-    /**
-     * @ODM\ReferenceOne(storeAs="dbRef")
-     *
-     * @var object|null
-     */
+    /** @var object|null */
+    #[ODM\ReferenceOne(storeAs: 'dbRef')]
     public $featurePartial;
 
-    /**
-     * @ODM\ReferenceMany(storeAs="dbRef")
-     *
-     * @var Collection<int, object>
-     */
+    /** @var Collection<int, object> */
+    #[ODM\ReferenceMany(storeAs: 'dbRef')]
     public $featurePartialMany;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
@@ -585,70 +585,43 @@ class QueryTest extends BaseTestCase
     }
 }
 
-/** @ODM\Document(collection="people") */
+#[ODM\Document(collection: 'people')]
 class Person
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $firstName;
 
-    /**
-     * @ODM\ReferenceOne(storeAs="dbRefWithDb")
-     *
-     * @var Person|null
-     */
+    /** @var Person|null */
+    #[ODM\ReferenceOne(storeAs: 'dbRefWithDb')]
     public $bestFriend;
 
-    /**
-     * @ODM\ReferenceOne(storeAs="id", targetDocument=Doctrine\ODM\MongoDB\Tests\Person::class)
-     *
-     * @var Person|null
-     */
+    /** @var Person|null */
+    #[ODM\ReferenceOne(storeAs: 'id', targetDocument: self::class)]
     public $bestFriendSimple;
 
-    /**
-     * @ODM\ReferenceOne
-     *
-     * @var Person|null
-     */
+    /** @var Person|null */
+    #[ODM\ReferenceOne]
     public $bestFriendPartial;
 
-    /**
-     * @ODM\ReferenceMany(storeAs="dbRefWithDb")
-     *
-     * @var DoctrineCollection<int, Person>|array<Person>
-     */
+    /** @var DoctrineCollection<int, Person>|array<Person> */
+    #[ODM\ReferenceMany(storeAs: 'dbRefWithDb')]
     public $friends = [];
 
-    /**
-     * @ODM\ReferenceMany(storeAs="id", targetDocument=Doctrine\ODM\MongoDB\Tests\Person::class)
-     *
-     * @var DoctrineCollection<int, Person>|array<Person>
-     */
+    /** @var DoctrineCollection<int, Person>|array<Person> */
+    #[ODM\ReferenceMany(storeAs: 'id', targetDocument: self::class)]
     public $friendsSimple = [];
 
-    /**
-     * @ODM\ReferenceMany
-     *
-     * @var DoctrineCollection<int, Person>|array<Person>
-     */
+    /** @var DoctrineCollection<int, Person>|array<Person> */
+    #[ODM\ReferenceMany]
     public $friendsPartial = [];
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Pet::class)
-     *
-     * @var Pet|null
-     */
+    /** @var Pet|null */
+    #[ODM\EmbedOne(targetDocument: Pet::class)]
     public $pet;
 
     public function __construct(string $firstName)
@@ -657,21 +630,15 @@ class Person
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Pet
 {
-    /**
-     * @ODM\ReferenceOne(name="pO", targetDocument=Doctrine\ODM\MongoDB\Tests\Person::class)
-     *
-     * @var Person|null
-     */
+    /** @var Person|null */
+    #[ODM\ReferenceOne(name: 'pO', targetDocument: Person::class)]
     public $owner;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function __construct(string $name, Person $owner)
@@ -681,41 +648,26 @@ class Pet
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbedTest
 {
-    /**
-     * @ODM\EmbedOne(name="eO", targetDocument=Doctrine\ODM\MongoDB\Tests\EmbedTest::class)
-     *
-     * @var EmbedTest|null
-     */
+    /** @var EmbedTest|null */
+    #[ODM\EmbedOne(name: 'eO', targetDocument: self::class)]
     public $embeddedOne;
 
-    /**
-     * @ODM\EmbedMany(name="e1", targetDocument=Doctrine\ODM\MongoDB\Tests\EmbedTest::class)
-     *
-     * @var DoctrineCollection<int, EmbedTest>
-     */
+    /** @var DoctrineCollection<int, EmbedTest> */
+    #[ODM\EmbedMany(name: 'e1', targetDocument: self::class)]
     public $embeddedMany;
 
-    /**
-     * @ODM\Field(name="n", type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(name: 'n', type: 'string')]
     public $name;
 
-    /**
-     * @ODM\ReferenceOne(name="p", targetDocument=Doctrine\ODM\MongoDB\Tests\Person::class)
-     *
-     * @var Person|null
-     */
+    /** @var Person|null */
+    #[ODM\ReferenceOne(name: 'p', targetDocument: Person::class)]
     public $person;
 
-    /**
-     * @ODM\EmbedOne(name="eP", targetDocument=Doctrine\ODM\MongoDB\Tests\Pet::class)
-     *
-     * @var Pet|null
-     */
+    /** @var Pet|null */
+    #[ODM\EmbedOne(name: 'eP', targetDocument: Pet::class)]
     public $pet;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/ResolveTargetDocumentListenerTest.php
@@ -89,42 +89,27 @@ abstract class AbstractResolveTarget implements ResolveTargetInterface
 {
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class ResolveTargetDocument extends AbstractResolveTarget implements ResolveTargetInterface
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Doctrine\ODM\MongoDB\Tests\Tools\ResolveTargetInterface::class)
-     *
-     * @var ResolveTargetInterface|null
-     */
+    /** @var ResolveTargetInterface|null */
+    #[ODM\ReferenceOne(targetDocument: ResolveTargetInterface::class)]
     private $refOne;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Doctrine\ODM\MongoDB\Tests\Tools\TargetInterface::class)
-     *
-     * @var Collection<int, TargetInterface>
-     */
+    /** @var Collection<int, TargetInterface> */
+    #[ODM\ReferenceMany(targetDocument: TargetInterface::class)]
     private $refMany;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Doctrine\ODM\MongoDB\Tests\Tools\ResolveTargetInterface::class)
-     *
-     * @var ResolveTargetInterface|null
-     */
+    /** @var ResolveTargetInterface|null */
+    #[ODM\EmbedOne(targetDocument: ResolveTargetInterface::class)]
     private $embedOne;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Doctrine\ODM\MongoDB\Tests\Tools\TargetInterface::class)
-     *
-     * @var Collection<int, TargetInterface>
-     */
+    /** @var Collection<int, TargetInterface> */
+    #[ODM\EmbedMany(targetDocument: TargetInterface::class)]
     private $embedMany;
 
     public function getId(): ?string
@@ -133,14 +118,11 @@ class ResolveTargetDocument extends AbstractResolveTarget implements ResolveTarg
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class TargetDocument implements TargetInterface
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
     public function getId(): ?string

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -617,34 +617,23 @@ class ParentAssociationTest
     }
 }
 
-/**
- * @ODM\Document
- * @ODM\ChangeTrackingPolicy("NOTIFY")
- */
+#[ODM\Document]
+#[ODM\ChangeTrackingPolicy('NOTIFY')]
 class NotifyChangedDocument implements NotifyPropertyChanged
 {
     /** @var PropertyChangedListener[] */
     private $_listeners = [];
 
-    /**
-     * @ODM\Id(type="int", strategy="none")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Id(type: 'int', strategy: 'none')]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $data;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=NotifyChangedRelatedItem::class)
-     *
-     * @var Collection<int, NotifyChangedRelatedItem>
-     */
+    /** @var Collection<int, NotifyChangedRelatedItem> */
+    #[ODM\ReferenceMany(targetDocument: NotifyChangedRelatedItem::class)]
     private $items;
 
     /** @var mixed */
@@ -714,21 +703,15 @@ class NotifyChangedDocument implements NotifyPropertyChanged
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class NotifyChangedRelatedItem
 {
-    /**
-     * @ODM\Id(type="int", strategy="none")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Id(type: 'int', strategy: 'none')]
     private $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=NotifyChangedDocument::class)
-     *
-     * @var NotifyChangedDocument|null
-     */
+    /** @var NotifyChangedDocument|null */
+    #[ODM\ReferenceOne(targetDocument: NotifyChangedDocument::class)]
     private $owner;
 
     public function getId(): ?int
@@ -752,21 +735,15 @@ class NotifyChangedRelatedItem
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class ArrayTest
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="hash")
-     *
-     * @var array<string, mixed>|null
-     */
+    /** @var array<string, mixed>|null */
+    #[ODM\Field(type: 'hash')]
     public $data;
 
     /** @param array<string, mixed>|null $data */
@@ -776,89 +753,68 @@ class ArrayTest
     }
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class UowCustomIdDocument
 {
-    /**
-     * @ODM\Id(type="custom_id")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id(type: 'custom_id')]
     public $id;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbeddedUpsertDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbeddedDocumentWithoutId
 {
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbeddedDocumentWithId
 {
     /** @var bool */
     public $preRemove = false;
 
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /** @ODM\PreRemove */
+    #[ODM\PreRemove]
     public function preRemove(): void
     {
         $this->preRemove = true;
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbeddedDocumentWithIdStrategyNone
 {
-    /**
-     * @ODM\Id(strategy="none")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id(strategy: 'none')]
     public $id;
 }
 
-/** @ODM\Document */
+#[ODM\Document]
 class PersistRemovedEmbeddedDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=EmbeddedDocumentWithId::class)
-     *
-     * @var EmbeddedDocumentWithId
-     */
+    /** @var EmbeddedDocumentWithId */
+    #[ODM\EmbedOne(targetDocument: EmbeddedDocumentWithId::class)]
     public $embedded;
 }
 
-/** @ODM\MappedSuperclass */
+#[ODM\MappedSuperclass]
 class MappedSuperclass
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }

--- a/tests/Documents/Account.php
+++ b/tests/Documents/Account.php
@@ -6,35 +6,23 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Account
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field]
     private $name;
 
-    /**
-     * @ODM\ReferenceOne(storeAs="dbRefWithDb")
-     *
-     * @var User|CustomUser|null
-     */
+    /** @var User|CustomUser|null */
+    #[ODM\ReferenceOne(storeAs: 'dbRefWithDb')]
     protected $user;
 
-    /**
-     * @ODM\ReferenceOne(storeAs="dbRef")
-     *
-     * @var User|null
-     */
+    /** @var User|null */
+    #[ODM\ReferenceOne(storeAs: 'dbRef')]
     protected $userDbRef;
 
     public function getId(): ?string

--- a/tests/Documents/Address.php
+++ b/tests/Documents/Address.php
@@ -6,56 +6,35 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Address
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $address;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $city;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $state;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $zipcode;
 
-    /**
-     * @ODM\Field(type="int", strategy="increment")
-     *
-     * @var int
-     */
+    /** @var int */
+    #[ODM\Field(type: 'int', strategy: 'increment')]
     public $count = 0;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Address::class)
-     *
-     * @var Address|null
-     */
+    /** @var Address|null */
+    #[ODM\EmbedOne(targetDocument: self::class)]
     private $subAddress;
 
-    /**
-     * @ODM\Field(name="testFieldName", type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(name: 'testFieldName', type: 'string')]
     private $test;
 
     public function setSubAddress(Address $subAddress): void

--- a/tests/Documents/Agent.php
+++ b/tests/Documents/Agent.php
@@ -6,23 +6,14 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="agents") */
+#[ODM\Document(collection: 'agents')]
 class Agent
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(discriminatorMap={
-     * "server"=Server::class,
-     * "server_guest"=GuestServer::class
-     * })
-     *
-     * @var Server|GuestServer|null
-     */
+    /** @var Server|GuestServer|null */
+    #[ODM\ReferenceOne(discriminatorMap: ['server' => Server::class, 'server_guest' => GuestServer::class])]
     public $server;
 }

--- a/tests/Documents/Album.php
+++ b/tests/Documents/Album.php
@@ -8,28 +8,19 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="albums") */
+#[ODM\Document(collection: 'albums')]
 class Album
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     private $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Song::class)
-     *
-     * @var Collection<int, Song>
-     */
+    /** @var Collection<int, Song> */
+    #[ODM\EmbedMany(targetDocument: Song::class)]
     private $songs;
 
     public function __construct(string $name)

--- a/tests/Documents/Article.php
+++ b/tests/Documents/Article.php
@@ -11,42 +11,27 @@ use MongoDB\BSON\UTCDateTime;
 use function array_search;
 use function in_array;
 
-/** @ODM\Document(collection="articles") */
+#[ODM\Document(collection: 'articles')]
 class Article
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $title;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $body;
 
-    /**
-     * @ODM\Field(type="date")
-     *
-     * @var string|UTCDateTime|DateTimeInterface|null
-     */
+    /** @var string|UTCDateTime|DateTimeInterface|null */
+    #[ODM\Field(type: 'date')]
     private $createdAt;
 
-    /**
-     * @ODM\Field(type="collection")
-     *
-     * @var int[]
-     */
+    /** @var int[] */
+    #[ODM\Field(type: 'collection')]
     private $tags = [];
 
     public function getId(): ?string

--- a/tests/Documents/Bars/Bar.php
+++ b/tests/Documents/Bars/Bar.php
@@ -8,28 +8,19 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="bars") */
+#[ODM\Document(collection: 'bars')]
 class Bar
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Documents\Bars\Location::class)
-     *
-     * @var Collection<int, Location>
-     */
+    /** @var Collection<int, Location> */
+    #[ODM\EmbedMany(targetDocument: Location::class)]
     private $locations;
 
     public function __construct(?string $name = null)

--- a/tests/Documents/Bars/Location.php
+++ b/tests/Documents/Bars/Location.php
@@ -6,14 +6,11 @@ namespace Documents\Bars;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Location
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $name;
 
     public function __construct(?string $name = null)

--- a/tests/Documents/BaseCategory.php
+++ b/tests/Documents/BaseCategory.php
@@ -7,21 +7,15 @@ namespace Documents;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\MappedSuperclass(repositoryClass="Documents\BaseCategoryRepository") */
+#[ODM\MappedSuperclass(repositoryClass: 'Documents\BaseCategoryRepository')]
 abstract class BaseCategory
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     protected $name;
 
-     /**
-      * @ODM\EmbedMany(targetDocument=SubCategory::class)
-      *
-      * @var Collection<int, SubCategory>|array<SubCategory>
-      */
+     /** @var Collection<int, SubCategory>|array<SubCategory> */
+    #[ODM\EmbedMany(targetDocument: SubCategory::class)]
     protected $children = [];
 
     public function __construct(?string $name = null)

--- a/tests/Documents/BaseDocument.php
+++ b/tests/Documents/BaseDocument.php
@@ -6,20 +6,15 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\MappedSuperclass
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\MappedSuperclass]
+#[ODM\HasLifecycleCallbacks]
 abstract class BaseDocument
 {
     /** @var bool */
     public $persisted = false;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     protected $inheritedProperty;
 
     public function setInheritedProperty(string $value): void
@@ -32,7 +27,7 @@ abstract class BaseDocument
         return $this->inheritedProperty;
     }
 
-    /** @ODM\PrePersist */
+    #[ODM\PrePersist]
     public function prePersist(): void
     {
         $this->persisted = true;

--- a/tests/Documents/BaseEmployee.php
+++ b/tests/Documents/BaseEmployee.php
@@ -7,63 +7,39 @@ namespace Documents;
 use DateTime;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\MappedSuperclass */
+#[ODM\MappedSuperclass]
 abstract class BaseEmployee
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="int", strategy="increment")
-     *
-     * @var int
-     */
+    /** @var int */
+    #[ODM\Field(type: 'int', strategy: 'increment')]
     protected $changes = 0;
 
-    /**
-     * @ODM\Field(type="collection")
-     *
-     * @var string[]
-     */
+    /** @var string[] */
+    #[ODM\Field(type: 'collection')]
     protected $notes = [];
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     protected $name;
 
-    /**
-     * @ODM\Field(type="float")
-     *
-     * @var float|null
-     */
+    /** @var float|null */
+    #[ODM\Field(type: 'float')]
     protected $salary;
 
-    /**
-     * @ODM\Field(type="date")
-     *
-     * @var DateTime|null
-     */
+    /** @var DateTime|null */
+    #[ODM\Field(type: 'date')]
     protected $started;
 
-    /**
-     * @ODM\Field(type="date")
-     *
-     * @var DateTime|null
-     */
+    /** @var DateTime|null */
+    #[ODM\Field(type: 'date')]
     protected $left;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Address::class)
-     *
-     * @var Address|null
-     */
+    /** @var Address|null */
+    #[ODM\EmbedOne(targetDocument: Address::class)]
     protected $address;
 
     public function getId(): ?string

--- a/tests/Documents/BlogPost.php
+++ b/tests/Documents/BlogPost.php
@@ -7,105 +7,63 @@ namespace Documents;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class BlogPost
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Tag::class, inversedBy="blogPosts", cascade={"all"})
-     *
-     * @var Collection<int, Tag>|array<Tag>
-     */
+    /** @var Collection<int, Tag>|array<Tag> */
+    #[ODM\ReferenceMany(targetDocument: Tag::class, inversedBy: 'blogPosts', cascade: ['all'])]
     public $tags = [];
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Comment::class, mappedBy="parent", cascade={"all"}, prime={"author"})
-     *
-     * @var Collection<int, Comment>|array<Comment>
-     */
+    /** @var Collection<int, Comment>|array<Comment> */
+    #[ODM\ReferenceMany(targetDocument: Comment::class, mappedBy: 'parent', cascade: ['all'], prime: ['author'])]
     public $comments = [];
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Comment::class, mappedBy="parent", sort={"date"="asc"})
-     *
-     * @var Comment|null
-     */
+    /** @var Comment|null */
+    #[ODM\ReferenceOne(targetDocument: Comment::class, mappedBy: 'parent', sort: ['date' => 'asc'])]
     public $firstComment;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Comment::class, mappedBy="parent", sort={"date"="desc"})
-     *
-     * @var Comment|null
-     */
+    /** @var Comment|null */
+    #[ODM\ReferenceOne(targetDocument: Comment::class, mappedBy: 'parent', sort: ['date' => 'desc'])]
     public $latestComment;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Comment::class, mappedBy="parent", sort={"date"="desc"}, limit=5)
-     *
-     * @var Collection<int, Comment>|array<Comment>
-     */
+    /** @var Collection<int, Comment>|array<Comment> */
+    #[ODM\ReferenceMany(targetDocument: Comment::class, mappedBy: 'parent', sort: ['date' => 'desc'], limit: 5)]
     public $last5Comments = [];
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Comment::class, mappedBy="parent", criteria={"isByAdmin"=true}, sort={"date"="desc"})
-     *
-     * @var Collection<int, Comment>|array<Comment>
-     */
+    /** @var Collection<int, Comment>|array<Comment> */
+    #[ODM\ReferenceMany(targetDocument: Comment::class, mappedBy: 'parent', criteria: ['isByAdmin' => true], sort: ['date' => 'desc'])]
     public $adminComments = [];
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Comment::class, mappedBy="parent", repositoryMethod="findOneComment")
-     *
-     * @var Comment|null
-     */
+    /** @var Comment|null */
+    #[ODM\ReferenceOne(targetDocument: Comment::class, mappedBy: 'parent', repositoryMethod: 'findOneComment')]
     public $repoComment;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Comment::class, mappedBy="parent", repositoryMethod="findManyComments")
-     *
-     * @var Collection<int, Comment>
-     */
+    /** @var Collection<int, Comment> */
+    #[ODM\ReferenceMany(targetDocument: Comment::class, mappedBy: 'parent', repositoryMethod: 'findManyComments')]
     public $repoComments;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Comment::class, mappedBy="parent", repositoryMethod="findManyComments", prime={"author"})
-     *
-     * @var Collection<int, Comment>
-     */
+    /** @var Collection<int, Comment> */
+    #[ODM\ReferenceMany(targetDocument: Comment::class, mappedBy: 'parent', repositoryMethod: 'findManyComments', prime: ['author'])]
     public $repoCommentsWithPrimer;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Comment::class, mappedBy="parent", strategy="set", repositoryMethod="findManyComments")
-     *
-     * @var Collection<int, Comment>
-     */
+    /** @var Collection<int, Comment> */
+    #[ODM\ReferenceMany(targetDocument: Comment::class, mappedBy: 'parent', strategy: 'set', repositoryMethod: 'findManyComments')]
     public $repoCommentsSet;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Comment::class, repositoryMethod="findManyComments")
-     *
-     * @var Collection<int, Comment>
-     */
+    /** @var Collection<int, Comment> */
+    #[ODM\ReferenceMany(targetDocument: Comment::class, repositoryMethod: 'findManyComments')]
     public $repoCommentsWithoutMappedBy;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=User::class, inversedBy="posts", nullable=true)
-     *
-     * @var User|null
-     */
+    /** @var User|null */
+    #[ODM\ReferenceOne(targetDocument: User::class, inversedBy: 'posts', nullable: true)]
     public $user;
 
     public function __construct(?string $name = null)

--- a/tests/Documents/BlogTagAggregation.php
+++ b/tests/Documents/BlogTagAggregation.php
@@ -6,20 +6,14 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\QueryResultDocument */
+#[ODM\QueryResultDocument]
 class BlogTagAggregation
 {
-    /**
-     * @ODM\ReferenceOne(targetDocument=Tag::class, name="_id")
-     *
-     * @var Tag|null
-     */
+    /** @var Tag|null */
+    #[ODM\ReferenceOne(targetDocument: Tag::class, name: '_id')]
     public $tag;
 
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Field(type: 'int')]
     public $numPosts;
 }

--- a/tests/Documents/Book.php
+++ b/tests/Documents/Book.php
@@ -8,38 +8,26 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Book
 {
     public const CLASSNAME = self::class;
 
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="int")
-     * @ODM\Version
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Field(type: 'int')]
+    #[ODM\Version]
     public $version = 1;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Chapter::class, strategy="atomicSet")
-     *
-     * @var Collection<int, Chapter>
-     */
+    /** @var Collection<int, Chapter> */
+    #[ODM\EmbedMany(targetDocument: Chapter::class, strategy: 'atomicSet')]
     public $chapters;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=IdentifiedChapter::class, strategy="atomicSet")
-     *
-     * @var Collection<int, IdentifiedChapter>
-     */
+    /** @var Collection<int, IdentifiedChapter> */
+    #[ODM\EmbedMany(targetDocument: IdentifiedChapter::class, strategy: 'atomicSet')]
     public $identifiedChapters;
 
     public function __construct()

--- a/tests/Documents/BrowseNode.php
+++ b/tests/Documents/BrowseNode.php
@@ -8,35 +8,23 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class BrowseNode
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=BrowseNode::class, inversedBy="children", cascade={"all"})
-     *
-     * @var BrowseNode|null
-     */
+    /** @var BrowseNode|null */
+    #[ODM\ReferenceOne(targetDocument: self::class, inversedBy: 'children', cascade: ['all'])]
     public $parent;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=BrowseNode::class, mappedBy="parent", cascade={"all"})
-     *
-     * @var Collection<int, BrowseNode>
-     */
+    /** @var Collection<int, BrowseNode> */
+    #[ODM\ReferenceMany(targetDocument: self::class, mappedBy: 'parent', cascade: ['all'])]
     public $children;
 
     public function __construct(?string $name = null)

--- a/tests/Documents/Cart.php
+++ b/tests/Documents/Cart.php
@@ -6,27 +6,18 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Cart
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int
-     */
+    /** @var int */
+    #[ODM\Field(type: 'int')]
     public $numItems = 0;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Customer::class, inversedBy="cart")
-     *
-     * @var Customer|null
-     */
+    /** @var Customer|null */
+    #[ODM\ReferenceOne(targetDocument: Customer::class, inversedBy: 'cart')]
     public $customer;
 }

--- a/tests/Documents/Category.php
+++ b/tests/Documents/Category.php
@@ -6,13 +6,10 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Category extends BaseCategory
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 }

--- a/tests/Documents/Chapter.php
+++ b/tests/Documents/Chapter.php
@@ -8,31 +8,20 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\EmbeddedDocument
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\EmbeddedDocument]
+#[ODM\HasLifecycleCallbacks]
 class Chapter
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Page::class)
-     *
-     * @var Collection<int, Page>
-     */
+    /** @var Collection<int, Page> */
+    #[ODM\EmbedMany(targetDocument: Page::class)]
     public $pages;
 
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int
-     */
+    /** @var int */
+    #[ODM\Field(type: 'int')]
     public $nbPages = 0;
 
     public function __construct(?string $name = null)
@@ -41,7 +30,7 @@ class Chapter
         $this->pages = new ArrayCollection();
     }
 
-    /** @ODM\PostUpdate */
+    #[ODM\PostUpdate]
     public function doThisAfterAnUpdate(): void
     {
         /* Do not do this at home, it is here only to see if nothing breaks,

--- a/tests/Documents/CmsAddress.php
+++ b/tests/Documents/CmsAddress.php
@@ -5,48 +5,30 @@ declare(strict_types=1);
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Index;
 
-/**
- * @ODM\Document
- * @ODM\Indexes({
- *   @ODM\Index(keys={"country"="asc", "zip"="asc", "city"="asc"})
- * })
- */
+#[Index(keys: ['country' => 'asc', 'zip' => 'asc', 'city' => 'asc'])]
+#[ODM\Document]
 class CmsAddress
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $country;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $zip;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $city;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=CmsUser::class)
-     *
-     * @var CmsUser|null
-     */
+    /** @var CmsUser|null */
+    #[ODM\ReferenceOne(targetDocument: CmsUser::class)]
     public $user;
 
     public function getId(): ?string

--- a/tests/Documents/CmsArticle.php
+++ b/tests/Documents/CmsArticle.php
@@ -6,50 +6,29 @@ namespace Documents;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Index;
 
-/**
- * @ODM\Document
- * @ODM\Indexes({
- *   @ODM\Index(keys={"topic"="asc"})
- * })
- */
+#[Index(keys: ['topic' => 'asc'])]
+#[ODM\Document]
 class CmsArticle
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $topic;
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $title;
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $text;
-    /**
-     * @ODM\ReferenceOne(targetDocument=CmsUser::class)
-     *
-     * @var CmsUser|null
-     */
+    /** @var CmsUser|null */
+    #[ODM\ReferenceOne(targetDocument: CmsUser::class)]
     public $user;
-    /**
-     * @ODM\ReferenceMany(targetDocument=CmsComment::class)
-     *
-     * @var Collection<int, CmsComment>
-     */
+    /** @var Collection<int, CmsComment> */
+    #[ODM\ReferenceMany(targetDocument: CmsComment::class)]
     public $comments;
 
     public function setAuthor(CmsUser $author): void

--- a/tests/Documents/CmsComment.php
+++ b/tests/Documents/CmsComment.php
@@ -5,55 +5,34 @@ declare(strict_types=1);
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Index;
 
-/**
- * @ODM\Document
- * @ODM\Indexes({
- *   @ODM\Index(keys={"topic"="asc"})
- * })
- */
+#[Index(keys: ['topic' => 'asc'])]
+#[ODM\Document]
 class CmsComment
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field]
     public $topic;
 
-    /**
-     * @ODM\Field
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field]
     public $text;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=CmsArticle::class)
-     *
-     * @var CmsArticle|null
-     */
+    /** @var CmsArticle|null */
+    #[ODM\ReferenceOne(targetDocument: CmsArticle::class)]
     public $article;
 
-    /**
-     * @ODM\Field(name="ip", type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(name: 'ip', type: 'string')]
     public $authorIp;
 
-    /**
-     * @ODM\Field(type="string", nullable=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string', nullable: true)]
     public $nullableField;
 
     public function setArticle(CmsArticle $article): void

--- a/tests/Documents/CmsContent.php
+++ b/tests/Documents/CmsContent.php
@@ -6,13 +6,10 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\MappedSuperclass */
+#[ODM\MappedSuperclass]
 abstract class CmsContent extends CmsPage
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $title;
 }

--- a/tests/Documents/CmsGroup.php
+++ b/tests/Documents/CmsGroup.php
@@ -7,28 +7,19 @@ namespace Documents;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class CmsGroup
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=CmsUser::class)
-     *
-     * @var Collection<int, CmsUser>
-     */
+    /** @var Collection<int, CmsUser> */
+    #[ODM\ReferenceMany(targetDocument: CmsUser::class)]
     public $users;
 
     public function setName(string $name): void

--- a/tests/Documents/CmsPage.php
+++ b/tests/Documents/CmsPage.php
@@ -5,26 +5,17 @@ declare(strict_types=1);
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Index;
 
-/**
- * @ODM\MappedSuperclass
- * @ODM\Indexes({
- *   @ODM\Index(keys={"slug"="asc"}, options={"unique"="true"})
- * })
- */
+#[Index(keys: ['slug' => 'asc'], options: ['unique' => 'true'])]
+#[ODM\MappedSuperclass]
 abstract class CmsPage
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $slug;
 }

--- a/tests/Documents/CmsPhonenumber.php
+++ b/tests/Documents/CmsPhonenumber.php
@@ -6,21 +6,15 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class CmsPhonenumber
 {
-    /**
-     * @ODM\Id(strategy="NONE", type="custom_id")
-     *
-     * @var int|string|null
-     */
+    /** @var int|string|null */
+    #[ODM\Id(strategy: 'NONE', type: 'custom_id')]
     public $phonenumber;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=CmsUser::class, cascade={"merge"})
-     *
-     * @var CmsUser|null
-     */
+    /** @var CmsUser|null */
+    #[ODM\ReferenceOne(targetDocument: CmsUser::class, cascade: ['merge'])]
     public $user;
 
     public function setUser(CmsUser $user): void

--- a/tests/Documents/CmsProduct.php
+++ b/tests/Documents/CmsProduct.php
@@ -6,13 +6,10 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class CmsProduct extends CmsContent
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }

--- a/tests/Documents/CmsUser.php
+++ b/tests/Documents/CmsUser.php
@@ -49,6 +49,7 @@ class CmsUser
      *
      * @var Collection<int, CmsPhonenumber>
      */
+    #[ODM\ReferenceMany(targetDocument: CmsPhonenumber::class, mappedBy: 'user', cascade: ['persist', 'remove', 'merge'])]
     public $phonenumbers;
 
     /**
@@ -56,6 +57,7 @@ class CmsUser
      *
      * @var Collection<int, CmsArticle>
      */
+    #[ODM\ReferenceMany(targetDocument: CmsArticle::class)]
     public $articles;
 
     /**
@@ -63,6 +65,7 @@ class CmsUser
      *
      * @var CmsAddress
      */
+    #[ODM\ReferenceOne(targetDocument: CmsAddress::class, cascade: ['persist'])]
     public $address;
 
     /**
@@ -70,6 +73,7 @@ class CmsUser
      *
      * @var Collection<int, CmsGroup>
      */
+    #[ODM\ReferenceMany(targetDocument: CmsGroup::class, cascade: ['persist', 'merge'])]
     public $groups;
 
     public function __construct()

--- a/tests/Documents/Comment.php
+++ b/tests/Documents/Comment.php
@@ -7,50 +7,32 @@ namespace Documents;
 use DateTime;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(repositoryClass=CommentRepository::class) */
+#[ODM\Document(repositoryClass: CommentRepository::class)]
 class Comment
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $text;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=User::class, cascade={"all"})
-     *
-     * @var User|null
-     */
+    /** @var User|null */
+    #[ODM\ReferenceOne(targetDocument: User::class, cascade: ['all'])]
     public $author;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=BlogPost::class, inversedBy="comments", cascade={"all"})
-     *
-     * @var BlogPost|null
-     */
+    /** @var BlogPost|null */
+    #[ODM\ReferenceOne(targetDocument: BlogPost::class, inversedBy: 'comments', cascade: ['all'])]
     public $parent;
 
-    /**
-     * @ODM\Field(type="date")
-     * @ODM\Index(order="1")
-     *
-     * @var DateTime
-     */
+    /** @var DateTime */
+    #[ODM\Field(type: 'date')]
+    #[ODM\Index(order: '1')]
     public $date;
 
-    /**
-     * @ODM\Field(type="bool")
-     *
-     * @var bool
-     */
+    /** @var bool */
+    #[ODM\Field(type: 'bool')]
     public $isByAdmin = false;
 
     public function __construct(string $text, DateTime $date, bool $isByAdmin = false)

--- a/tests/Documents/CustomRepository/Document.php
+++ b/tests/Documents/CustomRepository/Document.php
@@ -6,13 +6,10 @@ namespace Documents\CustomRepository;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(repositoryClass="Documents\CustomRepository\Repository") */
+#[ODM\Document(repositoryClass: 'Documents\CustomRepository\Repository')]
 class Document
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 }

--- a/tests/Documents/CustomUser.php
+++ b/tests/Documents/CustomUser.php
@@ -6,35 +6,23 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="custom_users") */
+#[ODM\Document(collection: 'custom_users')]
 class CustomUser
 {
-    /**
-     * @ODM\Id(strategy="none")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id(strategy: 'none')]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     protected $username;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     protected $password;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Account::class, cascade={"all"})
-     *
-     * @var Account|null
-     */
+    /** @var Account|null */
+    #[ODM\ReferenceOne(targetDocument: Account::class, cascade: ['all'])]
     protected $account;
 
     public function getId(): ?string

--- a/tests/Documents/Customer.php
+++ b/tests/Documents/Customer.php
@@ -6,34 +6,22 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Customer
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\Field(name="cartTest", type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(name: 'cartTest', type: 'string')]
     public $cartTest;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Cart::class, mappedBy="customer")
-     *
-     * @var Cart|null
-     */
+    /** @var Cart|null */
+    #[ODM\ReferenceOne(targetDocument: Cart::class, mappedBy: 'customer')]
     public $cart;
 }

--- a/tests/Documents/Developer.php
+++ b/tests/Documents/Developer.php
@@ -8,28 +8,19 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Developer
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     private $name;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Project::class, cascade="all")
-     *
-     * @var Collection<int, Project>
-     */
+    /** @var Collection<int, Project> */
+    #[ODM\ReferenceMany(targetDocument: Project::class, cascade: 'all')]
     private $projects;
 
     /** @param Collection<int, Project>|null $projects */

--- a/tests/Documents/Ecommerce/Basket.php
+++ b/tests/Documents/Ecommerce/Basket.php
@@ -7,21 +7,15 @@ namespace Documents\Ecommerce;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Basket
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Documents\Ecommerce\ConfigurableProduct::class)
-     *
-     * @var Collection<int, ConfigurableProduct>|array<ConfigurableProduct>
-     */
+    /** @var Collection<int, ConfigurableProduct>|array<ConfigurableProduct> */
+    #[ODM\ReferenceMany(targetDocument: ConfigurableProduct::class)]
     protected $products = [];
 
     public function getId(): ?string

--- a/tests/Documents/Ecommerce/ConfigurableProduct.php
+++ b/tests/Documents/Ecommerce/ConfigurableProduct.php
@@ -12,28 +12,19 @@ use function array_map;
 use function array_search;
 use function in_array;
 
-/** @ODM\Document */
+#[ODM\Document]
 class ConfigurableProduct
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     protected $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Documents\Ecommerce\Option::class)
-     *
-     * @var Collection<int, Option>|array<Option>
-     */
+    /** @var Collection<int, Option>|array<Option> */
+    #[ODM\EmbedMany(targetDocument: Option::class)]
     protected $options = [];
 
     /** @var Option|null */

--- a/tests/Documents/Ecommerce/Currency.php
+++ b/tests/Documents/Ecommerce/Currency.php
@@ -10,32 +10,23 @@ use InvalidArgumentException;
 use function implode;
 use function in_array;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Currency
 {
     public const USD  = 'USD';
     public const EURO = 'EURO';
     public const JPN  = 'JPN';
 
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     protected $name;
 
-    /**
-     * @ODM\Field(type="float")
-     *
-     * @var float
-     */
+    /** @var float */
+    #[ODM\Field(type: 'float')]
     protected $multiplier;
 
     /** @param float|int $multiplier */

--- a/tests/Documents/Ecommerce/Money.php
+++ b/tests/Documents/Ecommerce/Money.php
@@ -7,21 +7,15 @@ namespace Documents\Ecommerce;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use InvalidArgumentException;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Money
 {
-    /**
-     * @ODM\Field(type="float")
-     *
-     * @var float
-     */
+    /** @var float */
+    #[ODM\Field(type: 'float')]
     protected $amount;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Documents\Ecommerce\Currency::class, cascade="all")
-     *
-     * @var Currency
-     */
+    /** @var Currency */
+    #[ODM\ReferenceOne(targetDocument: Currency::class, cascade: 'all')]
     protected $currency;
 
     public function __construct(float $amount, Currency $currency)

--- a/tests/Documents/Ecommerce/Option.php
+++ b/tests/Documents/Ecommerce/Option.php
@@ -7,35 +7,23 @@ namespace Documents\Ecommerce;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use InvalidArgumentException;
 
-/** @ODM\EmbeddedDocument() */
+#[ODM\EmbeddedDocument]
 class Option
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     protected $name;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Documents\Ecommerce\Money::class)
-     *
-     * @var Money
-     */
+    /** @var Money */
+    #[ODM\EmbedOne(targetDocument: Money::class)]
     protected $money;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Documents\Ecommerce\StockItem::class, cascade="all")
-     *
-     * @var StockItem
-     */
+    /** @var StockItem */
+    #[ODM\ReferenceOne(targetDocument: StockItem::class, cascade: 'all')]
     protected $stockItem;
 
     public function __construct(string $name, Money $money, StockItem $stockItem)

--- a/tests/Documents/Ecommerce/Order.php
+++ b/tests/Documents/Ecommerce/Order.php
@@ -7,21 +7,15 @@ namespace Documents\Ecommerce;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Order
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=ConfigurableProduct::class, strategy="addToSet", storeEmptyArray=true)
-     *
-     * @var Collection<int, ConfigurableProduct>|array<ConfigurableProduct>
-     */
+    /** @var Collection<int, ConfigurableProduct>|array<ConfigurableProduct> */
+    #[ODM\ReferenceMany(targetDocument: ConfigurableProduct::class, strategy: 'addToSet', storeEmptyArray: true)]
     protected $products = [];
 
     public function getId(): ?string

--- a/tests/Documents/Ecommerce/StockItem.php
+++ b/tests/Documents/Ecommerce/StockItem.php
@@ -6,35 +6,23 @@ namespace Documents\Ecommerce;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class StockItem
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $name;
 
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Field(type: 'int')]
     private $inventory;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Documents\Ecommerce\Money::class)
-     *
-     * @var Money|null
-     */
+    /** @var Money|null */
+    #[ODM\EmbedOne(targetDocument: Money::class)]
     private $cost;
 
     public function getId(): ?string

--- a/tests/Documents/Employee.php
+++ b/tests/Documents/Employee.php
@@ -6,14 +6,11 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Employee extends BaseEmployee
 {
-    /**
-     * @ODM\ReferenceOne(targetDocument=Manager::class)
-     *
-     * @var Manager|null
-     */
+    /** @var Manager|null */
+    #[ODM\ReferenceOne(targetDocument: Manager::class)]
     private $manager;
 
     public function getManager(): ?Manager

--- a/tests/Documents/Event.php
+++ b/tests/Documents/Event.php
@@ -6,35 +6,23 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Event
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=User::class)
-     *
-     * @var User|null
-     */
+    /** @var User|null */
+    #[ODM\ReferenceOne(targetDocument: User::class)]
     private $user;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $title;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $type;
 
     public function getId(): ?string

--- a/tests/Documents/Feature.php
+++ b/tests/Documents/Feature.php
@@ -6,28 +6,19 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Feature
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Product::class, inversedBy="features", cascade={"all"})
-     *
-     * @var Product|null
-     */
+    /** @var Product|null */
+    #[ODM\ReferenceOne(targetDocument: Product::class, inversedBy: 'features', cascade: ['all'])]
     public $product;
 
     public function __construct(string $name)

--- a/tests/Documents/File.php
+++ b/tests/Documents/File.php
@@ -8,49 +8,31 @@ use DateTime;
 use DateTimeInterface;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\File(chunkSizeBytes=12345) */
+#[ODM\File(chunkSizeBytes: 12345)]
 class File
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\File\Filename
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\File\Filename]
     private $filename;
 
-    /**
-     * @ODM\File\ChunkSize
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\File\ChunkSize]
     private $chunkSize;
 
-    /**
-     * @ODM\File\Length
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\File\Length]
     private $length;
 
-    /**
-     * @ODM\File\UploadDate
-     *
-     * @var DateTime|null
-     */
+    /** @var DateTime|null */
+    #[ODM\File\UploadDate]
     private $uploadDate;
 
-    /**
-     * @ODM\File\Metadata(targetDocument=FileMetadata::class)
-     *
-     * @var FileMetadata|null
-     */
+    /** @var FileMetadata|null */
+    #[ODM\File\Metadata(targetDocument: FileMetadata::class)]
     private $metadata;
 
     public function getId(): ?string

--- a/tests/Documents/FileMetadata.php
+++ b/tests/Documents/FileMetadata.php
@@ -7,21 +7,15 @@ namespace Documents;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Documents\Functional\Embedded;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 final class FileMetadata
 {
-    /**
-     * @ODM\ReferenceOne(targetDocument=User::class, cascade={"persist"})
-     *
-     * @var User
-     */
+    /** @var User */
+    #[ODM\ReferenceOne(targetDocument: User::class, cascade: ['persist'])]
     private $owner;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Embedded::class)
-     *
-     * @var Embedded
-     */
+    /** @var Embedded */
+    #[ODM\EmbedOne(targetDocument: Embedded::class)]
     private $embedOne;
 
     public function __construct()

--- a/tests/Documents/FileWithoutChunkSize.php
+++ b/tests/Documents/FileWithoutChunkSize.php
@@ -8,49 +8,31 @@ use DateTime;
 use DateTimeInterface;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\File */
+#[ODM\File]
 class FileWithoutChunkSize
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\File\Filename
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\File\Filename]
     private $filename;
 
-    /**
-     * @ODM\File\ChunkSize
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\File\ChunkSize]
     private $chunkSize;
 
-    /**
-     * @ODM\File\Length
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\File\Length]
     private $length;
 
-    /**
-     * @ODM\File\UploadDate
-     *
-     * @var DateTime|null
-     */
+    /** @var DateTime|null */
+    #[ODM\File\UploadDate]
     private $uploadDate;
 
-    /**
-     * @ODM\File\Metadata(targetDocument=FileMetadata::class)
-     *
-     * @var FileMetadata|null
-     */
+    /** @var FileMetadata|null */
+    #[ODM\File\Metadata(targetDocument: FileMetadata::class)]
     private $metadata;
 
     public function getId(): ?string

--- a/tests/Documents/FileWithoutMetadata.php
+++ b/tests/Documents/FileWithoutMetadata.php
@@ -6,14 +6,11 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\File */
+#[ODM\File]
 class FileWithoutMetadata
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
     /**

--- a/tests/Documents/ForumAvatar.php
+++ b/tests/Documents/ForumAvatar.php
@@ -6,13 +6,10 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class ForumAvatar
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 }

--- a/tests/Documents/ForumUser.php
+++ b/tests/Documents/ForumUser.php
@@ -7,28 +7,19 @@ namespace Documents;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use MongoDB\BSON\ObjectId;
 
-/** @ODM\Document */
+#[ODM\Document]
 class ForumUser
 {
-    /**
-     * @ODM\Id
-     *
-     * @var ObjectId|int|null
-     */
+    /** @var ObjectId|int|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $username;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=ForumAvatar::class, cascade={"persist"})
-     *
-     * @var ForumAvatar|null
-     */
+    /** @var ForumAvatar|null */
+    #[ODM\ReferenceOne(targetDocument: ForumAvatar::class, cascade: ['persist'])]
     public $avatar;
 
     /** @return int|ObjectId|null */

--- a/tests/Documents/FriendUser.php
+++ b/tests/Documents/FriendUser.php
@@ -8,35 +8,23 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class FriendUser
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=FriendUser::class, mappedBy="myFriends", cascade={"all"})
-     *
-     * @var Collection<int, FriendUser>
-     */
+    /** @var Collection<int, FriendUser> */
+    #[ODM\ReferenceMany(targetDocument: self::class, mappedBy: 'myFriends', cascade: ['all'])]
     public $friendsWithMe;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=FriendUser::class, inversedBy="friendsWithMe", cascade={"all"})
-     *
-     * @var Collection<int, FriendUser>
-     */
+    /** @var Collection<int, FriendUser> */
+    #[ODM\ReferenceMany(targetDocument: self::class, inversedBy: 'friendsWithMe', cascade: ['all'])]
     public $myFriends;
 
     public function __construct(string $name)

--- a/tests/Documents/Functional/EmbedNamed.php
+++ b/tests/Documents/Functional/EmbedNamed.php
@@ -7,27 +7,18 @@ namespace Documents\Functional;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class EmbedNamed
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=EmbeddedWhichReferences::class, name="embedded_doc")
-     *
-     * @var EmbeddedWhichReferences|null
-     */
+    /** @var EmbeddedWhichReferences|null */
+    #[ODM\EmbedOne(targetDocument: EmbeddedWhichReferences::class, name: 'embedded_doc')]
     public $embeddedDoc;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=EmbeddedWhichReferences::class, name="embedded_docs")
-     *
-     * @var Collection<int, EmbeddedWhichReferences>|array<EmbeddedWhichReferences>
-     */
+    /** @var Collection<int, EmbeddedWhichReferences>|array<EmbeddedWhichReferences> */
+    #[ODM\EmbedMany(targetDocument: EmbeddedWhichReferences::class, name: 'embedded_docs')]
     public $embeddedDocs = [];
 }

--- a/tests/Documents/Functional/Embedded.php
+++ b/tests/Documents/Functional/Embedded.php
@@ -6,13 +6,10 @@ namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Embedded
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }

--- a/tests/Documents/Functional/EmbeddedTestLevel0.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel0.php
@@ -7,26 +7,17 @@ namespace Documents\Functional;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="embedded_test") */
+#[ODM\Document(collection: 'embedded_test')]
 class EmbeddedTestLevel0
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=EmbeddedTestLevel1::class)
-     *
-     * @var Collection<int, EmbeddedTestLevel1>|array<EmbeddedTestLevel1>
-     */
+    /** @var Collection<int, EmbeddedTestLevel1>|array<EmbeddedTestLevel1> */
+    #[ODM\EmbedMany(targetDocument: EmbeddedTestLevel1::class)]
     public $level1 = [];
 }

--- a/tests/Documents/Functional/EmbeddedTestLevel0b.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel0b.php
@@ -7,31 +7,19 @@ namespace Documents\Functional;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="embedded_test") */
+#[ODM\Document(collection: 'embedded_test')]
 class EmbeddedTestLevel0b
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
-    /**
-     * @ODM\EmbedOne(targetDocument=EmbeddedTestLevel1::class)
-     *
-     * @var EmbeddedTestLevel1|null
-     */
+    /** @var EmbeddedTestLevel1|null */
+    #[ODM\EmbedOne(targetDocument: EmbeddedTestLevel1::class)]
     public $oneLevel1;
-    /**
-     * @ODM\EmbedMany(targetDocument=EmbeddedTestLevel1::class)
-     *
-     * @var Collection<int, EmbeddedTestLevel1>|array<EmbeddedTestLevel1>
-     */
+    /** @var Collection<int, EmbeddedTestLevel1>|array<EmbeddedTestLevel1> */
+    #[ODM\EmbedMany(targetDocument: EmbeddedTestLevel1::class)]
     public $level1 = [];
 }

--- a/tests/Documents/Functional/EmbeddedTestLevel1.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel1.php
@@ -7,24 +7,16 @@ namespace Documents\Functional;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\EmbeddedDocument
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\EmbeddedDocument]
+#[ODM\HasLifecycleCallbacks]
 class EmbeddedTestLevel1
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=EmbeddedTestLevel2::class)
-     *
-     * @var Collection<int, EmbeddedTestLevel2>|array<EmbeddedTestLevel2>
-     */
+    /** @var Collection<int, EmbeddedTestLevel2>|array<EmbeddedTestLevel2> */
+    #[ODM\EmbedMany(targetDocument: EmbeddedTestLevel2::class)]
     public $level2 = [];
 
     /** @var bool */
@@ -39,25 +31,25 @@ class EmbeddedTestLevel1
     /** @var bool */
     public $postLoad = false;
 
-    /** @ODM\PreRemove */
+    #[ODM\PreRemove]
     public function onPreRemove(): void
     {
         $this->preRemove = true;
     }
 
-    /** @ODM\PostRemove */
+    #[ODM\PostRemove]
     public function onPostRemove(): void
     {
         $this->postRemove = true;
     }
 
-    /** @ODM\PreLoad */
+    #[ODM\PreLoad]
     public function onPreLoad(): void
     {
         $this->preLoad = true;
     }
 
-    /** @ODM\PostLoad */
+    #[ODM\PostLoad]
     public function onPostLoad(): void
     {
         $this->postLoad = true;

--- a/tests/Documents/Functional/EmbeddedTestLevel2.php
+++ b/tests/Documents/Functional/EmbeddedTestLevel2.php
@@ -6,17 +6,12 @@ namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\EmbeddedDocument
- * @ODM\HasLifecycleCallbacks
- */
+#[ODM\EmbeddedDocument]
+#[ODM\HasLifecycleCallbacks]
 class EmbeddedTestLevel2
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     /** @var bool */
@@ -31,25 +26,25 @@ class EmbeddedTestLevel2
     /** @var bool */
     public $postLoad = false;
 
-    /** @ODM\PreRemove */
+    #[ODM\PreRemove]
     public function onPreRemove(): void
     {
         $this->preRemove = true;
     }
 
-    /** @ODM\PostRemove */
+    #[ODM\PostRemove]
     public function onPostRemove(): void
     {
         $this->postRemove = true;
     }
 
-    /** @ODM\PreLoad */
+    #[ODM\PreLoad]
     public function onPreLoad(): void
     {
         $this->preLoad = true;
     }
 
-    /** @ODM\PostLoad */
+    #[ODM\PostLoad]
     public function onPostLoad(): void
     {
         $this->postLoad = true;

--- a/tests/Documents/Functional/EmbeddedWhichReferences.php
+++ b/tests/Documents/Functional/EmbeddedWhichReferences.php
@@ -7,20 +7,14 @@ namespace Documents\Functional;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbeddedWhichReferences
 {
-    /**
-     * @ODM\ReferenceOne(targetDocument=Reference::class, name="reference_doc")
-     *
-     * @var Reference|null
-     */
+    /** @var Reference|null */
+    #[ODM\ReferenceOne(targetDocument: Reference::class, name: 'reference_doc')]
     public $referencedDoc;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Reference::class, name="reference_docs")
-     *
-     * @var Collection<int, Reference>|array<Reference>
-     */
+    /** @var Collection<int, Reference>|array<Reference> */
+    #[ODM\ReferenceMany(targetDocument: Reference::class, name: 'reference_docs')]
     public $referencedDocs = [];
 }

--- a/tests/Documents/Functional/FavoritesUser.php
+++ b/tests/Documents/Functional/FavoritesUser.php
@@ -10,55 +10,31 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Documents\Group;
 use Documents\Project;
 
-/** @ODM\Document(collection="favorites_user") */
+#[ODM\Document(collection: 'favorites_user')]
 class FavoritesUser
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $name;
 
-    /**
-     * @ODM\ReferenceMany(
-     *   discriminatorField="type",
-     *   discriminatorMap={
-     *     "group"=Documents\Group::class,
-     *     "project"=Documents\Project::class
-     *   }
-     * )
-     *
-     * @var Collection<int, Group|Project>
-     */
+    /** @var Collection<int, Group|Project> */
+    #[ODM\ReferenceMany(discriminatorField: 'type', discriminatorMap: ['group' => Group::class, 'project' => Project::class])]
     private $favorites;
 
-    /**
-     * @ODM\EmbedMany
-     *
-     * @var Collection<int, object>|array<object>
-     */
+    /** @var Collection<int, object>|array<object> */
+    #[ODM\EmbedMany]
     private $embedded = [];
 
-    /**
-     * @ODM\ReferenceOne
-     *
-     * @var object|null
-     */
+    /** @var object|null */
+    #[ODM\ReferenceOne]
     private $favorite;
 
-    /**
-     * @ODM\EmbedOne
-     *
-     * @var object|null
-     */
+    /** @var object|null */
+    #[ODM\EmbedOne]
     private $embed;
 
     public function __construct()

--- a/tests/Documents/Functional/NotAnnotatedDocument.php
+++ b/tests/Documents/Functional/NotAnnotatedDocument.php
@@ -6,21 +6,15 @@ namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="functional_tests") */
+#[ODM\Document(collection: 'functional_tests')]
 class NotAnnotatedDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field]
     public $field;
 
     /** @var string|null */

--- a/tests/Documents/Functional/NotSaved.php
+++ b/tests/Documents/Functional/NotSaved.php
@@ -6,34 +6,22 @@ namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="functional_tests") */
+#[ODM\Document(collection: 'functional_tests')]
 class NotSaved
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\Field(notSaved=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(notSaved: true)]
     public $notSaved;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=NotSavedEmbedded::class)
-     *
-     * @var NotSavedEmbedded|null
-     */
+    /** @var NotSavedEmbedded|null */
+    #[ODM\EmbedOne(targetDocument: NotSavedEmbedded::class)]
     public $embedded;
 }

--- a/tests/Documents/Functional/NotSavedEmbedded.php
+++ b/tests/Documents/Functional/NotSavedEmbedded.php
@@ -6,20 +6,14 @@ namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class NotSavedEmbedded
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\Field(notSaved=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(notSaved: true)]
     public $notSaved;
 }

--- a/tests/Documents/Functional/NullFieldValues.php
+++ b/tests/Documents/Functional/NullFieldValues.php
@@ -6,20 +6,14 @@ namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="functional_tests") */
+#[ODM\Document(collection: 'functional_tests')]
 class NullFieldValues
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(nullable=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(nullable: true)]
     public $field;
 }

--- a/tests/Documents/Functional/PreUpdateTestProduct.php
+++ b/tests/Documents/Functional/PreUpdateTestProduct.php
@@ -6,28 +6,19 @@ namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="pre_update_test_product") */
+#[ODM\Document(collection: 'pre_update_test_product')]
 class PreUpdateTestProduct
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=PreUpdateTestSellable::class)
-     *
-     * @var PreUpdateTestSellable|null
-     */
+    /** @var PreUpdateTestSellable|null */
+    #[ODM\EmbedOne(targetDocument: PreUpdateTestSellable::class)]
     public $sellable;
 
     public function getName(): ?string

--- a/tests/Documents/Functional/PreUpdateTestSellable.php
+++ b/tests/Documents/Functional/PreUpdateTestSellable.php
@@ -6,21 +6,15 @@ namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class PreUpdateTestSellable
 {
-    /**
-     * @ODM\ReferenceOne(targetDocument=PreUpdateTestProduct::class)
-     *
-     * @var PreUpdateTestProduct|null
-     */
+    /** @var PreUpdateTestProduct|null */
+    #[ODM\ReferenceOne(targetDocument: PreUpdateTestProduct::class)]
     public $product;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=PreUpdateTestSeller::class)
-     *
-     * @var PreUpdateTestSeller|null
-     */
+    /** @var PreUpdateTestSeller|null */
+    #[ODM\ReferenceOne(targetDocument: PreUpdateTestSeller::class)]
     public $seller;
 
     public function getProduct(): ?PreUpdateTestProduct

--- a/tests/Documents/Functional/PreUpdateTestSeller.php
+++ b/tests/Documents/Functional/PreUpdateTestSeller.php
@@ -6,21 +6,15 @@ namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="pre_update_test_seller") */
+#[ODM\Document(collection: 'pre_update_test_seller')]
 class PreUpdateTestSeller
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function getName(): ?string
@@ -33,7 +27,7 @@ class PreUpdateTestSeller
         $this->name = $name;
     }
 
-    /** @ODM\PreUpdate */
+    #[ODM\PreUpdate]
     public function preUpdate(): void
     {
     }

--- a/tests/Documents/Functional/Reference.php
+++ b/tests/Documents/Functional/Reference.php
@@ -6,20 +6,14 @@ namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Reference
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }

--- a/tests/Documents/Functional/SameCollection1.php
+++ b/tests/Documents/Functional/SameCollection1.php
@@ -6,32 +6,21 @@ namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\Document(collection="same_collection")
- * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"test1"="Documents\Functional\SameCollection1", "test2"="Documents\Functional\SameCollection2"})
- * @ODM\DefaultDiscriminatorValue("test1")
- */
+#[ODM\Document(collection: 'same_collection')]
+#[ODM\DiscriminatorField('type')]
+#[ODM\DiscriminatorMap(['test1' => 'Documents\Functional\SameCollection1', 'test2' => 'Documents\Functional\SameCollection2'])]
+#[ODM\DefaultDiscriminatorValue('test1')]
 class SameCollection1
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $test;
 }

--- a/tests/Documents/Functional/SameCollection2.php
+++ b/tests/Documents/Functional/SameCollection2.php
@@ -6,39 +6,25 @@ namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\Document(collection="same_collection")
- * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"test1"="Documents\Functional\SameCollection1", "test2"="Documents\Functional\SameCollection2"})
- * @ODM\DefaultDiscriminatorValue("test1")
- */
+#[ODM\Document(collection: 'same_collection')]
+#[ODM\DiscriminatorField('type')]
+#[ODM\DiscriminatorMap(['test1' => 'Documents\Functional\SameCollection1', 'test2' => 'Documents\Functional\SameCollection2'])]
+#[ODM\DefaultDiscriminatorValue('test1')]
 class SameCollection2
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var bool|null
-     */
+    /** @var bool|null */
+    #[ODM\Field(type: 'string')]
     public $ok;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $w00t;
 }

--- a/tests/Documents/Functional/SameCollection3.php
+++ b/tests/Documents/Functional/SameCollection3.php
@@ -8,29 +8,19 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
  * Sample document without discriminator field to test defaultDiscriminatorValue
- *
- * @ODM\Document(collection="same_collection")
  */
+#[ODM\Document(collection: 'same_collection')]
 class SameCollection3
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $test;
 }

--- a/tests/Documents/Functional/SimpleEmbedAndReference.php
+++ b/tests/Documents/Functional/SimpleEmbedAndReference.php
@@ -7,41 +7,26 @@ namespace Documents\Functional;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="functional_tests") */
+#[ODM\Document(collection: 'functional_tests')]
 class SimpleEmbedAndReference
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Embedded::class)
-     *
-     * @var Collection<int, Embedded>|array<Embedded>
-     */
+    /** @var Collection<int, Embedded>|array<Embedded> */
+    #[ODM\EmbedMany(targetDocument: Embedded::class)]
     public $embedMany = [];
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Reference::class)
-     *
-     * @var Collection<int, Reference>|array<Reference>
-     */
+    /** @var Collection<int, Reference>|array<Reference> */
+    #[ODM\ReferenceMany(targetDocument: Reference::class)]
     public $referenceMany = [];
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Embedded::class)
-     *
-     * @var Embedded|null
-     */
+    /** @var Embedded|null */
+    #[ODM\EmbedOne(targetDocument: Embedded::class)]
     public $embedOne;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Reference::class)
-     *
-     * @var Reference|null
-     */
+    /** @var Reference|null */
+    #[ODM\ReferenceOne(targetDocument: Reference::class)]
     public $referenceOne;
 }

--- a/tests/Documents/Functional/Ticket/GH683/AbstractEmbedded.php
+++ b/tests/Documents/Functional/Ticket/GH683/AbstractEmbedded.php
@@ -6,17 +6,12 @@ namespace Documents\Functional\Ticket\GH683;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\EmbeddedDocument
- * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"e1"=EmbeddedSubDocument1::class, "e2"=EmbeddedSubDocument2::class})
- */
+#[ODM\EmbeddedDocument]
+#[ODM\DiscriminatorField('type')]
+#[ODM\DiscriminatorMap(['e1' => EmbeddedSubDocument1::class, 'e2' => EmbeddedSubDocument2::class])]
 class AbstractEmbedded
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }

--- a/tests/Documents/Functional/Ticket/GH683/EmbeddedSubDocument1.php
+++ b/tests/Documents/Functional/Ticket/GH683/EmbeddedSubDocument1.php
@@ -6,13 +6,10 @@ namespace Documents\Functional\Ticket\GH683;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbeddedSubDocument1 extends AbstractEmbedded
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }

--- a/tests/Documents/Functional/Ticket/GH683/EmbeddedSubDocument2.php
+++ b/tests/Documents/Functional/Ticket/GH683/EmbeddedSubDocument2.php
@@ -6,13 +6,10 @@ namespace Documents\Functional\Ticket\GH683;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbeddedSubDocument2 extends AbstractEmbedded
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }

--- a/tests/Documents/Functional/Ticket/GH683/ParentDocument.php
+++ b/tests/Documents/Functional/Ticket/GH683/ParentDocument.php
@@ -7,34 +7,22 @@ namespace Documents\Functional\Ticket\GH683;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="gh683_test") */
+#[ODM\Document(collection: 'gh683_test')]
 class ParentDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=AbstractEmbedded::class)
-     *
-     * @var AbstractEmbedded|null
-     */
+    /** @var AbstractEmbedded|null */
+    #[ODM\EmbedOne(targetDocument: AbstractEmbedded::class)]
     public $embedOne;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=AbstractEmbedded::class)
-     *
-     * @var Collection<int, AbstractEmbedded>
-     */
+    /** @var Collection<int, AbstractEmbedded> */
+    #[ODM\EmbedMany(targetDocument: AbstractEmbedded::class)]
     public $embedMany;
 }

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayCollectionLevel0.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayCollectionLevel0.php
@@ -8,27 +8,18 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="embedded_test") */
+#[ODM\Document(collection: 'embedded_test')]
 class EmbedManyInArrayCollectionLevel0
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=EmbedManyInArrayCollectionLevel1::class)
-     *
-     * @var Collection<int, EmbedManyInArrayCollectionLevel1>
-     */
+    /** @var Collection<int, EmbedManyInArrayCollectionLevel1> */
+    #[ODM\EmbedMany(targetDocument: EmbedManyInArrayCollectionLevel1::class)]
     public $level1;
 
     public function __construct()

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayCollectionLevel1.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayCollectionLevel1.php
@@ -8,21 +8,15 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbedManyInArrayCollectionLevel1
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=MODM160Level2::class)
-     *
-     * @var Collection<int, MODM160Level2>
-     */
+    /** @var Collection<int, MODM160Level2> */
+    #[ODM\EmbedMany(targetDocument: MODM160Level2::class)]
     public $level2;
 
     public function __construct()

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayLevel0.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayLevel0.php
@@ -7,26 +7,17 @@ namespace Documents\Functional\Ticket\MODM160;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="embedded_test") */
+#[ODM\Document(collection: 'embedded_test')]
 class EmbedManyInArrayLevel0
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=EmbedManyInArrayLevel1::class)
-     *
-     * @var Collection<int, EmbedManyInArrayLevel1>|array<EmbedManyInArrayLevel1>
-     */
+    /** @var Collection<int, EmbedManyInArrayLevel1>|array<EmbedManyInArrayLevel1> */
+    #[ODM\EmbedMany(targetDocument: EmbedManyInArrayLevel1::class)]
     public $level1 = [];
 }

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayLevel1.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedManyInArrayLevel1.php
@@ -7,20 +7,14 @@ namespace Documents\Functional\Ticket\MODM160;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbedManyInArrayLevel1
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=MODM160Level2::class)
-     *
-     * @var Collection<int, MODM160Level2>|array<MODM160Level2>
-     */
+    /** @var Collection<int, MODM160Level2>|array<MODM160Level2> */
+    #[ODM\EmbedMany(targetDocument: MODM160Level2::class)]
     public $level2 = [];
 }

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedOneLevel0.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedOneLevel0.php
@@ -6,25 +6,16 @@ namespace Documents\Functional\Ticket\MODM160;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="embedded_test") */
+#[ODM\Document(collection: 'embedded_test')]
 class EmbedOneLevel0
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
-    /**
-     * @ODM\EmbedOne(targetDocument=EmbedOneLevel1::class)
-     *
-     * @var EmbedOneLevel1|null
-     */
+    /** @var EmbedOneLevel1|null */
+    #[ODM\EmbedOne(targetDocument: EmbedOneLevel1::class)]
     public $level1;
 }

--- a/tests/Documents/Functional/Ticket/MODM160/EmbedOneLevel1.php
+++ b/tests/Documents/Functional/Ticket/MODM160/EmbedOneLevel1.php
@@ -6,19 +6,13 @@ namespace Documents\Functional\Ticket\MODM160;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class EmbedOneLevel1
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
-    /**
-     * @ODM\EmbedOne(targetDocument=MODM160Level2::class)
-     *
-     * @var MODM160Level2|null
-     */
+    /** @var MODM160Level2|null */
+    #[ODM\EmbedOne(targetDocument: MODM160Level2::class)]
     public $level2;
 }

--- a/tests/Documents/Functional/Ticket/MODM160/MODM160Level2.php
+++ b/tests/Documents/Functional/Ticket/MODM160/MODM160Level2.php
@@ -6,13 +6,10 @@ namespace Documents\Functional\Ticket\MODM160;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class MODM160Level2
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }

--- a/tests/Documents/Functional/VirtualHost.php
+++ b/tests/Documents/Functional/VirtualHost.php
@@ -6,21 +6,15 @@ namespace Documents\Functional;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="test_functional_virtual_host") */
+#[ODM\Document(collection: 'test_functional_virtual_host')]
 class VirtualHost
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Documents\Functional\VirtualHostDirective::class)
-     *
-     * @var VirtualHostDirective|null
-     */
+    /** @var VirtualHostDirective|null */
+    #[ODM\EmbedOne(targetDocument: VirtualHostDirective::class)]
     protected $vhostDirective;
 
     public function getId(): ?string

--- a/tests/Documents/Functional/VirtualHostDirective.php
+++ b/tests/Documents/Functional/VirtualHostDirective.php
@@ -10,32 +10,20 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 use function uniqid;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class VirtualHostDirective
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     protected $recId;
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     protected $name;
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     protected $value;
-    /**
-     * @ODM\EmbedMany(targetDocument=Documents\Functional\VirtualHostDirective::class)
-     *
-     * @var Collection<int, VirtualHostDirective>|null
-     */
+    /** @var Collection<int, VirtualHostDirective>|null */
+    #[ODM\EmbedMany(targetDocument: self::class)]
     protected $directives;
 
     public function __construct(string $name = '', string $value = '')

--- a/tests/Documents/GH2310Container.php
+++ b/tests/Documents/GH2310Container.php
@@ -6,13 +6,13 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document() */
+#[ODM\Document]
 class GH2310Container
 {
-    /** @ODM\Id */
+    #[ODM\Id]
     public ?string $id;
 
-    /** @ODM\EmbedOne(targetDocument=GH2310Embedded::class, nullable=true) */
+    #[ODM\EmbedOne(targetDocument: GH2310Embedded::class, nullable: true)]
     public ?GH2310Embedded $embedded;
 
     public function __construct(?string $id, ?GH2310Embedded $embedded)
@@ -22,9 +22,9 @@ class GH2310Container
     }
 }
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class GH2310Embedded
 {
-    /** @ODM\Field(type="integer") */
+    #[ODM\Field(type: 'integer')]
     public int $value;
 }

--- a/tests/Documents/GraphLookup/Airport.php
+++ b/tests/Documents/GraphLookup/Airport.php
@@ -8,35 +8,23 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Airport
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $code;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Airport::class, cascade={"persist"}, storeAs="ref")
-     *
-     * @var Collection<int, Airport>
-     */
+    /** @var Collection<int, Airport> */
+    #[ODM\ReferenceMany(targetDocument: self::class, cascade: ['persist'], storeAs: 'ref')]
     protected $connections;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Airport::class, cascade={"persist"}, storeAs="id")
-     *
-     * @var Collection<int, Airport>
-     */
+    /** @var Collection<int, Airport> */
+    #[ODM\ReferenceMany(targetDocument: self::class, cascade: ['persist'], storeAs: 'id')]
     protected $connectionIds;
 
     public function __construct(string $code)

--- a/tests/Documents/GraphLookup/Employee.php
+++ b/tests/Documents/GraphLookup/Employee.php
@@ -8,42 +8,27 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Employee
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Employee::class, cascade={"persist"}, storeAs="ref")
-     *
-     * @var Employee|null
-     */
+    /** @var Employee|null */
+    #[ODM\ReferenceOne(targetDocument: self::class, cascade: ['persist'], storeAs: 'ref')]
     public $reportsTo;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Employee::class, cascade={"persist"}, storeAs="id")
-     *
-     * @var Employee|null
-     */
+    /** @var Employee|null */
+    #[ODM\ReferenceOne(targetDocument: self::class, cascade: ['persist'], storeAs: 'id')]
     public $reportsToId;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Employee::class, mappedBy="reportsTo")
-     *
-     * @var Collection<int, Employee>
-     */
+    /** @var Collection<int, Employee> */
+    #[ODM\ReferenceMany(targetDocument: self::class, mappedBy: 'reportsTo')]
     public $reportingEmployees;
 
     public function __construct(string $name, ?Employee $reportsTo = null)

--- a/tests/Documents/GraphLookup/ReportingHierarchy.php
+++ b/tests/Documents/GraphLookup/ReportingHierarchy.php
@@ -8,42 +8,27 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\QueryResultDocument */
+#[ODM\QueryResultDocument]
 class ReportingHierarchy
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Employee::class, cascade={"persist"}, storeAs="ref")
-     *
-     * @var Employee|null
-     */
+    /** @var Employee|null */
+    #[ODM\ReferenceOne(targetDocument: Employee::class, cascade: ['persist'], storeAs: 'ref')]
     public $reportsTo;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Employee::class, cascade={"persist"}, storeAs="id")
-     *
-     * @var Employee|null
-     */
+    /** @var Employee|null */
+    #[ODM\ReferenceOne(targetDocument: Employee::class, cascade: ['persist'], storeAs: 'id')]
     public $reportsToId;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Employee::class)
-     *
-     * @var Collection<int, Employee>
-     */
+    /** @var Collection<int, Employee> */
+    #[ODM\EmbedMany(targetDocument: Employee::class)]
     public $reportingHierarchy;
 
     public function __construct()

--- a/tests/Documents/GraphLookup/Traveller.php
+++ b/tests/Documents/GraphLookup/Traveller.php
@@ -6,35 +6,23 @@ namespace Documents\GraphLookup;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Traveller
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Airport::class, cascade={"persist"}, storeAs="ref")
-     *
-     * @var Airport|null
-     */
+    /** @var Airport|null */
+    #[ODM\ReferenceOne(targetDocument: Airport::class, cascade: ['persist'], storeAs: 'ref')]
     public $nearestAirport;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Airport::class, cascade={"persist"}, storeAs="id")
-     *
-     * @var Airport|null
-     */
+    /** @var Airport|null */
+    #[ODM\ReferenceOne(targetDocument: Airport::class, cascade: ['persist'], storeAs: 'id')]
     public $nearestAirportId;
 
     public function __construct(string $name, Airport $nearestAirport)

--- a/tests/Documents/Group.php
+++ b/tests/Documents/Group.php
@@ -6,21 +6,15 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Group
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field]
     private $name;
 
     public function __construct(?string $name = null)

--- a/tests/Documents/GuestServer.php
+++ b/tests/Documents/GuestServer.php
@@ -6,7 +6,7 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class GuestServer extends Server
 {
 }

--- a/tests/Documents/IdentifiedChapter.php
+++ b/tests/Documents/IdentifiedChapter.php
@@ -8,28 +8,19 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class IdentifiedChapter
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Page::class)
-     *
-     * @var Collection<int, Page>
-     */
+    /** @var Collection<int, Page> */
+    #[ODM\EmbedMany(targetDocument: Page::class)]
     public $pages;
 
     public function __construct(?string $name = null)

--- a/tests/Documents/IndirectlyReferencedUser.php
+++ b/tests/Documents/IndirectlyReferencedUser.php
@@ -6,13 +6,10 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class IndirectlyReferencedUser
 {
-    /**
-     * @ODM\ReferenceOne(targetDocument=User::class, storeAs="ref")
-     *
-     * @var User
-     */
+    /** @var User */
+    #[ODM\ReferenceOne(targetDocument: User::class, storeAs: 'ref')]
     public $user;
 }

--- a/tests/Documents/Issue.php
+++ b/tests/Documents/Issue.php
@@ -6,21 +6,15 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Issue
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     private $name;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     private $description;
 
     public function __construct(string $name, string $description)

--- a/tests/Documents/Manager.php
+++ b/tests/Documents/Manager.php
@@ -7,14 +7,11 @@ namespace Documents;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Manager extends BaseEmployee
 {
-    /**
-     * @ODM\ReferenceMany(targetDocument=Project::class)
-     *
-     * @var Collection<int, Project>|array<Project>
-     */
+    /** @var Collection<int, Project>|array<Project> */
+    #[ODM\ReferenceMany(targetDocument: Project::class)]
     private $projects = [];
 
     /** @return Collection<int, Project>|array<Project> */

--- a/tests/Documents/Message.php
+++ b/tests/Documents/Message.php
@@ -6,21 +6,15 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Message
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     private $name;
 
     public function __construct(string $name)

--- a/tests/Documents/OtherSubProject.php
+++ b/tests/Documents/OtherSubProject.php
@@ -6,7 +6,7 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class OtherSubProject extends Project
 {
 }

--- a/tests/Documents/Page.php
+++ b/tests/Documents/Page.php
@@ -6,21 +6,15 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Page
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int
-     */
+    /** @var int */
+    #[ODM\Field(type: 'int')]
     public $number;
 
     public function __construct(int $number)

--- a/tests/Documents/Phonebook.php
+++ b/tests/Documents/Phonebook.php
@@ -8,21 +8,15 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Phonebook
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     private $title;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Phonenumber::class)
-     *
-     * @var Collection<int, Phonenumber>
-     */
+    /** @var Collection<int, Phonenumber> */
+    #[ODM\EmbedMany(targetDocument: Phonenumber::class)]
     private $phonenumbers;
 
     public function __construct(string $title)

--- a/tests/Documents/Phonenumber.php
+++ b/tests/Documents/Phonenumber.php
@@ -6,21 +6,15 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Phonenumber
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $phonenumber;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=User::class, cascade={"persist"})
-     *
-     * @var User|null
-     */
+    /** @var User|null */
+    #[ODM\ReferenceOne(targetDocument: User::class, cascade: ['persist'])]
     private $lastCalledBy;
 
     public function __construct(?string $phonenumber = null, ?User $lastCalledBy = null)

--- a/tests/Documents/Product.php
+++ b/tests/Documents/Product.php
@@ -8,28 +8,19 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Product
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Feature::class, mappedBy="product", cascade={"all"})
-     *
-     * @var Collection<int, Feature>
-     */
+    /** @var Collection<int, Feature> */
+    #[ODM\ReferenceMany(targetDocument: Feature::class, mappedBy: 'product', cascade: ['all'])]
     public $features;
 
     public function __construct(string $name)

--- a/tests/Documents/Profile.php
+++ b/tests/Documents/Profile.php
@@ -7,35 +7,23 @@ namespace Documents;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use MongoDB\BSON\ObjectId;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Profile
 {
-    /**
-     * @ODM\Id
-     *
-     * @var ObjectId|string|null
-     */
+    /** @var ObjectId|string|null */
+    #[ODM\Id]
     private $profileId;
 
-    /**
-     * @ODM\Field
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field]
     private $firstName;
 
-    /**
-     * @ODM\Field
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field]
     private $lastName;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=File::class, cascade={"all"})
-     *
-     * @var File|null
-     */
+    /** @var File|null */
+    #[ODM\ReferenceOne(targetDocument: File::class, cascade: ['all'])]
     private $image;
 
     public function setProfileId(ObjectId $profileId): void

--- a/tests/Documents/ProfileNotify.php
+++ b/tests/Documents/ProfileNotify.php
@@ -9,45 +9,28 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\Persistence\NotifyPropertyChanged;
 use Doctrine\Persistence\PropertyChangedListener;
 
-/**
- * @ODM\Document
- * @ODM\ChangeTrackingPolicy("NOTIFY")
- */
+#[ODM\Document]
+#[ODM\ChangeTrackingPolicy('NOTIFY')]
 class ProfileNotify implements NotifyPropertyChanged
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $profileId;
 
-    /**
-     * @ODM\Field
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field]
     private $firstName;
 
-    /**
-     * @ODM\Field
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field]
     private $lastName;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=File::class, cascade={"all"})
-     *
-     * @var File|null
-     */
+    /** @var File|null */
+    #[ODM\ReferenceOne(targetDocument: File::class, cascade: ['all'])]
     private $image;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=File::class, cascade={"all"}, collectionClass=ProfileNotifyImagesCollection::class)
-     *
-     * @var ProfileNotifyImagesCollection<int, File>
-     */
+    /** @var ProfileNotifyImagesCollection<int, File> */
+    #[ODM\ReferenceMany(targetDocument: File::class, cascade: ['all'], collectionClass: ProfileNotifyImagesCollection::class)]
     private $images;
 
     /** @var PropertyChangedListener[] */

--- a/tests/Documents/Project.php
+++ b/tests/Documents/Project.php
@@ -8,40 +8,26 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\Document
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("type")
- * @ODM\DiscriminatorMap({"project"="Documents\Project", "sub-project"="Documents\SubProject", "other-sub-project"="Documents\OtherSubProject"})
- */
+#[ODM\Document]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('type')]
+#[ODM\DiscriminatorMap(['project' => 'Documents\Project', 'sub-project' => 'Documents\SubProject', 'other-sub-project' => 'Documents\OtherSubProject'])]
 class Project
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $name;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Address::class)
-     *
-     * @var Address|null
-     */
+    /** @var Address|null */
+    #[ODM\EmbedOne(targetDocument: Address::class)]
     private $address;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=SubProject::class, cascade="all")
-     *
-     * @var Collection<int, SubProject>
-     */
+    /** @var Collection<int, SubProject> */
+    #[ODM\ReferenceMany(targetDocument: SubProject::class, cascade: 'all')]
     private $subProjects;
 
     /** @param Collection<int, SubProject>|null $subProjects */

--- a/tests/Documents/ReferenceUser.php
+++ b/tests/Documents/ReferenceUser.php
@@ -9,86 +9,52 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
  * A document to test the different "storeAs" values
- *
- * @ODM\Document
  */
+#[ODM\Document]
 class ReferenceUser
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=User::class, storeAs="id")
-     *
-     * @var User
-     */
+    /** @var User */
+    #[ODM\ReferenceOne(targetDocument: User::class, storeAs: 'id')]
     public $user;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=User::class, storeAs="id")
-     *
-     * @var Collection<int, User>|array<User>
-     */
+    /** @var Collection<int, User>|array<User> */
+    #[ODM\ReferenceMany(targetDocument: User::class, storeAs: 'id')]
     public $users = [];
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=User::class, storeAs="dbRef")
-     *
-     * @var User
-     */
+    /** @var User */
+    #[ODM\ReferenceOne(targetDocument: User::class, storeAs: 'dbRef')]
     public $parentUser;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=User::class, storeAs="dbRef")
-     *
-     * @var Collection<int, User>|array<User>
-     */
+    /** @var Collection<int, User>|array<User> */
+    #[ODM\ReferenceMany(targetDocument: User::class, storeAs: 'dbRef')]
     public $parentUsers = [];
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=User::class, storeAs="dbRefWithDb")
-     *
-     * @var User
-     */
+    /** @var User */
+    #[ODM\ReferenceOne(targetDocument: User::class, storeAs: 'dbRefWithDb')]
     public $otherUser;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=User::class, storeAs="dbRefWithDb")
-     *
-     * @var Collection<int, User>|array<User>
-     */
+    /** @var Collection<int, User>|array<User> */
+    #[ODM\ReferenceMany(targetDocument: User::class, storeAs: 'dbRefWithDb')]
     public $otherUsers = [];
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=User::class, storeAs="ref")
-     *
-     * @var User
-     */
+    /** @var User */
+    #[ODM\ReferenceOne(targetDocument: User::class, storeAs: 'ref')]
     public $referencedUser;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=User::class, storeAs="ref")
-     *
-     * @var Collection<int, User>|array<User>
-     */
+    /** @var Collection<int, User>|array<User> */
+    #[ODM\ReferenceMany(targetDocument: User::class, storeAs: 'ref')]
     public $referencedUsers = [];
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Documents\IndirectlyReferencedUser::class)
-     *
-     * @var Collection<int, IndirectlyReferencedUser>|array<IndirectlyReferencedUser>
-     */
+    /** @var Collection<int, IndirectlyReferencedUser>|array<IndirectlyReferencedUser> */
+    #[ODM\EmbedMany(targetDocument: IndirectlyReferencedUser::class)]
     public $indirectlyReferencedUsers = [];
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function setUser(User $user): void

--- a/tests/Documents/SchemaValidated.php
+++ b/tests/Documents/SchemaValidated.php
@@ -7,14 +7,8 @@ namespace Documents;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 
-/**
- * @ODM\Document
- * @ODM\Validation(
- *     validator=SchemaValidated::VALIDATOR,
- *     action=ClassMetadata::SCHEMA_VALIDATION_ACTION_WARN,
- *     level=ClassMetadata::SCHEMA_VALIDATION_LEVEL_MODERATE,
- * )
- */
+#[ODM\Document]
+#[ODM\Validation(validator: SchemaValidated::VALIDATOR, action: ClassMetadata::SCHEMA_VALIDATION_ACTION_WARN, level: ClassMetadata::SCHEMA_VALIDATION_LEVEL_MODERATE)]
 class SchemaValidated
 {
     public const VALIDATOR = <<<'EOT'
@@ -36,38 +30,23 @@ class SchemaValidated
 }
 EOT;
 
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $name;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $phone;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $email;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $status;
 }

--- a/tests/Documents/Server.php
+++ b/tests/Documents/Server.php
@@ -6,28 +6,17 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\Document(collection="servers")
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("stype")
- * @ODM\DiscriminatorMap({
- * "server"=Server::class,
- * "server_guest"=GuestServer::class
- * })
- */
+#[ODM\Document(collection: 'servers')]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('stype')]
+#[ODM\DiscriminatorMap(['server' => Server::class, 'server_guest' => GuestServer::class])]
 class Server
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }

--- a/tests/Documents/Sharded/ShardedByUser.php
+++ b/tests/Documents/Sharded/ShardedByUser.php
@@ -6,23 +6,15 @@ namespace Documents\Sharded;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\Document(collection="sharded.users")
- * @ODM\ShardKey(keys={"user"="asc"})
- */
+#[ODM\Document(collection: 'sharded.users')]
+#[ODM\ShardKey(keys: ['user' => 'asc'])]
 class ShardedByUser
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument="Documents\Sharded\ShardedUser", name="db_user")
-     *
-     * @var ShardedUser|null
-     */
+    /** @var ShardedUser|null */
+    #[ODM\ReferenceOne(targetDocument: 'Documents\Sharded\ShardedUser', name: 'db_user')]
     public $user;
 }

--- a/tests/Documents/Sharded/ShardedOne.php
+++ b/tests/Documents/Sharded/ShardedOne.php
@@ -7,40 +7,24 @@ namespace Documents\Sharded;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use MongoDB\BSON\ObjectId;
 
-/**
- * @ODM\Document(collection="sharded.one")
- * @ODM\Indexes(
- *     @ODM\Index(keys={"k"="asc"})
- * )
- * @ODM\ShardKey(keys={"k"="asc"})
- */
+#[ODM\Document(collection: 'sharded.one')]
+#[ODM\ShardKey(keys: ['k' => 'asc'])]
+#[ODM\Index(keys: ['k' => 'asc'])]
 class ShardedOne
 {
-    /**
-     * @ODM\Id
-     *
-     * @var ObjectId|null
-     */
+    /** @var ObjectId|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $title = 'test';
 
-    /**
-     * @ODM\Field(name="k", type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(name: 'k', type: 'string')]
     public $key = 'testing';
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=ShardedUser::class)
-     *
-     * @var ShardedUser|null
-     */
+    /** @var ShardedUser|null */
+    #[ODM\ReferenceOne(targetDocument: ShardedUser::class)]
     public $user;
 }

--- a/tests/Documents/Sharded/ShardedOneWithDifferentKey.php
+++ b/tests/Documents/Sharded/ShardedOneWithDifferentKey.php
@@ -8,40 +8,25 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
  * Note: this document intentially collides with ShardedOne to test shard key changes
- *
- * @ODM\Document(collection="sharded.one")
- * @ODM\Indexes(
- *     @ODM\Index(keys={"v"="asc"})
- * )
- * @ODM\ShardKey(keys={"v"="asc"})
  */
+#[ODM\Document(collection: 'sharded.one')]
+#[ODM\ShardKey(keys: ['v' => 'asc'])]
+#[ODM\Index(keys: ['v' => 'asc'])]
 class ShardedOneWithDifferentKey
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $title = 'test';
 
-    /**
-     * @ODM\Field(name="k", type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(name: 'k', type: 'string')]
     public $key = 'testing';
 
-    /**
-     * @ODM\Field(name="v", type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(name: 'v', type: 'string')]
     public $value = 'testing';
 }

--- a/tests/Documents/Sharded/ShardedUser.php
+++ b/tests/Documents/Sharded/ShardedUser.php
@@ -6,23 +6,15 @@ namespace Documents\Sharded;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\Document(collection="sharded.users")
- * @ODM\ShardKey(keys={"_id"="hashed"})
- */
+#[ODM\Document(collection: 'sharded.users')]
+#[ODM\ShardKey(keys: ['_id' => 'hashed'])]
 class ShardedUser
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 }

--- a/tests/Documents/SimpleReferenceUser.php
+++ b/tests/Documents/SimpleReferenceUser.php
@@ -7,36 +7,24 @@ namespace Documents;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class SimpleReferenceUser
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=User::class, storeAs="id", name="userId", inversedBy="simpleReferenceManyInverse")
-     * @ODM\Index
-     *
-     * @var User|null
-     */
+    /** @var User|null */
+    #[ODM\ReferenceOne(targetDocument: User::class, storeAs: 'id', name: 'userId', inversedBy: 'simpleReferenceManyInverse')]
+    #[ODM\Index]
     public $user;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=User::class, storeAs="id")
-     *
-     * @var Collection<int, User>|array<User>
-     */
+    /** @var Collection<int, User>|array<User> */
+    #[ODM\ReferenceMany(targetDocument: User::class, storeAs: 'id')]
     public $users = [];
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $name;
 
     public function setUser(User $user): void

--- a/tests/Documents/Song.php
+++ b/tests/Documents/Song.php
@@ -6,14 +6,11 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Song
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     private $name;
 
     public function __construct(string $name)

--- a/tests/Documents/SpecialUser.php
+++ b/tests/Documents/SpecialUser.php
@@ -6,14 +6,11 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class SpecialUser extends User
 {
-    /**
-     * @ODM\Field(type="collection")
-     *
-     * @var string[]
-     */
+    /** @var string[] */
+    #[ODM\Field(type: 'collection')]
     private $rules = [];
 
     /** @param string[] $rules */

--- a/tests/Documents/Strategy.php
+++ b/tests/Documents/Strategy.php
@@ -7,34 +7,22 @@ namespace Documents;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="strategy") */
+#[ODM\Document(collection: 'strategy')]
 class Strategy
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="collection")
-     *
-     * @var string[]
-     */
+    /** @var string[] */
+    #[ODM\Field(type: 'collection')]
     public $logs = [];
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Message::class, strategy="set")
-     *
-     * @var Collection<int, Message>|array<Message>
-     */
+    /** @var Collection<int, Message>|array<Message> */
+    #[ODM\EmbedMany(targetDocument: Message::class, strategy: 'set')]
     public $messages = [];
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Task::class, strategy="set")
-     *
-     * @var Collection<int, Task>|array<Task>
-     */
+    /** @var Collection<int, Task>|array<Task> */
+    #[ODM\ReferenceMany(targetDocument: Task::class, strategy: 'set')]
     public $tasks = [];
 }

--- a/tests/Documents/SubCategory.php
+++ b/tests/Documents/SubCategory.php
@@ -6,7 +6,7 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class SubCategory extends BaseCategory
 {
 }

--- a/tests/Documents/SubProject.php
+++ b/tests/Documents/SubProject.php
@@ -7,14 +7,11 @@ namespace Documents;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class SubProject extends Project
 {
-    /**
-     * @ODM\EmbedMany(targetDocument=Issue::class)
-     *
-     * @var Collection<int, Issue>
-     */
+    /** @var Collection<int, Issue> */
+    #[ODM\EmbedMany(targetDocument: Issue::class)]
     private $issues;
 
     /** @return Collection<int, Issue> */

--- a/tests/Documents/Tag.php
+++ b/tests/Documents/Tag.php
@@ -7,28 +7,19 @@ namespace Documents;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class Tag
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     public $name;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=BlogPost::class, mappedBy="tags")
-     *
-     * @var Collection<int, BlogPost>
-     */
+    /** @var Collection<int, BlogPost> */
+    #[ODM\ReferenceMany(targetDocument: BlogPost::class, mappedBy: 'tags')]
     public $blogPosts;
 
     public function __construct(string $name)

--- a/tests/Documents/Task.php
+++ b/tests/Documents/Task.php
@@ -6,21 +6,15 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="tasks") */
+#[ODM\Document(collection: 'tasks')]
 class Task
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field(type: 'string')]
     private $name;
 
     public function __construct(string $name)

--- a/tests/Documents/Tournament/Participant.php
+++ b/tests/Documents/Tournament/Participant.php
@@ -6,32 +6,21 @@ namespace Documents\Tournament;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\Document
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorMap({"solo"=ParticipantSolo::class, "team"=ParticipantTeam::class})
- */
+#[ODM\Document]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorMap(['solo' => ParticipantSolo::class, 'team' => ParticipantTeam::class])]
 class Participant
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field]
     private $name;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Tournament::class, cascade={"all"})
-     *
-     * @var Tournament|null
-     */
+    /** @var Tournament|null */
+    #[ODM\ReferenceOne(targetDocument: Tournament::class, cascade: ['all'])]
     protected $tournament;
 
     public function __construct(string $name)

--- a/tests/Documents/Tournament/ParticipantSolo.php
+++ b/tests/Documents/Tournament/ParticipantSolo.php
@@ -6,7 +6,7 @@ namespace Documents\Tournament;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class ParticipantSolo extends Participant
 {
 }

--- a/tests/Documents/Tournament/ParticipantTeam.php
+++ b/tests/Documents/Tournament/ParticipantTeam.php
@@ -6,7 +6,7 @@ namespace Documents\Tournament;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class ParticipantTeam extends Participant
 {
 }

--- a/tests/Documents/Tournament/Tournament.php
+++ b/tests/Documents/Tournament/Tournament.php
@@ -7,32 +7,21 @@ namespace Documents\Tournament;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\Document
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorMap({"football"=TournamentFootball::class,"tennis": TournamentTennis::class})
- */
+#[ODM\Document]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorMap(['football' => TournamentFootball::class, 'tennis' => TournamentTennis::class])]
 class Tournament
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Field]
     private $name;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Participant::class, cascade={"all"})
-     *
-     * @var Collection<int, Participant>|array<Participant>
-     */
+    /** @var Collection<int, Participant>|array<Participant> */
+    #[ODM\ReferenceMany(targetDocument: Participant::class, cascade: ['all'])]
     protected $participants = [];
 
     public function __construct(string $name)

--- a/tests/Documents/Tournament/TournamentFootball.php
+++ b/tests/Documents/Tournament/TournamentFootball.php
@@ -6,7 +6,7 @@ namespace Documents\Tournament;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class TournamentFootball extends Tournament
 {
 }

--- a/tests/Documents/Tournament/TournamentTennis.php
+++ b/tests/Documents/Tournament/TournamentTennis.php
@@ -6,7 +6,7 @@ namespace Documents\Tournament;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class TournamentTennis extends Tournament
 {
 }

--- a/tests/Documents/TypedDocument.php
+++ b/tests/Documents/TypedDocument.php
@@ -8,38 +8,35 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document() */
+#[ODM\Document]
 class TypedDocument
 {
-    /** @ODM\Id() */
+    #[ODM\Id]
     public string $id;
 
-    /** @ODM\Field(type="string") */
+    #[ODM\Field(type: 'string')]
     public string $name;
 
-    /** @ODM\EmbedOne(targetDocument=TypedEmbeddedDocument::class) */
+    #[ODM\EmbedOne(targetDocument: TypedEmbeddedDocument::class)]
     public TypedEmbeddedDocument $embedOne;
 
-    /** @ODM\EmbedOne(targetDocument=TypedEmbeddedDocument::class, nullable=true) */
+    #[ODM\EmbedOne(targetDocument: TypedEmbeddedDocument::class, nullable: true)]
     public ?TypedEmbeddedDocument $nullableEmbedOne;
 
-    /** @ODM\EmbedOne(targetDocument=TypedEmbeddedDocument::class, nullable=true) */
+    #[ODM\EmbedOne(targetDocument: TypedEmbeddedDocument::class, nullable: true)]
     public ?TypedEmbeddedDocument $initializedNullableEmbedOne = null;
 
-    /** @ODM\ReferenceOne(targetDocument=TypedDocument::class) */
+    #[ODM\ReferenceOne(targetDocument: self::class)]
     public TypedDocument $referenceOne;
 
-    /** @ODM\ReferenceOne(targetDocument=TypedDocument::class, nullable=true) */
+    #[ODM\ReferenceOne(targetDocument: self::class, nullable: true)]
     public ?TypedDocument $nullableReferenceOne;
 
-    /** @ODM\ReferenceOne(targetDocument=TypedDocument::class, nullable=true) */
+    #[ODM\ReferenceOne(targetDocument: self::class, nullable: true)]
     public ?TypedDocument $initializedNullableReferenceOne = null;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=TypedEmbeddedDocument::class)
-     *
-     * @var Collection<int, TypedEmbeddedDocument>
-     */
+    /** @var Collection<int, TypedEmbeddedDocument> */
+    #[ODM\EmbedMany(targetDocument: TypedEmbeddedDocument::class)]
     private Collection $embedMany;
 
     public function __construct()

--- a/tests/Documents/TypedEmbeddedDocument.php
+++ b/tests/Documents/TypedEmbeddedDocument.php
@@ -6,13 +6,13 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\EmbeddedDocument() */
+#[ODM\EmbeddedDocument]
 class TypedEmbeddedDocument
 {
-    /** @ODM\Field(type="string") */
+    #[ODM\Field(type: 'string')]
     private string $name;
 
-    /** @ODM\Field(type="int") */
+    #[ODM\Field(type: 'int')]
     private int $number;
 
     public function __construct(string $name, int $number)

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -14,220 +14,128 @@ use MongoDB\BSON\UTCDateTime;
 
 use function bcadd;
 
-/**
- * @ODM\Document(collection="users")
- * @ODM\InheritanceType("COLLECTION_PER_CLASS")
- */
+#[ODM\Document(collection: 'users')]
+#[ODM\InheritanceType('COLLECTION_PER_CLASS')]
 class User extends BaseDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var ObjectId|string|null
-     */
+    /** @var ObjectId|string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     protected $username;
 
-    /**
-     * @ODM\Field(type="bin_md5")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'bin_md5')]
     protected $password;
 
-    /**
-     * @ODM\Field(type="date")
-     *
-     * @var UTCDateTime|DateTimeInterface|string
-     */
+    /** @var UTCDateTime|DateTimeInterface|string */
+    #[ODM\Field(type: 'date')]
     protected $createdAt;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Address::class)
-     *
-     * @var Address|null
-     */
+    /** @var Address|null */
+    #[ODM\EmbedOne(targetDocument: Address::class)]
     protected $address;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Address::class, nullable=true)
-     *
-     * @var Address|null
-     */
+    /** @var Address|null */
+    #[ODM\EmbedOne(targetDocument: Address::class, nullable: true)]
     protected $addressNullable;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Profile::class, cascade={"all"})
-     *
-     * @var Profile|null
-     */
+    /** @var Profile|null */
+    #[ODM\ReferenceOne(targetDocument: Profile::class, cascade: ['all'])]
     protected $profile;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=ProfileNotify::class, cascade={"all"})
-     *
-     * @var ProfileNotify|null
-     */
+    /** @var ProfileNotify|null */
+    #[ODM\ReferenceOne(targetDocument: ProfileNotify::class, cascade: ['all'])]
     protected $profileNotify;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Phonenumber::class)
-     *
-     * @var Collection<int, Phonenumber>
-     */
+    /** @var Collection<int, Phonenumber> */
+    #[ODM\EmbedMany(targetDocument: Phonenumber::class)]
     protected $phonenumbers;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Phonebook::class)
-     *
-     * @var Collection<int, Phonebook>
-     */
+    /** @var Collection<int, Phonebook> */
+    #[ODM\EmbedMany(targetDocument: Phonebook::class)]
     protected $phonebooks;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Group::class, cascade={"all"})
-     *
-     * @var Collection<int, Group>|array<Group>
-     */
+    /** @var Collection<int, Group>|array<Group> */
+    #[ODM\ReferenceMany(targetDocument: Group::class, cascade: ['all'])]
     protected $groups;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Group::class, storeAs="id", cascade={"all"})
-     *
-     * @var Collection<int, Group>
-     */
+    /** @var Collection<int, Group> */
+    #[ODM\ReferenceMany(targetDocument: Group::class, storeAs: 'id', cascade: ['all'])]
     protected $groupsSimple;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Group::class, cascade={"all"}, strategy="addToSet")
-     *
-     * @var Collection<int, Group>
-     */
+    /** @var Collection<int, Group> */
+    #[ODM\ReferenceMany(targetDocument: Group::class, cascade: ['all'], strategy: 'addToSet')]
     protected $uniqueGroups;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Group::class, name="groups", notSaved=true, sort={"name"="asc"}, strategy="setArray")
-     *
-     * @var Collection<int, Group>
-     */
+    /** @var Collection<int, Group> */
+    #[ODM\ReferenceMany(targetDocument: Group::class, name: 'groups', notSaved: true, sort: ['name' => 'asc'], strategy: 'setArray')]
     protected $sortedAscGroups;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Group::class, name="groups", notSaved=true, sort={"name"="desc"}, strategy="setArray")
-     *
-     * @var Collection<int, Group>
-     */
+    /** @var Collection<int, Group> */
+    #[ODM\ReferenceMany(targetDocument: Group::class, name: 'groups', notSaved: true, sort: ['name' => 'desc'], strategy: 'setArray')]
     protected $sortedDescGroups;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Account::class, cascade={"all"})
-     *
-     * @var Account|null
-     */
+    /** @var Account|null */
+    #[ODM\ReferenceOne(targetDocument: Account::class, cascade: ['all'])]
     protected $account;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Account::class, storeAs="id", cascade={"all"})
-     *
-     * @var Account|null
-     */
+    /** @var Account|null */
+    #[ODM\ReferenceOne(targetDocument: Account::class, storeAs: 'id', cascade: ['all'])]
     protected $accountSimple;
 
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int
-     */
+    /** @var int */
+    #[ODM\Field(type: 'int')]
     protected $hits = 0;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     protected $nullTest;
 
-    /**
-     * @ODM\Field(type="int", strategy="increment")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Field(type: 'int', strategy: 'increment')]
     protected $count;
 
-    /**
-     * @ODM\Field(type="float", strategy="increment")
-     *
-     * @var float|null
-     */
+    /** @var float|null */
+    #[ODM\Field(type: 'float', strategy: 'increment')]
     protected $floatCount;
 
-    /**
-     * @ODM\Field(type="decimal128", strategy="increment")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'decimal128', strategy: 'increment')]
     protected $decimal128Count;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=BlogPost::class, mappedBy="user", nullable=true)
-     *
-     * @var Collection<int, BlogPost>
-     */
+    /** @var Collection<int, BlogPost> */
+    #[ODM\ReferenceMany(targetDocument: BlogPost::class, mappedBy: 'user', nullable: true)]
     protected $posts;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=SimpleReferenceUser::class, mappedBy="user")
-     *
-     * @var SimpleReferenceUser|null
-     */
+    /** @var SimpleReferenceUser|null */
+    #[ODM\ReferenceOne(targetDocument: SimpleReferenceUser::class, mappedBy: 'user')]
     protected $simpleReferenceOneInverse;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=SimpleReferenceUser::class, mappedBy="users")
-     *
-     * @var Collection<int, SimpleReferenceUser>
-     */
+    /** @var Collection<int, SimpleReferenceUser> */
+    #[ODM\ReferenceMany(targetDocument: SimpleReferenceUser::class, mappedBy: 'users')]
     protected $simpleReferenceManyInverse;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=ReferenceUser::class, mappedBy="referencedUser")
-     *
-     * @var ReferenceUser|null
-     */
+    /** @var ReferenceUser|null */
+    #[ODM\ReferenceOne(targetDocument: ReferenceUser::class, mappedBy: 'referencedUser')]
     protected $embeddedReferenceOneInverse;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=ReferenceUser::class, mappedBy="referencedUsers")
-     *
-     * @var Collection<int, ReferenceUser>
-     */
+    /** @var Collection<int, ReferenceUser> */
+    #[ODM\ReferenceMany(targetDocument: ReferenceUser::class, mappedBy: 'referencedUsers')]
     protected $embeddedReferenceManyInverse;
 
-    /**
-     * @ODM\Field(type="collection")
-     *
-     * @var string[]
-     */
+    /** @var string[] */
+    #[ODM\Field(type: 'collection')]
     private $logs = [];
 
-    /**
-     * @ODM\ReferenceOne(storeAs="dbRefWithDb")
-     *
-     * @var object|null
-     */
+    /** @var object|null */
+    #[ODM\ReferenceOne(storeAs: 'dbRefWithDb')]
     protected $referenceToAnything;
 
-    /**
-     * @ODM\ReferenceOne(storeAs="dbRef")
-     *
-     * @var object|null
-     */
+    /** @var object|null */
+    #[ODM\ReferenceOne(storeAs: 'dbRef')]
     protected $referenceToAnythingWithoutDb;
 
     public function __construct()

--- a/tests/Documents/UserName.php
+++ b/tests/Documents/UserName.php
@@ -7,34 +7,19 @@ namespace Documents;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 
-/**
- * @ODM\View(
- *     rootClass=CmsUser::class,
- *     repositoryClass=UserNameRepository::class,
- *     view="user-name"
- * )
- */
+#[ODM\View(rootClass: CmsUser::class, repositoryClass: UserNameRepository::class, view: 'user-name')]
 class UserName
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     private $username;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=ViewReference::class, name="_id", storeAs=ClassMetadata::REFERENCE_STORE_AS_ID, notSaved=true)
-     *
-     * @var ViewReference|null
-     */
+    /** @var ViewReference|null */
+    #[ODM\ReferenceOne(targetDocument: ViewReference::class, name: '_id', storeAs: ClassMetadata::REFERENCE_STORE_AS_ID, notSaved: true)]
     private $viewReference;
 
     public function getId(): ?string

--- a/tests/Documents/UserUpsert.php
+++ b/tests/Documents/UserUpsert.php
@@ -7,56 +7,33 @@ namespace Documents;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\Document(collection="users_upsert")
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("discriminator")
- * @ODM\DiscriminatorMap({
- *     "user"="Documents\UserUpsert",
- *     "child"="Documents\UserUpsertChild"
- * })
- */
+#[ODM\Document(collection: 'users_upsert')]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('discriminator')]
+#[ODM\DiscriminatorMap(['user' => 'Documents\UserUpsert', 'child' => 'Documents\UserUpsertChild'])]
 class UserUpsert
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $username;
 
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Field(type: 'int')]
     public $hits;
 
-    /**
-     * @ODM\Field(type="int", strategy="increment")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Field(type: 'int', strategy: 'increment')]
     public $count;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Group::class, cascade={"all"})
-     *
-     * @var Collection<int, Group>
-     */
+    /** @var Collection<int, Group> */
+    #[ODM\ReferenceMany(targetDocument: Group::class, cascade: ['all'])]
     public $groups;
 
-    /**
-     * @ODM\Field(type="string", nullable=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string', nullable: true)]
     public $nullableField;
 }

--- a/tests/Documents/UserUpsertChild.php
+++ b/tests/Documents/UserUpsertChild.php
@@ -6,7 +6,7 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document(collection="users_upsert") */
+#[ODM\Document(collection: 'users_upsert')]
 class UserUpsertChild extends UserUpsert
 {
 }

--- a/tests/Documents/UserUpsertIdStrategyNone.php
+++ b/tests/Documents/UserUpsertIdStrategyNone.php
@@ -7,55 +7,33 @@ namespace Documents;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\Document(collection="users_upsert_id_strategy_none")
- * @ODM\InheritanceType("SINGLE_COLLECTION")
- * @ODM\DiscriminatorField("discriminator")
- * @ODM\DiscriminatorMap({
- *     "user"="Documents\UserUpsertIdStrategyNone"
- * })
- */
+#[ODM\Document(collection: 'users_upsert_id_strategy_none')]
+#[ODM\InheritanceType('SINGLE_COLLECTION')]
+#[ODM\DiscriminatorField('discriminator')]
+#[ODM\DiscriminatorMap(['user' => 'Documents\UserUpsertIdStrategyNone'])]
 class UserUpsertIdStrategyNone
 {
-    /**
-     * @ODM\Id(strategy="none")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id(strategy: 'none')]
     public $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string')]
     public $username;
 
-    /**
-     * @ODM\Field(type="int")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Field(type: 'int')]
     public $hits;
 
-    /**
-     * @ODM\Field(type="int", strategy="increment")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Field(type: 'int', strategy: 'increment')]
     public $count;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=Group::class, cascade={"all"})
-     *
-     * @var Collection<int, Group>
-     */
+    /** @var Collection<int, Group> */
+    #[ODM\ReferenceMany(targetDocument: Group::class, cascade: ['all'])]
     public $groups;
 
-    /**
-     * @ODM\Field(type="string", nullable=true)
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Field(type: 'string', nullable: true)]
     public $nullableField;
 }

--- a/tests/Documents/VersionedDocument.php
+++ b/tests/Documents/VersionedDocument.php
@@ -8,23 +8,16 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
  * Documents\VersionedDocument
- *
- * @ODM\Document
  */
+#[ODM\Document]
 class VersionedDocument extends BaseDocument
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
+    /** @var string|null */
+    #[ODM\Id]
     protected $id;
 
-    /**
-     * @ODM\Version
-     * @ODM\Field(type="int")
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Version]
+    #[ODM\Field(type: 'int')]
     public $version;
 }

--- a/tests/Documents/VersionedUser.php
+++ b/tests/Documents/VersionedUser.php
@@ -6,18 +6,13 @@ namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/**
- * @ODM\Document(collection="users")
- * @ODM\InheritanceType("COLLECTION_PER_CLASS")
- */
+#[ODM\Document(collection: 'users')]
+#[ODM\InheritanceType('COLLECTION_PER_CLASS')]
 class VersionedUser extends User
 {
-    /**
-     * @ODM\Field(type="int")
-     * @ODM\Version
-     *
-     * @var int|null
-     */
+    /** @var int|null */
+    #[ODM\Field(type: 'int')]
+    #[ODM\Version]
     protected $version;
 
     public function getVersion(): ?int

--- a/tests/Documents/ViewReference.php
+++ b/tests/Documents/ViewReference.php
@@ -8,42 +8,27 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-/** @ODM\Document */
+#[ODM\Document]
 class ViewReference
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string
-     */
+    /** @var string */
+    #[ODM\Id]
     private $id;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=UserName::class, cascade={"persist"})
-     *
-     * @var UserName
-     */
+    /** @var UserName */
+    #[ODM\ReferenceOne(targetDocument: UserName::class, cascade: ['persist'])]
     private $referenceOneView;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=UserName::class, mappedBy="viewReference")
-     *
-     * @var UserName
-     */
+    /** @var UserName */
+    #[ODM\ReferenceOne(targetDocument: UserName::class, mappedBy: 'viewReference')]
     private $referenceOneViewMappedBy;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=UserName::class, cascade={"persist"})
-     *
-     * @var Collection<int, UserName>
-     */
+    /** @var Collection<int, UserName> */
+    #[ODM\ReferenceMany(targetDocument: UserName::class, cascade: ['persist'])]
     private $referenceManyView;
 
-    /**
-     * @ODM\ReferenceMany(targetDocument=UserName::class, mappedBy="viewReference")
-     *
-     * @var Collection<int, UserName>
-     */
+    /** @var Collection<int, UserName> */
+    #[ODM\ReferenceMany(targetDocument: UserName::class, mappedBy: 'viewReference')]
     private $referenceManyViewMappedBy;
 
     public function __construct(string $id)

--- a/tools/sandbox/Documents/Account.php
+++ b/tools/sandbox/Documents/Account.php
@@ -5,23 +5,16 @@ declare(strict_types=1);
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 
-/** @ODM\Document(collection="accounts") */
+#[ODM\Document(collection: 'accounts')]
 class Account
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
-    protected $id;
+    #[ODM\Id]
+    protected ?string $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string
-     */
-    protected $name;
+    #[ODM\Field(type: Type::STRING)]
+    protected string $name;
 
     public function __construct(string $name)
     {

--- a/tools/sandbox/Documents/Address.php
+++ b/tools/sandbox/Documents/Address.php
@@ -5,37 +5,22 @@ declare(strict_types=1);
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Address
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
-    protected $street;
+    #[ODM\Field(type: Type::STRING)]
+    protected ?string $street;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
-    protected $city;
+    #[ODM\Field(type: Type::STRING)]
+    protected ?string $city;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
-    protected $state;
+    #[ODM\Field(type: Type::STRING)]
+    protected ?string $state;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
-    protected $postalCode;
+    #[ODM\Field(type: Type::STRING)]
+    protected ?string $postalCode;
 
     public function getStreet(): ?string
     {

--- a/tools/sandbox/Documents/Phonenumber.php
+++ b/tools/sandbox/Documents/Phonenumber.php
@@ -5,16 +5,13 @@ declare(strict_types=1);
 namespace Documents;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 
-/** @ODM\EmbeddedDocument */
+#[ODM\EmbeddedDocument]
 class Phonenumber
 {
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
-    protected $phonenumber;
+    #[ODM\Field(type: Type::STRING)]
+    protected ?string $phonenumber;
 
     public function __construct(?string $phonenumber = null)
     {

--- a/tools/sandbox/Documents/User.php
+++ b/tools/sandbox/Documents/User.php
@@ -7,52 +7,30 @@ namespace Documents;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Types\Type;
 
 use function md5;
 
-/** @ODM\Document(collection="users") */
+#[ODM\Document(collection: 'users')]
 class User
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
-    protected $id;
+    #[ODM\Id]
+    protected ?string $id;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
-    private $username;
+    #[ODM\Field(type: Type::STRING)]
+    private ?string $username;
 
-    /**
-     * @ODM\Field(type="string")
-     *
-     * @var string|null
-     */
-    protected $password;
+    #[ODM\Field(type: Type::STRING)]
+    protected ?string $password;
 
-    /**
-     * @ODM\EmbedOne(targetDocument=Address::class)
-     *
-     * @var Address|null
-     */
-    protected $address;
+    #[ODM\EmbedOne(targetDocument: Address::class)]
+    protected ?Address $address;
 
-    /**
-     * @ODM\ReferenceOne(targetDocument=Account::class)
-     *
-     * @var Account|null
-     */
-    protected $account;
+    #[ODM\ReferenceOne(targetDocument: Account::class)]
+    protected ?Account $account;
 
-    /**
-     * @ODM\EmbedMany(targetDocument=Phonenumber::class)
-     *
-     * @var Collection<int, Phonenumber>
-     */
+    /** @var Collection<int, Phonenumber> */
+    #[ODM\EmbedMany(targetDocument: Phonenumber::class)]
     protected $phonenumbers;
 
     public function __construct()

--- a/tools/sandbox/config.php
+++ b/tools/sandbox/config.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
-use Symfony\Component\Cache\Adapter\ApcuAdapter;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 $file = __DIR__ . '/../../vendor/autoload.php';
 
@@ -21,7 +21,7 @@ $config->setProxyNamespace('Proxies');
 $config->setHydratorDir(__DIR__ . '/Hydrators');
 $config->setHydratorNamespace('Hydrators');
 $config->setDefaultDB('doctrine_odm_sandbox');
-$config->setMetadataCache(new ApcuAdapter());
-$config->setMetadataDriverImpl(AnnotationDriver::create(__DIR__ . '/Documents'));
+$config->setMetadataCache(new ArrayAdapter());
+$config->setMetadataDriverImpl(AttributeDriver::create(__DIR__ . '/Documents'));
 
 $dm = DocumentManager::create(null, $config);


### PR DESCRIPTION
This PR changes most of the annotations for attributes since our minimum PHP version is 8.1, the tests changed are the ones relying on `BaseTestCase::createMetadataDriverImpl()`

This builds on top of https://github.com/doctrine/mongodb-odm/pull/2502 to make sure it works fine.

[I've used rector](https://github.com/rectorphp/rector-doctrine/pull/239) with some manual adjustments.