### PR TITLE
Support version 2.0 of the MongoDB driver

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,7 +42,7 @@ jobs:
           - dependencies: "lowest"
             php-version: "8.1"
             mongodb-version: "5.0"
-            driver-version: "1.20.0"
+            driver-version: "1.21.0"
             topology: "server"
             symfony-version: "stable"
             proxy: "lazy-ghost"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: "ubuntu-20.04"
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - "8.1"
@@ -68,6 +69,13 @@ jobs:
             dependencies: "highest"
             symfony-version: "stable"
             proxy: "proxy-manager"
+          # Test with ext-2.0
+          - topology: "server"
+            php-version: "8.2"
+            mongodb-version: "7.0"
+            driver-version: "mongodb/mongo-php-driver@v2.x"
+            dependencies: "highest"
+            symfony-version: "7"
           # Test with a 5.0 sharded cluster
           # Currently disabled due to a bug where MongoDB reports "sharding status unknown"
 #          - topology: "sharded_cluster"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,7 +42,7 @@ jobs:
           - dependencies: "lowest"
             php-version: "8.1"
             mongodb-version: "5.0"
-            driver-version: "1.17.0"
+            driver-version: "1.20.0"
             topology: "server"
             symfony-version: "stable"
             proxy: "lazy-ghost"

--- a/benchmark/BaseBench.php
+++ b/benchmark/BaseBench.php
@@ -68,7 +68,7 @@ abstract class BaseBench
             return;
         }
 
-        $collections = $client->selectDatabase(self::DATABASE_NAME)->listCollections();
+        $collections = $client->getDatabase(self::DATABASE_NAME)->listCollections();
 
         foreach ($collections as $collection) {
             // See https://jira.mongodb.org/browse/SERVER-16541
@@ -76,7 +76,7 @@ abstract class BaseBench
                 continue;
             }
 
-            $client->selectCollection(self::DATABASE_NAME, $collection->getName())->drop();
+            $client->getCollection(self::DATABASE_NAME, $collection->getName())->drop();
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "ext-mongodb": "^1.17",
+        "ext-mongodb": "^1.20 || ^2.0",
         "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.5 || ^2.0",
         "doctrine/event-manager": "^1.0 || ^2.0",
@@ -30,7 +30,7 @@
         "doctrine/persistence": "^3.2 || ^4",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "jean85/pretty-package-versions": "^1.3.0 || ^2.0.1",
-        "mongodb/mongodb": "^1.17.0",
+        "mongodb/mongodb": "^1.20 || ^2.0@dev",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "ext-mongodb": "^1.20 || ^2.0",
+        "ext-mongodb": "^1.21 || ^2.0",
         "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.5 || ^2.0",
         "doctrine/event-manager": "^1.0 || ^2.0",
@@ -30,7 +30,7 @@
         "doctrine/persistence": "^3.2 || ^4",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "jean85/pretty-package-versions": "^1.3.0 || ^2.0.1",
-        "mongodb/mongodb": "^1.20 || ^2.0@dev",
+        "mongodb/mongodb": "^1.21 || ^2.0@dev",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0",

--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -322,7 +322,7 @@ class DocumentManager implements ObjectManager
         $db                                  = $metadata->getDatabase();
         $db                                  = $db ?: $this->config->getDefaultDB();
         $db                                  = $db ?: 'doctrine';
-        $this->documentDatabases[$className] = $this->client->selectDatabase($db);
+        $this->documentDatabases[$className] = $this->client->getDatabase($db);
 
         return $this->documentDatabases[$className];
     }
@@ -364,7 +364,7 @@ class DocumentManager implements ObjectManager
                 $options['readPreference'] = new ReadPreference($metadata->readPreference, $metadata->readPreferenceTags);
             }
 
-            $this->documentCollections[$className] = $db->selectCollection($collectionName, $options);
+            $this->documentCollections[$className] = $db->getCollection($collectionName, $options);
         }
 
         return $this->documentCollections[$className];

--- a/lib/Doctrine/ODM/MongoDB/Id/IncrementGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Id/IncrementGenerator.php
@@ -56,7 +56,7 @@ class IncrementGenerator extends AbstractIdGenerator
 
         $key            = $this->key ?: $dm->getDocumentCollection($className)->getCollectionName();
         $collectionName = $this->collection ?: 'doctrine_increment_ids';
