### PR TITLE
Fix of static analysis errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,12 +42,12 @@
         "doctrine/coding-standard": "^12.0",
         "jmikola/geojson": "^1.0",
         "phpbench/phpbench": "^1.0.0",
-        "phpstan/phpstan": "^1.10.11",
+        "phpstan/phpstan": "~1.10.67",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^10.4",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/cache": "^5.4 || ^6.0 || ^7.0",
-        "vimeo/psalm": "^5.9.0"
+        "vimeo/psalm": "~5.24.0"
     },
     "conflict": {
         "doctrine/annotations": "<1.12 || >=3.0"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -296,9 +296,6 @@
     <NullableReturnStatement>
       <code><![CDATA[$mapping['targetDocument']]]></code>
     </NullableReturnStatement>
-    <TypeDoesNotContainType>
-      <code><![CDATA[empty($divided[$class->name])]]></code>
-    </TypeDoesNotContainType>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnsetTest.php">
     <InvalidArgument>
@@ -487,9 +484,6 @@
     <InvalidArgument>
       <code><![CDATA[$options + $expectedWriteOptions]]></code>
     </InvalidArgument>
-    <TypeDoesNotContainType>
-      <code><![CDATA[empty($dbCommands[$databaseName])]]></code>
-    </TypeDoesNotContainType>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Types/DateImmutableTypeTest.php">
     <TypeDoesNotContainType>


### PR DESCRIPTION
Fixes Static analysis errors

|      Q       |   A
|------------- | -----------
| Type         | bug/improvement
| BC Break     | no

#### Summary

Static analysis does fail because there are fixes in new versions that the composer constraint allows. I reduce the constraints' range a bit with this PR and fix the psalm baseline.
