### PR TITLE
Preserve collection changes until transaction has succeeded

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1512,14 +1512,11 @@ final class DocumentPersister
             $collections[] = $coll;
         }
 
-        if (! empty($collections)) {
-            $this->cp->update($document, $collections, $options);
+        if (empty($collections)) {
+            return;
         }
 
-        // Take new snapshots from visited collections
-        foreach ($this->uow->getVisitedCollections($document) as $coll) {
-            $coll->takeSnapshot();
-        }
+        $this->cp->update($document, $collections, $options);
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -477,6 +477,12 @@ final class UnitOfWork implements PropertyChangedListener
             $this->evm->dispatchEvent(Events::postFlush, new Event\PostFlushEventArgs($this->dm));
 
             // Clear up
+            foreach ($this->visitedCollections as $collections) {
+                foreach ($collections as $coll) {
+                    $coll->takeSnapshot();
+                }
+            }
+
             $this->scheduledDocumentInsertions  =
             $this->scheduledDocumentUpserts     =
             $this->scheduledDocumentUpdates     =


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

While debugging test failures on sharded clusters, I noticed that UnitOfWork loses track of collection changes if a subsequent operation fails. This is due to collection snapshots being taken directly after a document operation, which means the collection sees itself as unmodified when the transaction is retried.

To fix this, we need to hold off on taking collection snapshots until all writes have completed. Unfortunately, this means that the behaviour for collections modified in `post` events changes. Previously, these collections were considered dirty, whereas they are now considered clean. Note that it is not advised to change documents in `post`, as other operations may or may not influenced by such operations, depending on execution order.

Fixing this would require us to compute collection changes way earlier in the flow, which would also change the expectation that changes to collections happening in `pre` events are properly handled. As there is no good way of fixing this, I'm more comfortable breaking the flow of changing collections in `post` rather than in `pre`.
