### PR TITLE
doc: Add type to properties

### DIFF
--- a/docs/en/reference/aggregation-builder.rst
+++ b/docs/en/reference/aggregation-builder.rst
@@ -133,13 +133,13 @@ they can't be persisted to the database.
         class UserPurchases
         {
             #[ReferenceOne(targetDocument: User::class, name: '_id')]
-            private $user;
+            private User $user;
 
             #[Field(type: 'int')]
-            private $numPurchases;
+            private int $numPurchases;
 
             #[Field(type: 'float')]
-            private $amount;
+            private float $amount;
         }
 
     .. code-block:: xml

--- a/docs/en/reference/aggregation-stage-reference.rst
+++ b/docs/en/reference/aggregation-stage-reference.rst
@@ -413,13 +413,12 @@ to be considered when looking up one-to-one relationships:
 
     class Orders
     {
-        /** @var Collection<Item> */
         #[ReferenceOne(
             targetDocument: Item::class,
             cascade: 'all',
             storeAs: 'id',
         )]
-        private Collection $items;
+        private Item $items;
     }
 
 .. code-block:: php

--- a/docs/en/reference/aggregation-stage-reference.rst
+++ b/docs/en/reference/aggregation-stage-reference.rst
@@ -386,7 +386,7 @@ pipeline stages. Take the following relationship for example:
             cascade: 'all',
             storeAs: 'id',
         )]
-        private $items;
+        private Collection $items;
     }
 
 .. code-block:: php
@@ -417,7 +417,7 @@ to be considered when looking up one-to-one relationships:
             cascade: 'all',
             storeAs: 'id',
         )]
-        private $items;
+        private Collection $items;
     }
 
 .. code-block:: php

--- a/docs/en/reference/aggregation-stage-reference.rst
+++ b/docs/en/reference/aggregation-stage-reference.rst
@@ -381,6 +381,7 @@ pipeline stages. Take the following relationship for example:
 
     class Orders
     {
+        /** @var Collection<Item> */
         #[ReferenceMany(
             targetDocument: Item::class,
             cascade: 'all',
@@ -412,6 +413,7 @@ to be considered when looking up one-to-one relationships:
 
     class Orders
     {
+        /** @var Collection<Item> */
         #[ReferenceOne(
             targetDocument: Item::class,
             cascade: 'all',

--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -18,7 +18,7 @@ does not exist.
     {
         #[Field(type: 'string')]
         #[AlsoLoad('name')]
-        public $fullName;
+        public string $fullName;
     }
 
 The ``$fullName`` property will be loaded from ``fullName`` if it exists, but
@@ -226,7 +226,7 @@ Optional attributes:
             ],
             defaultDiscriminatorValue: 'book',
         )]
-        private $tags = [];
+        private Collection $tags;
     }
 
 Depending on the embedded document's class, a value of ``user`` or ``author``
@@ -281,7 +281,7 @@ Optional attributes:
              ],
              defaultDiscriminatorValue: 'user',
         )]
-        private $creator;
+        private User|Author $creator;
     }
 
 Depending on the embedded document's class, a value of ``user`` or ``author``
