### PR TITLE
Gracefully handle search index exceptions if possible

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -1057,6 +1057,13 @@ final class SchemaManager
 
     private function isSearchIndexCommandException(CommandException $e): bool
     {
-        return $e->getCode() === self::CODE_COMMAND_NOT_SUPPORTED && str_contains($e->getMessage(), 'Search index');
+        // MongoDB 6.0.7+ and 7.0+: "Search indexes are only available on Atlas"
+        if ($e->getCode() === self::CODE_COMMAND_NOT_SUPPORTED && str_contains($e->getMessage(), 'Search index')) {
+            return true;
+        }
+
+        // Older server versions don't support $listSearchIndexes
+        // We don't check for an error code here as the code is not documented and we can't rely on it
+        return str_contains($e->getMessage(), 'Unrecognized pipeline stage name: \'$listSearchIndexes\'');
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -8,6 +8,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactoryInterface;
 use Doctrine\ODM\MongoDB\Repository\ViewRepository;
 use InvalidArgumentException;
+use MongoDB\Driver\Exception\CommandException;
 use MongoDB\Driver\Exception\RuntimeException;
 use MongoDB\Driver\Exception\ServerException;
 use MongoDB\Driver\WriteConcern;
@@ -32,6 +33,7 @@ use function iterator_count;
 use function iterator_to_array;
 use function ksort;
 use function sprintf;
+use function str_contains;
 
 /**
  * @psalm-import-type IndexMapping from ClassMetadata
@@ -44,6 +46,7 @@ final class SchemaManager
     private const GRIDFS_CHUNKS_COLLECTION_INDEX = ['filename' => 1, 'uploadDate' => 1];
 
     private const CODE_SHARDING_ALREADY_INITIALIZED = 23;
+    private const CODE_COMMAND_NOT_SUPPORTED        = 115;
 
     private const ALLOWED_MISSING_INDEX_OPTIONS = [
         'background',
@@ -408,8 +411,19 @@ final class SchemaManager
         $searchIndexes = $class->getSearchIndexes();
         $collection    = $this->dm->getDocumentCollection($class->name);
 
-        $definedNames  = array_column($searchIndexes, 'name');
-        $existingNames = array_column(iterator_to_array($collection->listSearchIndexes()), 'name');
+        $definedNames = array_column($searchIndexes, 'name');
+        try {
+            $existingNames = array_column(iterator_to_array($collection->listSearchIndexes()), 'name');
+        } catch (CommandException $e) {
+            /* If $listSearchIndexes doesn't exist, only throw if search indexes have been defined.
+             * If no search indexes are defined and the server doesn't support search indexes, there's
+             * nothing for us to do here and we can safely return */
+            if ($definedNames === [] && $this->isSearchIndexCommandException($e)) {
+                return;
+            }
+
+            throw $e;
+        }
 
         foreach (array_diff($existingNames, $definedNames) as $name) {
             $collection->dropSearchIndex($name);
@@ -450,7 +464,18 @@ final class SchemaManager
 
         $collection = $this->dm->getDocumentCollection($class->name);
 
-        foreach ($collection->listSearchIndexes() as $searchIndex) {
+        try {
+            $searchIndexes = $collection->listSearchIndexes();
+        } catch (CommandException $e) {
+            // If the server does not support search indexes, there are no indexes to remove in any case
+            if ($this->isSearchIndexCommandException($e)) {
+                return;
+            }
+
+            throw $e;
+        }
+
+        foreach ($searchIndexes as $searchIndex) {
             $collection->dropSearchIndex($searchIndex['name']);
         }
     }
@@ -1028,5 +1053,10 @@ final class SchemaManager
         }
 
         return $options;
+    }
+
+    private function isSearchIndexCommandException(CommandException $e): bool
+    {
+        return $e->getCode() === self::CODE_COMMAND_NOT_SUPPORTED && str_contains($e->getMessage(), 'Search index');
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -26,6 +26,7 @@ use InvalidArgumentException;
 use MongoDB\Client;
 use MongoDB\Collection;
 use MongoDB\Database;
+use MongoDB\Driver\Exception\CommandException;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\GridFS\Bucket;
 use MongoDB\Model\CollectionInfo;
@@ -420,6 +421,27 @@ class SchemaManagerTest extends BaseTestCase
         $this->schemaManager->createDocumentSearchIndexes(CmsArticle::class);
     }
 
