### PR TITLE
Decouple UnitOfWork from Hydrators

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -179,8 +179,7 @@ class DocumentManager implements ObjectManager
             $this->config->getAutoGenerateHydratorClasses(),
         );
 
-        $this->unitOfWork = new UnitOfWork($this, $this->eventManager, $this->hydratorFactory);
-        $this->hydratorFactory->setUnitOfWork($this->unitOfWork);
+        $this->unitOfWork        = new UnitOfWork($this, $this->eventManager, $this->hydratorFactory);
         $this->schemaManager     = new SchemaManager($this, $this->metadataFactory);
         $this->proxyFactory      = new StaticProxyFactory($this);
         $this->repositoryFactory = $this->config->getRepositoryFactory();

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -368,7 +368,6 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Hydrator\HydratorException;
 use Doctrine\ODM\MongoDB\Hydrator\HydratorInterface;
 use Doctrine\ODM\MongoDB\Query\Query;
-use Doctrine\ODM\MongoDB\UnitOfWork;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 
 /**

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -232,7 +232,7 @@ EOF
                     throw HydratorException::associationTypeMismatch('%3$s', '%1$s', 'array', gettype($return));
                 }
 
-                $className = $this->dm->getUnitOfWork()->getClassNameForAssociation($this->class->fieldMappings['%2$s'], $return);
+                $className = $this->dm->getClassNameForAssociation($this->class->fieldMappings['%2$s'], $return);
                 $identifier = ClassMetadata::getReferenceId($return, $this->class->fieldMappings['%2$s']['storeAs']);
                 $targetMetadata = $this->dm->getClassMetadata($className);
                 $id = $targetMetadata->getPHPIdentifierValue($identifier);
@@ -330,7 +330,7 @@ EOF
                     throw HydratorException::associationTypeMismatch('%3$s', '%1$s', 'array', gettype($embeddedDocument));
                 }
         
-                $className = $this->dm->getUnitOfWork()->getClassNameForAssociation($this->class->fieldMappings['%2$s'], $embeddedDocument);
+                $className = $this->dm->getClassNameForAssociation($this->class->fieldMappings['%2$s'], $embeddedDocument);
                 $embeddedMetadata = $this->dm->getClassMetadata($className);
                 $return = $embeddedMetadata->newInstance();
 

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -696,7 +696,7 @@ final class DocumentPersister
         }
 
         foreach ($embeddedDocuments as $key => $embeddedDocument) {
-            $className              = $this->uow->getClassNameForAssociation($mapping, $embeddedDocument);
+            $className              = $this->dm->getClassNameForAssociation($mapping, $embeddedDocument);
             $embeddedMetadata       = $this->dm->getClassMetadata($className);
             $embeddedDocumentObject = $embeddedMetadata->newInstance();
 
@@ -735,7 +735,7 @@ final class DocumentPersister
         $sorted = isset($mapping['sort']) && $mapping['sort'];
 
         foreach ($collection->getMongoData() as $key => $reference) {
-            $className = $this->uow->getClassNameForAssociation($mapping, $reference);
+            $className = $this->dm->getClassNameForAssociation($mapping, $reference);
 
             if ($mapping['storeAs'] !== ClassMetadata::REFERENCE_STORE_AS_ID && ! is_array($reference)) {
                 throw HydratorException::associationItemTypeMismatch($owner::class, $mapping['name'], $key, 'array', gettype($reference));

--- a/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/ReferencePrimer.php
@@ -258,7 +258,7 @@ final class ReferencePrimer
             $id = ClassMetadata::getReferenceId($reference, $mapping['storeAs']);
 
             if ($mapping['storeAs'] !== ClassMetadata::REFERENCE_STORE_AS_ID) {
-                $className = $this->uow->getClassNameForAssociation($mapping, $reference);
+                $className = $this->dm->getClassNameForAssociation($mapping, $reference);
                 $class     = $this->dm->getClassMetadata($className);
             }
 

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2728,48 +2728,6 @@ final class UnitOfWork implements PropertyChangedListener
     }
 
     /**
-     * Gets the class name for an association (embed or reference) with respect
-     * to any discriminator value.
-     *
-     * @internal
-     *
-     * @param FieldMapping              $mapping
-     * @param array<string, mixed>|null $data
-     *
-     * @psalm-return class-string
-     */
-    public function getClassNameForAssociation(array $mapping, $data): string
-    {
-        $discriminatorField = $mapping['discriminatorField'] ?? null;
-
-        $discriminatorValue = null;
-        if (isset($discriminatorField, $data[$discriminatorField])) {
-            $discriminatorValue = $data[$discriminatorField];
-        } elseif (isset($mapping['defaultDiscriminatorValue'])) {
-            $discriminatorValue = $mapping['defaultDiscriminatorValue'];
-        }
-
-        if ($discriminatorValue !== null) {
-            return $mapping['discriminatorMap'][$discriminatorValue]
-                ?? (string) $discriminatorValue;
-        }
-
-        $class = $this->dm->getClassMetadata($mapping['targetDocument']);
-
-        if (isset($class->discriminatorField, $data[$class->discriminatorField])) {
-            $discriminatorValue = $data[$class->discriminatorField];
-        } elseif ($class->defaultDiscriminatorValue !== null) {
-            $discriminatorValue = $class->defaultDiscriminatorValue;
-        }
-
-        if ($discriminatorValue !== null) {
-            return $class->discriminatorMap[$discriminatorValue] ?? $discriminatorValue;
-        }
-
-        return $mapping['targetDocument'];
-    }
-
-    /**
      * Creates a document. Used for reconstitution of documents during hydration.
      *
      * @psalm-param class-string<T> $className

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -28,6 +28,9 @@
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[ClassMetadataFactoryInterface]]></code>
     </ImplementedReturnTypeMismatch>
+    <NullableReturnStatement>
+      <code><![CDATA[$mapping['targetDocument']]]></code>
+    </NullableReturnStatement>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Event/OnClearEventArgs.php">
     <TooManyArguments>
@@ -296,9 +299,6 @@
     <InvalidReturnType>
       <code><![CDATA[array<class-string, array{0: ClassMetadata<object>, 1: array<string, object>}>]]></code>
     </InvalidReturnType>
-    <NullableReturnStatement>
-      <code><![CDATA[$mapping['targetDocument']]]></code>
-    </NullableReturnStatement>
   </file>
   <file src="tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/UnsetTest.php">
     <InvalidArgument>

--- a/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/DocumentManagerTest.php
@@ -26,6 +26,7 @@ use Documents\CmsPhonenumber;
 use Documents\CmsUser;
 use Documents\CustomRepository\Document;
 use Documents\CustomRepository\Repository;
+use Documents\ForumUser;
 use Documents\Tournament\Participant;
 use Documents\Tournament\ParticipantSolo;
 use Documents\User;
@@ -228,6 +229,37 @@ class DocumentManagerTest extends BaseTestCase
         self::assertIsArray($dbRef);
         self::assertCount(1, $dbRef);
         self::assertArrayHasKey('id', $dbRef);
+    }
+
+    public function testGetClassNameForAssociation(): void
+    {
+        $mapping = ClassMetadataTestUtil::getFieldMapping([
+            'discriminatorField' => 'type',
+            'discriminatorMap' => ['forum_user' => ForumUser::class],
+            'targetDocument' => User::class,
+        ]);
+        $data    = ['type' => 'forum_user'];
+
+        self::assertEquals(ForumUser::class, $this->dm->getClassNameForAssociation($mapping, $data));
+    }
+
+    public function testGetClassNameForAssociationWithClassMetadataDiscriminatorMap(): void
+    {
+        $mapping = ClassMetadataTestUtil::getFieldMapping(['targetDocument' => User::class]);
+        $data    = ['type' => 'forum_user'];
+
+        $userClassMetadata                     = new ClassMetadata(ForumUser::class);
+        $userClassMetadata->discriminatorField = 'type';
+        $userClassMetadata->discriminatorMap   = ['forum_user' => ForumUser::class];
+        $this->dm->getMetadataFactory()->setMetadataFor(User::class, $userClassMetadata);
+
+        self::assertEquals(ForumUser::class, $this->dm->getClassNameForAssociation($mapping, $data));
+    }
+
+    public function testGetClassNameForAssociationReturnsTargetDocumentWithNullData(): void
+    {
+        $mapping = ClassMetadataTestUtil::getFieldMapping(['targetDocument' => User::class]);
+        self::assertEquals(User::class, $this->dm->getClassNameForAssociation($mapping, null));
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -475,37 +475,6 @@ class UnitOfWorkTest extends BaseTestCase
         self::assertEquals('Nashville', $changeSet['city'][1]);
     }
 
-    public function testGetClassNameForAssociation(): void
-    {
-        $mapping = ClassMetadataTestUtil::getFieldMapping([
-            'discriminatorField' => 'type',
-            'discriminatorMap' => ['forum_user' => ForumUser::class],
-            'targetDocument' => User::class,
-        ]);
-        $data    = ['type' => 'forum_user'];
-
-        self::assertEquals(ForumUser::class, $this->uow->getClassNameForAssociation($mapping, $data));
-    }
-
-    public function testGetClassNameForAssociationWithClassMetadataDiscriminatorMap(): void
-    {
-        $mapping = ClassMetadataTestUtil::getFieldMapping(['targetDocument' => User::class]);
-        $data    = ['type' => 'forum_user'];
-
-        $userClassMetadata                     = new ClassMetadata(ForumUser::class);
-        $userClassMetadata->discriminatorField = 'type';
-        $userClassMetadata->discriminatorMap   = ['forum_user' => ForumUser::class];
-        $this->dm->getMetadataFactory()->setMetadataFor(User::class, $userClassMetadata);
-
-        self::assertEquals(ForumUser::class, $this->uow->getClassNameForAssociation($mapping, $data));
-    }
-
-    public function testGetClassNameForAssociationReturnsTargetDocumentWithNullData(): void
-    {
-        $mapping = ClassMetadataTestUtil::getFieldMapping(['targetDocument' => User::class]);
-        self::assertEquals(User::class, $this->uow->getClassNameForAssociation($mapping, null));
-    }
-
     public function testRecomputeChangesetForUninitializedProxyDoesNotCreateChangeset(): void
     {
         $user           = new ForumUser();

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -10,7 +10,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\APM\CommandLogger;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\Tests\Mocks\ExceptionThrowingListenerMock;
 use Doctrine\ODM\MongoDB\Tests\Mocks\PreUpdateListenerMock;


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

Hydrators currently get the `UnitOfWork` injected directly. This leads to a circular dependency, as the `DocumentManager` needs a `HydratorFactory`, but the `HydratorFactory` needs a `UnitOfWork` instance which can't exist without a `DocumentManager`. To resolve this, `HydratorFactory` no longer takes a `UnitOfWork` instance, and generated hydrators instead take the `UnitOfWork` instance exposed by the document manager.

This PR also moves a method from `UnitOfWork` to the `DocumentManager` as it's not tied to `UnitOfWork`.

Note that this PR is only the first of a few refactorings necessary to properly decouple things from `UnitOfWork`, with the goal of having `UnitOfWork` represent a single set of persistable document changes. Removing the circular dependency also allows us to make hydrator factories configurable, which is important to leverage the new codec infrastructure in the PHP driver and thus speed up a lot of hydration operations.