@@ -304,7 +304,7 @@ relationship.
     class Money
     {
         #[Field(type: 'float')]
-        private $amount;
+        private float $amount;
 
         public function __construct(float $amount)
         {
@@ -317,7 +317,7 @@ relationship.
     class Wallet
     {
         #[EmbedOne(targetDocument: Money::class)]
-        private $money;
+        private Money $money;
 
         public function setMoney(Money $money): void
         {
@@ -374,13 +374,13 @@ Examples:
     class User
     {
         #[Field(type: 'string')]
-        protected $username;
+        protected string $username;
 
         #[Field(type: 'string', name: 'co')]
-        protected $country;
+        protected string $country;
 
         #[Field(type: 'float')]
-        protected $height;
+        protected float $height;
     }
 
 .. _file:
@@ -501,8 +501,15 @@ customize this via the :ref:`strategy <basic_mapping_identifiers>` attribute.
     class User
     {
         #[Id]
-        protected $id;
+        protected string $id;
     }
+
+.. note::
+
+   The property annotated with `#[Id]`_ cannot be ``readonly`` even if the
+   value is set only once and should never be updated. This is because the
+   property is set outside of the scope of the class, which is not allowed in
+   PHP for ``readonly`` properties.
 
 #[Index]
 --------
@@ -551,7 +558,7 @@ If you are creating a single-field index, you can simply specify an `#[Index]`_ 
     {
         #[Field(type: 'string')]
         #[UniqueIndex]
-        private $username;
+        private string $username;
     }
 
 .. note::
@@ -631,7 +638,7 @@ This is only compatible with the ``int`` type, and cannot be combined with `#[Id
     {
         #[Field(type: 'int')]
         #[Lock]
-        private $lock;
+        private int $lock;
     }
 
 #[MappedSuperclass]
@@ -979,6 +986,7 @@ Optional attributes:
 
     class User
     {
+        /** @var Collection<Item> */
         #[ReferenceMany(
             strategy: 'set',
             targetDocument: Documents\Item::class,
@@ -991,7 +999,7 @@ Optional attributes:
             ],
             defaultDiscriminatorValue: 'book',
         )]
-        private $cart;
+        private Collection $cart;
     }
 
 .. _attributes_reference_reference_one:
@@ -1061,7 +1069,7 @@ Optional attributes:
             ],
             defaultDiscriminatorValue: 'book'
         )]
-        private $cart;
+        private Item $cart;
     }
 
 #[SearchIndex]
@@ -1148,7 +1156,7 @@ Alias of `#[Index]`_, with the ``unique`` option set by default.
     {
         #[Field(type: 'string')]
         #[UniqueIndex]
-        private $email;
+        private string $email;
     }
 
 .. _attributes_reference_version:
@@ -1258,7 +1266,7 @@ combined with `#[Id]`_. Following ODM types can be used for versioning: ``int``,
     {
         #[Field(type: 'int')]
         #[Version]
-        private $version;
+        private int $version;
     }
 
 By default, Doctrine ODM updates :ref:`embed-many <embed_many>` and

--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -217,6 +217,7 @@ Optional attributes:
 
     class User
     {
+        /** @var Collection<BookTag|SongTag> */
         #[EmbedMany(
             strategy:'set',
             discriminatorField:'type',
@@ -989,13 +990,13 @@ Optional attributes:
         /** @var Collection<Item> */
         #[ReferenceMany(
             strategy: 'set',
-            targetDocument: Documents\Item::class,
+            targetDocument: Item::class,
             cascade: 'all',
             sort: ['sort_field' => 'asc'],
             discriminatorField: 'type',
             discriminatorMap: [
-                'book' => Documents\BookItem::class,
-                'song' => Documents\SongItem::class,
+                'book' => BookItem::class,
+                'song' => SongItem::class,
             ],
             defaultDiscriminatorValue: 'book',
         )]

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -247,7 +247,7 @@ Here is an example:
         class User
         {
             #[Id]
-            private $id;
+            private string $id;
         }
 
     .. code-block:: xml
@@ -284,7 +284,7 @@ Here is an example how to manually set a string identifier for your documents:
         class MyPersistentClass
         {
             #[Id(strategy: 'NONE', type: 'string')]
-            private $id;
+            private string $id;
 
             public function setId(string $id): void
             {
@@ -362,7 +362,7 @@ Then specify the ``class`` option for the ``CUSTOM`` strategy:
         class MyPersistentClass
         {
             #[Id(strategy: 'CUSTOM', type: 'string', options: ['class' => \Vendor\Specific\Generator::class])]
-            private $id;
+            private string $id;
 
             public function setId(string $id): void
             {
@@ -412,7 +412,7 @@ Example:
             // ...
 
             #[Field(type: 'string')]
-            private $username;
+            private string $username;
         }
 
     .. code-block:: xml
@@ -443,7 +443,7 @@ as follows:
         <?php
 
         #[Field(name: 'db_name')]
-        private $name;
+        private string $name;
 
     .. code-block:: xml
 

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -442,8 +442,11 @@ as follows:
 
         <?php
 
-        #[Field(name: 'db_name')]
-        private string $name;
+        class User
+        {
+            #[Field(name: 'db_name')]
+            private string $name;
+        }
 
     .. code-block:: xml
 

--- a/docs/en/reference/best-practices.rst
+++ b/docs/en/reference/best-practices.rst
@@ -69,3 +69,10 @@ Example:
             $this->articles = new ArrayCollection();
         }
     }
+
+.. note::
+
+   The properties' type hints must be ``Collection``, and cannot be
+   ``ArrayCollection``. When the ``User`` object is retrieved from the database,
+   the properties ``$addresses`` and ``$articles`` are instances of
+   ``Doctrine\ODM\MongoDB\PersistentCollection`` to track changes.

--- a/docs/en/reference/best-practices.rst
+++ b/docs/en/reference/best-practices.rst
@@ -56,15 +56,12 @@ Example:
     namespace MyProject\Model;
 
     use Doctrine\Common\Collections\ArrayCollection;
+    use Doctrine\Common\Collections\Collection;
 
     class User
     {
-
-        /** @var ArrayCollection  */
-        private $addresses;
-
-        /** @var ArrayCollection  */
-        private $articles;
+        private Collection $addresses;
+        private Collection $articles;
 
         public function __construct()
         {

--- a/docs/en/reference/bidirectional-references.rst
+++ b/docs/en/reference/bidirectional-references.rst
@@ -15,7 +15,7 @@ and changes are tracked and persisted separately. Here is an example:
         // ...
 
         #[ReferenceOne(targetDocument: User::class)]
-        private $user;
+        private User $user;
     }
 
     #[Document]
@@ -23,8 +23,9 @@ and changes are tracked and persisted separately. Here is an example:
     {
         // ...
 
+        /** @var Collection<BlogPost> */
         #[ReferenceMany(targetDocument: BlogPost::class)]
-        private $posts;
+        private Collection $posts;
     }
 
 When I persist some instances of the above classes the references would exist on both sides! The
@@ -57,7 +58,7 @@ One to Many
         // ...
 
         #[ReferenceOne(targetDocument: User::class, inversedBy: 'posts')]
-        private $user;
+        private User $user;
     }
 
     #[Document]
@@ -65,8 +66,9 @@ One to Many
     {
         // ...
 
+        /** @var Collection<BlogPost> */
         #[ReferenceMany(targetDocument: BlogPost::class, mappedBy: 'user')]
-        private $posts;
+        private Collection $posts;
     }
 
 So now when we persist a ``User`` and multiple ``BlogPost`` instances for that ``User``:
@@ -136,7 +138,7 @@ Here is an example where we have a one to one relationship between ``Cart`` and 
         // ...
 
         #[ReferenceOne(targetDocument: Customer::class, inversedBy: 'cart')]
-        public $customer;
+        public Customer $customer;
     }
 
     #[Document]
@@ -145,7 +147,7 @@ Here is an example where we have a one to one relationship between ``Cart`` and 
         // ...
 
         #[ReferenceOne(targetDocument: Cart::class, mappedBy: 'customer')]
-        public $cart;
+        public Cart $cart;
     }
 
 The owning side is on ``Cart.customer`` and the ``Customer.cart`` referenced is loaded with a query
@@ -187,11 +189,13 @@ Self-Referencing Many to Many
     {
         // ...
 
+        /** @var Collection<User> */
         #[ReferenceMany(targetDocument: User::class, mappedBy: 'myFriends')]
-        public $friendsWithMe;
+        public Collection $friendsWithMe;
 
+        /** @var Collection<User> */
         #[ReferenceMany(targetDocument: User::class, inversedBy: 'friendsWithMe')]
-        public $myFriends;
+        public Collection $myFriends;
 
         public function __construct($name)
         {

--- a/docs/en/reference/capped-collections.rst
+++ b/docs/en/reference/capped-collections.rst
@@ -31,10 +31,10 @@ the ``#[Document]`` attribute:
         class Category
         {
             #[Id]
-            public $id;
+            public string $id;
 
             #[Field(type: 'string')]
-            public $name;
+            public string $name;
         }
 
     .. code-block:: xml

--- a/docs/en/reference/change-tracking-policies.rst
+++ b/docs/en/reference/change-tracking-policies.rst
@@ -85,11 +85,11 @@ follows:
     {
         // ...
 
-        private $_listeners = [];
+        private array $listeners = [];
 
         public function addPropertyChangedListener(PropertyChangedListener $listener): void
         {
-            $this->_listeners[] = $listener;
+            $this->listeners[] = $listener;
         }
     }
 

--- a/docs/en/reference/change-tracking-policies.rst
+++ b/docs/en/reference/change-tracking-policies.rst
@@ -85,6 +85,7 @@ follows:
     {
         // ...
 
+        /** @var PropertyChangedListener[] */
         private array $listeners = [];
 
         public function addPropertyChangedListener(PropertyChangedListener $listener): void

--- a/docs/en/reference/complex-references.rst
+++ b/docs/en/reference/complex-references.rst
@@ -35,16 +35,18 @@ querying by the BlogPost's ID.
     {
         // ...
 
+        /** @var Collection<Comment> */
         #[ReferenceMany(targetDocument: Comment::class, mappedBy: 'blogPost')]
-        private $comments;
+        private Collection $comments;
 
+        /** @var Collection<Comment> */
         #[ReferenceMany(
              targetDocument: Comment::class,
              mappedBy: 'blogPost',
              sort: ['date' => 'desc'],
              limit: 5,
         )]
-        private $last5Comments;
+        private Collection $last5Comments;
     }
 
     #[Document]
@@ -53,7 +55,7 @@ querying by the BlogPost's ID.
         // ...
 
         #[ReferenceOne(targetDocument: BlogPost::class, inversedBy: 'comments')]
-        private $blogPost;
+        private BlogPost $blogPost;
     }
 
 You can also use ``mappedBy`` for referencing a single document, as in the
@@ -70,7 +72,7 @@ following example:
              mappedBy: 'blogPost',
              sort: ['date' => 'desc']
         )]
