### PR TITLE
Only retry transaction once

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -621,6 +621,11 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/UnitOfWork.php
 
 		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\UnitOfWork\\:\\:withTransaction\\(\\) has parameter \\$transactionOptions with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+
+		-
 			message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getClassMetadata\\(\\)$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/UnitOfWork.php


### PR DESCRIPTION
This PR adds a modified implementation of MongoDB's [Convenient Transaction API](https://github.com/mongodb/specifications/blob/master/source/transactions-convenient-api/transactions-convenient-api.rst) specification that is better suited for our use case. When encountering transient errors, the convenient API will retry the transaction for up to 120 seconds. The only way to change this time limit is by using the `timeoutMS` option specified in the [Client Side Operations Timeout (CSOT)](https://github.com/mongodb/specifications/blob/master/source/client-side-operations-timeout/client-side-operations-timeout.md) specification. However, libmongoc and thus by extension the PHP driver do not yet implement this specification, so users have no way of reducing the time `with_transaction` will potentially take. Since 120 seconds is not a good default timeout in a web context and users of the ODM will most likely want to abort sooner on transient errors, a custom implementation is needed.

The implementation in this PR takes the entire logic of the convenient transaction API, but only allows the closure to be run twice, meaning that transient command errors will lead to a single retry. For the time being, the amount of retries is not configurable, but this can be added later. I would like to avoid introducing a config setting unless absolutely needed so that we remain flexible to switch back to using the API provided by the driver once it implements the CSOT specification.