### PR TITLE
Support mapping time series collections

### DIFF
--- a/docs/en/cookbook/time-series-data.rst
+++ b/docs/en/cookbook/time-series-data.rst
@@ -5,8 +5,9 @@ Storing Time Series Data
 
     Support for mapping time series data was added in ODM 2.10.
 
-Time series data is a sequence of data points in which insights are gained by
-analyzing changes over time.
+`time-series data <https://www.mongodb.com/docs/manual/core/timeseries-collections/>`__
+is a sequence of data points in which insights are gained by analyzing changes
+over time.
 
 Time series data is generally composed of these components:
 

--- a/docs/en/cookbook/time-series-data.rst
+++ b/docs/en/cookbook/time-series-data.rst
@@ -92,8 +92,8 @@ measurement:
         // ...
     }
 
-Once we created the schema, we can store our measurements in this time series
-collection and let MongoDB optimise the storage for faster queries:
+Once we create the schema, we can store our measurements in this time series
+collection and let MongoDB optimize the storage for faster queries:
 
 .. code-block:: php
 
@@ -109,8 +109,8 @@ collection and let MongoDB optimise the storage for faster queries:
     $documentManager->persist($measurement);
     $documentManager->flush();
 
-Note that other functionality, such as querying, aggregating data using
-aggregation pipeline, or removing data works the same as with other collections.
+Note that other functionality such as querying, using aggregation pipelines, or
+removing data works the same as with other collections.
 
 Considerations
 --------------
@@ -122,7 +122,7 @@ size. This affects storage requirements and query performance.
 
 For example, with the default ``seconds`` granularity, each bucket groups
 documents for one hour. If each sensor only reports data every few minutes, we'd
-do well to only store them with a ``minute`` granularity. This reduces the
+do well to configure ``minute`` granularity. This reduces the
 number of buckets created, reducing storage and making queries more efficient.
 However, if we were to choose ``hours`` for granularity, readings for a whole
 month would be grouped into one bucket, resulting in slower queries as more

--- a/docs/en/cookbook/time-series-data.rst
+++ b/docs/en/cookbook/time-series-data.rst
@@ -21,6 +21,11 @@ Time series data is generally composed of these components:
 -
     Measurements, which are the data points tracked at increments in time.
 
+A time series document always contains a time value, and one or more measurement
+fields. Metadata is optional, but cannot be added to a time series collection
+after creating it. When using an embedded document for metadata, fields can be
+added to this document after creating the collection.
+
 .. note::
 
     Support for time series collections was added in MongoDB 5.0. Attempting to
@@ -30,9 +35,10 @@ Time series data is generally composed of these components:
 Creating The Model
 ------------------
 
-For this example, we'll be storing data from multiple temperature sensors. Other
-examples for time series include stock data, price information, website visitors,
-and vehicle telemetry (speed, position, etc.).
+For this example, we'll be storing data from multiple sensors measuring
+temperature and humidity. Other examples for time series include stock data,
+price information, website visitors, or vehicle telemetry (speed, position,
+etc.).
 
 First, we define the model for our data:
 
@@ -57,6 +63,8 @@ First, we define the model for our data:
             public int $sensorId,
             #[ODM\Field(type: 'float')]
             public float $temperature,
+            #[ODM\Field(type: 'float')]
+            public float $humidity,
         ) {
             $this->id = (string) new ObjectId();
         }
@@ -66,11 +74,10 @@ Note that we defined the entire model as readonly. While we could theoretically
 change values in the document, in this example we'll assume that the data will
 not change.
 
-Now we can mark the document as a time series document. This is done using the
-``TimeSeries`` attribute. Since we'll be storing data from multiple sensors, we
-store the ID of each sensor as metadata. We only use the temperature as a
-measurement, but we could also add additional sensors. With that in mind, we can
-add the ``TimeSeries`` attribute:
+Now we can mark the document as a time series document. To do so, we use the
+``TimeSeries`` attribute, configuring appropriate values for the time and
+metadata field, which in our case stores the ID of the sensor reporting the
+measurement:
 
 .. code-block:: php
 
@@ -96,6 +103,7 @@ collection and let MongoDB optimise the storage for faster queries:
         time: new DateTimeImmutable(),
         sensorId: $sensorId,
         temperature: $temperature,
+        humidity: $humidity,
     );
 
     $documentManager->persist($measurement);

--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -1144,6 +1144,64 @@ for sharding the document collection.
         //...
     }
 
