### PR TITLE
Fix access to null `$config` variable

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -159,7 +159,7 @@ class DocumentManager implements ObjectManager
             ],
         );
 
-        $this->classNameResolver = $config->isLazyGhostObjectEnabled()
+        $this->classNameResolver = $this->config->isLazyGhostObjectEnabled()
             ? new CachingClassNameResolver(new LazyGhostProxyClassNameResolver())
             : new CachingClassNameResolver(new ProxyManagerClassNameResolver($this->config));
 
@@ -186,8 +186,8 @@ class DocumentManager implements ObjectManager
 
         $this->unitOfWork        = new UnitOfWork($this, $this->eventManager, $this->hydratorFactory);
         $this->schemaManager     = new SchemaManager($this, $this->metadataFactory);
-        $this->proxyFactory      = $config->isLazyGhostObjectEnabled()
-            ? new LazyGhostProxyFactory($this, $config->getProxyDir(), $config->getProxyNamespace(), $config->getAutoGenerateProxyClasses())
+        $this->proxyFactory      = $this->config->isLazyGhostObjectEnabled()
+            ? new LazyGhostProxyFactory($this, $this->config->getProxyDir(), $this->config->getProxyNamespace(), $this->config->getAutoGenerateProxyClasses())
             : new StaticProxyFactory($this);
         $this->repositoryFactory = $this->config->getRepositoryFactory();
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2731

#### Summary

Issue introduced in #2700, the variable `$config` can be null.

However, calling `DocumentManager::create()` without argument fails because the hydrator requires the directory and namespace configuration. So I could not add a test. https://github.com/doctrine/mongodb-odm/blob/a33bf090401ed1138a289c5e866fcc7e70c88379/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php#L78-L86