-        private $lastComment;
+        private ?Comment $lastComment = null;
     }
 
 ``criteria`` Example
@@ -86,12 +88,13 @@ administrators:
 
     class BlogPost
     {
+        /** @var Collection<Comment> */
         #[ReferenceMany(
              targetDocument: Comment::class,
              mappedBy: 'blogPost',
              criteria: ['isByAdmin' => true]
         )]
-        private $commentsByAdmin;
+        private Collection $commentsByAdmin;
     }
 
 ``repositoryMethod`` Example
@@ -106,12 +109,13 @@ call on the Comment repository class to populate the reference.
 
     class BlogPost
     {
+        /** @var Collection<Comment> */
         #[ReferenceMany(
              targetDocument: Comment::class,
              mappedBy: 'blogPost',
              repositoryMethod: 'findSomeComments',
         )]
-        private $someComments;
+        private Collection $someComments;
     }
 
 The ``Comment`` class will need to have a custom repository class configured:

--- a/docs/en/reference/custom-collections.rst
+++ b/docs/en/reference/custom-collections.rst
@@ -22,11 +22,7 @@ persistence-related features.
 
         /** @var Collection<Section> */
         #[EmbedMany(targetDocument: Section::class)]
-<<<<<<< HEAD
         public Collection $sections;
-=======
-        private Collection $sections;
->>>>>>> 4f01d6eb (Add type to properties)
 
         public function __construct()
         {
@@ -105,12 +101,8 @@ Alternatively, you may want to implement the whole class from scratch:
     {
         public function __construct(
             private array $elements = []
-<<<<<<< HEAD
-        ) {}
-=======
         ) {
         }
->>>>>>> 4f01d6eb (Add type to properties)
 
         // your implementation of all methods interface requires
     }
@@ -136,12 +128,13 @@ methods such as ``map`` or ``filter`` are called:
     use Doctrine\Common\Collections\ArrayCollection;
     use Doctrine\Common\Collections\Collection;
 
-    class SectionCollection extend ArrayCollection
+    class SectionCollection extends ArrayCollection
     {
         public function __construct(
             private EventDispatcherInterface $eventDispatcher,
             private array $elements = [],
-        ) {}
+        ) {
+        }
 
         public function createFrom(array $elements): static
         {

--- a/docs/en/reference/custom-collections.rst
+++ b/docs/en/reference/custom-collections.rst
@@ -22,7 +22,11 @@ persistence-related features.
 
         /** @var Collection<Section> */
         #[EmbedMany(targetDocument: Section::class)]
+<<<<<<< HEAD
         public Collection $sections;
+=======
+        private Collection $sections;
+>>>>>>> 4f01d6eb (Add type to properties)
 
         public function __construct()
         {
@@ -55,6 +59,7 @@ and ensuring that your custom class is initialized in the owning class' construc
     {
         // ...
 
+        /** @var Collection<Section> */
         #[EmbedMany(
             collectionClass: SectionCollection::class,
             targetDocument: Section::class,
@@ -100,7 +105,12 @@ Alternatively, you may want to implement the whole class from scratch:
     {
         public function __construct(
             private array $elements = []
+<<<<<<< HEAD
         ) {}
+=======
+        ) {
+        }
+>>>>>>> 4f01d6eb (Add type to properties)
 
         // your implementation of all methods interface requires
     }

--- a/docs/en/reference/custom-mapping-types.rst
+++ b/docs/en/reference/custom-mapping-types.rst
@@ -31,7 +31,7 @@ class:
         public function convertToPHPValue($value): \DateTime
         {
             // This is called to convert a Mongo value to a PHP representation
-            return new \DateTime('@' . $value->sec);
+            return $value->toDateTime();
         }
 
         public function convertToDatabaseValue($value): UTCDateTime
@@ -88,7 +88,7 @@ type in your mapping like this:
         class MyPersistentClass
         {
             #[Field(type: 'mytype')]
-            private $field;
+            private \DateTime $field;
         }
 
     .. code-block:: xml

--- a/docs/en/reference/document-repositories.rst
+++ b/docs/en/reference/document-repositories.rst
@@ -146,8 +146,9 @@ event dispatcher to the repository constructor.
     final class YourRepositoryFactory extends AbstractRepositoryFactory
     {
         public function __construct(
-            private EventDispatcherInterface $eventDispatcher
-        ) {}
+            private EventDispatcherInterface $eventDispatcher,
+        ) {
+        }
 
         protected function instantiateRepository(string $repositoryClassName, DocumentManager $documentManager, ClassMetadata $metadata)
         {
@@ -155,6 +156,7 @@ event dispatcher to the repository constructor.
                 UserRepository::class => new UserRepository($this->eventDispatcher, $documentManager, $metadata),
                 default               => new $repositoryClassName($documentManager, $documentManager->getUnitOfWork(), $metadata),
             };
+            }
         }
     }
 

--- a/docs/en/reference/document-repositories.rst
+++ b/docs/en/reference/document-repositories.rst
@@ -156,7 +156,6 @@ event dispatcher to the repository constructor.
                 UserRepository::class => new UserRepository($this->eventDispatcher, $documentManager, $metadata),
                 default               => new $repositoryClassName($documentManager, $documentManager->getUnitOfWork(), $metadata),
             };