+#[TimeSeries]
+-------------
+
+This attribute may be used at the class level to mark a collection as containing
+`time-series data <https://www.mongodb.com/docs/manual/core/timeseries-collections/>`__.
+
+.. code-block:: php
+
+    <?php
+
+    use Doctrine\ODM\MongoDB\Mapping\TimeSeries\Granularity;
+
+    #[Document]
+    #[TimeSeries(timeField: 'time', metaField: 'metadata', granularity: Granularity::Seconds)]
+    class Measurements
+    {
+        #[Id]
+        public string $id;
+
+        #[Field]
+        public DateTimeImmutable $time;
+
+        #[EmbedOne(targetDocument: MeasurementMetadata)]
+        public MeasurementMetadata $metadata;
+
+        #[Field]
+        public int $measurement;
+    }
+
+The ``timeField`` attribute is required and denotes the field where the time of
+a time series entry is stored. The following optional attributes may be set:
+
+-
+    ``metaField`` -  The name of the field which contains metadata in each time
+    series document. The field can be of any data type.
+
+-
+    ``granularity`` - Set the granularity to the value that most closely matches
+    the time between consecutive incoming timestamps. This allows MongoDB to
+    optimize how data is stored. Note: this attribute cannot be combined with
+    ``bucketMaxSpanSeconds`` and ``bucketRoundingSeconds``.
+
+-
+    ``bucketMaxSpanSeconds`` - Used with ``bucketRoundingSeconds`` as an
+    alternative to ``granularity``. Sets the maximum time between timestamps
+    in the same bucket. Possible values are 1 - 31356000.
+
+-
+    ``bucketRoundingSeconds`` - Used with ``bucketMaxSpanSeconds``, must be set
+    to the same value as ``bucketMaxSpanSeconds``. When a document requires a
+    new bucket, MongoDB rounds down the document's timestamp value by this
+    interval to set the minimum time for the bucket.
+
+-
+    ``expireAfterSeconds`` - Enables the automatic deletion of documents in a
+    time series collection by specifying the number of seconds after which
+    documents expire. MongoDB deletes these expired documents automatically.
+
 #[UniqueIndex]
 --------------
 

--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -1148,7 +1148,7 @@ for sharding the document collection.
 -------------
 
 This attribute may be used at the class level to mark a collection as containing
-`time-series data <https://www.mongodb.com/docs/manual/core/timeseries-collections/>`__.
+:doc:`time-series data <../cookbook/time-series-data>`.
 
 .. code-block:: php
 

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -640,6 +640,8 @@
     <xs:attribute name="meta-field" type="xs:NMTOKEN" />
     <xs:attribute name="granularity" type="odm:time-series-granularity" />
     <xs:attribute name="expire-after-seconds" type="xs:integer" />
+    <xs:attribute name="bucket-max-span-seconds" type="odm:time-series-group-seconds" />
+    <xs:attribute name="bucket-rounding-seconds" type="odm:time-series-group-seconds" />
   </xs:complexType>
 
   <xs:simpleType name="time-series-granularity">
@@ -647,6 +649,13 @@
       <xs:enumeration value="seconds" />
       <xs:enumeration value="minutes" />
       <xs:enumeration value="hours" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="time-series-group-seconds">
+    <xs:restriction base="xs:integer">
+      <xs:minInclusive value="1" />
+      <xs:maxInclusive value="31536000" />
     </xs:restriction>
   </xs:simpleType>
 

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -104,6 +104,7 @@
       <xs:element name="shard-key" type="odm:shard-key" minOccurs="0" />
       <xs:element name="read-preference" type="odm:read-preference" minOccurs="0" />
       <xs:element name="schema-validation" type="odm:schema-validation" minOccurs="0" />
+      <xs:element name="time-series" type="odm:time-series" minOccurs="0" />
     </xs:choice>
 
     <xs:attribute name="db" type="xs:NMTOKEN" />
@@ -631,6 +632,21 @@
       <xs:enumeration value="off" />
       <xs:enumeration value="strict" />
       <xs:enumeration value="moderate" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="time-series">
