### PR TITLE
doc: Fix simple search engine cookbook

### DIFF
--- a/docs/en/cookbook/simple-search-engine.rst
+++ b/docs/en/cookbook/simple-search-engine.rst
@@ -27,7 +27,7 @@ setup a document like the following with a ``$keywords`` property that is mapped
 
         #[Field(type: 'collection')]
         #[Index]
-        public array $keywords;
+        public array $keywords = [];
 
         public function __construct()
         {

--- a/docs/en/cookbook/simple-search-engine.rst
+++ b/docs/en/cookbook/simple-search-engine.rst
@@ -28,11 +28,6 @@ setup a document like the following with a ``$keywords`` property that is mapped
         #[Field(type: 'collection')]
         #[Index]
         public array $keywords = [];
-
-        public function __construct()
-        {
-            $this->keywords = [];
-        }
     }
 
 Working with Keywords

--- a/docs/en/cookbook/simple-search-engine.rst
+++ b/docs/en/cookbook/simple-search-engine.rst
@@ -3,7 +3,7 @@ Simple Search Engine
 
 It is very easy to implement a simple keyword search engine with MongoDB. Because of
 its flexible schema less nature we can store the keywords we want to search through directly
-on the document. MongoDB is capable of indexing the embedded documents so the results are fast
+on the document. MongoDB is capable of indexing an array field, so the results are fast
 and scalable.
 
 Sample Model: Product
@@ -25,14 +25,13 @@ setup a document like the following with a ``$keywords`` property that is mapped
         #[Field(type: 'string')]
         public string $title;
 
-        /** @var Collection<string> */
         #[Field(type: 'collection')]
         #[Index]
-        public Collection $keywords;
+        public array $keywords;
 
         public function __construct()
         {
-            $this->keywords = new ArrayCollection();
+            $this->keywords = [];
         }
     }
 
@@ -47,11 +46,11 @@ Now, create a product and add some keywords:
 
     $product = new Product();
     $product->title = 'Nike Air Jordan 2011';
-    $product->keywords->add('nike shoes');
-    $product->keywords->add('jordan shoes');
-    $product->keywords->add('air jordan');
-    $product->keywords->add('shoes');
-    $product->keywords->add('2011');
+    $product->keywords[] = 'nike shoes';
+    $product->keywords[] = 'jordan shoes';
+    $product->keywords[] = 'air jordan';
+    $product->keywords[] = 'shoes';
+    $product->keywords[] = '2011';
 
     $dm->persist($product);
     $dm->flush();


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | doc
| BC Break     | no
| Fixed issues | -

#### Summary

Use array instead of ArrayCollection. It is not possible to use an ArrayCollection with a collection field type. This would result in a runtime exception: "Collection type requires value of type array or null, Doctrine\Common\Collections\ArrayCollection given (Doctrine\ODM\MongoDB\MongoDBException)".

Conversation with @malarzm in the Slack channel #mongodm-odm on 12/12/2024:

> th docs are wrong, public Collection $keywords; has to be public array $keywords; and used as such