### PR TITLE
Fix deprecation notices Indexes annotation

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
@@ -241,6 +241,14 @@ class AttributeDriver implements MappingDriver
                 }
 
                 if ($propertyAttribute instanceof ODM\Indexes) {
+                    trigger_deprecation(
+                        'doctrine/mongodb-odm',
+                        '2.2',
+                        'The "@Indexes" attribute used in property "%s" of class "%s" is deprecated. Specify all "@Index" and "@UniqueIndex" attributes on the class.',
+                        $property->getName(),
+                        $className,
+                    );
+
                     $value = $propertyAttribute->value;
                     foreach (is_array($value) ? $value : [$value] as $index) {
                         $indexes[] = $index;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
@@ -205,8 +205,8 @@ class AttributeDriver implements MappingDriver
                 'doctrine/mongodb-odm',
                 '2.2',
                 'The "indexes" parameter in the "%s" attribute for class "%s" is deprecated. Specify all "@Index" and "@UniqueIndex" attributes on the class.',
-                $className,
                 $documentAttribute::class,
+                $className,
             );
 
             foreach ($documentAttribute->indexes as $index) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
@@ -5,8 +5,18 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+
+use function call_user_func;
+use function restore_error_handler;
+use function set_error_handler;
+use function sprintf;
+
+use const E_USER_DEPRECATED;
 
 class AnnotationDriverTest extends AbstractAnnotationDriverTestCase
 {
@@ -16,4 +26,125 @@ class AnnotationDriverTest extends AbstractAnnotationDriverTestCase
 
         return new AnnotationDriver($reader);
     }
+
+    public function testIndexesClassAnnotationEmitsDeprecationMessage(): void
+    {
+        $driver        = static::loadDriver();
+        $classMetadata = new ClassMetadata(DeprecatedIndexesClassAnnotation::class);
+
+        $this->captureDeprecationMessages(
+            static fn () => $driver->loadMetadataForClass($classMetadata->name, $classMetadata),
+            $errors,
+        );
+
+        self::assertCount(1, $errors);
+        self::assertSame(sprintf('Since doctrine/mongodb-odm 2.2: The "@Indexes" attribute used in class "%s" is deprecated. Specify all "@Index" and "@UniqueIndex" attributes on the class.', DeprecatedIndexesClassAnnotation::class), $errors[0]);
+
+        $indexes = $classMetadata->indexes;
+
+        self::assertTrue(isset($indexes[0]['keys']['foo']));
+        self::assertEquals(1, $indexes[0]['keys']['foo']);
+    }
+
+    public function testIndexesOptionOfDocumentClassAnnotationEmitsDeprecationMessage(): void
+    {
+        $driver        = static::loadDriver();
+        $classMetadata = new ClassMetadata(DeprecatedDocumentClassAnnotationIndexesOption::class);
+
+        $this->captureDeprecationMessages(
+            static fn () => $driver->loadMetadataForClass($classMetadata->name, $classMetadata),
+            $errors,
+        );
+
+        self::assertCount(1, $errors);
+        self::assertSame(sprintf('Since doctrine/mongodb-odm 2.2: The "indexes" parameter in the "%s" attribute for class "%s" is deprecated. Specify all "@Index" and "@UniqueIndex" attributes on the class.', Document::class, DeprecatedDocumentClassAnnotationIndexesOption::class), $errors[0]);
+
+        $indexes = $classMetadata->indexes;
+
+        self::assertTrue(isset($indexes[0]['keys']['foo']));
+        self::assertEquals(1, $indexes[0]['keys']['foo']);
+    }
+
+    public function testIndexesPropertyAnnotationEmitsDeprecationMessage(): void
+    {
+        $driver        = static::loadDriver();
+        $classMetadata = new ClassMetadata(DeprecatedIndexesPropertyAnnotation::class);
+
+        $this->captureDeprecationMessages(
+            static fn () => $driver->loadMetadataForClass($classMetadata->name, $classMetadata),
+            $errors,
+        );
+
+        self::assertCount(1, $errors);
+        self::assertSame(sprintf('Since doctrine/mongodb-odm 2.2: The "@Indexes" attribute used in property "foo" of class "%s" is deprecated. Specify all "@Index" and "@UniqueIndex" attributes on the class.', DeprecatedIndexesPropertyAnnotation::class), $errors[0]);
+
+        $indexes = $classMetadata->indexes;
+
+        self::assertTrue(isset($indexes[0]['keys']['foo']));
+        self::assertEquals(1, $indexes[0]['keys']['foo']);
+    }
+
+    /** @param list<string>|null $errors */
+    private function captureDeprecationMessages(callable $callable, ?array &$errors): mixed
+    {
+        /* TODO: this method can be replaced with expectUserDeprecationMessage() in PHPUnit 11+.
+         * See: https://docs.phpunit.de/en/11.1/error-handling.html#expecting-deprecations-e-user-deprecated */
+        $errors = [];
+
+        set_error_handler(static function (int $errno, string $errstr) use (&$errors): bool {
+            $errors[] = $errstr;
+
+            return false;
+        }, E_USER_DEPRECATED);
+
+        try {
+            return call_user_func($callable);
+        } finally {
+            restore_error_handler();
+        }
+    }
+}
+
+/**
+ * @ODM\Document
+ * @ODM\Indexes({
+ *   @ODM\Index(keys={"foo"="asc"})
+ * })
+ */
+class DeprecatedIndexesClassAnnotation
+{
+    /** @ODM\Id */
+    public ?string $id;
+
+    /** @ODM\Field(type="string") */
+    public string $foo;
+}
+
+/**
+ * @ODM\Document(indexes={
+ *   @ODM\Index(keys={"foo"="asc"})
+ * })
+ */
+class DeprecatedDocumentClassAnnotationIndexesOption
+{
+    /** @ODM\Id */
+    public ?string $id;
+
+    /** @ODM\Field(type="string") */
+    public string $foo;
+}
+
+/** @ODM\Document */
+class DeprecatedIndexesPropertyAnnotation
+{
+    /** @ODM\Id */
+    public ?string $id;
+
+    /**
+     * @ODM\Field(type="string")
+     * @ODM\Indexes({
+     *   @ODM\Index
+     * })
+     */
+    public string $foo;
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Related issues | #2235, #2249

#### Summary

The `Indexes` attribute/annotation was deprecated in [doctrine/mongodb-odm@7435e66](https://github.com/doctrine/mongodb-odm/commit/7435e66b974130931b3a4acadb492fe572ff9298) for 2.2. There were deprecation messages added for using `Indexes` at the class level, and `indexes` within the Document annotation; however, it looks like Indexes on the property level was [missed](https://github.com/doctrine/mongodb-odm/blob/7435e66b974130931b3a4acadb492fe572ff9298/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php#L189).

Also, one of the deprecation messages got screwed up in [doctrine/mongodb-odm@3bdfe97](https://github.com/doctrine/mongodb-odm/commit/3bdfe97be472160ebbc924d5882ce61bd640a515#diff-65de5973d8c41abd6a3cc14c862908909d49367a01216544630b343b500929d1R153). The message changed but the sprintf args weren't swapped to account for that.

I struggled to add tests for this because:

 * `trigger_deprecation` calls `@trigger_error()`, so output is silenced. I could theoretically use [`error_get_last()`](https://www.php.net/manual/en/function.error-get-last.php) to check for the deprecation message, but there's no prior art for doing so. In fact, no deprecation messages seem to be tested.
 * The `Indexes` attribute cannot target a property, so the property-level deprecation message could only trigger when using it as annotation.
 * I couldn't discern the syntax for using `Indexes` as a class-level attribute with `Index` nested within. I consulted doctrine/orm#9241 some some examples of nesting attributes, but all of my attempts resulted in exceptions (e.g. `$value` property of `Indexes` couldn't be set).

For manual testing of the annotation form, this is what I used:

```php
/**
 * @ODM\Document
 * @ODM\Indexes({
 *   @ODM\Index(keys={"foo"="asc"})
 * })
 */
class DeprecatedIndexesAttributeOnClass
{
    /**
     * @ODM\Field(type="string")
     * @ODM\Indexes({
     *   @ODM\Index()
     * })
     */
    public string $foo;
}
```