### PR TITLE
Remove usage of deprecated driver functionality

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
@@ -15,6 +15,7 @@ use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\ClassMetadata as PersistenceClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\ColocatedMappingDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use MongoDB\BSON\Document;
 use MongoDB\Driver\Exception\UnexpectedValueException;
 use ReflectionClass;
 use ReflectionMethod;
@@ -27,8 +28,6 @@ use function class_exists;
 use function constant;
 use function count;
 use function is_array;
-use function MongoDB\BSON\fromJSON;
-use function MongoDB\BSON\toPHP;
 use function trigger_deprecation;
 
 /**
@@ -133,12 +132,12 @@ class AttributeDriver implements MappingDriver
             } elseif ($attribute instanceof ODM\Validation) {
                 if (isset($attribute->validator)) {
                     try {
-                        $validatorBson = fromJSON($attribute->validator);
+                        $validatorBson = Document::fromJSON($attribute->validator);
                     } catch (UnexpectedValueException $e) {
                         throw MappingException::schemaValidationError($e->getCode(), $e->getMessage(), $className, 'validator');
                     }
 
-                    $validator = toPHP($validatorBson, []);
+                    $validator = $validatorBson->toPHP();
                     $metadata->setValidator($validator);
                 }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -11,6 +11,7 @@ use Doctrine\Persistence\Mapping\Driver\FileDriver;
 use DOMDocument;
 use InvalidArgumentException;
 use LibXMLError;
+use MongoDB\BSON\Document;
 use MongoDB\Driver\Exception\UnexpectedValueException;
 use SimpleXMLElement;
 
@@ -31,8 +32,6 @@ use function iterator_to_array;
 use function libxml_clear_errors;
 use function libxml_get_errors;
 use function libxml_use_internal_errors;
-use function MongoDB\BSON\fromJSON;
-use function MongoDB\BSON\toPHP;
 use function next;
 use function preg_match;
 use function simplexml_load_file;
@@ -215,12 +214,12 @@ class XmlDriver extends FileDriver
 
             $validatorJson = (string) $xmlSchemaValidation;
             try {
-                $validatorBson = fromJSON($validatorJson);
+                $validatorBson = Document::fromJSON($validatorJson);
             } catch (UnexpectedValueException $e) {
                 throw MappingException::schemaValidationError($e->getCode(), $e->getMessage(), $className, 'schema-validation');
             }
 
-            $validator = toPHP($validatorBson, []);
+            $validator = $validatorBson->toPHP();
             $metadata->setValidator($validator);
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -956,12 +956,12 @@ parameters:
 			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest\\.php\\:231\\>\\:\\:mapField\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\{fieldName\\: 'enum', enumType\\: 'Documents\\\\\\\\Card'\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest\\.php\\:230\\>\\:\\:mapField\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\{fieldName\\: 'enum', enumType\\: 'Documents\\\\\\\\Card'\\} given\\.$#"
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest\\.php\\:250\\>\\:\\:mapField\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\{fieldName\\: 'enum', enumType\\: 'Documents\\\\\\\\SuitNonBacked'\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest\\.php\\:249\\>\\:\\:mapField\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\{fieldName\\: 'enum', enumType\\: 'Documents\\\\\\\\SuitNonBacked'\\} given\\.$#"
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
@@ -46,7 +46,7 @@ class ReadPreferenceTest extends BaseTestCase
 
     /** @psalm-param ReadPreferenceTagShape[] $tags */
     #[DataProvider('provideReadPreferenceHints')]
-    public function testHintIsSetOnQuery(int $readPreference, array $tags = []): void
+    public function testHintIsSetOnQuery(string $readPreference, array $tags = []): void
     {
         $this->skipTestIfSharded(User::class);
 
@@ -68,9 +68,9 @@ class ReadPreferenceTest extends BaseTestCase
     public static function provideReadPreferenceHints(): array
     {
         return [
-            [ReadPreference::RP_PRIMARY, []],
-            [ReadPreference::RP_SECONDARY_PREFERRED, []],
-            [ReadPreference::RP_SECONDARY, [['dc' => 'east'], []]],
+            [ReadPreference::PRIMARY, []],
+            [ReadPreference::SECONDARY_PREFERRED, []],
+            [ReadPreference::SECONDARY, [['dc' => 'east'], []]],
         ];
     }
 
@@ -78,7 +78,7 @@ class ReadPreferenceTest extends BaseTestCase
     {
         $coll = $this->dm->getDocumentCollection(DocumentWithReadPreference::class);
 
-        self::assertSame(ReadPreference::RP_NEAREST, $coll->getReadPreference()->getMode());
+        self::assertSame(ReadPreference::NEAREST, $coll->getReadPreference()->getModeString());
         self::assertSame([['dc' => 'east']], $coll->getReadPreference()->getTagSets());
     }
 
@@ -88,7 +88,7 @@ class ReadPreferenceTest extends BaseTestCase
             ->createQueryBuilder()
             ->getQuery();
 
-        $this->assertReadPreferenceHint(ReadPreference::RP_NEAREST, $query->getQuery()['readPreference'], [['dc' => 'east']]);
+        $this->assertReadPreferenceHint(ReadPreference::NEAREST, $query->getQuery()['readPreference'], [['dc' => 'east']]);
     }
 
     public function testDocumentLevelReadPreferenceCanBeOverriddenInQueryBuilder(): void