+    <xs:attribute name="time-field" type="xs:NMTOKEN" use="required" />
+    <xs:attribute name="meta-field" type="xs:NMTOKEN" />
+    <xs:attribute name="granularity" type="odm:time-series-granularity" />
+    <xs:attribute name="expire-after-seconds" type="xs:integer" />
+  </xs:complexType>
+
+  <xs:simpleType name="time-series-granularity">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="seconds" />
+      <xs:enumeration value="minutes" />
+      <xs:enumeration value="hours" />
     </xs:restriction>
   </xs:simpleType>
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/TimeSeries.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/TimeSeries.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
+
+use Attribute;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+use Doctrine\ODM\MongoDB\Mapping\TimeSeries\Granularity;
+
+/**
+ * Marks a document or superclass as a time series document
+ *
+ * @Annotation
+ * @NamedArgumentConstructor
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final class TimeSeries implements Annotation
+{
+    public function __construct(
+        public readonly string $timeField,
+        public readonly ?string $metaField = null,
+        public readonly ?Granularity $granularity = null,
+        public readonly ?int $expireAfterSeconds = null,
+    ) {
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/TimeSeries.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/TimeSeries.php
@@ -22,6 +22,8 @@ final class TimeSeries implements Annotation
         public readonly ?string $metaField = null,
         public readonly ?Granularity $granularity = null,
         public readonly ?int $expireAfterSeconds = null,
+        public readonly ?int $bucketMaxSpanSeconds = null,
+        public readonly ?int $bucketRoundingSeconds = null,
     ) {
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -800,9 +800,6 @@ use function trigger_deprecation;
      */
     public $isReadOnly;
 
-    /** READ ONLY: indicates whether the collection is a time series collection */
-    public bool $isTimeSeries = false;
-
     /** READ ONLY: stores metadata about the time series collection */
     public ?TimeSeries $timeSeriesOptions = null;
 
@@ -2185,7 +2182,6 @@ use function trigger_deprecation;
     {
         $this->validateTimeSeriesOptions($options);
 
-        $this->isTimeSeries      = true;
         $this->timeSeriesOptions = $options;
     }
 
@@ -2542,7 +2538,6 @@ use function trigger_deprecation;
             'idGenerator',
             'indexes',
             'shardKey',
-            'isTimeSeries',
             'timeSeriesOptions',
         ];
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -2782,7 +2782,7 @@ use function trigger_deprecation;
             throw MappingException::timeSeriesFieldNotFound($this->name, $options->timeField, 'time');
         }
 
-        if ($options->metaField && ! $this->hasField($options->metaField)) {
+        if ($options->metaField !== null && ! $this->hasField($options->metaField)) {
             throw MappingException::timeSeriesFieldNotFound($this->name, $options->metaField, 'metadata');
         }
     }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
@@ -10,6 +10,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\Annotations\AbstractIndex;
 use Doctrine\ODM\MongoDB\Mapping\Annotations\SearchIndex;
 use Doctrine\ODM\MongoDB\Mapping\Annotations\ShardKey;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\TimeSeries;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\ClassMetadata as PersistenceClassMetadata;
@@ -286,6 +287,12 @@ class AttributeDriver implements MappingDriver
         if (isset($classAttributes[ShardKey::class])) {
             assert($classAttributes[ShardKey::class] instanceof ShardKey);
             $this->setShardKey($metadata, $classAttributes[ShardKey::class]);
+        }
+
+        // Mark as time series only after mapping all fields
+        if (isset($classAttributes[TimeSeries::class])) {
+            assert($classAttributes[TimeSeries::class] instanceof TimeSeries);
+            $metadata->markAsTimeSeries($classAttributes[TimeSeries::class]);
         }
 
         foreach ($reflClass->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Mapping\Driver;
 
+use Doctrine\ODM\MongoDB\Mapping\Annotations\TimeSeries;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
+use Doctrine\ODM\MongoDB\Mapping\TimeSeries\Granularity;
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 use Doctrine\Persistence\Mapping\Driver\FileDriver;
 use DOMDocument;
@@ -335,13 +337,34 @@ class XmlDriver extends FileDriver
             }
         }
 
-        if (! isset($xmlRoot->{'also-load-methods'})) {
+        if (isset($xmlRoot->{'also-load-methods'})) {
+            foreach ($xmlRoot->{'also-load-methods'}->{'also-load-method'} as $alsoLoadMethod) {
+                $metadata->registerAlsoLoadMethod((string) $alsoLoadMethod['method'], (string) $alsoLoadMethod['field']);
+            }
+        }
+
+        if (! isset($xmlRoot->{'time-series'})) {
             return;
         }
 
-        foreach ($xmlRoot->{'also-load-methods'}->{'also-load-method'} as $alsoLoadMethod) {
-            $metadata->registerAlsoLoadMethod((string) $alsoLoadMethod['method'], (string) $alsoLoadMethod['field']);
-        }
+        $attributes = $xmlRoot->{'time-series'}->attributes();
+
+        $metaField          = isset($attributes['meta-field'])
+            ? (string) $attributes['meta-field']
+            : null;
+        $granularity        = isset($attributes['granularity'])
+            ? Granularity::from((string) $attributes['granularity'])
+            : null;
+        $expireAfterSeconds = isset($attributes['expire-after-seconds'])
+            ? (int) $attributes['expire-after-seconds']
+            : null;
+
+        $metadata->markAsTimeSeries(new TimeSeries(
+            timeField: (string) $attributes['time-field'],
+            metaField: $metaField,
+            granularity: $granularity,
+            expireAfterSeconds: $expireAfterSeconds,
+        ));
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -80,6 +80,7 @@ class XmlDriver extends FileDriver
         parent::__construct($locator, $fileExtension);
     }
 