-        $collection     = $db->selectCollection($collectionName);
+        $collection     = $db->getCollection($collectionName);
 
         /*
          * Unable to use '$inc' and '$setOnInsert' together due to known bug.

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -544,6 +544,8 @@ final class DocumentPersister
         assert($this->collection instanceof Collection);
         $baseCursor = $this->collection->find($criteria, $options);
 
+        assert($baseCursor instanceof CursorInterface && $baseCursor instanceof SplIterator);
+
         return $this->wrapCursor($baseCursor);
     }
 

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -956,7 +956,7 @@ final class SchemaManager
     public function enableShardingForDbByDocumentName(string $documentName): void
     {
         $dbName  = $this->dm->getDocumentDatabase($documentName)->getDatabaseName();
-        $adminDb = $this->dm->getClient()->selectDatabase('admin');
+        $adminDb = $this->dm->getClient()->getDatabase('admin');
 
         try {
             $adminDb->command(['enableSharding' => $dbName]);
@@ -976,7 +976,7 @@ final class SchemaManager
         $class    = $this->dm->getClassMetadata($documentName);
         $dbName   = $this->dm->getDocumentDatabase($documentName)->getDatabaseName();
         $shardKey = $class->getShardKey();
-        $adminDb  = $this->dm->getClient()->selectDatabase('admin');
+        $adminDb  = $this->dm->getClient()->getDatabase('admin');
 
         $shardKeyPart = [];
         foreach ($shardKey['keys'] as $key => $order) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -51,29 +51,9 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GraphLookup.php
 
 		-
-			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Lookup\\:\\:getExpression\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
-
-		-
-			message: "#^PHPDoc tag @return with type mixed is not subtype of native type array\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
-
-		-
 			message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getClassMetadata\\(\\)$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
-
-		-
-			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Merge\\:\\:whenMatched\\(\\) has parameter \\$whenMatched with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
-
-		-
-			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Aggregation\\\\Stage\\\\Merge\\:\\:\\$whenMatched type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
 
 		-
 			message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getClassMetadata\\(\\)$#"
@@ -531,11 +511,6 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
-
-		-
 			message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getClassMetadata\\(\\)$#"
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/PersistentCollection.php
@@ -961,16 +936,6 @@ parameters:
 			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest\\.php\\:232\\>\\:\\:mapField\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\{fieldName\\: 'enum', enumType\\: 'Documents\\\\\\\\Card'\\} given\\.$#"
-			count: 1
-			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest\\.php\\:251\\>\\:\\:mapField\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\{fieldName\\: 'enum', enumType\\: 'Documents\\\\\\\\SuitNonBacked'\\} given\\.$#"
-			count: 1
-			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
-
-		-
 			message: "#^Property DoctrineGlobal_User\\:\\:\\$email is unused\\.$#"
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/Documents/GlobalNamespaceDocument.php
@@ -1031,7 +996,32 @@ parameters:
 			path: tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
 
 		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\QueryTest\\:\\:createCursorMock\\(\\) return type has no value type specified in iterable type Traversable\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+
+		-
+			message: "#^Method class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/QueryTest\\.php\\:561\\:\\:current\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+
+		-
+			message: "#^Method class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/QueryTest\\.php\\:561\\:\\:setTypeMap\\(\\) has parameter \\$typemap with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+
+		-
+			message: "#^Method class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/QueryTest\\.php\\:561\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+
+		-
 			message: "#^Parameter \\#4 \\$query of class Doctrine\\\\ODM\\\\MongoDB\\\\Query\\\\Query constructor expects array\\{distinct\\?\\: string, hint\\?\\: array\\<string, \\-1\\|1\\>\\|string, limit\\?\\: int, maxTimeMS\\?\\: int, multiple\\?\\: bool, new\\?\\: bool, newObj\\?\\: array\\<string, mixed\\>, query\\?\\: array\\<string, mixed\\>, \\.\\.\\.\\}, array\\{type\\: \\-1\\} given\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+
+		-
+			message: "#^Return type \\(MongoDB\\\\BSON\\\\Int64\\) of method class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/QueryTest\\.php\\:561\\:\\:getId\\(\\) should be compatible with return type \\(MongoDB\\\\Driver\\\\CursorId\\) of method MongoDB\\\\Driver\\\\CursorInterface\\:\\:getId\\(\\)$#"
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
 
@@ -1039,6 +1029,36 @@ parameters:
 			message: "#^Used constant DOCTRINE_MONGODB_DATABASE not found\\.$#"
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/QueryTest.php
+
+		-
+			message: "#^Instantiated class MongoDB\\\\Model\\\\CollectionInfoCommandIterator not found\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+
+		-
+			message: "#^Instantiated class MongoDB\\\\Model\\\\IndexInfoIteratorIterator not found\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\SchemaManagerTest\\:\\:createCollectionIterator\\(\\) has parameter \\$collections with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\SchemaManagerTest\\:\\:createCollectionIterator\\(\\) should return Iterator but returns MongoDB\\\\Model\\\\CollectionInfoCommandIterator\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\SchemaManagerTest\\:\\:createIndexIterator\\(\\) has parameter \\$indexes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\SchemaManagerTest\\:\\:createIndexIterator\\(\\) should return Iterator but returns MongoDB\\\\Model\\\\IndexInfoIteratorIterator\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
 
 		-
 			message: "#^Property Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Tools\\\\GH297\\\\User\\:\\:\\$id is never written, only read\\.$#"

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
@@ -65,7 +65,7 @@ abstract class BaseTestCase extends TestCase
             return;
         }
 
-        $collections = $client->selectDatabase(DOCTRINE_MONGODB_DATABASE)->listCollections();
+        $collections = $client->getDatabase(DOCTRINE_MONGODB_DATABASE)->listCollections();
 
         foreach ($collections as $collection) {
             // See https://jira.mongodb.org/browse/SERVER-16541
@@ -73,7 +73,7 @@ abstract class BaseTestCase extends TestCase
                 continue;
             }
 
-            $client->selectCollection(DOCTRINE_MONGODB_DATABASE, $collection->getName())->drop();
+            $client->getCollection(DOCTRINE_MONGODB_DATABASE, $collection->getName())->drop();
         }
     }
 
@@ -137,7 +137,7 @@ abstract class BaseTestCase extends TestCase
 
     protected function getServerVersion(): string
     {
-        $result = $this->dm->getClient()->selectDatabase(DOCTRINE_MONGODB_DATABASE)->command(['buildInfo' => 1], ['typeMap' => DocumentManager::CLIENT_TYPEMAP])->toArray()[0];
+        $result = $this->dm->getClient()->getDatabase(DOCTRINE_MONGODB_DATABASE)->command(['buildInfo' => 1], ['typeMap' => DocumentManager::CLIENT_TYPEMAP])->toArray()[0];
 
         return $result['version'];
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/TransactionalLifecycleEventsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/TransactionalLifecycleEventsTest.php
@@ -25,7 +25,7 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
 
     public function tearDown(): void
     {
-        $this->dm->getClient()->selectDatabase('admin')->command([
+        $this->dm->getClient()->getDatabase('admin')->command([
             'configureFailPoint' => 'failCommand',
             'mode' => 'off',
         ]);
@@ -188,7 +188,7 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
 
     private function createFailPoint(string $failCommand): void
     {
-        $this->dm->getClient()->selectDatabase('admin')->command([
+        $this->dm->getClient()->getDatabase('admin')->command([
             'configureFailPoint' => 'failCommand',
             'mode' => ['times' => 1],
             'data' => [

--- a/tests/Doctrine/ODM/MongoDB/Tests/Id/IncrementGeneratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Id/IncrementGeneratorTest.php
@@ -17,7 +17,7 @@ class IncrementGeneratorTest extends BaseTestCase
         $generator = new IncrementGenerator();
         $generator->setStartingId(10);
 
-        $collection = $this->dm->getClient()->selectCollection(DOCTRINE_MONGODB_DATABASE, 'doctrine_increment_ids');
+        $collection = $this->dm->getClient()->getCollection(DOCTRINE_MONGODB_DATABASE, 'doctrine_increment_ids');
 
         self::assertSame(10, $generator->generate($this->dm, new User()));
         $result = $collection->findOne(['_id' => 'users']);
@@ -34,7 +34,7 @@ class IncrementGeneratorTest extends BaseTestCase
 
         self::assertSame(1, $generator->generate($this->dm, new User()));
 
-        $collection = $this->dm->getClient()->selectCollection(DOCTRINE_MONGODB_DATABASE, 'doctrine_increment_ids');
+        $collection = $this->dm->getClient()->getCollection(DOCTRINE_MONGODB_DATABASE, 'doctrine_increment_ids');
         $result     = $collection->findOne(['_id' => 'users']);
         self::assertSame(1, $result['current_id']);
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Proxy/Factory/ProxyFactoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Proxy/Factory/ProxyFactoryTest.php
@@ -32,11 +32,11 @@ class ProxyFactoryTest extends BaseTestCase
         $database   = $this->createMock(Database::class);
 
         $this->client->expects($this->once())
-            ->method('selectDatabase')
+            ->method('getDatabase')
             ->willReturn($database);
 
         $database->expects($this->once())
-            ->method('selectCollection')
+            ->method('getCollection')
             ->willReturn($collection);
 
         $collection->expects($this->once())

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -26,6 +26,7 @@ use Documents\TimeSeries\TimeSeriesDocument;
 use Documents\Tournament\Tournament;
 use Documents\UserName;
 use InvalidArgumentException;
+use Iterator;
 use MongoDB\BSON\Document;
 use MongoDB\Client;
 use MongoDB\Collection;
@@ -34,7 +35,10 @@ use MongoDB\Driver\Exception\CommandException;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\GridFS\Bucket;
 use MongoDB\Model\CollectionInfo;
+use MongoDB\Model\CollectionInfoCommandIterator;
+use MongoDB\Model\CollectionInfoIterator;
 use MongoDB\Model\IndexInfo;
+use MongoDB\Model\IndexInfoIterator;
 use MongoDB\Model\IndexInfoIteratorIterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Constraint\ArrayHasKey;
@@ -47,6 +51,7 @@ use function array_count_values;
 use function array_map;
 use function assert;
 use function in_array;
+use function interface_exists;
 
 /**
  * @phpstan-import-type IndexMapping from ClassMetadata
@@ -199,7 +204,7 @@ class SchemaManagerTest extends BaseTestCase
 
             $filesCollection
                 ->method('listIndexes')
-                ->willReturn([]);
+                ->willReturn($this->createIndexIterator());
             $filesCollection
                 ->expects($this->atLeastOnce())
                 ->method('createIndex')
@@ -207,7 +212,7 @@ class SchemaManagerTest extends BaseTestCase
 
             $chunksCollection
                 ->method('listIndexes')
-                ->willReturn([]);
+                ->willReturn($this->createIndexIterator());
             $chunksCollection
                 ->expects($this->atLeastOnce())
                 ->method('createIndex')
@@ -255,7 +260,7 @@ class SchemaManagerTest extends BaseTestCase
             if ($class === $fileBucket) {
                 $filesCollection
                     ->method('listIndexes')
-                    ->willReturn([]);
+                    ->willReturn($this->createIndexIterator());
                 $filesCollection
                     ->expects($this->once())
                     ->method('createIndex')
@@ -263,7 +268,7 @@ class SchemaManagerTest extends BaseTestCase
 
                 $chunksCollection
                     ->method('listIndexes')
-                    ->willReturn([]);
+                    ->willReturn($this->createIndexIterator());
                 $chunksCollection
                     ->expects($this->once())
                     ->method('createIndex')
@@ -300,7 +305,7 @@ class SchemaManagerTest extends BaseTestCase
         $collection
             ->expects($this->once())
             ->method('listIndexes')
-            ->willReturn(new IndexInfoIteratorIterator(new ArrayIterator([])));
+            ->willReturn($this->createIndexIterator());
         $collection
             ->expects($this->once())
             ->method('createIndex')
@@ -330,7 +335,7 @@ class SchemaManagerTest extends BaseTestCase
         $collection
             ->expects($this->once())
             ->method('listIndexes')
-            ->willReturn(new IndexInfoIteratorIterator(new ArrayIterator($indexes)));
+            ->willReturn($this->createIndexIterator($indexes));
         $collection
             ->expects($this->once())
             ->method('createIndex')
@@ -1338,10 +1343,10 @@ EOT;
         $db->method('listCollections')->willReturnCallback(function () {
             $collections = [];
             foreach ($this->documentCollections as $collectionName => $collection) {
-                $collections[] = new CollectionInfo(['name' => $collectionName]);
+                $collections[] = ['name' => $collectionName];
             }
 
-            return $collections;
+            return $this->createCollectionIterator($collections);
         });
 
         return $db;
@@ -1373,5 +1378,29 @@ EOT;
     private function createSearchIndexCommandExceptionForOlderServers(): CommandException
     {
         return new CommandException('Unrecognized pipeline stage name: \'$listSearchIndexes\'', 40234);
+    }
+
+    private function createIndexIterator(array $indexes = []): Iterator
+    {
+        if (interface_exists(IndexInfoIterator::class)) {
+            return new IndexInfoIteratorIterator(new ArrayIterator($indexes));
+        }
+
+        return new ArrayIterator(array_map(
+            static fn (array $indexInfo) => new IndexInfo($indexInfo),
+            $indexes,
+        ));
+    }
+
+    private function createCollectionIterator(array $collections = []): Iterator
+    {
+        if (interface_exists(CollectionInfoIterator::class)) {
+            return new CollectionInfoCommandIterator(new ArrayIterator($collections));
+        }
+
+        return new ArrayIterator(array_map(
+            static fn (array $collectionInfo) => new CollectionInfo($collectionInfo),
+            $collections,
+        ));
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -120,7 +120,7 @@ class SchemaManagerTest extends BaseTestCase
             $this->documentDatabases[$db] = $this->getMockDatabase();
         }
 
-        $client->method('selectDatabase')->willReturnCallback(fn (string $db) => $this->documentDatabases[$db]);
+        $client->method('getDatabase')->willReturnCallback(fn (string $db) => $this->documentDatabases[$db]);
 
         $this->schemaManager = $this->dm->getSchemaManager();
     }
@@ -1338,7 +1338,7 @@ EOT;
     private function getMockDatabase()
     {
         $db = $this->createMock(Database::class);
-        $db->method('selectCollection')->willReturnCallback(fn (string $collection) => $this->documentCollections[$collection]);
+        $db->method('getCollection')->willReturnCallback(fn (string $collection) => $this->documentCollections[$collection]);
         $db->method('selectGridFSBucket')->willReturnCallback(fn (array $options) => $this->documentBuckets[$options['bucketName']]);
         $db->method('listCollections')->willReturnCallback(function () {
             $collections = [];

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
@@ -20,7 +20,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
 
     public function tearDown(): void
     {
-        $this->dm->getClient()->selectDatabase('admin')->command([
+        $this->dm->getClient()->getDatabase('admin')->command([
             'configureFailPoint' => 'failCommand',
             'mode' => 'off',
         ]);
@@ -449,7 +449,7 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
 
     private function createFailpoint(string $commandName): void
     {
-        $this->dm->getClient()->selectDatabase('admin')->command([
+        $this->dm->getClient()->getDatabase('admin')->command([
             'configureFailPoint' => 'failCommand',
             'mode' => ['times' => 1],
             'data' => [

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTransactionalCommitConsistencyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTransactionalCommitConsistencyTest.php
@@ -27,7 +27,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
 
     public function tearDown(): void
     {
-        $this->dm->getClient()->selectDatabase('admin')->command([
+        $this->dm->getClient()->getDatabase('admin')->command([
             'configureFailPoint' => 'failCommand',
             'mode' => 'off',
         ]);
@@ -611,7 +611,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
 
     private function createTransientFailPoint(string $failCommand, int $times = 1): void
     {
-        $this->dm->getClient()->selectDatabase('admin')->command([
+        $this->dm->getClient()->getDatabase('admin')->command([
             'configureFailPoint' => 'failCommand',
             'mode' => ['times' => $times],
             'data' => [
@@ -624,7 +624,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
 
     private function createFatalFailPoint(string $failCommand): void
     {
-        $this->dm->getClient()->selectDatabase('admin')->command([
+        $this->dm->getClient()->getDatabase('admin')->command([
             'configureFailPoint' => 'failCommand',
             'mode' => ['times' => 1],
             'data' => [


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

The 2.0 release of the PHP driver will mainly remove deprecated functionality, which was already removed in a previous pull request. This PR adds a separate build job to test the ODM with version 2.0 of the extension and library to ensure everything continues to work. The goal is to support both versions of the extension at the same time to make upgrading easier.