### PR TITLE
Root document Entity Map

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -2044,11 +2044,9 @@ use function trigger_deprecation;
     {
         $this->parentClasses = $classNames;
 
-        if (count($classNames) <= 0) {
+        if ($this->isEmbeddedDocument || count($classNames) <= 0) {
             return;
         }
-
-        if ($this->isEmbeddedDocument) return;
 
         $this->rootDocumentName = (string) array_pop($classNames);
     }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -2048,6 +2048,8 @@ use function trigger_deprecation;
             return;
         }
 
+        if ($this->isEmbeddedDocument) return;
+
         $this->rootDocumentName = (string) array_pop($classNames);
     }
 

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1505,7 +1505,7 @@ final class UnitOfWork implements PropertyChangedListener
         $class = $this->dm->getClassMetadata($document::class);
         $id    = $this->getIdForIdentityMap($document);
 
-        if ($class->isEmbeddedDocument || isset($this->identityMap[$class->rootDocumentName][$id])) {
+        if (isset($this->identityMap[$class->rootDocumentName][$id])) {
             return false;
         }
 

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1505,7 +1505,7 @@ final class UnitOfWork implements PropertyChangedListener
         $class = $this->dm->getClassMetadata($document::class);
         $id    = $this->getIdForIdentityMap($document);
 
-        if (isset($this->identityMap[$class->rootDocumentName][$id])) {
+        if ($class->isEmbeddedDocument || isset($this->identityMap[$class->rootDocumentName][$id])) {
             return false;
         }
 

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1505,11 +1505,11 @@ final class UnitOfWork implements PropertyChangedListener
         $class = $this->dm->getClassMetadata($document::class);
         $id    = $this->getIdForIdentityMap($document);
 
-        if (isset($this->identityMap[$class->name][$id])) {
+        if (isset($this->identityMap[$class->rootDocumentName][$id])) {
             return false;
         }
 
-        $this->identityMap[$class->name][$id] = $document;
+        $this->identityMap[$class->rootDocumentName][$id] = $document;
 
         if ($document instanceof NotifyPropertyChanged && ! $this->isUninitializedObject($document)) {
             $document->addPropertyChangedListener($this);
@@ -1597,8 +1597,8 @@ final class UnitOfWork implements PropertyChangedListener
         $class = $this->dm->getClassMetadata($document::class);
         $id    = $this->getIdForIdentityMap($document);
 
-        if (isset($this->identityMap[$class->name][$id])) {
-            unset($this->identityMap[$class->name][$id]);
+        if (isset($this->identityMap[$class->rootDocumentName][$id])) {
+            unset($this->identityMap[$class->rootDocumentName][$id]);
             $this->documentStates[$oid] = self::STATE_DETACHED;
 
             return true;
@@ -1629,7 +1629,7 @@ final class UnitOfWork implements PropertyChangedListener
 
         $serializedId = serialize($class->getDatabaseIdentifierValue($id));
 
-        return $this->identityMap[$class->name][$serializedId];
+        return $this->identityMap[$class->rootDocumentName][$serializedId];
     }
 
     /**
@@ -1658,7 +1658,7 @@ final class UnitOfWork implements PropertyChangedListener
 
         $serializedId = serialize($class->getDatabaseIdentifierValue($id));
 
-        return $this->identityMap[$class->name][$serializedId] ?? false;
+        return $this->identityMap[$class->rootDocumentName][$serializedId] ?? false;
     }
 
     /**
@@ -1688,7 +1688,7 @@ final class UnitOfWork implements PropertyChangedListener
         $class = $this->dm->getClassMetadata($document::class);
         $id    = $this->getIdForIdentityMap($document);
 
-        return isset($this->identityMap[$class->name][$id]);
+        return isset($this->identityMap[$class->rootDocumentName][$id]);
     }
 
     private function getIdForIdentityMap(object $document): string
@@ -2768,13 +2768,13 @@ final class UnitOfWork implements PropertyChangedListener
         if (! $class->isQueryResultDocument) {
             $id              = $class->getDatabaseIdentifierValue($data['_id']);
             $serializedId    = serialize($id);
-            $isManagedObject = isset($this->identityMap[$class->name][$serializedId]);
+            $isManagedObject = isset($this->identityMap[$class->rootDocumentName][$serializedId]);
         }
 
         $oid = null;
         if ($isManagedObject) {
             /** @phpstan-var T $document */
-            $document = $this->identityMap[$class->name][$serializedId];
+            $document = $this->identityMap[$class->rootDocumentName][$serializedId];
             $oid      = spl_object_hash($document);
             if ($this->isUninitializedObject($document)) {
                 $document->setProxyInitializer(null);
@@ -2800,7 +2800,7 @@ final class UnitOfWork implements PropertyChangedListener
                 $this->registerManaged($document, $id, $data);
                 $oid                                            = spl_object_hash($document);
                 $this->documentStates[$oid]                     = self::STATE_MANAGED;
-                $this->identityMap[$class->name][$serializedId] = $document;
+                $this->identityMap[$class->rootDocumentName][$serializedId] = $document;
             }
 
             $data = $this->hydratorFactory->hydrate($document, $data, $hints);

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -2798,8 +2798,8 @@ final class UnitOfWork implements PropertyChangedListener
 
             if (! $class->isQueryResultDocument) {
                 $this->registerManaged($document, $id, $data);
-                $oid                                            = spl_object_hash($document);
-                $this->documentStates[$oid]                     = self::STATE_MANAGED;
+                $oid                                                        = spl_object_hash($document);
+                $this->documentStates[$oid]                                 = self::STATE_MANAGED;
                 $this->identityMap[$class->rootDocumentName][$serializedId] = $document;
             }
 


### PR DESCRIPTION
### Bug Report

<!-- Fill in the relevant information below to help triage your issue. -->

|    Q        |   A
|------------ | ------
| BC Break    | no
| Version     | 2.10.x

#### Summary

Problem class inheritance save in entitymap 

#### How to reproduce

I have a simple class inheritance like this:

```
#[ODM\DiscriminatorMap([3 => Tag::class, 4 => Category::class])]
class Section {}


class Tag extends Section {}
class Category extends Section {}
```

Then I do something like this:

```
/** @var DocumentManager $manager */
$manager = Kernel::stGetObj()->getContainer()->get('doctrine_mongodb')->getManager();
$manager->getRepository(Section::class)->find(68);
$manager->getRepository(Section::class)->find(68);
```
It seems like two database queries are made, but only one should be executed since it should be cached in the entity map. The issue seems to be that when it looks up the entity map, it does so using the repository class, but then stores it with the actual class (the child class) instead.

```
18:33:35 DEBUG     [doctrine] MongoDB command: {"find":"section","filter":{"_id":68,"type":{"$in":[3,4]}},"limit":1,"$db":"db","lsid":{"id":{"$binary":"R5St6qBWSAqg\/2jT16lktA==","$type":"04"}}}
18:33:35 DEBUG     [doctrine] MongoDB command: {"find":"section","filter":{"_id":68,"type":{"$in":[3,4]}},"limit":1,"$db":"db","lsid":{"id":{"$binary":"R5St6qBWSAqg\/2jT16lktA==","$type":"04"}}}
```

However, if I do this:

```
/** @var DocumentManager $manager */
$manager = Kernel::stGetObj()->getContainer()->get('doctrine_mongodb')->getManager();
$manager->getRepository(Tag::class)->find(68);
$manager->getRepository(Tag::class)->find(68);
```

It works correctly, and only one query is made.

When fetching the same document twice, only one database query should be executed if the entity is already cached in the entity map, regardless of whether the parent or child class is used.

To resolve the issue, I have overridden the find method of the DocumentRepository and do the following:
```
$parentClass = $this->getReflectionParentClass(new \ReflectionClass($documentName));        
if ($map = $this->getDocumentManager()->getClassMetadata($parentClass->getName())->discriminatorMap) {
     foreach ($map as $class) {
        if ($ret = $this->getDocumentManager()->getUnitOfWork()->tryGetById($id, $this->getDocumentManager()->getClassMetadata($class))) {
            return $ret;
          }
     }
}
```
but method tryGetById is marked internal :(