+    // phpcs:disable SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
     public function loadMetadataForClass($className, \Doctrine\Persistence\Mapping\ClassMetadata $metadata)
     {
         assert($metadata instanceof ClassMetadata);
@@ -343,29 +344,29 @@ class XmlDriver extends FileDriver
             }
         }
 
-        if (! isset($xmlRoot->{'time-series'})) {
-            return;
+        if (isset($xmlRoot->{'time-series'})) {
+            $attributes = $xmlRoot->{'time-series'}->attributes();
+
+            $metaField          = isset($attributes['meta-field'])
+                ? (string) $attributes['meta-field']
+                : null;
+            $granularity        = isset($attributes['granularity'])
+                ? Granularity::from((string) $attributes['granularity'])
+                : null;
+            $expireAfterSeconds = isset($attributes['expire-after-seconds'])
+                ? (int) $attributes['expire-after-seconds']
+                : null;
+
+            $metadata->markAsTimeSeries(new TimeSeries(
+                timeField: (string) $attributes['time-field'],
+                metaField: $metaField,
+                granularity: $granularity,
+                expireAfterSeconds: $expireAfterSeconds,
+            ));
         }
-
-        $attributes = $xmlRoot->{'time-series'}->attributes();
-
-        $metaField          = isset($attributes['meta-field'])
-            ? (string) $attributes['meta-field']
-            : null;
-        $granularity        = isset($attributes['granularity'])
-            ? Granularity::from((string) $attributes['granularity'])
-            : null;
-        $expireAfterSeconds = isset($attributes['expire-after-seconds'])
-            ? (int) $attributes['expire-after-seconds']
-            : null;
-
-        $metadata->markAsTimeSeries(new TimeSeries(
-            timeField: (string) $attributes['time-field'],
-            metaField: $metaField,
-            granularity: $granularity,
-            expireAfterSeconds: $expireAfterSeconds,
-        ));
     }
