### PR TITLE
Fix "Cannot use object of type stdClass as array" in search index drop

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -413,7 +413,9 @@ final class SchemaManager
 
         $definedNames = array_column($searchIndexes, 'name');
         try {
-            $existingNames = array_column(iterator_to_array($collection->listSearchIndexes()), 'name');
+            /* The typeMap option can be removed when bug is fixed in the minimum required version.
+             * https://jira.mongodb.org/browse/PHPLIB-1548 */
+            $existingNames = array_column(iterator_to_array($collection->listSearchIndexes(['typeMap' => ['root' => 'array']])), 'name');
         } catch (CommandException $e) {
             /* If $listSearchIndexes doesn't exist, only throw if search indexes have been defined.
              * If no search indexes are defined and the server doesn't support search indexes, there's
@@ -465,7 +467,9 @@ final class SchemaManager
         $collection = $this->dm->getDocumentCollection($class->name);
 
         try {
-            $searchIndexes = $collection->listSearchIndexes();
+            /* The typeMap option can be removed when bug is fixed in the minimum required version.
+             * https://jira.mongodb.org/browse/PHPLIB-1548 */
+            $searchIndexes = $collection->listSearchIndexes(['typeMap' => ['root' => 'array']]);
         } catch (CommandException $e) {
             // If the server does not support search indexes, there are no indexes to remove in any case
             if ($this->isSearchIndexCommandException($e)) {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -184,6 +184,12 @@
       <code><![CDATA[array]]></code>
     </LessSpecificImplementedReturnType>
   </file>
+  <file src="lib/Doctrine/ODM/MongoDB/SchemaManager.php">
+    <InvalidArgument>
+      <code><![CDATA[['typeMap' => ['root' => 'array']]]]></code>
+      <code><![CDATA[['typeMap' => ['root' => 'array']]]]></code>
+    </InvalidArgument>
+  </file>
   <file src="lib/Doctrine/ODM/MongoDB/Tools/Console/Command/ClearCache/MetadataCommand.php">
     <UndefinedInterfaceMethod>
       <code><![CDATA[getDocumentManager]]></code>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | fix #2684

#### Summary

The `typeMap` option from the `Collection` instance is not inherited (bug report [PHPLIB-1548](https://jira.mongodb.org/browse/PHPLIB-1548)).

This was not detected by unit tests as the call to `Collection::listSearchIndexes()` is mocked. https://github.com/doctrine/mongodb-odm/blob/ff90e9ab519560ec8a09794e9778dcd7d59f10ad/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php#L444-L454
