### PR TITLE
Drop support for MongoDB 4.4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,6 @@ jobs:
           - "7.0"
           - "6.0"
           - "5.0"
-          - "4.4"
         driver-version:
           - "stable"
         topology:
@@ -38,7 +37,7 @@ jobs:
           # Test against lowest dependencies
           - dependencies: "lowest"
             php-version: "8.1"
-            mongodb-version: "4.4"
+            mongodb-version: "5.0"
             driver-version: "1.11.0"
             topology: "server"
             symfony-version: "stable"
@@ -49,17 +48,17 @@ jobs:
             driver-version: "stable"
             dependencies: "highest"
             symfony-version: "7"
-          # Test with a 4.4 replica set
+          # Test with a 5.0 replica set
           - topology: "replica_set"
             php-version: "8.2"
-            mongodb-version: "4.4"
+            mongodb-version: "5.0"
             driver-version: "stable"
             dependencies: "highest"
             symfony-version: "stable"
-          # Test with a 4.4 sharded cluster
+          # Test with a 5.0 sharded cluster
           - topology: "sharded_cluster"
             php-version: "8.2"
-            mongodb-version: "4.4"
+            mongodb-version: "5.0"
             driver-version: "stable"
             dependencies: "highest"
             symfony-version: "stable"

--- a/docs/en/reference/transactions-and-concurrency.rst
+++ b/docs/en/reference/transactions-and-concurrency.rst
@@ -15,8 +15,7 @@ atomic, the operation as a whole is not and other operations may interleave.
 Transaction support
 ~~~~~~~~~~~~~~~~~~~
 
-MongoDB supports multi-document transactions on replica sets (starting in MongoDB 4.2) and sharded clusters (MongoDB
-4.4). Standalone topologies do not support multi-document transactions.
+MongoDB supports multi-document transactions on replica sets and sharded clusters. Standalone topologies do not support multi-document transactions.
 
 Transaction Support in Doctrine MongoDB ODM
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
MongoDB 4.4 reached its EOL in February so let's make the CI lighter for upcoming version

