### PR TITLE
Replace `wrapTransversable` generators to prevent memory leaks

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Iterator;
 
 use Countable;
-use Iterator;
+use Iterator as SPLIterator;
 use IteratorIterator;
 use ReturnTypeWillChange;
 use RuntimeException;
@@ -34,8 +34,8 @@ final class CachingIterator implements Countable, Iterator
     /** @var array<mixed, TValue> */
     private array $items = [];
 
-    /** @var Iterator<mixed, TValue>|null */
-    private ?Iterator $iterator;
+    /** @var SPLIterator<mixed, TValue>|null */
+    private ?SPLIterator $iterator;
 
     private bool $iteratorAdvanced = false;
 
@@ -136,8 +136,8 @@ final class CachingIterator implements Countable, Iterator
         }
     }
 
-    /** @return Iterator<mixed, TValue> */
-    private function getIterator(): Iterator
+    /** @return SPLIterator<mixed, TValue> */
+    private function getIterator(): SPLIterator
     {
         if ($this->iterator === null) {
             throw new RuntimeException('Iterator has already been destroyed');

--- a/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
@@ -52,11 +52,7 @@ final class CachingIterator implements Countable, Iterator
     {
         $this->iterator = new IteratorIterator($iterator);
         $this->iterator->rewind();
-        if ($this->iterator->valid()) {
-            $this->storeCurrentItem();
-        } else {
-            $this->iterator = null;
-        }
+        $this->storeCurrentItem();
     }
 
     /** @see https://php.net/countable.count */
@@ -102,10 +98,6 @@ final class CachingIterator implements Countable, Iterator
             $this->iterator->next();
             $this->storeCurrentItem();
             $this->iteratorAdvanced = true;
-
-            if (! $this->iterator->valid()) {
-                $this->iterator = null;
-            }
         }
 
         next($this->items);
@@ -155,12 +147,12 @@ final class CachingIterator implements Countable, Iterator
      */
     private function storeCurrentItem(): void
     {
-        $key = $this->getIterator()->key();
+        $key = $this->iterator->key();
 
         if ($key === null) {
-            return;
+            $this->iterator = null;
+        } else {
+            $this->items[$key] = $this->getIterator()->current();
         }
-
-        $this->items[$key] = $this->getIterator()->current();
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
@@ -52,7 +52,11 @@ final class CachingIterator implements Countable, Iterator
     {
         $this->iterator = new IteratorIterator($iterator);
         $this->iterator->rewind();
-        $this->storeCurrentItem();
+        if ($this->iterator->valid()) {
+            $this->storeCurrentItem();
+        } else {
+            $this->iterator = null;
+        }
     }
 
     /** @see https://php.net/countable.count */

--- a/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/CachingIterator.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Iterator;
 
 use Countable;
-use Generator;
+use Iterator;
+use IteratorIterator;
 use ReturnTypeWillChange;
 use RuntimeException;
 use Traversable;
@@ -33,12 +34,10 @@ final class CachingIterator implements Countable, Iterator
     /** @var array<mixed, TValue> */
     private array $items = [];
 
-    /** @var Generator<mixed, TValue>|null */
-    private ?Generator $iterator;
+    /** @var Iterator<mixed, TValue>|null */
+    private ?Iterator $iterator;
 
     private bool $iteratorAdvanced = false;
-
-    private bool $iteratorExhausted = false;
 
     /**
      * Initialize the iterator and stores the first item in the cache. This
@@ -51,7 +50,8 @@ final class CachingIterator implements Countable, Iterator
      */
     public function __construct(Traversable $iterator)
     {
-        $this->iterator = $this->wrapTraversable($iterator);
+        $this->iterator = new IteratorIterator($iterator);
+        $this->iterator->rewind();
         $this->storeCurrentItem();
     }
 
@@ -94,9 +94,14 @@ final class CachingIterator implements Countable, Iterator
     /** @see http://php.net/iterator.next */
     public function next(): void
     {
-        if (! $this->iteratorExhausted) {
-            $this->getIterator()->next();
+        if ($this->iterator !== null) {
+            $this->iterator->next();
             $this->storeCurrentItem();
+            $this->iteratorAdvanced = true;
+
+            if (! $this->iterator->valid()) {
+                $this->iterator = null;
+            }
         }
 
         next($this->items);
@@ -126,15 +131,13 @@ final class CachingIterator implements Countable, Iterator
      */
     private function exhaustIterator(): void
     {
-        while (! $this->iteratorExhausted) {
+        while ($this->iterator !== null) {
             $this->next();
         }
-
-        $this->iterator = null;
     }
 
-    /** @return Generator<mixed, TValue> */
-    private function getIterator(): Generator
+    /** @return Iterator<mixed, TValue> */
+    private function getIterator(): Iterator
     {
         if ($this->iterator === null) {
             throw new RuntimeException('Iterator has already been destroyed');
@@ -155,21 +158,5 @@ final class CachingIterator implements Countable, Iterator
         }
 
         $this->items[$key] = $this->getIterator()->current();
-    }
-
-    /**
-     * @param Traversable<mixed, TValue> $traversable
-     *
-     * @return Generator<mixed, TValue>
-     */
-    private function wrapTraversable(Traversable $traversable): Generator
-    {
-        foreach ($traversable as $key => $value) {
-            yield $key => $value;
-
-            $this->iteratorAdvanced = true;
-        }
-
-        $this->iteratorExhausted = true;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
@@ -35,6 +35,7 @@ final class HydratingIterator implements Iterator
     public function __construct(Traversable $traversable, private UnitOfWork $unitOfWork, private ClassMetadata $class, private array $unitOfWorkHints = [])
     {
         $this->iterator = new IteratorIterator($traversable);
+        $this->iterator->rewind();
     }
 
     public function __destruct()

--- a/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/HydratingIterator.php
@@ -6,8 +6,8 @@ namespace Doctrine\ODM\MongoDB\Iterator;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\UnitOfWork;
-use Generator;
 use Iterator;
+use IteratorIterator;
 use ReturnTypeWillChange;
 use RuntimeException;
 use Traversable;
@@ -24,8 +24,8 @@ use Traversable;
  */
 final class HydratingIterator implements Iterator
 {
-    /** @var Generator<mixed, array<string, mixed>>|null */
-    private ?Generator $iterator;
+    /** @var Iterator<mixed, array<string, mixed>>|null */
+    private ?Iterator $iterator;
 
     /**
      * @param Traversable<mixed, array<string, mixed>> $traversable
@@ -34,7 +34,7 @@ final class HydratingIterator implements Iterator
      */
     public function __construct(Traversable $traversable, private UnitOfWork $unitOfWork, private ClassMetadata $class, private array $unitOfWorkHints = [])
     {
-        $this->iterator = $this->wrapTraversable($traversable);
+        $this->iterator = new IteratorIterator($traversable);
     }
 
     public function __destruct()
@@ -74,8 +74,8 @@ final class HydratingIterator implements Iterator
         return $this->key() !== null;
     }
 
-    /** @return Generator<mixed, array<string, mixed>> */
-    private function getIterator(): Generator
+    /** @return Iterator<mixed, array<string, mixed>> */
+    private function getIterator(): Iterator
     {
         if ($this->iterator === null) {
             throw new RuntimeException('Iterator has already been destroyed');
@@ -92,17 +92,5 @@ final class HydratingIterator implements Iterator
     private function hydrate(?array $document): ?object
     {
         return $document !== null ? $this->unitOfWork->getOrCreateDocument($this->class->name, $document, $this->unitOfWorkHints) : null;
-    }
-
-    /**
-     * @param Traversable<mixed, array<string, mixed>> $traversable
-     *
-     * @return Generator<mixed, array<string, mixed>>
-     */
-    private function wrapTraversable(Traversable $traversable): Generator
-    {
-        foreach ($traversable as $key => $value) {
-            yield $key => $value;
-        }
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Iterator/UnrewindableIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/UnrewindableIterator.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Iterator;
 
-use Generator;
+use Iterator;
+use IteratorIterator;
 use LogicException;
 use ReturnTypeWillChange;
 use RuntimeException;
@@ -23,39 +24,34 @@ use function sprintf;
  */
 final class UnrewindableIterator implements Iterator
 {
-    /** @var Generator<mixed, TValue>|null */
-    private ?Generator $iterator;
+    /** @var Iterator<mixed, TValue>|null */
+    private ?Iterator $iterator;
 
     private bool $iteratorAdvanced = false;
 
     /**
-     * Initialize the iterator. This effectively rewinds the Traversable and
-     * the wrapping Generator, which will execute up to its first yield statement.
-     * Additionally, this mimics behavior of the SPL iterators and allows users
-     * to omit an explicit call to rewind() before using the other methods.
+     * Initialize the iterator. This effectively rewinds the Traversable.
+     * This mimics behavior of the SPL iterators and allows users to omit an
+     * explicit call to rewind() before using the other methods.
      *
      * @param Traversable<mixed, TValue> $iterator
      */
     public function __construct(Traversable $iterator)
     {
-        $this->iterator = $this->wrapTraversable($iterator);
-        $this->iterator->key();
+        $this->iterator = new IteratorIterator($iterator);
+        $this->iterator->rewind();
     }
 
     public function toArray(): array
     {
         $this->preventRewinding(__METHOD__);
 
-        $toArray = function () {
-            if (! $this->valid()) {
-                return;
-            }
-
-            yield $this->key() => $this->current();
-            yield from $this->getIterator();
-        };
-
-        return iterator_to_array($toArray());
+        try {
+            return iterator_to_array($this->getIterator());
+        } finally {
+            $this->iteratorAdvanced = true;
+            $this->iterator         = null;
+        }
     }
 
     /** @return TValue|null */
@@ -84,6 +80,13 @@ final class UnrewindableIterator implements Iterator
         }
 
         $this->iterator->next();
+        $this->iteratorAdvanced = true;
+
+        if ($this->iterator->valid()) {
+            return;
+        }
+
+        $this->iterator = null;
     }
 
     /** @see http://php.net/iterator.rewind */
@@ -108,29 +111,13 @@ final class UnrewindableIterator implements Iterator
         }
     }
 
-    /** @return Generator<mixed, TValue> */
-    private function getIterator(): Generator
+    /** @return Iterator<mixed, TValue> */
+    private function getIterator(): Iterator
     {
         if ($this->iterator === null) {
             throw new RuntimeException('Iterator has already been destroyed');
         }
 
         return $this->iterator;
-    }
-
-    /**
-     * @param Traversable<mixed, TValue> $traversable
-     *
-     * @return Generator<mixed, TValue>
-     */
-    private function wrapTraversable(Traversable $traversable): Generator
-    {
-        foreach ($traversable as $key => $value) {
-            yield $key => $value;
-
-            $this->iteratorAdvanced = true;
-        }
-
-        $this->iterator = null;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Iterator/UnrewindableIterator.php
+++ b/lib/Doctrine/ODM/MongoDB/Iterator/UnrewindableIterator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Iterator;
 
-use Iterator;
+use Iterator as SPLIterator;
 use IteratorIterator;
 use LogicException;
 use ReturnTypeWillChange;
@@ -24,8 +24,8 @@ use function sprintf;
  */
 final class UnrewindableIterator implements Iterator
 {
-    /** @var Iterator<mixed, TValue>|null */
-    private ?Iterator $iterator;
+    /** @var SPLIterator<mixed, TValue>|null */
+    private ?SPLIterator $iterator;
 
     private bool $iteratorAdvanced = false;
 
@@ -111,8 +111,8 @@ final class UnrewindableIterator implements Iterator
         }
     }
 
-    /** @return Iterator<mixed, TValue> */
-    private function getIterator(): Iterator
+    /** @return SPLIterator<mixed, TValue> */
+    private function getIterator(): SPLIterator
     {
         if ($this->iterator === null) {
             throw new RuntimeException('Iterator has already been destroyed');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/CachingIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/CachingIteratorTest.php
@@ -59,6 +59,19 @@ class CachingIteratorTest extends TestCase
         self::assertFalse($iterator->valid());
     }
 
+    public function testIterationWithInvalidIterator(): void
+    {
+        $mock = $this->createMock(Iterator::class);
+        // The method next() should not be called on a dead cursor.
+        $mock->expects(self::never())->method('next');
+        // The method valid() return false on a dead cursor.
+        $mock->expects(self::once())->method('valid')->willReturn(false);
+
+        $iterator = new CachingIterator($mock);
+
+        $this->assertEquals([], $iterator->toArray());
+    }
+
     public function testPartialIterationDoesNotExhaust(): void
     {
         $traversable = $this->getTraversableThatThrows([1, 2, new Exception()]);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/UnrewindableIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/UnrewindableIteratorTest.php
@@ -100,6 +100,15 @@ class UnrewindableIteratorTest extends TestCase
         iterator_to_array($iterator);
     }
 
+    public function testRewingAfterToArray(): void
+    {
+        $iterator = new UnrewindableIterator($this->getTraversable([1, 2, 3]));
+
+        $iterator->toArray();
+        $this->expectException(LogicException::class);
+        $iterator->rewind();
+    }
+
     public function testToArray(): void
     {
         $iterator = new UnrewindableIterator($this->getTraversable([1, 2, 3]));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/UnrewindableIteratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Iterator/UnrewindableIteratorTest.php
@@ -100,7 +100,7 @@ class UnrewindableIteratorTest extends TestCase
         iterator_to_array($iterator);
     }
 
-    public function testRewingAfterToArray(): void
+    public function testRewindAfterToArray(): void
     {
         $iterator = new UnrewindableIterator($this->getTraversable([1, 2, 3]));
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2105

#### Problem

A non-static generator created with a method of a class instance holds the reference to this instance. When assigned to a property of this instance, this creates a circular reference (instance -> generator -> instance). The reference is destroyed only when the generator is exhausted.

Most of the time, when the memory limit is sufficient, this is not an issue. The garbage collector should remove this circular references, but it runs automatically only when reaching the [`GC_THRESHOLD_DEFAULT`](https://www.php.net/manual/en/features.gc.collecting-cycles.php). 

When working with a MongoDB Cursor, this is a single object which can fill up a lot of memory, that explains why `gc_collect_cycles()` is not run automatically.

#### Solution

Using `IteratorIterator` instead of `Generator`, we remove this circular reference . Also, I find the code simpler.
Same as https://github.com/mongodb/mongo-php-library/pull/694

#### Demonstration

In the following example, if `gc_collect_cycles()` is not called in the loop, we can see the memory leak. When calling `gc_collect_cycles()` explicitly, we can see 300 "collected" references. The memory leak disappears when the `Generator` is replaced by an `IteratorIterator`.

<details>
  <summary>Source code</summary>

```php
<?php

namespace Hell;

class Iterator implements \Iterator
{
    private iterable $iterator;

    public function __construct(\Traversable $data)
    {
        $this->iterator = $this->wrapTraversable($data);
        //$this->iterator = new \IteratorIterator($data);
    }

    public function current(): mixed
    {
        return $this->iterator->current();
    }

    public function next(): void
    {
        $this->iterator->next();
    }

    public function key(): mixed
    {
        return $this->iterator->key();
    }

    public function valid(): bool
    {
        return $this->iterator->valid();
    }

    public function rewind(): void
    {
        $this->iterator->rewind();
    }

    private function wrapTraversable(iterable $data): \Generator
    {
        foreach ($data as $key => $value) {
            yield $key => $value;
        }
    }
}

foreach (range(0, 100) as $i) {
    $data = new \ArrayObject(array_fill(0, 1_000_00, bin2hex(random_bytes(1_000))));
    $iterator = new Iterator($data);
    $iterator->next();
    unset($data);
    echo (memory_get_usage()).PHP_EOL;
}

gc_collect_cycles();
print_r(gc_status());
```

</details>