+
+    // phpcs:enable SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
 
     /**
      * @param ClassMetadata<object> $class

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -347,21 +347,19 @@ class XmlDriver extends FileDriver
         if (isset($xmlRoot->{'time-series'})) {
             $attributes = $xmlRoot->{'time-series'}->attributes();
 
-            $metaField          = isset($attributes['meta-field'])
-                ? (string) $attributes['meta-field']
-                : null;
-            $granularity        = isset($attributes['granularity'])
-                ? Granularity::from((string) $attributes['granularity'])
-                : null;
-            $expireAfterSeconds = isset($attributes['expire-after-seconds'])
-                ? (int) $attributes['expire-after-seconds']
-                : null;
+            $metaField             = isset($attributes['meta-field']) ? (string) $attributes['meta-field'] : null;
+            $granularity           = isset($attributes['granularity']) ? Granularity::from((string) $attributes['granularity']) : null;
+            $expireAfterSeconds    = isset($attributes['expire-after-seconds']) ? (int) $attributes['expire-after-seconds'] : null;
+            $bucketMaxSpanSeconds  = isset($attributes['bucket-max-span-seconds']) ? (int) $attributes['bucket-max-span-seconds'] : null;
+            $bucketRoundingSeconds = isset($attributes['bucket-rounding-seconds']) ? (int) $attributes['bucket-rounding-seconds'] : null;
 
             $metadata->markAsTimeSeries(new TimeSeries(
                 timeField: (string) $attributes['time-field'],
                 metaField: $metaField,
                 granularity: $granularity,
                 expireAfterSeconds: $expireAfterSeconds,
+                bucketMaxSpanSeconds: $bucketMaxSpanSeconds,
+                bucketRoundingSeconds: $bucketRoundingSeconds,
             ));
         }
     }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -296,4 +296,14 @@ final class MappingException extends BaseMappingException
     {
         return new self(sprintf('%s search index "%s" must be dynamic or specify a field mapping', $className, $indexName));
     }
+
+    public static function timeSeriesFieldNotFound(string $className, string $fieldName, string $field): self
+    {
+        return new self(sprintf(
+            'The %s field %s::%s was not found',
+            $field,
+            $className,
+            $fieldName,
+        ));
+    }
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/TimeSeries/Granularity.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/TimeSeries/Granularity.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Mapping\TimeSeries;
+
+enum Granularity: string
+{
+    case Seconds = 'seconds';
+    case Minutes = 'minutes';
+    case Hours   = 'hours';
+}

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -626,7 +626,8 @@ final class SchemaManager
                 [
                     'timeField' => $class->timeSeriesOptions->timeField,
                     'metaField' => $class->timeSeriesOptions->metaField,
-                    'granularity' => $class->timeSeriesOptions->granularity?->value,
+                    // ext-mongodb will automatically encode backed enums, so we can use the value directly here
+                    'granularity' => $class->timeSeriesOptions->granularity,
                 ],
             );
 

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -628,6 +628,8 @@ final class SchemaManager
                     'metaField' => $class->timeSeriesOptions->metaField,
                     // ext-mongodb will automatically encode backed enums, so we can use the value directly here
                     'granularity' => $class->timeSeriesOptions->granularity,
+                    'bucketMaxSpanSeconds' => $class->timeSeriesOptions->bucketMaxSpanSeconds,
+                    'bucketRoundingSeconds' => $class->timeSeriesOptions->bucketRoundingSeconds,
                 ],
                 static fn (mixed $value): bool => $value !== null,
             );

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -629,6 +629,7 @@ final class SchemaManager
                     // ext-mongodb will automatically encode backed enums, so we can use the value directly here
                     'granularity' => $class->timeSeriesOptions->granularity,
                 ],
+                static fn (mixed $value): bool => $value !== null,
             );
 
             if ($class->timeSeriesOptions->expireAfterSeconds) {

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -621,7 +621,7 @@ final class SchemaManager
             $options['validationLevel']  = $class->getValidationLevel();
         }
 
-        if ($class->isTimeSeries) {
+        if ($class->timeSeriesOptions !== null) {
             $options['timeseries'] = array_filter(
                 [
                     'timeField' => $class->timeSeriesOptions->timeField,

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -621,6 +621,20 @@ final class SchemaManager
             $options['validationLevel']  = $class->getValidationLevel();
         }
 
+        if ($class->isTimeSeries) {
+            $options['timeseries'] = array_filter(
+                [
+                    'timeField' => $class->timeSeriesOptions->timeField,
+                    'metaField' => $class->timeSeriesOptions->metaField,
+                    'granularity' => $class->timeSeriesOptions->granularity?->value,
+                ],
+            );
+
+            if ($class->timeSeriesOptions->expireAfterSeconds) {
+                $options['expireAfterSeconds'] = $class->timeSeriesOptions->expireAfterSeconds;
+            }
+        }
+
         $this->dm->getDocumentDatabase($documentName)->createCollection(
             $class->getCollection(),
             $this->getWriteOptions($maxTimeMs, $writeConcern, $options),

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -956,12 +956,12 @@ parameters:
 			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest\\.php\\:230\\>\\:\\:mapField\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\{fieldName\\: 'enum', enumType\\: 'Documents\\\\\\\\Card'\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest\\.php\\:232\\>\\:\\:mapField\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\{fieldName\\: 'enum', enumType\\: 'Documents\\\\\\\\Card'\\} given\\.$#"
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest\\.php\\:249\\>\\:\\:mapField\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\{fieldName\\: 'enum', enumType\\: 'Documents\\\\\\\\SuitNonBacked'\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$mapping of method Doctrine\\\\ODM\\\\MongoDB\\\\Mapping\\\\ClassMetadata\\<class@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest\\.php\\:251\\>\\:\\:mapField\\(\\) expects array\\{type\\?\\: string, fieldName\\?\\: string, name\\?\\: string, strategy\\?\\: string, association\\?\\: int, id\\?\\: bool, isOwningSide\\?\\: bool, collectionClass\\?\\: class\\-string, \\.\\.\\.\\}, array\\{fieldName\\: 'enum', enumType\\: 'Documents\\\\\\\\SuitNonBacked'\\} given\\.$#"
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
@@ -683,7 +683,6 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
     {
         $metadata = $this->dm->getClassMetadata(AbstractMappingDriverTimeSeriesDocument::class);
 
-        self::assertTrue($metadata->isTimeSeries);
         self::assertEquals(
             new ODM\TimeSeries('time', 'metadata', Granularity::Seconds, 86400),
             $metadata->timeSeriesOptions,

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
@@ -679,12 +679,22 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
         self::assertInstanceOf(EnumReflectionProperty::class, $metadata->reflFields['nullableSuit']);
     }
 
-    public function testTimeSeriesDocument(): void
+    public function testTimeSeriesDocumentWithGranularity(): void
     {
-        $metadata = $this->dm->getClassMetadata(AbstractMappingDriverTimeSeriesDocument::class);
+        $metadata = $this->dm->getClassMetadata(AbstractMappingDriverTimeSeriesDocumentWithGranularity::class);
 
         self::assertEquals(
             new ODM\TimeSeries('time', 'metadata', Granularity::Seconds, 86400),
+            $metadata->timeSeriesOptions,
+        );
+    }
+
+    public function testTimeSeriesDocumentWithBucket(): void
+    {
+        $metadata = $this->dm->getClassMetadata(AbstractMappingDriverTimeSeriesDocumentWithBucket::class);
+
+        self::assertEquals(
+            new ODM\TimeSeries('time', 'metadata', expireAfterSeconds: 86400, bucketMaxSpanSeconds: 10, bucketRoundingSeconds: 15),
             $metadata->timeSeriesOptions,
         );
     }
@@ -1314,7 +1324,32 @@ class AbstractMappingDriverViewRepository extends DocumentRepository implements 
  */
 #[ODM\Document]
 #[ODM\TimeSeries(timeField: 'time', metaField: 'metadata', granularity: Granularity::Seconds, expireAfterSeconds: 86400)]