+    public function testCreateDocumentSearchIndexesNotSupported(): void
+    {
+        $exception = $this->createSearchIndexCommandException();
+
+        $cmsArticleCollectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
+        foreach ($this->documentCollections as $collectionName => $collection) {
+            if ($collectionName === $cmsArticleCollectionName) {
+                $collection
+                    ->expects($this->once())
+                    ->method('createSearchIndexes')
+                    ->with($this->anything())
+                    ->willThrowException($exception);
+            } else {
+                $collection->expects($this->never())->method('createSearchIndexes');
+            }
+        }
+
+        $this->expectExceptionObject($exception);
+        $this->schemaManager->createDocumentSearchIndexes(CmsArticle::class);
+    }
+
     public function testUpdateDocumentSearchIndexes(): void
     {
         $collectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
@@ -443,6 +465,47 @@ class SchemaManagerTest extends BaseTestCase
         $this->schemaManager->updateDocumentSearchIndexes(CmsArticle::class);
     }
 
+    public function testUpdateDocumentSearchIndexesNotSupportedForClassWithoutSearchIndexes(): void
+    {
+        // Class has no search indexes, so if the server doesn't support them we assume everything is fine
+        $collectionName = $this->dm->getClassMetadata(CmsProduct::class)->getCollection();
+        $collection     = $this->documentCollections[$collectionName];
+        $collection
+            ->expects($this->once())
+            ->method('listSearchIndexes')
+            ->willThrowException($this->createSearchIndexCommandException());
+        $collection
+            ->expects($this->never())
+            ->method('dropSearchIndex');
+        $collection
+            ->expects($this->never())
+            ->method('updateSearchIndex');
+
+        $this->schemaManager->updateDocumentSearchIndexes(CmsProduct::class);
+    }
+
+    public function testUpdateDocumentSearchIndexesNotSupportedForClassWithSearchIndexes(): void
+    {
+        $exception = $this->createSearchIndexCommandException();
+
+        // This class has search indexes, so we do expect an exception
+        $collectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
+        $collection     = $this->documentCollections[$collectionName];
+        $collection
+            ->expects($this->once())
+            ->method('listSearchIndexes')
+            ->willThrowException($exception);
+        $collection
+            ->expects($this->never())
+            ->method('dropSearchIndex');
+        $collection
+            ->expects($this->never())
+            ->method('updateSearchIndex');
+
+        $this->expectExceptionObject($exception);
+        $this->schemaManager->updateDocumentSearchIndexes(CmsArticle::class);
+    }
+
     public function testDeleteDocumentSearchIndexes(): void
     {
         $collectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
@@ -455,6 +518,21 @@ class SchemaManagerTest extends BaseTestCase
             ->expects($this->once())
             ->method('dropSearchIndex')
             ->with('default');
+
+        $this->schemaManager->deleteDocumentSearchIndexes(CmsArticle::class);
+    }
+
+    public function testDeleteDocumentSearchIndexesNotSupported(): void
+    {
+        $collectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
+        $collection     = $this->documentCollections[$collectionName];
+        $collection
+            ->expects($this->once())
+            ->method('listSearchIndexes')
+            ->willThrowException($this->createSearchIndexCommandException());
+        $collection
+            ->expects($this->never())
+            ->method('dropSearchIndex');
 
         $this->schemaManager->deleteDocumentSearchIndexes(CmsArticle::class);
     }
@@ -1238,5 +1316,10 @@ EOT;
 
             return true;
         });
+    }
+
+    private function createSearchIndexCommandException(): CommandException
+    {
+        return new CommandException('PlanExecutor error during aggregation :: caused by :: Search index commands are only supported with Atlas.', 115);
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | https://github.com/doctrine/mongodb-odm/issues/2634#issuecomment-2239054724

#### Summary

#2630 introduces support for managing search indexes in the schema manager. However, the logic does not correctly handle cases when the server does not support search indexes. This PR adds more graceful handling in cases where no search index changes are necessary. Here's a list of the changes:

* creating search indexes: no changes; if search indexes are declared on a class and the command to create them fails, we expect an exception to be thrown
* updating search indexes: if no search indexes are declared on a class, failure of the `listSearchIndexes` command will no longer cause an exception. If a class has search indexes, the old behaviour still applies
* deleting search indexes: failure of the `listSearchIndexes` command no longer throws an exception, since there are no search indexes to be removed.

We specifically check for error code 115 (CommandNotSupported) and check the exception message to make sure that it's actually an issue with the search index command, as there are no good ways to check for search index support.