### PR TITLE
Label PRs about GH actions with "CI"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "CI"


### PR DESCRIPTION
People that read the changelog might get confused if they find those under "dependencies".