-class AbstractMappingDriverTimeSeriesDocument
+class AbstractMappingDriverTimeSeriesDocumentWithGranularity
+{
+    /** @ODM\Id */
+    #[ODM\Id]
+    public ?string $id = null;
+
+    /** @ODM\Field(type="date") */
+    #[ODM\Field(type: 'date')]
+    public DateTime $time;
+
+    /** @ODM\Field */
+    #[ODM\Field]
+    public string $metadata;
+
+    /** @ODM\Field(type="int") */
+    #[ODM\Field(type: 'int')]
+    public int $value;
+}
+
+/**
+ * @ODM\Document(collection="cms_users", writeConcern=1, readOnly=true)
+ * @ODM\TimeSeries(timeField="time", metaField="metadata", expireAfterSeconds=86400, bucketMaxSpanSeconds=10, bucketRoundingSeconds=15)
+ */
+#[ODM\Document]
+#[ODM\TimeSeries(timeField: 'time', metaField: 'metadata', expireAfterSeconds: 86400, bucketMaxSpanSeconds: 10, bucketRoundingSeconds: 15)]
+class AbstractMappingDriverTimeSeriesDocumentWithBucket
 {
     /** @ODM\Id */
     #[ODM\Id]

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
@@ -1314,7 +1314,7 @@ class AbstractMappingDriverViewRepository extends DocumentRepository implements 
  * @ODM\TimeSeries(timeField="time", metaField="metadata", granularity=Granularity::Seconds, expireAfterSeconds=86400)
  */
 #[ODM\Document]
-#[ODM\TimeSeries('time', 'metadata', Granularity::Seconds, 86400)]
+#[ODM\TimeSeries(timeField: 'time', metaField: 'metadata', granularity: Granularity::Seconds, expireAfterSeconds: 86400)]
 class AbstractMappingDriverTimeSeriesDocument
 {
     /** @ODM\Id */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -987,7 +987,7 @@ class ClassMetadataTest extends BaseTestCase
     {
         $metadata = $this->dm->getClassMetadata(TimeSeriesTestDocument::class);
 
-        self::assertFalse($metadata->isTimeSeries);
+        self::assertNull($metadata->timeSeriesOptions);
     }
 
     public function testTimeSeriesMappingOnlyWithTimeField(): void
@@ -995,7 +995,7 @@ class ClassMetadataTest extends BaseTestCase
         $metadata = $this->dm->getClassMetadata(TimeSeriesTestDocument::class);
         $metadata->markAsTimeSeries(new ODM\TimeSeries('time'));
 
-        self::assertTrue($metadata->isTimeSeries);
+        self::assertNotNull($metadata->timeSeriesOptions);
         self::assertSame('time', $metadata->timeSeriesOptions->timeField);
     }
 
@@ -1012,7 +1012,7 @@ class ClassMetadataTest extends BaseTestCase
         $metadata = $this->dm->getClassMetadata(TimeSeriesTestDocument::class);
         $metadata->markAsTimeSeries(new ODM\TimeSeries('time', 'metadata'));
 
-        self::assertTrue($metadata->isTimeSeries);
+        self::assertNotNull($metadata->timeSeriesOptions);
         self::assertSame('metadata', $metadata->timeSeriesOptions->metaField);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -1039,6 +1039,35 @@ class ClassMetadataTest extends BaseTestCase
 
         self::assertSame(10, $metadata->timeSeriesOptions->expireAfterSeconds);
     }
