### PR TITLE
Ensure compatibility with persistence 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "doctrine/collections": "^1.5 || ^2.0",
         "doctrine/event-manager": "^1.0 || ^2.0",
         "doctrine/instantiator": "^1.1 || ^2",
-        "doctrine/persistence": "^3.2",
+        "doctrine/persistence": "^3.2 || ^4",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "jean85/pretty-package-versions": "^1.3.0 || ^2.0.1",
         "mongodb/mongodb": "^1.17.0",

--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -21,6 +21,7 @@ use Doctrine\ODM\MongoDB\Repository\RepositoryFactory;
 use Doctrine\ODM\MongoDB\Repository\ViewRepository;
 use Doctrine\Persistence\Mapping\ProxyClassNameResolver;
 use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
 use InvalidArgumentException;
 use Jean85\PrettyVersions;
 use MongoDB\Client;
@@ -218,12 +219,8 @@ class DocumentManager implements ObjectManager
         return $this->client;
     }
 
-    /**
-     * Gets the metadata factory used to gather the metadata of classes.
-     *
-     * @return ClassMetadataFactoryInterface
-     */
-    public function getMetadataFactory()
+    /** Gets the metadata factory used to gather the metadata of classes. */
+    public function getMetadataFactory(): ClassmetadataFactoryInterface
     {
         return $this->metadataFactory;
     }
@@ -235,7 +232,7 @@ class DocumentManager implements ObjectManager
      *
      * @param object $obj
      */
-    public function initializeObject($obj)
+    public function initializeObject($obj): void
     {
         $this->unitOfWork->initializeObject($obj);
     }
@@ -243,8 +240,12 @@ class DocumentManager implements ObjectManager
     /**
      * Helper method to check whether a lazy loading proxy or persistent collection has been initialized.
      */
-    public function isUninitializedObject(object $obj): bool
+    public function isUninitializedObject(mixed $obj): bool
     {
+        if (! is_object($obj)) {
+            return false;
+        }
+
         return $this->unitOfWork->isUninitializedObject($obj);
     }
 
@@ -437,7 +438,7 @@ class DocumentManager implements ObjectManager
      *
      * @throws InvalidArgumentException When the given $object param is not an object.
      */
