### PR TITLE
Add native type to private properties and final classes

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/APM/Command.php
+++ b/lib/Doctrine/ODM/MongoDB/APM/Command.php
@@ -14,9 +14,7 @@ use Throwable;
 final class Command
 {
     private CommandStartedEvent $startedEvent;
-
-    /** @var CommandSucceededEvent|CommandFailedEvent */
-    private $finishedEvent;
+    private CommandSucceededEvent|CommandFailedEvent $finishedEvent;
 
     private function __construct()
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Bucket.php
@@ -10,9 +10,7 @@ class Bucket extends AbstractBucket
 {
     /** @var mixed[] */
     private array $boundaries;
-
-    /** @var mixed */
-    private $default;
+    private mixed $default = null;
 
     /**
      * An array of values based on the groupBy expression that specify the

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill.php
@@ -32,8 +32,7 @@ use function strtolower;
  */
 class Fill extends Stage
 {
-    /** @var mixed|Expr|null */
-    private $partitionBy = null;
+    private mixed $partitionBy = null;
 
     /** @var array<string> */
     private array $partitionByFields = [];

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill/Output.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill/Output.php
@@ -23,7 +23,7 @@ class Output extends Stage
     private string $currentField = '';
 
     /** @var array<string, array<string, mixed>> */
-    private $output = [];
+    private array $output = [];
 
     public function __construct(Builder $builder, private Fill $fill)
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GeoNear.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GeoNear.php
@@ -25,7 +25,7 @@ class GeoNear extends MatchStage
     private ?float $minDistance = null;
 
     /** @var array<string, mixed>|array{int|float, int|float} */
-    private $near;
+    private array $near;
 
     private ?int $num = null;
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup.php
@@ -26,7 +26,7 @@ class GraphLookup extends Stage
     private ?string $from;
 
     /** @var string|Expr|mixed[]|null */
-    private $startWith;
+    private string|Expr|array|null $startWith;
 
     private ?string $connectFromField = null;
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
@@ -48,7 +48,7 @@ class Lookup extends Stage
      * @var Builder|array<array<string, mixed>>|null
      * @psalm-var Builder|PipelineExpression|null
      */
-    private $pipeline = null;
+    private Builder|array|null $pipeline = null;
 
     private bool $excludeLocalAndForeignField = false;
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
@@ -33,11 +33,8 @@ use function is_array;
  */
 class Merge extends Stage
 {
-    /**
-     * @var string|array
-     * @psalm-var OutputCollection
-     */
-    private $into;
+    /** @psalm-var OutputCollection */
+    private string|array $into;
 
     /** @var list<string> */
     private array $on = [];
@@ -45,11 +42,8 @@ class Merge extends Stage
     /** @var array<string, mixed|Expr> */
     private array $let = [];
 
-    /**
-     * @var string|array|Builder|Stage
-     * @psalm-var WhenMatchedParamType
-     */
-    private $whenMatched;
+    /** @psalm-var WhenMatchedParamType */
+    private string|array|Builder|Stage|null $whenMatched = null;
 
     private ?string $whenNotMatched = null;
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Out.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Out.php
@@ -19,11 +19,8 @@ use function is_array;
  */
 class Out extends Stage
 {
-    /**
-     * @var array|string
-     * @psalm-var OutputCollection
-     */
-    private $out;
+    /** @psalm-var OutputCollection */
+    private array|string $out;
 
     public function __construct(Builder $builder, string $collection, private DocumentManager $dm)
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Equals.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Equals.php
@@ -19,8 +19,7 @@ class Equals extends AbstractSearchOperator implements ScoredSearchOperator
 
     private string $path = '';
 
-    /** @var mixed */
-    private $value;
+    private mixed $value;
 
     /** @param string|int|float|ObjectId|UTCDateTime|null $value */
     public function __construct(Search $search, string $path = '', $value = null)

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoShape.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoShape.php
@@ -24,8 +24,7 @@ class GeoShape extends AbstractSearchOperator implements ScoredSearchOperator
     private array $path      = [];
     private string $relation = '';
 
-    /** @var LineString|Point|Polygon|MultiPolygon|array|null */
-    private $geometry = null;
+    private LineString|Point|Polygon|MultiPolygon|array|null $geometry = null;
 
     /** @param LineString|Point|Polygon|MultiPolygon|array|null $geometry */
     public function __construct(Search $search, $geometry = null, string $relation = '', string ...$path)

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoWithin.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoWithin.php
@@ -25,8 +25,7 @@ class GeoWithin extends AbstractSearchOperator implements ScoredSearchOperator
     private ?object $box     = null;
     private ?object $circle  = null;
 
-    /** @var array|MultiPolygon|Polygon|null */
-    private $geometry = null;
+    private array|MultiPolygon|Polygon|null $geometry = null;
 
     public function __construct(Search $search, string ...$path)
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Near.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Near.php
@@ -18,11 +18,9 @@ class Near extends AbstractSearchOperator implements ScoredSearchOperator
 {
     use ScoredSearchOperatorTrait;
 
-    /** @var int|float|UTCDateTime|array|Point|null */
-    private $origin;
+    private int|float|UTCDateTime|array|Point|null $origin;
 
-    /** @var int|float|null */
-    private $pivot;
+    private int|float|null $pivot;
 
     /** @var list<string> */
     private array $path;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Range.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Range.php
@@ -15,14 +15,10 @@ class Range extends AbstractSearchOperator implements ScoredSearchOperator
 {
     use ScoredSearchOperatorTrait;
 
-    /** @var int|float|UTCDateTime|null */
-    private $gt = null;
-
-    /** @var int|float|UTCDateTime|null */
-    private $lt = null;
-
-    private bool $includeLowerBound = false;
-    private bool $includeUpperBound = false;
+    private int|float|UTCDateTime|null $gt = null;
+    private int|float|UTCDateTime|null $lt = null;
+    private bool $includeLowerBound        = false;
+    private bool $includeUpperBound        = false;
 
     /** @var list<string> */
     private array $path;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SetWindowFields.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SetWindowFields.php
@@ -28,8 +28,7 @@ use function strtolower;
  */
 class SetWindowFields extends Stage
 {
-    /** @var mixed|Expr|null */
-    private $partitionBy = null;
+    private mixed $partitionBy = null;
 
     /** @var array<string, int> */
     private array $sortBy = [];

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
@@ -24,11 +24,8 @@ use InvalidArgumentException;
  */
 class UnionWith extends Stage
 {
-    /**
-     * @var array|Builder|null
-     * @psalm-var ?PipelineParamType
-     */
-    private $pipeline = null;
+    /** @psalm-var ?PipelineParamType */
+    private array|Builder|Stage|null $pipeline = null;
 
     public function __construct(Builder $builder, private DocumentManager $dm, private string $collection)
     {

--- a/lib/Doctrine/ODM/MongoDB/Event/DocumentNotFoundEventArgs.php
+++ b/lib/Doctrine/ODM/MongoDB/Event/DocumentNotFoundEventArgs.php
@@ -13,8 +13,7 @@ final class DocumentNotFoundEventArgs extends LifecycleEventArgs
 {
     private bool $disableException = false;
 
-    /** @param mixed $identifier */
-    public function __construct(object $document, DocumentManager $dm, private $identifier)
+    public function __construct(object $document, DocumentManager $dm, private mixed $identifier)
     {
         parent::__construct($document, $dm);
     }

--- a/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
@@ -25,7 +25,7 @@ use Traversable;
 final class HydratingIterator implements Iterator
 {
     /** @var Generator<mixed, array<string, mixed>>|null */
-    private $iterator;
+    private ?Generator $iterator;
 
     /**
      * @param Traversable<mixed, array<string, mixed>> $traversable

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -539,17 +539,14 @@ use function trigger_deprecation;
     /**
      * Allows users to specify a validation schema for the collection.
      *
-     * @var array|object|null
      * @psalm-var array<string, mixed>|object|null
      */
-    private $validator;
+    private array|object|null $validator = null;
 
     /**
      * Determines whether to error on invalid documents or just warn about the violations but allow invalid documents to be inserted.
-     *
-     * @var string
      */
-    private $validationAction = self::SCHEMA_VALIDATION_ACTION_ERROR;
+    private string $validationAction = self::SCHEMA_VALIDATION_ACTION_ERROR;
 
     /**
      * Determines how strictly MongoDB applies the validation rules to existing documents during an update.
@@ -813,11 +810,8 @@ use function trigger_deprecation;
 
     private ReflectionService $reflectionService;
 
-    /**
-     * @var string|null
-     * @psalm-var class-string|null
-     */
-    private $rootClass;
+    /** @var class-string|null */
+    private ?string $rootClass;
 
     /**
      * Initializes a new ClassMetadata instance that will hold the object-document mapping

--- a/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php
@@ -41,71 +41,61 @@ trait PersistentCollectionTrait
      *
      * @var array<TKey, T>
      */
-    private $snapshot = [];
+    private array $snapshot = [];
 
     /**
      * Collection's owning document
-     *
-     * @var object|null
      */
-    private $owner;
+    private ?object $owner = null;
 
     /**
-     * @var array|null
+     * @var array<string, mixed>|null
      * @psalm-var FieldMapping|null
      */
-    private $mapping;
+    private ?array $mapping = null;
 
     /**
      * Whether the collection is dirty and needs to be synchronized with the database
      * when the UnitOfWork that manages its persistent state commits.
-     *
-     * @var bool
      */
-    private $isDirty = false;
+    private bool $isDirty = false;
 
     /**
      * Whether the collection has already been initialized.
-     *
-     * @var bool
      */
-    private $initialized = true;
+    private bool $initialized = true;
 
     /**
      * The wrapped Collection instance.
      *
      * @var BaseCollection<TKey, T>
      */
-    private $coll;
+    private BaseCollection $coll;
 
     /**
      * The DocumentManager that manages the persistence of the collection.
-     *
-     * @var DocumentManager|null
      */
-    private $dm;
+    private DocumentManager $dm;
 
     /**
      * The UnitOfWork that manages the persistence of the collection.
-     *
-     * @var UnitOfWork
      */
-    private $uow;
+    private UnitOfWork $uow;
 
     /**
      * The raw mongo data that will be used to initialize this collection.
      *
      * @var mixed[]
      */
-    private $mongoData = [];
+    private array $mongoData = [];
 
     /**
      * Any hints to account for during reconstitution/lookup of the documents.
      *
-     * @var array
+     * @var array<int, mixed>
      * @psalm-var Hints
      */
-    private $hints = [];
+    private array $hints = [];
 
     public function setDocumentManager(DocumentManager $dm)
     {
@@ -292,7 +282,7 @@ trait PersistentCollectionTrait
 
     public function getTypeClass()
     {
-        if ($this->dm === null) {
+        if (! isset($this->dm)) {
             throw new MongoDBException('No DocumentManager is associated with this PersistentCollection, please set one using setDocumentManager method.');
         }
 
@@ -653,7 +643,7 @@ trait PersistentCollectionTrait
         $arrayAccess ? $this->coll->offsetSet(null, $value) : $this->coll->add($value);
         $this->changed();
 
-        if ($this->uow !== null && $this->isOrphanRemovalEnabled() && $value !== null) {
+        if (isset($this->uow) && $this->isOrphanRemovalEnabled() && $value !== null) {
             $this->uow->unscheduleOrphanRemoval($value);
         }
 
@@ -702,7 +692,7 @@ trait PersistentCollectionTrait
         $arrayAccess ? $this->coll->offsetSet($offset, $value) : $this->coll->set($offset, $value);
 
         // Handle orphanRemoval
-        if ($this->uow !== null && $this->isOrphanRemovalEnabled() && $value !== null) {
+        if (isset($this->uow) && $this->isOrphanRemovalEnabled() && $value !== null) {
             $this->uow->unscheduleOrphanRemoval($value);
         }
 
@@ -733,7 +723,7 @@ trait PersistentCollectionTrait
      */
     private function needsSchedulingForSynchronization(): bool
     {
-        return $this->owner && $this->dm && ! empty($this->mapping['isOwningSide'])
+        return $this->owner && isset($this->dm) && ! empty($this->mapping['isOwningSide'])
             && $this->dm->getClassMetadata(get_class($this->owner))->isChangeTrackingNotify();
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Proxy/Factory/StaticProxyFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Factory/StaticProxyFactory.php
@@ -25,11 +25,8 @@ use function count;
  */
 final class StaticProxyFactory implements ProxyFactory
 {
-    /** @var UnitOfWork The UnitOfWork this factory is bound to. */
     private UnitOfWork $uow;
-
     private LifecycleEventManager $lifecycleEventManager;
-
     private LazyLoadingGhostFactory $proxyFactory;
 
     public function __construct(DocumentManager $documentManager)

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -85,10 +85,9 @@ class Builder
     /**
      * Array containing the query data.
      *
-     * @var array
      * @psalm-var QueryShape
      */
-    private $query = ['type' => Query::TYPE_FIND];
+    private array $query = ['type' => Query::TYPE_FIND];
 
     /**
      * The Expr instance used for building this query.

--- a/lib/Doctrine/ODM/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Expr.php
@@ -40,10 +40,8 @@ class Expr
 {
     /**
      * The query criteria array.
-     *
-     * @var array<string, mixed>|mixed
      */
-    private $query = [];
+    private mixed $query = [];
 
     /**
      * The "new object" array containing either a full document or a number of

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -496,52 +496,17 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
 
 		-
-			message: "#^Access to offset 'embedded' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
-
-		-
-			message: "#^Access to offset 'isOwningSide' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\.$#"
-			count: 3
-			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
-
-		-
-			message: "#^Access to offset 'orphanRemoval' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
-
-		-
-			message: "#^Access to offset 'reference' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
-
-		-
-			message: "#^Access to offset 'strategy' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\.$#"
-			count: 4
-			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
-
-		-
-			message: "#^Access to offset 'targetDocument' on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\.$#"
-			count: 2
-			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
-
-		-
 			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:add\\(\\) with return type void returns true but should not return anything\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
 		-
-			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:getHints\\(\\) should return array\\<int, mixed\\> but returns Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints\\.$#"
+			message: "#^PHPDoc tag @var for property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:\\$hints with type Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints is incompatible with native type array\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
 		-
-			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:getMapping\\(\\) should return array\\{type\\: string, fieldName\\: string, name\\: string, isCascadeRemove\\: bool, isCascadePersist\\: bool, isCascadeRefresh\\: bool, isCascadeMerge\\: bool, isCascadeDetach\\: bool, \\.\\.\\.\\} but returns Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\|null\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
-
-		-
-			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:\\$hints \\(Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints\\) does not accept default value of type array\\.$#"
+			message: "#^PHPDoc tag @var for property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:\\$mapping with type Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\|null is not subtype of native type array\\|null\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
@@ -551,17 +516,22 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
 		-
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:\\$hints type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
+
+		-
 			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:\\$mapping has unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping as its type\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
 		-
-			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\<TKey of \\(int\\|string\\),T of object\\>\\:\\:\\$hints \\(Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\Hints\\) does not accept array\\<int, mixed\\>\\.$#"
+			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\:\\:\\$mapping type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
 		-
-			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\<TKey of \\(int\\|string\\),T of object\\>\\:\\:\\$mapping \\(Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\\\FieldMapping\\|null\\) does not accept array\\<string, array\\<int\\|string, mixed\\>\\|bool\\|int\\|string\\|null\\>\\.$#"
+			message: "#^Right side of && is always true\\.$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
@@ -864,16 +834,6 @@ parameters:
 			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\Ticket\\\\GH1990Document\\:\\:\\$parent is never read, only written\\.$#"
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1990Test.php
-
-		-
-			message: "#^Dead catch \\- MongoDB\\\\Driver\\\\Exception\\\\BulkWriteException is never thrown in the try block\\.$#"
-			count: 1
-			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH580Test.php
 
 		-
 			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Functional\\\\Ticket\\\\GH921Post\\:\\:\\$id is never written, only read\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -142,7 +142,15 @@
   <file src="lib/Doctrine/ODM/MongoDB/PersistentCollection/PersistentCollectionTrait.php">
     <RedundantCondition>
       <code><![CDATA[is_object($this->coll)]]></code>
+      <code><![CDATA[isset($this->uow) && $this->isOrphanRemovalEnabled() && $value !== null]]></code>
+      <code><![CDATA[isset($this->uow) && $this->isOrphanRemovalEnabled() && $value !== null]]></code>
     </RedundantCondition>
+    <RedundantPropertyInitializationCheck>
+      <code><![CDATA[$this->owner && isset($this->dm)]]></code>
+      <code><![CDATA[isset($this->dm)]]></code>
+      <code><![CDATA[isset($this->uow)]]></code>
+      <code><![CDATA[isset($this->uow)]]></code>
+    </RedundantPropertyInitializationCheck>
   </file>
   <file src="lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php">
     <RedundantFunctionCall>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

Some private properties were not typed, mainly because `mixed` or union types were not available in previous PHP version. 