@@ -98,14 +98,14 @@ class ReadPreferenceTest extends BaseTestCase
             ->setReadPreference(new ReadPreference('secondary', []))
             ->getQuery();
 
-        $this->assertReadPreferenceHint(ReadPreference::RP_SECONDARY, $query->getQuery()['readPreference']);
+        $this->assertReadPreferenceHint(ReadPreference::SECONDARY, $query->getQuery()['readPreference']);
     }
 
     /** @psalm-param ReadPreferenceTagShape[] $tags */
-    private function assertReadPreferenceHint(int $mode, ReadPreference $readPreference, array $tags = []): void
+    private function assertReadPreferenceHint(string $mode, ReadPreference $readPreference, array $tags = []): void
     {
         self::assertInstanceOf(ReadPreference::class, $readPreference);
-        self::assertEquals($mode, $readPreference->getMode());
+        self::assertEquals($mode, $readPreference->getModeString());
         self::assertEquals($tags, $readPreference->getTagSets());
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
@@ -391,7 +391,7 @@ class ReferencePrimerTest extends BaseTestCase
 
         // Note: using a secondary read preference here can cause issues when using transactions
         // Using a primaryPreferred works just as well to check if the hint is passed on to the primer
-        $readPreference = new ReadPreference(ReadPreference::RP_PRIMARY_PREFERRED);
+        $readPreference = new ReadPreference(ReadPreference::PRIMARY_PREFERRED);
         $this->dm->createQueryBuilder(User::class)
             ->field('account')->prime($primer)
             ->field('groups')->prime($primer)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ValidationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ValidationTest.php
@@ -8,11 +8,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\SchemaValidated;
-
-use function MongoDB\BSON\fromJSON;
-use function MongoDB\BSON\fromPHP;
-use function MongoDB\BSON\toCanonicalExtendedJSON;
-use function MongoDB\BSON\toPHP;
+use MongoDB\BSON\Document;
 
 class ValidationTest extends BaseTestCase
 {
@@ -41,15 +37,13 @@ class ValidationTest extends BaseTestCase
     ]
 }
 EOT;
-        $expectedValidatorBson = fromJSON($expectedValidatorJson);
-        $expectedValidator     = toPHP($expectedValidatorBson, []);
+        $expectedValidator     = Document::fromJSON($expectedValidatorJson)->toPHP();
         $expectedOptions       = [
             'validator' => $expectedValidator,
             'validationLevel' => ClassMetadata::SCHEMA_VALIDATION_LEVEL_MODERATE,
             'validationAction' => ClassMetadata::SCHEMA_VALIDATION_ACTION_WARN,
         ];
-        $expectedOptionsBson   = fromPHP($expectedOptions);
-        $expectedOptionsJson   = toCanonicalExtendedJSON($expectedOptionsBson);
+        $expectedOptionsJson   = Document::fromPHP($expectedOptions)->toCanonicalExtendedJSON();
         $collections           = $this->dm->getDocumentDatabase($cm->name)->listCollections();
         $assertNb              = 0;
         foreach ($collections as $collection) {
@@ -58,8 +52,7 @@ EOT;
             }
 
             $assertNb++;
-            $collectionOptionsBson = fromPHP($collection->getOptions());
-            $collectionOptionsJson = toCanonicalExtendedJSON($collectionOptionsBson);
+            $collectionOptionsJson = Document::fromPHP($collection->getOptions())->toCanonicalExtendedJSON();
             self::assertJsonStringEqualsJsonString($expectedOptionsJson, $collectionOptionsJson);
         }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -35,6 +35,7 @@ use Documents\UserRepository;
 use Documents\UserTyped;
 use Generator;
 use InvalidArgumentException;
+use MongoDB\BSON\Document;
 use PHPUnit\Framework\Attributes\DataProvider;
 use ProxyManager\Proxy\GhostObjectInterface;
 use ReflectionClass;
@@ -42,8 +43,6 @@ use ReflectionException;
 use stdClass;
 
 use function array_merge;
-use function MongoDB\BSON\fromJSON;
-use function MongoDB\BSON\toPHP;
 use function serialize;
 use function unserialize;
 