-            }
         }
     }
 

--- a/docs/en/reference/embedded-mapping.rst
+++ b/docs/en/reference/embedded-mapping.rst
@@ -73,7 +73,7 @@ Embed many documents:
         {
             // ...
 
-            /** @var Collection<PhoneNumber>
+            /** @var Collection<PhoneNumber> */
             #[EmbedMany(targetDocument: Phonenumber::class)]
             private Collection $phoneNumbers;
 
@@ -282,6 +282,8 @@ You can achieve this behavior by using the `storeEmptyArray` option for embedded
         class User
         {
             // ...
+
+            /** @var Collection<PhoneNumber> */
             #[EmbedMany(targetDocument: PhoneNumber::class, storeEmptyArray: true)]
             private Collection $phoneNumbers;
             // ...
@@ -299,5 +301,6 @@ You can achieve this behavior by using the `storeEmptyArray` option for embedded
                 <field name="number" type="string" />
           </embedded-document>
         </doctrine-mongo-mapping>
+
 Now, when the `$phoneNumbers` collection is empty, an empty array will be stored in the database for the `User`
 document's embedded `phoneNumbers` collection, even if there are no actual embedded documents in the collection.

--- a/docs/en/reference/embedded-mapping.rst
+++ b/docs/en/reference/embedded-mapping.rst
@@ -196,7 +196,7 @@ in each embedded document:
 
             #[EmbedMany(
               discriminatorMap: [
-                  'download" => DownloadTask::class,
+                  'download' => DownloadTask::class,
                   'build' => BuildTask::class,
               ]
             )]
@@ -235,7 +235,7 @@ discriminator:
 
             #[EmbedMany(
                 discriminatorMap: [
-                  'download" => DownloadTask::class,
+                  'download' => DownloadTask::class,
                   'build' => BuildTask::class,
                 ],
                 defaultDiscriminatorValue: 'download',

--- a/docs/en/reference/embedded-mapping.rst
+++ b/docs/en/reference/embedded-mapping.rst
@@ -23,7 +23,7 @@ Embed a single document:
             // ...
 
             #[EmbedOne(targetDocument: Address::class)]
-            private $address;
+            private ?Address $address;
 
             // ...
         }
@@ -32,7 +32,7 @@ Embed a single document:
         class Address
         {
             #[Field(type: 'string')]
-            private $street;
+            private string $street;
 
             // ...
         }
@@ -73,8 +73,9 @@ Embed many documents:
         {
             // ...
 
+            /** @var Collection<PhoneNumber>
             #[EmbedMany(targetDocument: Phonenumber::class)]
-            private $phoneNumbers;
+            private Collection $phoneNumbers;
 
             // ...
             public function __construct()
@@ -87,7 +88,7 @@ Embed many documents:
         class PhoneNumber
         {
             #[Field(type: 'string')]
-            private $number;
+            private string $number;
 
             // ...
         }
@@ -130,7 +131,7 @@ you can simply omit the ``targetDocument`` option:
             // ..
 
             #[EmbedMany]
-            private $tasks;
+            private Collection $tasks;
 
             // ...
             public function __construct()
@@ -162,7 +163,7 @@ the embedded document. The field name can be customized with the
             // ..
 
             #[EmbedMany(discriminatorField: 'type')]
-            private $tasks;
+            private Collection $tasks;
 
             // ...
             public function __construct()
@@ -199,7 +200,7 @@ in each embedded document:
                   'build' => BuildTask::class,
               ]
             )]
-            private $tasks;
+            private Collection $tasks;
 
             // ...
             public function __construct()
@@ -239,7 +240,7 @@ discriminator:
                 ],
                 defaultDiscriminatorValue: 'download',
             )]
-            private $tasks = [];
+            private Collection $tasks;
 
             // ...
         }
@@ -282,7 +283,7 @@ You can achieve this behavior by using the `storeEmptyArray` option for embedded
         {
             // ...
             #[EmbedMany(targetDocument: PhoneNumber::class, storeEmptyArray: true)]
-            private $phoneNumbers = [];
+            private Collection $phoneNumbers;
             // ...
         }
     .. code-block:: xml

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -29,17 +29,12 @@ Now we can add some event listeners to the ``$evm``. Let's create a
 
     class EventTest
     {
-        const preFoo = 'preFoo';
-        const postFoo = 'postFoo';
-
-        private $_evm;
-
-        public $preFooInvoked = false;
-        public $postFooInvoked = false;
+        public bool $preFooInvoked = false;
+        public bool $postFooInvoked = false;
 
         public function __construct(EventManager $evm)
         {
-            $evm->addEventListener([self::preFoo, self::postFoo], $this);
+            $evm->addEventListener(['preFoo', 'postFoo'], $this);
         }
 
         public function preFoo(EventArgs $e): void
@@ -88,7 +83,7 @@ array of events it should be subscribed to.
     {
         const preFoo = 'preFoo';
 
-        public $preFooInvoked = false;
+        public bool $preFooInvoked = false;
 
         public function preFoo(): void
         {
@@ -248,15 +243,15 @@ event occurs.
         // ...
 
         #[Field]
-        public $value;
+        public string $value;
 
         #[Field]
-        private $createdAt;
+        private \DateTimeInterface $createdAt;
 
         #[PrePersist]
         public function doStuffOnPrePersist(\Doctrine\ODM\MongoDB\Event\LifecycleEventArgs $eventArgs): void
         {
-            $this->createdAt = date('Y-m-d H:i:s');
+            $this->createdAt = new DateTimeImmutable();
         }
 
         #[PrePersist]

--- a/docs/en/reference/geospatial-queries.rst
+++ b/docs/en/reference/geospatial-queries.rst
@@ -20,23 +20,23 @@ First, setup some documents like the following:
         class City
         {
             #[Id]
-            public $id;
+            public string $id;
 
             #[Field(type: 'string')]
-            public $name;
+            public string $name;
 
             #[EmbedOne(targetDocument: Coordinates::class)]
-            public $coordinates;
+            public ?Coordinates $coordinates;
         }
 
         #[EmbeddedDocument]
         class Coordinates
         {
             #[Field(type: 'float')]
-            public $x;
+            public float $x;
 
             #[Field(type: 'float')]
-            public $y;
+            public float $y;
         }
 
     .. code-block:: xml

--- a/docs/en/reference/indexes.rst
+++ b/docs/en/reference/indexes.rst
@@ -244,6 +244,7 @@ Now if we had a ``BlogPost`` document with the ``Comment`` document embedded man
         #[Index]
         private string $slug;
 
+        /** @var Collection<Comment> */
         #[EmbedMany(targetDocument: Comment::class)]
         private Collection $comments;
     }