+
+    public function testTimeSeriesMappingWithBucketMaxSpanSeconds(): void
+    {
+        $metadata = $this->dm->getClassMetadata(TimeSeriesTestDocument::class);
+        $metadata->markAsTimeSeries(new ODM\TimeSeries('time', bucketMaxSpanSeconds: 10));
+
+        // We don't throw for invalid settings here, e.g. bucketMaxSpanSeconds not being equal to bucketRoundingSeconds
+        self::assertSame(10, $metadata->timeSeriesOptions->bucketMaxSpanSeconds);
+    }
+
+    public function testTimeSeriesMappingWithBucketRoundingSeconds(): void
+    {
+        $metadata = $this->dm->getClassMetadata(TimeSeriesTestDocument::class);
+        $metadata->markAsTimeSeries(new ODM\TimeSeries('time', bucketRoundingSeconds: 10));
+
+        // We don't throw for invalid settings here, e.g. bucketMaxSpanSeconds not being equal to bucketRoundingSeconds
+        self::assertSame(10, $metadata->timeSeriesOptions->bucketRoundingSeconds);
+    }
+
+    public function testTimeSeriesMappingWithGranularityAndBucketMaxSpanSeconds(): void
+    {
+        $metadata = $this->dm->getClassMetadata(TimeSeriesTestDocument::class);
+        $metadata->markAsTimeSeries(new ODM\TimeSeries('time', granularity: Granularity::Hours, bucketMaxSpanSeconds: 15, bucketRoundingSeconds: 20));
+
+        // We don't throw for invalid settings here, e.g. bucketMaxSpanSeconds not being equal to bucketRoundingSeconds
+        self::assertSame(Granularity::Hours, $metadata->timeSeriesOptions->granularity);
+        self::assertSame(15, $metadata->timeSeriesOptions->bucketMaxSpanSeconds);
+        self::assertSame(20, $metadata->timeSeriesOptions->bucketRoundingSeconds);
+    }
 }
 
 /** @template-extends DocumentRepository<self> */

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -983,13 +983,6 @@ class ClassMetadataTest extends BaseTestCase
         $cm->addSearchIndex(['mappings' => []]);
     }
 
-    public function testDefaultTimeSeriesMapping(): void
-    {
-        $metadata = $this->dm->getClassMetadata(TimeSeriesTestDocument::class);
-
-        self::assertNull($metadata->timeSeriesOptions);
-    }
-
     public function testTimeSeriesMappingOnlyWithTimeField(): void
     {
         $metadata = $this->dm->getClassMetadata(TimeSeriesTestDocument::class);
@@ -1024,14 +1017,6 @@ class ClassMetadataTest extends BaseTestCase
         $metadata->markAsTimeSeries(new ODM\TimeSeries('time', 'foo'));
     }
 
-    public function testTimeSeriesMappingWithGranularity(): void
-    {
-        $metadata = $this->dm->getClassMetadata(TimeSeriesTestDocument::class);
-        $metadata->markAsTimeSeries(new ODM\TimeSeries('time', granularity: Granularity::Seconds));
-
-        self::assertSame(Granularity::Seconds, $metadata->timeSeriesOptions->granularity);
-    }
-
     public function testTimeSeriesMappingWithExpireAfterSeconds(): void
     {
         $metadata = $this->dm->getClassMetadata(TimeSeriesTestDocument::class);
@@ -1040,30 +1025,16 @@ class ClassMetadataTest extends BaseTestCase
         self::assertSame(10, $metadata->timeSeriesOptions->expireAfterSeconds);
     }
 
