### PR TITLE
Always use insert for time series documents

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1129,7 +1129,7 @@ final class UnitOfWork implements PropertyChangedListener
         $upsert = false;
         if ($class->identifier) {
             $idValue = $class->getIdentifierValue($document);
-            $upsert  = ! $class->isEmbeddedDocument && $idValue !== null;
+            $upsert  = ! $class->isEmbeddedDocument && ! $class->timeSeriesOptions && $idValue !== null;
 
             if ($class->generatorType === ClassMetadata::GENERATOR_TYPE_NONE && $idValue === null) {
                 throw new InvalidArgumentException(sprintf(

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
@@ -211,6 +211,11 @@ abstract class BaseTestCase extends TestCase
         $this->requireVersion($this->getServerVersion(), '4.2.0', '<', $message);
     }
 
+    protected function requireMongoDB63(string $message): void
+    {
+        $this->requireVersion($this->getServerVersion(), '6.3.0', '<', $message);
+    }
+
     protected static function getUri(bool $useMultipleMongoses = true): string
     {
         $uri = getenv('DOCTRINE_MONGODB_SERVER') ?: DOCTRINE_MONGODB_SERVER;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TimeSeriesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TimeSeriesTest.php
@@ -13,6 +13,13 @@ use function iterator_to_array;
 
 class TimeSeriesTest extends BaseTestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->requireMongoDB63('Time series tests require MonogDB 6.3 or newer');
+    }
+
     public function testCreateTimeSeriesCollection(): void
     {
         $this->createTimeSeriesCollection(TimeSeriesDocument::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/TimeSeriesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/TimeSeriesTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use DateTime;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\TimeSeries\TimeSeriesDocument;
+use MongoDB\BSON\ObjectId;
+
+use function iterator_to_array;
+
+class TimeSeriesTest extends BaseTestCase
+{
+    public function testCreateTimeSeriesCollection(): void
+    {
+        $this->createTimeSeriesCollection(TimeSeriesDocument::class);
+
+        $indexes = iterator_to_array($this->dm->getDocumentCollection(TimeSeriesDocument::class)->listIndexes());
+
+        $this->assertCount(1, $indexes);
+
+        self::assertSame(['metadata' => 1, 'time' => 1], $indexes[0]['key']);
+    }
+
+    public function testCreateTimeSeriesDocumentWithoutId(): void
+    {
+        $this->createTimeSeriesCollection(TimeSeriesDocument::class);
+
+        $document           = new TimeSeriesDocument();
+        $document->time     = new DateTime('2025-02-05T08:53:12+00:00');
+        $document->value    = 9;
+        $document->metadata = 'energy';
+
+        $this->dm->persist($document);
+        $this->dm->flush();
+
+        $this->assertCount(1, $this->dm->getDocumentCollection(TimeSeriesDocument::class)->find());
+    }
+
+    public function testCreateTimeSeriesDocumentWithId(): void
+    {
+        $this->createTimeSeriesCollection(TimeSeriesDocument::class);
+
+        $document           = new TimeSeriesDocument();
+        $document->id       = (string) new ObjectId();
+        $document->time     = new DateTime('2025-02-05T08:53:12+00:00');
+        $document->value    = 9;
+        $document->metadata = 'energy';
+
+        $this->dm->persist($document);
+        $this->dm->flush();
+
+        $this->assertCount(1, $this->dm->getDocumentCollection(TimeSeriesDocument::class)->find());
+    }
+
+    private function createTimeSeriesCollection(string $documentClass): void
+    {
+        $this->dm->getSchemaManager()->createDocumentCollection($documentClass);
+        $this->dm->getSchemaManager()->ensureDocumentIndexes($documentClass);
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

This fixes an issue where assigning an ID to a time series document triggers an upsert, which is not allowed in time series collections. To work around this, we always use an `insert` command when inserting time series documents.
