### PR TITLE
Fix bucket typemap

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -389,7 +389,7 @@ class DocumentManager implements ObjectManager
         if (! isset($this->documentBuckets[$className])) {
             $db = $this->getDocumentDatabase($className);
 
-            $options = ['bucketName' => $bucketName];
+            $options = ['bucketName' => $bucketName, 'typeMap' => self::CLIENT_TYPEMAP];
             if ($metadata->readPreference !== null) {
                 $options['readPreference'] = new ReadPreference($metadata->readPreference, $metadata->readPreferenceTags);
             }

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
@@ -108,14 +108,14 @@ abstract class BaseTestCase extends TestCase
     protected static function createTestDocumentManager(): DocumentManager
     {
         $config = static::getConfiguration();
-        $client = new Client(getenv('DOCTRINE_MONGODB_SERVER') ?: DOCTRINE_MONGODB_SERVER, [], ['typeMap' => ['root' => 'array', 'document' => 'array']]);
+        $client = new Client(getenv('DOCTRINE_MONGODB_SERVER') ?: DOCTRINE_MONGODB_SERVER);
 
         return DocumentManager::create($client, $config);
     }
 
     protected function getServerVersion(): string
     {
-        $result = $this->dm->getClient()->selectDatabase(DOCTRINE_MONGODB_DATABASE)->command(['buildInfo' => 1])->toArray()[0];
+        $result = $this->dm->getClient()->selectDatabase(DOCTRINE_MONGODB_DATABASE)->command(['buildInfo' => 1], ['typeMap' => DocumentManager::CLIENT_TYPEMAP])->toArray()[0];
 
         return $result['version'];
     }
@@ -123,7 +123,7 @@ abstract class BaseTestCase extends TestCase
     /** @psalm-param class-string $className */
     protected function skipTestIfNotSharded(string $className): void
     {
-        $result = $this->dm->getDocumentDatabase($className)->command(['listCommands' => true])->toArray()[0];
+        $result = $this->dm->getDocumentDatabase($className)->command(['listCommands' => true], ['typeMap' => DocumentManager::CLIENT_TYPEMAP])->toArray()[0];
 
         if (array_key_exists('shardCollection', $result['commands'])) {
             return;
@@ -135,7 +135,7 @@ abstract class BaseTestCase extends TestCase
     /** @psalm-param class-string $className */
     protected function skipTestIfSharded(string $className): void
     {
-        $result = $this->dm->getDocumentDatabase($className)->command(['listCommands' => true])->toArray()[0];
+        $result = $this->dm->getDocumentDatabase($className)->command(['listCommands' => true], ['typeMap' => DocumentManager::CLIENT_TYPEMAP])->toArray()[0];
 
         if (! array_key_exists('shardCollection', $result['commands'])) {
             return;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/EnsureShardingTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Sharded\ShardedByUser;
@@ -31,7 +32,7 @@ class EnsureShardingTest extends BaseTestCase
 
         $collection = $this->dm->getDocumentCollection($class);
         $indexes    = iterator_to_array($collection->listIndexes());
-        $stats      = $this->dm->getDocumentDatabase($class)->command(['collstats' => $collection->getCollectionName()])->toArray()[0];
+        $stats      = $this->dm->getDocumentDatabase($class)->command(['collstats' => $collection->getCollectionName()], ['typeMap' => DocumentManager::CLIENT_TYPEMAP])->toArray()[0];
 
         self::assertCount(2, $indexes);
         self::assertSame(['k' => 1], $indexes[1]['key']);
@@ -45,7 +46,7 @@ class EnsureShardingTest extends BaseTestCase
 
         $collection = $this->dm->getDocumentCollection($class);
         $indexes    = iterator_to_array($collection->listIndexes());
-        $stats      = $this->dm->getDocumentDatabase($class)->command(['collstats' => $collection->getCollectionName()])->toArray()[0];
+        $stats      = $this->dm->getDocumentDatabase($class)->command(['collstats' => $collection->getCollectionName()], ['typeMap' => DocumentManager::CLIENT_TYPEMAP])->toArray()[0];
 
         self::assertCount(2, $indexes);
         self::assertSame(['k' => 1], $indexes[1]['key']);
@@ -64,7 +65,7 @@ class EnsureShardingTest extends BaseTestCase
         $this->dm->getSchemaManager()->ensureDocumentSharding($class);
 
         $collection = $this->dm->getDocumentCollection($class);
-        $stats      = $this->dm->getDocumentDatabase($class)->command(['collstats' => $collection->getCollectionName()])->toArray()[0];
+        $stats      = $this->dm->getDocumentDatabase($class)->command(['collstats' => $collection->getCollectionName()], ['typeMap' => DocumentManager::CLIENT_TYPEMAP])->toArray()[0];
 
         self::assertTrue($stats['sharded']);
     }
@@ -83,7 +84,7 @@ class EnsureShardingTest extends BaseTestCase
         $this->dm->getSchemaManager()->ensureDocumentSharding($class);
 
         $collection = $this->dm->getDocumentCollection($class);
-        $stats      = $this->dm->getDocumentDatabase($class)->command(['collstats' => $collection->getCollectionName()])->toArray()[0];
+        $stats      = $this->dm->getDocumentDatabase($class)->command(['collstats' => $collection->getCollectionName()], ['typeMap' => DocumentManager::CLIENT_TYPEMAP])->toArray()[0];
 
         self::assertFalse($stats['sharded']);
     }
@@ -97,7 +98,7 @@ class EnsureShardingTest extends BaseTestCase
         $this->dm->getSchemaManager()->ensureDocumentSharding(ShardedOne::class);
 
         $collection = $this->dm->getDocumentCollection($class);
-        $stats      = $this->dm->getDocumentDatabase($class)->command(['collstats' => $collection->getCollectionName()])->toArray()[0];
+        $stats      = $this->dm->getDocumentDatabase($class)->command(['collstats' => $collection->getCollectionName()], ['typeMap' => DocumentManager::CLIENT_TYPEMAP])->toArray()[0];
 
         self::assertTrue($stats['sharded']);
     }
@@ -110,7 +111,7 @@ class EnsureShardingTest extends BaseTestCase
         $this->dm->getSchemaManager()->ensureDocumentSharding($class);
 
         $collection = $this->dm->getDocumentCollection($class);
-        $stats      = $this->dm->getDocumentDatabase($class)->command(['collstats' => $collection->getCollectionName()])->toArray()[0];
+        $stats      = $this->dm->getDocumentDatabase($class)->command(['collstats' => $collection->getCollectionName()], ['typeMap' => DocumentManager::CLIENT_TYPEMAP])->toArray()[0];
         $indexes    = iterator_to_array($collection->listIndexes());
 
         self::assertTrue($stats['sharded']);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Repository/DefaultGridFSRepositoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Repository/DefaultGridFSRepositoryTest.php
@@ -279,6 +279,21 @@ class DefaultGridFSRepositoryTest extends BaseTestCase
         self::assertSame(261120, $file->getChunkSize());
     }
 
+    public function testReadingFileWithMetadata(): void
+    {
+        $uploadOptions                                = new UploadOptions();
+        $uploadOptions->metadata                      = new FileMetadata();
+        $uploadOptions->metadata->getEmbedOne()->name = 'foo';
+
+        $file = $this->getRepository()->uploadFromFile(__FILE__, uploadOptions: $uploadOptions);
+        $this->dm->detach($file);
+
+        $retrievedFile = $this->getRepository()->find($file->getId());
+        self::assertInstanceOf(File::class, $retrievedFile);
+        self::assertInstanceOf(FileMetadata::class, $retrievedFile->getMetadata());
+        self::assertSame('foo', $retrievedFile->getMetadata()->getEmbedOne()->name);
+    }
+
     /**
      * @param class-string<T> $className
      *


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2599 

#### Summary

Fixes an issue introduced in #2288. The type map was not correctly applied to GridFS buckets, so if the document manager was created without the explicit type map (which was required before #2288), GridFS metadata relationships were broken. I've also removed the `typeMap` option when creating the document manager in tests to ensure the issue doesn't stay hidden.