### PR TITLE
Add transactional helper to DocumentManager

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB;
 
+use Closure;
 use Doctrine\Common\EventManager;
 use Doctrine\ODM\MongoDB\Hydrator\HydratorFactory;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
@@ -881,6 +882,22 @@ class DocumentManager implements ObjectManager
         }
 
         return $this->filterCollection;
+    }
+
+    /**
+     * @psalm-param Closure():T $closure
+     *
+     * @return mixed
+     * @psalm-return T
+     *
+     * @psalm-template T
+     */
+    public function transactional(Closure $closure)
+    {
+        $return = $closure();
+        $this->flush(['withTransaction' => true]);
+
+        return $return;
     }
 
     private static function getVersion(): string

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
@@ -253,4 +253,29 @@ abstract class BaseTestCase extends TestCase
 
         return $manager->selectServer()->getType() !== Server::TYPE_STANDALONE;
     }
+
+    protected function createFatalFailPoint(string $failCommand): void
+    {
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => ['times' => 1],
+            'data' => [
+                'errorCode' => 192, // FailPointEnabled
+                'failCommands' => [$failCommand],
+            ],
+        ]);
+    }
+
+    protected function createTransientFailPoint(string $failCommand, int $times = 1): void
+    {
+        $this->dm->getClient()->selectDatabase('admin')->command([
+            'configureFailPoint' => 'failCommand',
+            'mode' => ['times' => $times],
+            'data' => [
+                'errorCode' => 192, // FailPointEnabled
+                'errorLabels' => ['TransientTransactionError'],
+                'failCommands' => [$failCommand],
+            ],
+        ]);
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTransactionalCommitConsistencyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTransactionalCommitConsistencyTest.php
@@ -577,29 +577,4 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
 
         return $configuration;
     }
-
-    private function createTransientFailPoint(string $failCommand, int $times = 1): void
-    {
-        $this->dm->getClient()->selectDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => ['times' => $times],
-            'data' => [
-                'errorCode' => 192, // FailPointEnabled
-                'errorLabels' => ['TransientTransactionError'],
-                'failCommands' => [$failCommand],
-            ],
-        ]);
-    }
-
-    private function createFatalFailPoint(string $failCommand): void
-    {
-        $this->dm->getClient()->selectDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => ['times' => 1],
-            'data' => [
-                'errorCode' => 192, // FailPointEnabled
-                'failCommands' => [$failCommand],
-            ],
-        ]);
-    }
 }


### PR DESCRIPTION
This PR adds a `transactional` method to the `DocumentManager` class, similar to the one present in ORM's `EntityManager`. However, the transaction is not started before closure execution, but only during the `flush` operation. This is due to MongoDB's different handling of transactions, which would entail invoking the closure multiple times (which does not happen in ORM). It would also require us to add detection logic in UnitOfWork to not start a new transaction is already in progress (which can lead to issues in other places), and it would also require a different closure signature, as the transaction is not bound to the connection but rather to a session, which would then have to be passed to all operations that happen within a transaction.