-    public function persist($object)
+    public function persist($object): void
     {
         if (! is_object($object)) {
             throw new InvalidArgumentException(gettype($object));
@@ -457,7 +458,7 @@ class DocumentManager implements ObjectManager
      *
      * @throws InvalidArgumentException When the $object param is not an object.
      */
-    public function remove($object)
+    public function remove($object): void
     {
         if (! is_object($object)) {
             throw new InvalidArgumentException(gettype($object));
@@ -475,7 +476,7 @@ class DocumentManager implements ObjectManager
      *
      * @throws InvalidArgumentException When the given $object param is not an object.
      */
-    public function refresh($object)
+    public function refresh($object): void
     {
         if (! is_object($object)) {
             throw new InvalidArgumentException(gettype($object));
@@ -496,7 +497,7 @@ class DocumentManager implements ObjectManager
      *
      * @throws InvalidArgumentException When the $object param is not an object.
      */
-    public function detach($object)
+    public function detach($object): void
     {
         if (! is_object($object)) {
             throw new InvalidArgumentException(gettype($object));
@@ -556,7 +557,7 @@ class DocumentManager implements ObjectManager
      *
      * @template T of object
      */
-    public function getRepository($className)
+    public function getRepository($className): ObjectRepository
     {
         return $this->repositoryFactory->getRepository($this, $className);
     }
@@ -572,7 +573,7 @@ class DocumentManager implements ObjectManager
      * @throws MongoDBException
      * @throws Throwable From event listeners.
      */
-    public function flush(array $options = [])
+    public function flush(array $options = []): void
     {
         $this->errorIfClosed();
         $this->unitOfWork->commit($options);
@@ -680,7 +681,7 @@ class DocumentManager implements ObjectManager
      *
      * @param string|null $objectName if given, only documents of this type will get detached
      */
-    public function clear($objectName = null)
+    public function clear($objectName = null): void
     {
         if ($objectName !== null) {
             trigger_deprecation(
@@ -716,7 +717,7 @@ class DocumentManager implements ObjectManager
      *
      * @throws InvalidArgumentException When the $object param is not an object.
      */
-    public function contains($object)
+    public function contains($object): bool
     {
         if (! is_object($object)) {
             throw new InvalidArgumentException(gettype($object));

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -2241,7 +2241,7 @@ use function trigger_deprecation;
     }
 
     /** @param string $assocName */
-    public function getAssociationMappedByTargetField($assocName)
+    public function getAssociationMappedByTargetField($assocName): string
     {
         throw new BadMethodCallException(__METHOD__ . '() is not implemented yet.');
     }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadataFactory.php
@@ -40,9 +40,6 @@ use function ucfirst;
  */
 final class ClassMetadataFactory extends AbstractClassMetadataFactory implements ClassMetadataFactoryInterface
 {
-    /** @var string */
-    protected $cacheSalt = '$MONGODBODMCLASSMETADATA';
-
     /** @var DocumentManager The DocumentManager instance */
     private DocumentManager $dm;
 
@@ -54,6 +51,11 @@ final class ClassMetadataFactory extends AbstractClassMetadataFactory implements
 
     /** @var EventManager The event manager instance */
     private EventManager $evm;
+
+    public function __construct()
+    {
+        $this->cacheSalt = '$MONGODBODMCLASSMETADATA';
+    }
 
     public function setDocumentManager(DocumentManager $dm): void
     {
@@ -82,7 +84,7 @@ final class ClassMetadataFactory extends AbstractClassMetadataFactory implements
     }
 
     /** @param string $className */
-    protected function onNotFoundMetadata($className)
+    protected function onNotFoundMetadata($className): ?ClassMetadata
     {
         if (! $this->evm->hasListeners(Events::onClassMetadataNotFound)) {
             return null;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
@@ -62,7 +62,7 @@ class AttributeDriver implements MappingDriver
         $this->addPaths((array) $paths);
     }
 
-    public function isTransient($className)
+    public function isTransient($className): bool
     {
         $classAttributes = $this->getClassAttributes(new ReflectionClass($className));
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -81,7 +81,7 @@ class XmlDriver extends FileDriver
     }
 
     // phpcs:disable SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
-    public function loadMetadataForClass($className, \Doctrine\Persistence\Mapping\ClassMetadata $metadata)
+    public function loadMetadataForClass($className, \Doctrine\Persistence\Mapping\ClassMetadata $metadata): void
     {
         assert($metadata instanceof ClassMetadata);
         $xmlRoot = $this->getElement($className);

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2968,7 +2968,7 @@ final class UnitOfWork implements PropertyChangedListener
      * @param mixed  $oldValue     The old value of the property.
      * @param mixed  $newValue     The new value of the property.
      */
-    public function propertyChanged($sender, $propertyName, $oldValue, $newValue)
+    public function propertyChanged($sender, $propertyName, $oldValue, $newValue): void
     {
         $oid   = spl_object_hash($sender);
         $class = $this->dm->getClassMetadata($sender::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -653,7 +653,7 @@ class NotifyChangedDocument implements NotifyPropertyChanged
         $this->transient = $value;
     }
 
-    public function addPropertyChangedListener(PropertyChangedListener $listener)
+    public function addPropertyChangedListener(PropertyChangedListener $listener): void
     {
         $this->_listeners[] = $listener;
     }


### PR DESCRIPTION
This is mostly about adding return type declarations. In one instance though, it is more than that: ClassMetadataFactory redeclares $cacheSalt, a protected property inherited from the persistence package. Since it is not possible to widen or narrow the type, and since the redeclaration seems to be about setting a default value, let us set it in the constructor.

