### PR TITLE
Fixes changeset being empty when datetime change is sub second

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -835,7 +835,7 @@ final class UnitOfWork implements PropertyChangedListener
                     $dbActualValue = $dateType->convertToDatabaseValue($actualValue);
 
                     // We rely on loose comparison to compare every field (including microseconds)
-                    // phpcs:ignore Squiz.Operators.ComparisonOperatorUsage.NotAllowed
+                    // phpcs:ignore SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedEqualOperator
                     if ($dbOrgValue == $dbActualValue) {
                         continue;
                     }

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -835,10 +835,7 @@ final class UnitOfWork implements PropertyChangedListener
                     $dbOrgValue    = $dateType->convertToDatabaseValue($orgValue);
                     $dbActualValue = $dateType->convertToDatabaseValue($actualValue);
 
-                    $orgTimestamp    = $dbOrgValue instanceof UTCDateTime ? $dbOrgValue->toDateTime()->getTimestamp() : null;
-                    $actualTimestamp = $dbActualValue instanceof UTCDateTime ? $dbActualValue->toDateTime()->getTimestamp() : null;
-
-                    if ($orgTimestamp === $actualTimestamp) {
+                    if ($dbOrgValue == $dbActualValue) {
                         continue;
                     }
                 }

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -24,7 +24,6 @@ use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Persistence\NotifyPropertyChanged;
 use Doctrine\Persistence\PropertyChangedListener;
 use InvalidArgumentException;
-use MongoDB\BSON\UTCDateTime;
 use MongoDB\Driver\Exception\RuntimeException;
 use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
@@ -835,6 +834,8 @@ final class UnitOfWork implements PropertyChangedListener
                     $dbOrgValue    = $dateType->convertToDatabaseValue($orgValue);
                     $dbActualValue = $dateType->convertToDatabaseValue($actualValue);
 
+                    // We rely on loose comparison to compare every field (including microseconds)
+                    // pspcs:ignore Squiz.Operators.ComparisonOperatorUsage.NotAllowed
                     if ($dbOrgValue == $dbActualValue) {
                         continue;
                     }

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -835,17 +835,9 @@ final class UnitOfWork implements PropertyChangedListener
                     $dbOrgValue    = $dateType->convertToDatabaseValue($orgValue);
                     $dbActualValue = $dateType->convertToDatabaseValue($actualValue);
 
-                    // to be removed in MR
-                    $orgTimestamp    = $dbOrgValue instanceof UTCDateTime ? $dbOrgValue->toDateTime()->getTimestamp() : null;
-                    $actualTimestamp = $dbActualValue instanceof UTCDateTime ? $dbActualValue->toDateTime()->getTimestamp() : null;
-
-                    if ($orgTimestamp === $actualTimestamp) {
+                    if ($dbOrgValue == $dbActualValue) {
                         continue;
                     }
-
-                    // if ($dbOrgValue == $dbActualValue) {
-                    //     continue;
-                    // }
                 }
 
                 // regular field

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -835,9 +835,16 @@ final class UnitOfWork implements PropertyChangedListener
                     $dbOrgValue    = $dateType->convertToDatabaseValue($orgValue);
                     $dbActualValue = $dateType->convertToDatabaseValue($actualValue);
 
-                    if ($dbOrgValue == $dbActualValue) {
+                    $orgTimestamp    = $dbOrgValue instanceof UTCDateTime ? $dbOrgValue->toDateTime()->getTimestamp() : null;
+                    $actualTimestamp = $dbActualValue instanceof UTCDateTime ? $dbActualValue->toDateTime()->getTimestamp() : null;
+
+                    if ($orgTimestamp === $actualTimestamp) {
                         continue;
                     }
+
+                    // if ($dbOrgValue == $dbActualValue) {
+                    //     continue;
+                    // }
                 }
 
                 // regular field

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -835,6 +835,7 @@ final class UnitOfWork implements PropertyChangedListener
                     $dbOrgValue    = $dateType->convertToDatabaseValue($orgValue);
                     $dbActualValue = $dateType->convertToDatabaseValue($actualValue);
 
+                    // to be removed in MR
                     $orgTimestamp    = $dbOrgValue instanceof UTCDateTime ? $dbOrgValue->toDateTime()->getTimestamp() : null;
                     $actualTimestamp = $dbActualValue instanceof UTCDateTime ? $dbActualValue->toDateTime()->getTimestamp() : null;
 

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -835,7 +835,7 @@ final class UnitOfWork implements PropertyChangedListener
                     $dbActualValue = $dateType->convertToDatabaseValue($actualValue);
 
                     // We rely on loose comparison to compare every field (including microseconds)
-                    // pspcs:ignore Squiz.Operators.ComparisonOperatorUsage.NotAllowed
+                    // phpcs:ignore Squiz.Operators.ComparisonOperatorUsage.NotAllowed
                     if ($dbOrgValue == $dbActualValue) {
                         continue;
                     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
@@ -69,6 +69,21 @@ class DateTest extends BaseTestCase
         ];
     }
 
+    public function testDateInstanceChangeWhenValueDifferenceIsSubSecond(): void
+    {
+        $user = new User();
+        $user->setCreatedAt(new UTCDateTime(100000000000));
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $user = $this->dm->getRepository($user::class)->findOneBy([]);
+        $user->setCreatedAt(new UTCDateTime(100000000123));
+        $this->dm->getUnitOfWork()->computeChangeSets();
+        $changeset = $this->dm->getUnitOfWork()->getDocumentChangeSet($user);
+        self::assertNotEmpty($changeset);
+    }
+
     public function testDateInstanceValueChangeDoesCauseUpdateIfValueIsTheSame(): void
     {
         $user = new User();


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | fix
| BC Break     | no
| Fixed issues | #2538

#### Summary

The ODM was ignoring changes when they are under a second (because of the cast as timestmap).

It might be a BC break because people can rely on the old behavior ?