@@ -78,7 +77,7 @@ class ClassMetadataTest extends BaseTestCase
         $cm->setVersioned(true);
         $cm->setVersionField('version');
         $validatorJson = '{ "$and": [ { "email": { "$regularExpression" : { "pattern": "@mongodb\\\\.com$", "options": "" } } } ] }';
-        $cm->setValidator(toPHP(fromJSON($validatorJson)));
+        $cm->setValidator(Document::fromJSON($validatorJson)->toPHP());
         $cm->setValidationAction(ClassMetadata::SCHEMA_VALIDATION_ACTION_WARN);
         $cm->setValidationLevel(ClassMetadata::SCHEMA_VALIDATION_LEVEL_OFF);
         self::assertIsArray($cm->getFieldMapping('phonenumbers'));
@@ -110,7 +109,7 @@ class ClassMetadataTest extends BaseTestCase
         self::assertEquals('lock', $cm->lockField);
         self::assertEquals(true, $cm->isVersioned);
         self::assertEquals('version', $cm->versionField);
-        self::assertEquals(toPHP(fromJSON($validatorJson)), $cm->getValidator());
+        self::assertEquals(Document::fromJSON($validatorJson)->toPHP(), $cm->getValidator());
         self::assertEquals(ClassMetadata::SCHEMA_VALIDATION_ACTION_WARN, $cm->getValidationAction());
         self::assertEquals(ClassMetadata::SCHEMA_VALIDATION_LEVEL_OFF, $cm->getValidationLevel());
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Mapping\Driver;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
+use MongoDB\BSON\Document;
 use TestDocuments\AlsoLoadDocument;
 use TestDocuments\CustomIdGenerator;
 use TestDocuments\InvalidPartialFilterDocument;
@@ -15,9 +16,6 @@ use TestDocuments\SchemaValidatedDocument;
 use TestDocuments\UserCustomIdGenerator;
 use TestDocuments\UserNonStringOptions;
 use TestDocuments\WildcardIndexDocument;
-
-use function MongoDB\BSON\fromJSON;
-use function MongoDB\BSON\toPHP;
 
 class XmlDriverTest extends AbstractDriverTestCase
 {
@@ -137,8 +135,7 @@ class XmlDriverTest extends AbstractDriverTestCase
     ]
 }
 EOT;
-        $expectedValidatorBson = fromJSON($expectedValidatorJson);
-        $expectedValidator     = toPHP($expectedValidatorBson, []);
+        $expectedValidator     = Document::fromJSON($expectedValidatorJson)->toPHP();
         self::assertEquals($expectedValidator, $classMetadata->getValidator());
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -675,7 +675,7 @@ class BuilderTest extends BaseTestCase
 
         $readPreference = $qb->debug('readPreference');
         self::assertInstanceOf(ReadPreference::class, $readPreference);
-        self::assertEquals(ReadPreference::RP_SECONDARY, $readPreference->getMode());
+        self::assertEquals(ReadPreference::SECONDARY, $readPreference->getModeString());
         self::assertEquals([['dc' => 'east']], $readPreference->getTagSets());
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -23,6 +23,7 @@ use Documents\SimpleReferenceUser;
 use Documents\Tournament\Tournament;
 use Documents\UserName;
 use InvalidArgumentException;
+use MongoDB\BSON\Document;
 use MongoDB\Client;
 use MongoDB\Collection;
 use MongoDB\Database;
@@ -43,8 +44,6 @@ use function array_count_values;
 use function array_map;
 use function assert;
 use function in_array;
-use function MongoDB\BSON\fromJSON;
-use function MongoDB\BSON\toPHP;
 
 /**
  * @psalm-import-type IndexMapping from ClassMetadata
@@ -601,8 +600,7 @@ class SchemaManagerTest extends BaseTestCase
     ]
 }
 EOT;
-        $expectedValidatorBson = fromJSON($expectedValidatorJson);
-        $expectedValidator     = toPHP($expectedValidatorBson, []);
+        $expectedValidator     = Document::fromJSON($expectedValidatorJson)->toPHP();
         $database
             ->expects($this->once())
             ->method('command')
@@ -707,8 +705,7 @@ EOT;
     ]
 }
 EOT;
-        $expectedValidatorBson = fromJSON($expectedValidatorJson);
-        $expectedValidator     = toPHP($expectedValidatorBson, []);
+        $expectedValidator     = Document::fromJSON($expectedValidatorJson)->toPHP();
         $options               = [
             'capped' => false,
             'size' => null,


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

To prepare for an upcoming 2.0 release of the extension, we need to stop using deprecated symbols. In this PR:
* replace usages of deprecated BSON functions with functionality from `MongoDB\BSON\Document`
* replace usages of deprecated `ReadPreference::RP_*` constants
* replace usages of deprecated `ReadPreference::getMode()` method

Additional pull requests will be made as changes happen in the driver.