-    public function testTimeSeriesMappingWithBucketMaxSpanSeconds(): void
-    {
-        $metadata = $this->dm->getClassMetadata(TimeSeriesTestDocument::class);
-        $metadata->markAsTimeSeries(new ODM\TimeSeries('time', bucketMaxSpanSeconds: 10));
-
-        // We don't throw for invalid settings here, e.g. bucketMaxSpanSeconds not being equal to bucketRoundingSeconds
-        self::assertSame(10, $metadata->timeSeriesOptions->bucketMaxSpanSeconds);
-    }
-
-    public function testTimeSeriesMappingWithBucketRoundingSeconds(): void
-    {
-        $metadata = $this->dm->getClassMetadata(TimeSeriesTestDocument::class);
-        $metadata->markAsTimeSeries(new ODM\TimeSeries('time', bucketRoundingSeconds: 10));
-
-        // We don't throw for invalid settings here, e.g. bucketMaxSpanSeconds not being equal to bucketRoundingSeconds
-        self::assertSame(10, $metadata->timeSeriesOptions->bucketRoundingSeconds);
-    }
-
     public function testTimeSeriesMappingWithGranularityAndBucketMaxSpanSeconds(): void
     {
         $metadata = $this->dm->getClassMetadata(TimeSeriesTestDocument::class);
         $metadata->markAsTimeSeries(new ODM\TimeSeries('time', granularity: Granularity::Hours, bucketMaxSpanSeconds: 15, bucketRoundingSeconds: 20));
 
-        // We don't throw for invalid settings here, e.g. bucketMaxSpanSeconds not being equal to bucketRoundingSeconds
+        /*
+         * We don't throw for invalid settings here, including:
+         * - bucketMaxSpanSeconds not being equal to bucketRoundingSeconds
+         * - granularity and bucket settings applied together
+         */
         self::assertSame(Granularity::Hours, $metadata->timeSeriesOptions->granularity);
         self::assertSame(15, $metadata->timeSeriesOptions->bucketMaxSpanSeconds);
         self::assertSame(20, $metadata->timeSeriesOptions->bucketRoundingSeconds);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverTimeSeriesDocument.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverTimeSeriesDocument.dcm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverTimeSeriesDocument">
+        <time-series time-field="time" meta-field="metadata" granularity="seconds" expire-after-seconds="86400" />
+
+        <id />
+        <field field-name="time" type="date" />
+        <field field-name="metadata" type="string" />
+    </document>
+</doctrine-mongo-mapping>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverTimeSeriesDocumentWithBucket.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverTimeSeriesDocumentWithBucket.dcm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverTimeSeriesDocumentWithBucket">
+        <time-series time-field="time" meta-field="metadata" expire-after-seconds="86400" bucket-max-span-seconds="10" bucket-rounding-seconds="15" />
+
+        <id />
+        <field field-name="time" type="date" />
+        <field field-name="metadata" type="string" />
+    </document>
+</doctrine-mongo-mapping>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverTimeSeriesDocumentWithGranularity.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverTimeSeriesDocumentWithGranularity.dcm.xml
@@ -5,7 +5,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                   http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-    <document name="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverTimeSeriesDocument">
+    <document name="Doctrine\ODM\MongoDB\Tests\Mapping\AbstractMappingDriverTimeSeriesDocumentWithGranularity">
         <time-series time-field="time" meta-field="metadata" granularity="seconds" expire-after-seconds="86400" />
 
         <id />

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -8,6 +8,7 @@ use ArrayIterator;
 use Doctrine\Common\EventManager;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\TimeSeries\Granularity;
 use Doctrine\ODM\MongoDB\SchemaManager;
 use Documents\BaseDocument;
 use Documents\CmsAddress;
@@ -771,7 +772,7 @@ EOT;
             'timeseries' => [
                 'timeField' => 'time',
                 'metaField' => 'metadata',
-                'granularity' => 'seconds',
+                'granularity' => Granularity::Seconds,
             ],
             'expireAfterSeconds' => 86400,
         ];

--- a/tests/Documents/TimeSeries/TimeSeriesDocument.php
+++ b/tests/Documents/TimeSeries/TimeSeriesDocument.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents\TimeSeries;
+
+use DateTime;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\TimeSeries\Granularity;
+
+#[ODM\Document]
+#[ODM\TimeSeries('time', 'metadata', Granularity::Seconds, 86400)]
+class TimeSeriesDocument
+{
+    #[ODM\Id]
+    public ?string $id;
+
+    #[ODM\Field]
+    public DateTime $time;
+
+    #[ODM\Field]
+    public string $metadata;
+
+    #[ODM\Field]
+    public int $value;
+}

--- a/tests/Documents/TimeSeries/TimeSeriesDocument.php
+++ b/tests/Documents/TimeSeries/TimeSeriesDocument.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\TimeSeries\Granularity;
 
 #[ODM\Document]
-#[ODM\TimeSeries('time', 'metadata', Granularity::Seconds, 86400)]
+#[ODM\TimeSeries(timeField: 'time', metaField: 'metadata', granularity: Granularity::Seconds, expireAfterSeconds: 86400)]
 class TimeSeriesDocument
 {
     #[ODM\Id]


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

Supersedes #2597. I was unhappy with the way we were mapping time series collections, so instead of adding more options to the `Document` attribute I decided to introduce a new attribute and XML mapping element to handle time series data. To make data handling easier, the `ClassMetadataInstance` will store the attribute instance entirely, as it serves as a value object for time series options. As a result, the XML driver is able to create the attribute instance from the data in the XML, needing no additional validation.

The only other change needed was to add support for time series options in the schema manager. Since time series collections need to be created as such, no handling is needed to update time series collections at all. Dropping time series collections works the same as dropping other collections, again requiring no other changes.

The tests in this PR cover the basic mapping and schema manager changes. No functional testing for time series collections was added, but I can add those tests if necessary.