--- a/docs/en/reference/indexes.rst
+++ b/docs/en/reference/indexes.rst
@@ -21,11 +21,11 @@ property:
         class User
         {
             #[Id]
-            public $id;
+            public string $id;
 
             #[Field(type: 'string')]
             #[Index]
-            public $username;
+            public string $username;
         }
 
     .. code-block:: xml
@@ -80,11 +80,11 @@ Unique Index
         class User
         {
             #[Id]
-            public $id;
+            public string $id;
 
             #[Field(type: 'string')]
             #[Index(unique: true, order: 'asc')]
-            public $username;
+            public string $username;
         }
 
     .. code-block:: xml
@@ -105,11 +105,11 @@ For your convenience you can quickly specify a unique index with
         class User
         {
             #[Id]
-            public $id;
+            public string $id;
 
             #[Field(type: 'string')]
             #[UniqueIndex(order: 'asc')]
-            public $username;
+            public string $username;
         }
 
     .. code-block:: xml
@@ -132,13 +132,13 @@ you can specify them on the class doc block:
         class User
         {
             #[Id]
-            public $id;
+            public string $id;
 
             #[Field(type: 'int')]
-            public $accountId;
+            public int $accountId;
 
             #[Field(type: 'string')]
-            public $username;
+            public string $username;
         }
 
     .. code-block:: xml
@@ -174,13 +174,13 @@ attribute:
         class User
         {
             #[Id]
-            public $id;
+            public string $id;
 
             #[ODM\Field(type: 'int')]
-            public $accountId;
+            public int $accountId;
 
             #[Field(type: 'string')]
-            public $username;
+            public string $username;
         }
 
     .. code-block:: xml
@@ -220,7 +220,7 @@ documents.
     {
         #[Field(type: 'date')]
         #[Index]
-        private $date;
+        private \DateTime $date;
 
         // ...
     }
@@ -233,6 +233,8 @@ Now if we had a ``BlogPost`` document with the ``Comment`` document embedded man
 
     namespace Documents;
 
+    use Doctrine\Common\Collections\Collection;
+
     #[Document]
     class BlogPost
     {
@@ -240,10 +242,10 @@ Now if we had a ``BlogPost`` document with the ``Comment`` document embedded man
 
         #[Field(type: 'string')]
         #[Index]
-        private $slug;
+        private string $slug;
 
         #[EmbedMany(targetDocument: Comment::class)]
-        private $comments;
+        private Collection $comments;
     }
 
 If we were to create the indexes with the ``SchemaManager``:
@@ -302,20 +304,20 @@ options structures manually:
         class Place
         {
             #[Id]
-            public $id;
+            public string $id;
 
             #[EmbedOne(targetDocument: Coordinates::class)]
-            public $coordinates;
+            public ?Coordinates $coordinates;
         }
 
         #[EmbeddedDocument]
         class Coordinates
         {
             #[Field(type: 'float')]
-            public $latitude;
+            public float $latitude;
 
             #[Field(type: 'float')]
-            public $longitude;
+            public float $longitude;
         }
 
     .. code-block:: xml
@@ -343,13 +345,13 @@ index.
         class Place
         {
             #[Id]
-            public $id;
+            public string $id;
 
             #[Field(type: 'string')]
-            public $city;
+            public string $city;
 
             #[ODM\Field(type: 'int')]
-            public $version;
+            public int $version;
         }
 
     .. code-block:: xml

--- a/docs/en/reference/indexes.rst
+++ b/docs/en/reference/indexes.rst
@@ -76,7 +76,9 @@ Unique Index
 
         <?php
 
