### PR TITLE
Prevent search index creation with `dynamic: false` and empty `fields` mapping

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -1220,9 +1220,15 @@ use function trigger_deprecation;
      */
     public function addSearchIndex(array $definition, ?string $name = null): void
     {
+        $name ??= self::DEFAULT_SEARCH_INDEX_NAME;
+
+        if (empty($definition['mappings']['dynamic']) && empty($definition['mappings']['fields'])) {
+            throw MappingException::emptySearchIndexDefinition($this->name, $name);
+        }
+
         $this->searchIndexes[] = [
             'definition' => $definition,
-            'name' => $name ?? self::DEFAULT_SEARCH_INDEX_NAME,
+            'name' => $name,
         ];
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -291,4 +291,9 @@ final class MappingException extends BaseMappingException
             $fieldName,
         ));
     }
+
+    public static function emptySearchIndexDefinition(string $className, string $indexName): self
+    {
+        return new self(sprintf('%s search index "%s" must be dynamic or specify a field mapping', $className, $indexName));
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -971,6 +971,15 @@ class ClassMetadataTest extends BaseTestCase
         $cm = new ClassMetadata('stdClass');
         self::assertEquals(ClassMetadata::SCHEMA_VALIDATION_LEVEL_STRICT, $cm->getValidationLevel());
     }
+
+    public function testEmptySearchIndexDefinition(): void
+    {
+        $cm = new ClassMetadata('stdClass');
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('stdClass search index "default" must be dynamic or specify a field mapping');
+        $cm->addSearchIndex(['mappings' => []]);
+    }
 }
 
 /** @template-extends DocumentRepository<self> */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

#### Summary

When creating a document with `SearchIndex` configuration missing both `dynamic` and `fields` config, the index definition sent to MongoDB is incorrect. `definition.mappings` is required and must be an object.

By default, when  `definition.mappings` is an empty object, the server fallbacks to `dynamic: false` without fields. This mapping is useless as this means no field is mapped.

Prevent this invalid configuration by throwing a MappingException when `dynamic` is not set or `false`, and `fields` is not set or empty.
