### PR TITLE
Relax final constraints on stage classes

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AddFields.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AddFields.php
@@ -11,8 +11,9 @@ use Doctrine\ODM\MongoDB\Aggregation\Expr;
  *
  * @psalm-import-type OperatorExpression from Expr
  * @psalm-type AddFieldsStageExpression = array{'$addFields': array<string, OperatorExpression|mixed>}
+ * @final
  */
-final class AddFields extends Operator
+class AddFields extends Operator
 {
     /** @return AddFieldsStageExpression */
     public function getExpression(): array

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Set.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Set.php
@@ -11,8 +11,9 @@ use Doctrine\ODM\MongoDB\Aggregation\Expr;
  *
  * @psalm-import-type OperatorExpression from Expr
  * @psalm-type SetStageExpression = array{'$set': array<string, OperatorExpression|mixed>}
+ * @final
  */
-final class Set extends Operator
+class Set extends Operator
 {
     /** @psalm-return SetStageExpression */
     public function getExpression(): array


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Related to https://github.com/api-platform/core/pull/6912#discussion_r1911459888

#### Summary

Classes that are used for type hint cannot be "hard" final, otherwise they cannot be mocked. Even if I agree that mocking is not the best approach for testing aggregation builders.