-        namespace Documents;#[Document */]
+        namespace Documents;
+
+        #[Document]
         class User
         {
             #[Id]

--- a/docs/en/reference/introduction.rst
+++ b/docs/en/reference/introduction.rst
@@ -42,7 +42,8 @@ the features.
 
     <?php
 
-    use DateTime, DateTimeImmutable;
+    use DateTime;
+    use DateTimeImmutable;
     use Doctrine\Common\Collections\ArrayCollection;
     use Doctrine\Common\Collections\Collection;
     use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;

--- a/docs/en/reference/introduction.rst
+++ b/docs/en/reference/introduction.rst
@@ -42,7 +42,7 @@ the features.
 
     <?php
 
-    use DateTimeImmutable;
+    use DateTime, DateTimeImmutable;
     use Doctrine\Common\Collections\ArrayCollection;
     use Doctrine\Common\Collections\Collection;
     use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -66,11 +66,11 @@ the features.
         #[ODM\Field(type: 'int')]
         public int $salary;
 
-        #[ODM\Field(type: 'date')]
+        #[ODM\Field(type: 'date_immutable')]
         public DateTimeImmutable $started;
 
         #[ODM\Field(type: 'date')]
-        public DateTimeImmutable $left;
+        public DateTime $left;
 
         #[ODM\EmbedOne(targetDocument: Address::class)]
         public Address $address;

--- a/docs/en/reference/migrating-schemas.rst
+++ b/docs/en/reference/migrating-schemas.rst
@@ -28,10 +28,10 @@ Let's say you have a simple document that starts off with the following fields:
     class Person
     {
         #[Id]
-        public $id;
+        public string $id;
 
         #[Field(type: 'string')]
-        public $name;
+        public string $name;
     }
 
 Later on, you need rename ``name`` to ``fullName``; however, you'd like to
@@ -45,11 +45,11 @@ hydrate ``fullName`` from ``name`` if the new field doesn't exist.
     class Person
     {
         #[Id]
-        public $id;
+        public string $id;
 
         #[Field(type: 'string')]
         #[AlsoLoad('name')]
-        public $fullName;
+        public string $fullName;
     }
 
 When a Person is loaded, the ``fullName`` field will be populated with the value
@@ -80,13 +80,13 @@ before normal hydration.
     class Person
     {
         #[Id]
-        public $id;
+        public string $id;
 
         #[Field(type: 'string')]
-        public $firstName;
+        public string $firstName;
 
         #[Field(type: 'string')]
-        public $lastName;
+        public string $lastName;
 
         #[AlsoLoad(['name', 'fullName'])]
         public function populateFirstAndLastName(string $fullName): void
@@ -125,16 +125,16 @@ Imagine you have some address-related fields on a Person document:
     class Person
     {
         #[Id]
-        public $id;
+        public string $id;
 
         #[Field(type: 'string')]
-        public $name;
+        public string $name;
 
         #[Field(type: 'string')]
-        public $street;
+        public string $street;
 
         #[Field(type: 'string')]
-        public $city;
+        public string $city;
     }
 
 Later on, you may want to migrate this data into an embedded Address document:
@@ -146,16 +146,13 @@ Later on, you may want to migrate this data into an embedded Address document:
     #[EmbeddedDocument]
     class Address
     {
-        #[Field(type: 'string')]
-        public $street;
+        public function __construct(
+            #[Field(type: 'string')]
+            public string $street,
 
-        #[Field(type: 'string')]
-        public $city;
-
-        public function __construct(string $street, string $city)
-        {
-            $this->street = $street;
-            $this->city = $city;
+            #[Field(type: 'string')]
+            public string $city,
+        ) {
         }
     }
 
@@ -164,19 +161,19 @@ Later on, you may want to migrate this data into an embedded Address document:
     class Person
     {
         #[Id]
-        public $id;
+        public string $id;
 
         #[Field(type: 'string')]
-        public $name;
+        public string $name;
 
         #[Field(notSaved: true)]
-        public $street;
+        public string $street;
 
         #[Field(notSaved: true)]
-        public $city;
+        public string $city;
 
         #[EmbedOne(targetDocument: Address::class)]
-        public $address;
+        public Address $address;
 
         #[PostLoad]
         public function postLoad(): void

--- a/docs/en/reference/priming-references.rst
+++ b/docs/en/reference/priming-references.rst
@@ -19,7 +19,7 @@ Consider the following abbreviated model:
     class User
     {
         #[ReferenceMany(targetDocument: Account::class)]
-        private $accounts;
+        private Collection $accounts;
     }
 
 We would like to query for 100 users and then iterate over their referenced
@@ -112,7 +112,7 @@ specifying them in the mapping:
     class User
     {
         #[ReferenceMany(targetDocument: Account::class, prime: ['user'])]
-        private $accounts;
+        private Collection $accounts;
     }
 
 When the collection is initialized, the configured primers are automatically

--- a/docs/en/reference/priming-references.rst
+++ b/docs/en/reference/priming-references.rst
@@ -18,6 +18,7 @@ Consider the following abbreviated model:
     #[Document]
     class User
     {
+        /** @var Collection<Account> */
         #[ReferenceMany(targetDocument: Account::class)]
         private Collection $accounts;
     }
@@ -111,6 +112,7 @@ specifying them in the mapping:
     #[Document]
     class User
     {
+        /** @var Collection<Account> */
         #[ReferenceMany(targetDocument: Account::class, prime: ['user'])]
         private Collection $accounts;
     }

--- a/docs/en/reference/query-builder-api.rst
+++ b/docs/en/reference/query-builder-api.rst
@@ -589,13 +589,13 @@ document with a text index:
         class Document
         {
             #[Id]
-            public $id;
+            public string $id;
 
             #[Field(type: 'string')]
-            public $description;
+            public string $description;
 
             #[Field(notSaved: true)]
-            public $score;
+            public int $score;
         }
 
 You can then run queries using the text operator:

--- a/docs/en/reference/query-builder-api.rst
+++ b/docs/en/reference/query-builder-api.rst
@@ -594,7 +594,7 @@ document with a text index:
             #[Field(type: 'string')]
             public string $description;
 
-            #[Field(notSaved: true)]
+            #[Field(type: 'int', notSaved: true)]
             public int $score;
         }
 

--- a/docs/en/reference/reference-mapping.rst
+++ b/docs/en/reference/reference-mapping.rst
@@ -53,7 +53,7 @@ Reference one document:
             // ...
 
             #[ReferenceOne(targetDocument: Shipping::class)]
-            private $shipping;
+            private Shipping $shipping;
 
             // ...
         }
@@ -94,8 +94,9 @@ Reference many documents:
         {
             // ...
 
+            /** @var Collection<Account> */
             #[ReferenceMany(targetDocument: Account::class)]
-            private $accounts = [];
+            private Collection $accounts;
 
             // ...
         }
@@ -138,7 +139,7 @@ omit the ``targetDocument`` option:
             // ..
 
             #[ReferenceMany]
-            private $favorites = [];
+            private Collection $favorites;
 
             // ...
         }
@@ -174,7 +175,7 @@ The name of the field within the DBRef object can be customized via the
             // ..
 
             #[ReferenceMany(discriminatorField: 'type')]
-            private $favorites = [];
+            private Collection $favorites;
 
             // ...
         }
@@ -205,7 +206,7 @@ in each `DBRef`_ object:
                     'song' => Song::class,
                 ]
             )]
-            private $favorites = [];
+            private Collection $favorites;
 
             // ...
         }
@@ -233,6 +234,7 @@ a certain class, you can optionally specify a default discriminator value:
         {
             // ..
 
+            /** @var Collection<Album|Song> */
             #[ReferenceMany(
                 discriminatorMap: [
                     'album' => Album::class,
@@ -240,7 +242,7 @@ a certain class, you can optionally specify a default discriminator value:
                 ],
                 defaultDiscriminatorValue: 'album',
             )]
-            private $favorites = [];
+            private Collection $favorites;
 
             // ...
         }
@@ -276,7 +278,7 @@ Example:
         <?php
 
         #[ReferenceOne(targetDocument: Profile::class, storeAs: 'id')]
-        private $profile;
+        private Profile $profile;
 
     .. code-block:: xml
 
@@ -322,7 +324,7 @@ referenced documents. You must explicitly enable this functionality:
         <?php
 
         #[ReferenceOne(targetDocument: Profile::class, cascade: ['persist'])]
-        private $profile;
+        private Profile $profile;
 
     .. code-block:: xml
 
@@ -368,18 +370,19 @@ and StandingData:
     namespace Addressbook;
 
     use Doctrine\Common\Collections\ArrayCollection;
