### PR TITLE
Allow elements from other namespaces

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -103,6 +103,7 @@
       <xs:element name="shard-key" type="odm:shard-key" minOccurs="0" />
       <xs:element name="read-preference" type="odm:read-preference" minOccurs="0" />
       <xs:element name="schema-validation" type="odm:schema-validation" minOccurs="0" />
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:choice>
 
     <xs:attribute name="db" type="xs:NMTOKEN" />

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
@@ -8,6 +8,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use ReflectionMethod;
 use SimpleXMLElement;
 use stdClass;
@@ -50,4 +51,20 @@ class XmlMappingDriverTest extends AbstractMappingDriverTestCase
 
         $mappingDriver->loadMetadataForClass($className, $class);
     }
+
+    #[DoesNotPerformAssertions]
+    public function testExtensionTagsAreAllowedWhenNamespaced(): void
+    {
+        $className     = DocumentWithExtension::class;
+        $mappingDriver = $this->loadDriver();
+
+        $class = new ClassMetadata($className);
+
+        $mappingDriver->loadMetadataForClass($className, $class);
+    }
+}
+
+class DocumentWithExtension
+{
+    public ?string $id;
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.DocumentWithExtension.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.DocumentWithExtension.dcm.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping
+    xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping"
+    xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+    http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd"
+>
+    <document name="Doctrine\ODM\MongoDB\Tests\Mapping\DocumentWithExtension">
+        <field name="id"/>
+        <gedmo:loggable/>
+    </document>
+</doctrine-mongo-mapping>


### PR DESCRIPTION
This is how we should ideally allow extensions to be combined with ODM's schema. Sadly, this does not work and it seems work on extensions' maintainers is needed anyway :( 

Cross referencing https://github.com/doctrine-extensions/DoctrineExtensions/issues/2318