### PR TITLE
Ensure data provider params are consistent with test methods

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -607,19 +607,19 @@ class DocumentPersisterTest extends BaseTestCase
     {
         return [
             'default' => [
-                'className' => DocumentPersisterTestDocument::class,
+                'class' => DocumentPersisterTestDocument::class,
                 'writeConcern' => 1,
             ],
             'acknowledged' => [
-                'className' => DocumentPersisterWriteConcernAcknowledged::class,
+                'class' => DocumentPersisterWriteConcernAcknowledged::class,
                 'writeConcern' => 1,
             ],
             'unacknowledged' => [
-                'className' => DocumentPersisterWriteConcernUnacknowledged::class,
+                'class' => DocumentPersisterWriteConcernUnacknowledged::class,
                 'writeConcern' => 0,
             ],
             'majority' => [
-                'className' => DocumentPersisterWriteConcernMajority::class,
+                'class' => DocumentPersisterWriteConcernMajority::class,
                 'writeConcern' => 'majority',
             ],
         ];


### PR DESCRIPTION
This addresses a deprecation notice that was introduced in PHPUnit 10.5.18

This is a backport of https://github.com/doctrine/mongodb-odm/pull/2623, per @malarzm's suggestion. PHPUnit 10 was introduced in https://github.com/doctrine/mongodb-odm/commit/0aa0e7b9ee31148a0e522aa1fb42fb7f4459c2c8 for 2.6.0.

Changes have already been reviewed, so I'll merge pending a clear CI result.