### PR TITLE
Remove usage of deprecated `ReadPreference::RP_*` constants

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReadPreferenceTest.php
@@ -46,7 +46,7 @@ class ReadPreferenceTest extends BaseTestCase
 
     /** @psalm-param ReadPreferenceTagShape[] $tags */
     #[DataProvider('provideReadPreferenceHints')]
-    public function testHintIsSetOnQuery(int $readPreference, array $tags = []): void
+    public function testHintIsSetOnQuery(string $readPreference, array $tags = []): void
     {
         $this->skipTestIfSharded(User::class);
 
@@ -68,9 +68,9 @@ class ReadPreferenceTest extends BaseTestCase
     public static function provideReadPreferenceHints(): array
     {
         return [
-            [ReadPreference::RP_PRIMARY, []],
-            [ReadPreference::RP_SECONDARY_PREFERRED, []],
-            [ReadPreference::RP_SECONDARY, [['dc' => 'east'], []]],
+            [ReadPreference::PRIMARY, []],
+            [ReadPreference::SECONDARY_PREFERRED, []],
+            [ReadPreference::SECONDARY, [['dc' => 'east'], []]],
         ];
     }
 
@@ -78,7 +78,7 @@ class ReadPreferenceTest extends BaseTestCase
     {
         $coll = $this->dm->getDocumentCollection(DocumentWithReadPreference::class);
 
-        self::assertSame(ReadPreference::RP_NEAREST, $coll->getReadPreference()->getMode());
+        self::assertSame(ReadPreference::NEAREST, $coll->getReadPreference()->getModeString());
         self::assertSame([['dc' => 'east']], $coll->getReadPreference()->getTagSets());
     }
 
@@ -88,7 +88,7 @@ class ReadPreferenceTest extends BaseTestCase
             ->createQueryBuilder()
             ->getQuery();
 
-        $this->assertReadPreferenceHint(ReadPreference::RP_NEAREST, $query->getQuery()['readPreference'], [['dc' => 'east']]);
+        $this->assertReadPreferenceHint(ReadPreference::NEAREST, $query->getQuery()['readPreference'], [['dc' => 'east']]);
     }
 
     public function testDocumentLevelReadPreferenceCanBeOverriddenInQueryBuilder(): void
@@ -98,14 +98,14 @@ class ReadPreferenceTest extends BaseTestCase
             ->setReadPreference(new ReadPreference('secondary', []))
             ->getQuery();
 
-        $this->assertReadPreferenceHint(ReadPreference::RP_SECONDARY, $query->getQuery()['readPreference']);
+        $this->assertReadPreferenceHint(ReadPreference::SECONDARY, $query->getQuery()['readPreference']);
     }
 
     /** @psalm-param ReadPreferenceTagShape[] $tags */
-    private function assertReadPreferenceHint(int $mode, ReadPreference $readPreference, array $tags = []): void
+    private function assertReadPreferenceHint(string $mode, ReadPreference $readPreference, array $tags = []): void
     {
         self::assertInstanceOf(ReadPreference::class, $readPreference);
-        self::assertEquals($mode, $readPreference->getMode());
+        self::assertEquals($mode, $readPreference->getModeString());
         self::assertEquals($tags, $readPreference->getTagSets());
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/ReferencePrimerTest.php
@@ -391,7 +391,7 @@ class ReferencePrimerTest extends BaseTestCase
 
         // Note: using a secondary read preference here can cause issues when using transactions
         // Using a primaryPreferred works just as well to check if the hint is passed on to the primer
-        $readPreference = new ReadPreference(ReadPreference::RP_PRIMARY_PREFERRED);
+        $readPreference = new ReadPreference(ReadPreference::PRIMARY_PREFERRED);
         $this->dm->createQueryBuilder(User::class)
             ->field('account')->prime($primer)
             ->field('groups')->prime($primer)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -675,7 +675,7 @@ class BuilderTest extends BaseTestCase
 
         $readPreference = $qb->debug('readPreference');
         self::assertInstanceOf(ReadPreference::class, $readPreference);
-        self::assertEquals(ReadPreference::RP_SECONDARY, $readPreference->getMode());
+        self::assertEquals(ReadPreference::SECONDARY, $readPreference->getModeString());
         self::assertEquals([['dc' => 'east']], $readPreference->getTagSets());
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

This constants are removed from `ext-mongodb: 2.0`: https://github.com/mongodb/mongo-php-driver/pull/1666

The new constants have been introduced before `ext-mongodb: 1.17` (current minimal version).