+    use Doctrine\Common\Collections\Collection;
 
     #[Document]
     class Contact
     {
         #[Id]
-        private $id;
+        private string $id;
 
         #[ReferenceOne(targetDocument: StandingData::class, orphanRemoval: true)]
-        private $standingData;
+        private ?StandingData $standingData;
 
         #[ReferenceMany(targetDocument: Address::class, mappedBy: 'contact', orphanRemoval: true)]
-        private $addresses;
+        private Collection $addresses;
 
         public function __construct()
         {
@@ -436,8 +439,9 @@ You can achieve this behavior by using the `storeEmptyArray` option.
         class User
         {
             // ...
+            /** @var Collection<Account> */
             #[ReferenceMany(targetDocument: Account::class, storeEmptyArray: true)]
-            private $accounts = [];
+            private Collection $accounts = [];
             // ...
         }
     .. code-block:: xml

--- a/docs/en/reference/reference-mapping.rst
+++ b/docs/en/reference/reference-mapping.rst
@@ -200,6 +200,7 @@ in each `DBRef`_ object:
         {
             // ..
 
+            /** @var Collection<Album|Song> */
             #[ReferenceMany(
                 discriminatorMap: [
                     'album' => Album::class,
@@ -277,8 +278,11 @@ Example:
 
         <?php
 
-        #[ReferenceOne(targetDocument: Profile::class, storeAs: 'id')]
-        private Profile $profile;
+        class User
+        {
+            #[ReferenceOne(targetDocument: Profile::class, storeAs: 'id')]
+            private Profile $profile;
+        }
 
     .. code-block:: xml
 
@@ -323,8 +327,11 @@ referenced documents. You must explicitly enable this functionality:
 
         <?php
 
-        #[ReferenceOne(targetDocument: Profile::class, cascade: ['persist'])]
-        private Profile $profile;
+        class User
+        {
+            #[ReferenceOne(targetDocument: Profile::class, cascade: ['persist'])]
+            private Profile $profile;
+        }
 
     .. code-block:: xml
 
@@ -435,13 +442,16 @@ You can achieve this behavior by using the `storeEmptyArray` option.
 
     .. code-block:: php
         <?php
+
         #[Document]
         class User
         {
             // ...
+
             /** @var Collection<Account> */
             #[ReferenceMany(targetDocument: Account::class, storeEmptyArray: true)]
-            private Collection $accounts = [];
+            private Collection $accounts;
+
             // ...
         }
     .. code-block:: xml

--- a/docs/en/reference/reference-mapping.rst
+++ b/docs/en/reference/reference-mapping.rst
@@ -53,7 +53,7 @@ Reference one document:
             // ...
 
             #[ReferenceOne(targetDocument: Shipping::class)]
-            private Shipping $shipping;
+            private ?Shipping $shipping = null;
 
             // ...
         }
@@ -97,6 +97,11 @@ Reference many documents:
             /** @var Collection<Account> */
             #[ReferenceMany(targetDocument: Account::class)]
             private Collection $accounts;
+
+            public function __construct()
+            {
+                $this->accounts = new ArrayCollection();
+            }
 
             // ...
         }

--- a/docs/en/reference/search-indexes.rst
+++ b/docs/en/reference/search-indexes.rst
@@ -89,13 +89,13 @@ mapping.
         class User
         {
             #[Id]
-            private $id;
+            private string $id;
 
             #[Field(type: 'string')]
-            private $username;
+            private string $username;
 
             #[EmbedMany(targetDocument: Address::class)]
-            private $addresses;
+            private ?Address $addresses;
 
             // ...
         }
@@ -156,13 +156,13 @@ mapping:
         class BlogPost
         {
             #[Id]
-            private $id;
+            private string $id;
 
             #[Field(type: 'string')]
-            private $title;
+            private string $title;
 
             #[Field(type: 'string')]
-            private $body;
+            private string $body;
 
             // ...
         }

--- a/docs/en/reference/sharding.rst
+++ b/docs/en/reference/sharding.rst
@@ -23,13 +23,13 @@ the document as well as an appropriate index:
         class User
         {
             #[Id]
-            public $id;
+            public string $id;
 
             #[Field(type: 'int')]
-            public $accountId;
+            public int $accountId;
 
             #[Field(type: 'string')]
-            public $username;
+            public string $username;
         }
 
     .. code-block:: xml

--- a/docs/en/reference/storing-files-with-gridfs.rst
+++ b/docs/en/reference/storing-files-with-gridfs.rst
@@ -48,22 +48,22 @@ Mapping documents as GridFS files
     class Image
     {
         #[Id]
-        private $id;
+        private ?string $id;
 
         #[File\Filename]
-        private $name;
+        private ?string $name;
 
         #[File\UploadDate]
-        private $uploadDate;
+        private \DateTimeInterface $uploadDate;
 
         #[File\Length]
-        private $length;
+        private ?int $length;
 
         #[File\ChunkSize]
-        private $chunkSize;
+        private ?int $chunkSize;
 
         #[File\Metadata(targetDocument: ImageMetadata::class)]
-        private $metadata;
+        private ImageMetadata $metadata;
 
         public function getId(): ?string
         {
@@ -138,7 +138,7 @@ The ``ImageMetadata`` class must be an embedded document:
     class ImageMetadata
     {
         #[Field(type: 'string')]
-        private $contentType;
+        private string $contentType;
 
         public function __construct(string $contentType)
         {

--- a/docs/en/reference/transactions-and-concurrency.rst
+++ b/docs/en/reference/transactions-and-concurrency.rst
@@ -117,9 +117,13 @@ The following example designates a version field using the ``int`` type:
     .. code-block:: php
 
         <?php
-        #[Version]
-        #[Field(type: 'int')]
-        private int $version = 0;
+
+        class Thing
+        {
+            #[Version]
+            #[Field(type: 'int')]
+            private int $version = 0;
+        }
 
     .. code-block:: xml
 
@@ -132,9 +136,13 @@ Or with ``decimal128`` type:
     .. code-block:: php
 
         <?php
-        #[Version]
-        #[Field(type: 'decimal128')]
-        private Decimal128 $version;
+
+        class Thing
+        {
+            #[Version]
+            #[Field(type: 'decimal128')]
+            private Decimal128 $version;
+        }
 
     .. code-block:: xml
 
@@ -147,9 +155,13 @@ Alternatively, the ``date`` type may be used:
     .. code-block:: php
 
         <?php
-        #[Version]
-        #[Field(type: 'date')]
-        private \DateTime $version;
+
+        class Thing
+        {
+            #[Version]
+            #[Field(type: 'date')]
+            private \DateTime $version;
+        }
 
     .. code-block:: xml
 
@@ -162,9 +174,13 @@ Or its immutable counterpart ``date_immutable``:
     .. code-block:: php
 
         <?php
-        #[Version]
-        #[Field(type: "date_immutable")]
-        private \DateTimeImmutable $version;
+
+        class Thing
+        {
+            #[Version]
+            #[Field(type: "date_immutable")]
+            private \DateTimeImmutable $version;
+        }
 
     .. code-block:: xml
 
@@ -321,9 +337,13 @@ Pessimistic locking requires a document to designate a lock field using the ``in
     .. code-block:: php
 
         <?php
-        #[Lock]
-        #[Field(type="int")]
-        private int $lock;
+
+        class Thing
+        {
+            #[Lock]
+            #[Field(type: "int")]
+            private int $lock;
+        }
 
     .. code-block:: xml
 

--- a/docs/en/reference/transactions-and-concurrency.rst
+++ b/docs/en/reference/transactions-and-concurrency.rst
@@ -119,7 +119,7 @@ The following example designates a version field using the ``int`` type:
         <?php
         #[Version]
         #[Field(type: 'int')]
-        private $version;
+        private int $version = 0;
 
     .. code-block:: xml
 
@@ -134,7 +134,7 @@ Or with ``decimal128`` type:
         <?php
         #[Version]
         #[Field(type: 'decimal128')]
-        private $version;
+        private Decimal128 $version;
 
     .. code-block:: xml
 
@@ -149,7 +149,7 @@ Alternatively, the ``date`` type may be used:
         <?php
         #[Version]
         #[Field(type: 'date')]
-        private $version;
+        private \DateTime $version;
 
     .. code-block:: xml
 
@@ -164,7 +164,7 @@ Or its immutable counterpart ``date_immutable``:
         <?php
         #[Version]
         #[Field(type: "date_immutable")]
-        private $version;
+        private \DateTimeImmutable $version;
 
     .. code-block:: xml
 
@@ -323,7 +323,7 @@ Pessimistic locking requires a document to designate a lock field using the ``in
         <?php
         #[Lock]
         #[Field(type="int")]
-        private $lock;
+        private int $lock;
 
     .. code-block:: xml
 

--- a/docs/en/reference/trees.rst
+++ b/docs/en/reference/trees.rst
@@ -15,16 +15,16 @@ Full Tree in Single Document
     class BlogPost
     {
         #[Id]
-        private $id;
+        private string $id;
 
         #[Field(type: 'string')]
-        private $title;
+        private string $title;
 
         #[Field(type: 'string')]
-        private $body;
+        private string $body;
 
         #[EmbedMany(targetDocument: Comment::class)]
-        private $comments = [];
+        private Collection $comments;
 
         // ...
     }
@@ -33,13 +33,13 @@ Full Tree in Single Document
     class Comment
     {
         #[Field(type: 'string')]
-        private $by;
+        private string $by;
 
         #[Field(type: 'string')]
-        private $text;
+        private string $text;
 
         #[EmbedMany(targetDocument: Comment::class)]
-        private $replies = [];
+        private Collection $replies;
 
         // ...
     }
@@ -71,14 +71,14 @@ Parent Reference
     class Category
     {
         #[Id]
-        private $id;
+        private string $id;
 
         #[Field(type: 'string')]
-        private $name;
+        private string $name;
 
         #[ReferenceOne(targetDocument: Category::class)]
         #[Index]
-        private $parent;
+        private ?Category $parent = null;
 
         // ...
     }
@@ -108,14 +108,14 @@ Child Reference
     class Category
     {
         #[Id]
-        private $id;
+        private string $id;
 
         #[Field(type: 'string')]
-        private $name;
+        private string $name;
 
         #[ReferenceMany(targetDocument: Category::class)]
         #[Index]
-        private $children = [];
+        private Collection $children;
 
         // ...
     }
@@ -158,7 +158,7 @@ Array of Ancestors
     class BaseCategory
     {
         #[Field(type: 'string')]
-        private $name;
+        private string $name;
 
         // ...
     }
@@ -167,15 +167,15 @@ Array of Ancestors
     class Category extends BaseCategory
     {
         #[Id]
-        private $id;
+        private string $id;
 
         #[ReferenceMany(targetDocument: Category::class)]
         #[Index]
-        private $ancestors = [];
+        private Collection $ancestors;
 
         #[ReferenceOne(targetDocument: Category::class)]
         #[Index]
-        private $parent;
+        private ?Category $parent = null;
 
         // ...
     }
@@ -223,13 +223,13 @@ Materialized Paths
     class Category
     {
         #[Id]
-        private $id;
+        private string $id;
 
         #[Field(type: 'string')]
-        private $name;
+        private string $name;
 
         #[Field(type: 'string')]
-        private $path;
+        private string $path;
 
         // ...
     }

--- a/docs/en/reference/trees.rst
+++ b/docs/en/reference/trees.rst
@@ -23,6 +23,7 @@ Full Tree in Single Document
         #[Field(type: 'string')]
         private string $body;
 
+        /** @var Collection<Comment> */
         #[EmbedMany(targetDocument: Comment::class)]
         private Collection $comments;
 
@@ -38,6 +39,7 @@ Full Tree in Single Document
         #[Field(type: 'string')]
         private string $text;
 
+        /** @var Collection<Comment> */
         #[EmbedMany(targetDocument: Comment::class)]
         private Collection $replies;
 
@@ -113,6 +115,7 @@ Child Reference
         #[Field(type: 'string')]
         private string $name;
 
+        /** @var Collection<Category> */
         #[ReferenceMany(targetDocument: Category::class)]
         #[Index]
         private Collection $children;
@@ -169,10 +172,12 @@ Array of Ancestors
         #[Id]
         private string $id;
 
+        /** @var Collection<Category> */
         #[ReferenceMany(targetDocument: Category::class)]
         #[Index]
         private Collection $ancestors;
 
+        /** @var Collection<Category> */
         #[ReferenceOne(targetDocument: Category::class)]
         #[Index]
         private ?Category $parent = null;

--- a/docs/en/reference/working-with-objects.rst
+++ b/docs/en/reference/working-with-objects.rst
@@ -423,8 +423,9 @@ in the $addresses collection.
     class User
     {
         //...
+        /** @var Collection<Address> */
         #[ReferenceMany(targetDocument: Address::class, cascade: ['persist', 'remove'])]
-        private $addresses;
+        private Collection $addresses;
         //...
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | doc
| BC Break     | no
| Fixed issues | -

#### Summary

Using types properties is recommended to improve type safety.

I still have to check that everything works properly if the properties are not set with a default value. Because when there's no type, the value is `null` by default.
