### PR TITLE
Gracefully handle search index exceptions on non MongoDB Atlas

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -1061,6 +1061,8 @@ final class SchemaManager
         if ($e->getCode() === self::CODE_COMMAND_NOT_SUPPORTED && str_contains($e->getMessage(), 'Search index')) {
             return true;
         }
+
+        // MongoDB 6.0.7+ and 7.0+: "$listSearchIndexes stage is only allowed on MongoDB Atlas"
         if ($e->getMessage() === '$listSearchIndexes stage is only allowed on MongoDB Atlas') {
             return true;
         }

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -1061,6 +1061,9 @@ final class SchemaManager
         if ($e->getCode() === self::CODE_COMMAND_NOT_SUPPORTED && str_contains($e->getMessage(), 'Search index')) {
             return true;
         }
+        if ($e->getMessage() === '$listSearchIndexes stage is only allowed on MongoDB Atlas') {
+            return true;
+        }
 
         // Older server versions don't support $listSearchIndexes
         // We don't check for an error code here as the code is not documented and we can't rely on it


### PR DESCRIPTION
Allow users to explicitly exclude features (e.g. search indexes) in CLI commands.

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | https://github.com/doctrine/mongodb-odm/pull/2671#issuecomment-2312782111

#### Summary

The CLI commands for managing schema entities (e.g. creating collections and indexes) attempt to process all schema definitions by default. This is problematic for features such as Atlas Search indexes, which have more restrictions.

For example, CreateCommand defines an ordered list (i.e. $createOrder) for schema entities to process when no command line arguments are specified. If any Atlas Search indexes exist in class metadata, those will be processed by default; however, that may not be supported in a development environment.

If users want to exclude certain DDL operations, they cannot rely on the default order and must manually enumerate all schema entities to process. Consider introducing skip-<feature> options to allow users to opt out of specific features.

Context: https://github.com/doctrine/mongodb-odm/pull/2671#issuecomment-2312782111
