### PR TITLE
Fix handling of unmapped properties in proxy objects

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Proxy/Factory/StaticProxyFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Proxy/Factory/StaticProxyFactory.php
@@ -145,13 +145,21 @@ final class StaticProxyFactory implements ProxyFactory
      */
     private function skippedFieldsFqns(ClassMetadata $metadata): array
     {
-        $idFieldFqcns = [];
+        $skippedFieldsFqns = [];
 
         foreach ($metadata->getIdentifierFieldNames() as $idField) {
-            $idFieldFqcns[] = $this->propertyFqcn($metadata->getReflectionProperty($idField));
+            $skippedFieldsFqns[] = $this->propertyFqcn($metadata->getReflectionProperty($idField));
         }
 
-        return $idFieldFqcns;
+        foreach ($metadata->getReflectionClass()->getProperties() as $property) {
+            if ($metadata->hasField($property->getName())) {
+                continue;
+            }
+
+            $skippedFieldsFqns[] = $this->propertyFqcn($property);
+        }
+
+        return $skippedFieldsFqns;
     }
 
     private function propertyFqcn(ReflectionProperty $property): string

--- a/tests/Doctrine/ODM/MongoDB/Tests/Proxy/Factory/StaticProxyFactoryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Proxy/Factory/StaticProxyFactoryTest.php
@@ -11,6 +11,7 @@ use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\LockException;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Cart;
+use Documents\DocumentWithUnmappedProperties;
 use MongoDB\Client;
 use MongoDB\Collection;
 use MongoDB\Database;
@@ -22,15 +23,10 @@ class StaticProxyFactoryTest extends BaseTestCase
     /** @var Client|MockObject */
     private Client $client;
 
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->dm = $this->createMockedDocumentManager();
-    }
-
     public function testProxyInitializeWithException(): void
     {
+        $this->dm = $this->createMockedDocumentManager();
+
         $collection = $this->createMock(Collection::class);
         $database   = $this->createMock(Database::class);
 
@@ -80,6 +76,17 @@ class StaticProxyFactoryTest extends BaseTestCase
         $this->client = $this->createMock(Client::class);
 
         return DocumentManager::create($this->client, $config);
+    }
+
+    public function testCreateProxyForDocumentWithUnmappedProperties(): void
+    {
+        $proxy = $this->dm->getReference(DocumentWithUnmappedProperties::class, '123');
+        self::assertInstanceOf(GhostObjectInterface::class, $proxy);
+
+        // Disable initialiser so we can access properties without initialising the object
+        $proxy->setProxyInitializer(null);
+
+        self::assertSame('bar', $proxy->foo);
     }
 }
 

--- a/tests/Documents/DocumentWithUnmappedProperties.php
+++ b/tests/Documents/DocumentWithUnmappedProperties.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Id;
+
+#[Document]
+class DocumentWithUnmappedProperties
+{
+    #[Id]
+    public string $id;
+
+    public string $foo = 'bar';
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

While working on a project that contained unmapped hooked properties, I realised that proxies try to unset these hooked properties, despite them not even being mapped properties. Note that this doesn't mean ODM supports hooked properties - it just removes an edge case where you can't use hooked properties at all, even when they aren't mapped and thus shouldn't be handled by ODM at all.

To work around this issue, when creating a proxy we now also skip all properties of the class that aren't mapped, leaving them set and not triggering initialisation when they are accessed.
