### PR TITLE
Create `UTCDateTime` from `DateTimeInterface` directly

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/DateType.php
@@ -90,7 +90,7 @@ class DateType extends Type implements Versionable
 
         $datetime = static::getDateTime($value);
 
-        return new UTCDateTime((int) $datetime->format('Uv'));
+        return new UTCDateTime($datetime);
     }
 
     public function convertToPHPValue($value)
@@ -104,7 +104,7 @@ class DateType extends Type implements Versionable
 
     public function closureToMongo(): string
     {
-        return 'if ($value === null || $value instanceof \MongoDB\BSON\UTCDateTime) { $return = $value; } else { $datetime = \\' . static::class . '::getDateTime($value); $return = new \MongoDB\BSON\UTCDateTime((int) $datetime->format(\'Uv\')); }';
+        return 'if ($value === null || $value instanceof \MongoDB\BSON\UTCDateTime) { $return = $value; } else { $datetime = \\' . static::class . '::getDateTime($value); $return = new \MongoDB\BSON\UTCDateTime($datetime); }';
     }
 
     public function closureToPHP(): string


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

The constructor of `UTCDateTime` accepts `DateTimeInterface` since ext-mongodb 1.2 https://github.com/mongodb/mongo-php-driver/pull/336

Interestingly, it seems that it was already supported when this code was written. https://github.com/doctrine/mongodb-odm/commit/567bb758ad5779236e4f0cb44026704504f19dc3
