### PR TITLE
Improve query and aggregator classes

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
@@ -7,11 +7,11 @@ namespace Doctrine\ODM\MongoDB\Aggregation;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Iterator\CachingIterator;
 use Doctrine\ODM\MongoDB\Iterator\HydratingIterator;
+use Doctrine\ODM\MongoDB\Iterator\IterableResult;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Iterator\UnrewindableIterator;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Iterator as SPLIterator;
-use IteratorAggregate;
 use MongoDB\Collection;
 use MongoDB\Driver\CursorInterface;
 
@@ -19,7 +19,7 @@ use function array_merge;
 use function assert;
 
 /** @phpstan-import-type PipelineExpression from Builder */
-final class Aggregation implements IteratorAggregate
+final class Aggregation implements IterableResult
 {
     /**
      * @param array<string, mixed> $pipeline
@@ -28,6 +28,26 @@ final class Aggregation implements IteratorAggregate
      */
     public function __construct(private DocumentManager $dm, private ?ClassMetadata $classMetadata, private Collection $collection, private array $pipeline, private array $options = [], private bool $rewindable = true)
     {
+    }
+
+    public function execute(): Iterator
+    {
+        return $this->getIterator();
+    }
+
+    /**
+     * Execute the query and return the first result.
+     *
+     * @return array<string, mixed>|object|null
+     */
+    public function getSingleResult(): mixed
+    {
+        $clone = clone $this;
+
+        // Limit the pipeline to a single result for efficiency
+        $this->pipeline[] = ['$limit' => 1];
+
+        return $clone->getIterator()->current() ?: null;
     }
 
     public function getIterator(): Iterator

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Aggregation;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Iterator\IterableResult;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
@@ -246,8 +247,10 @@ class Builder
      * Returns an aggregation object for the current pipeline
      *
      * @param array<string, mixed> $options
+     *
+     * @return Aggregation
      */
-    public function getAggregation(array $options = []): Aggregation
+    public function getAggregation(array $options = []): IterableResult
     {
         $class = $this->hydrationClass ? $this->dm->getClassMetadata($this->hydrationClass) : null;
 

--- a/lib/Doctrine/ODM/MongoDB/Iterator/IterableResult.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/IterableResult.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Iterator;
+
+use BadMethodCallException;
+use IteratorAggregate;
+
+interface IterableResult extends IteratorAggregate
+{
+    /**
+     * Executes the operation and returns a result if available; null otherwise
+     */
+    public function execute(): mixed;
+
+    /**
+     * Executes the operation and returns a result iterator. If the operation
+     * did not yield an iterator, this method will throw
+     *
+     * @throws BadMethodCallException if the operation did not yield an iterator.
+     */
+    public function getIterator(): Iterator;
+
+    /**
+     * Returns the first result only from the operation
+     *
+     * Note that the behaviour of fetching the first result is dependent on the
+     * implementation. A separate operation might be involved.
+     */
+    public function getSingleResult(): mixed;
+}

--- a/lib/Doctrine/ODM/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Builder.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Query;
 use BadMethodCallException;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Iterator\IterableResult;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use GeoJson\Geometry\Geometry;
 use GeoJson\Geometry\Point;
@@ -659,8 +660,10 @@ class Builder
      * Gets the Query executable.
      *
      * @param array<string, mixed> $options
+     *
+     * @return Query
      */
-    public function getQuery(array $options = []): Query
+    public function getQuery(array $options = []): IterableResult
     {
         $documentPersister = $this->dm->getUnitOfWork()->getDocumentPersister($this->class->name);
 

--- a/lib/Doctrine/ODM/MongoDB/Query/Query.php
+++ b/lib/Doctrine/ODM/MongoDB/Query/Query.php
@@ -9,6 +9,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Iterator\CachingIterator;
 use Doctrine\ODM\MongoDB\Iterator\HydratingIterator;
+use Doctrine\ODM\MongoDB\Iterator\IterableResult;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Iterator\PrimingIterator;
 use Doctrine\ODM\MongoDB\Iterator\UnrewindableIterator;
@@ -16,7 +17,6 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use InvalidArgumentException;
-use IteratorAggregate;
 use MongoDB\Collection;
 use MongoDB\DeleteResult;
 use MongoDB\Driver\ReadPreference;
@@ -63,7 +63,7 @@ use function is_string;
  * @phpstan-import-type Hints from UnitOfWork
  * @phpstan-import-type SortMeta from Sort
  */
-final class Query implements IteratorAggregate
+final class Query implements IterableResult
 {
     public const TYPE_FIND            = 1;
     public const TYPE_FIND_AND_UPDATE = 2;
@@ -200,7 +200,7 @@ final class Query implements IteratorAggregate
      *
      * @throws MongoDBException
      */
-    public function execute()
+    public function execute(): mixed
     {
         $results = $this->runQuery();
 
@@ -298,7 +298,7 @@ final class Query implements IteratorAggregate
      *
      * @return array<string, mixed>|object|null
      */
-    public function getSingleResult()
+    public function getSingleResult(): mixed
     {
         $clonedQuery                 = clone $this;
         $clonedQuery->query['limit'] = 1;
@@ -355,7 +355,7 @@ final class Query implements IteratorAggregate
     /**
      * Execute the query and return its results as an array.
      *
-     * @see IteratorAggregate::toArray()
+     * @see Iterator::toArray()
      *
      * @return mixed[]
      */


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | Fixes #2699 (cc @soyuka)

#### Summary

To improve handling of query and aggregation classes, a new joint `IterableResult` interface is introduced. This method includes the `execute`, `getIterator`, and `getSingleResult` methods that are common to both queries and aggregations. In addition, this allows us to keep the actual classes final, while allowing other platforms to mock what's returned from the builders for testing purposes.

Note that while the return type of `getAggregation` and `getQuery` in the builders has widened, I've added an `@return` statement to indicate that the methods themselves still return the same class instances that they returned previously. However, changing the return type is necessary to allow the mocking described above. So while this is technically a BC break, in practice it has no effect, especially as any class extending the builders would still be allowed to use the narrower return type.