### PR TITLE
Install latest python version to fix CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -118,6 +118,11 @@ jobs:
           dependency-versions: "${{ matrix.dependencies }}"
           composer-options: "--prefer-dist"
 
+      - name: "Install latest Python version"
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
       - id: setup-mongodb
         uses: mongodb-labs/drivers-evergreen-tools@master
         with:


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

A recent change to drivers-evergreen-tools made the action incompatible with the Python version installed by default. To work around the issue, we now install the latest version ourselves.