### PR TITLE
Fix duplicate object hash for removed object

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1790,7 +1790,7 @@ final class UnitOfWork implements PropertyChangedListener
                 // Document becomes managed again
                 unset($this->scheduledDocumentDeletions[$oid]);
 
-                $this->documentStates[$oid] = self::STATE_MANAGED;
+                $this->persistNew($class, $document);
                 break;
 
             case self::STATE_DETACHED:

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2730Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2730Test.php
@@ -13,10 +13,11 @@ class GH2730Test extends BaseTestCase
 {
     public function testUniqueObjectIdentifier(): void
     {
-        $document = new GH2730Document();
+        $document = new GH2730();
         $oid      = spl_object_hash($document);
         $this->dm->persist($document);
         $this->dm->flush();
+        $id = $document->id;
 
         // Remove the document
         $this->dm->remove($document);
@@ -26,21 +27,26 @@ class GH2730Test extends BaseTestCase
         unset($document);
 
         // Create a new document
-        $document = new GH2730Document();
+        $document = new GH2730();
         $this->dm->persist($document);
+
+        // If this assertion fails in a future version of PHP, this test case can be skipped.
+        self::assertSame($oid, spl_object_hash($document), 'PHP created a new object with the same object hash');
+        self::assertNotEquals($document->id, $id, 'New ID generated');
+        self::assertCount(1, $this->dm->getUnitOfWork()->getScheduledDocumentInsertions());
+        self::assertCount(0, $this->dm->getUnitOfWork()->getScheduledDocumentUpserts());
+
         $this->dm->flush();
 
         self::assertSame(1, $this->countDocuments());
-
-        // If this assertion fails in a future version of PHP, this test case can be skipped.
-        self::assertSame($oid, spl_object_hash($document), 'PHP created a new object wit the same object hash');
     }
 
     public function testRemoveFlushPersist(): void
     {
-        $document = new GH2730Document();
+        $document = new GH2730();
         $this->dm->persist($document);
         $this->dm->flush();
+        $id = $document->id;
 
         // Remove the document
         $this->dm->remove($document);
@@ -48,6 +54,10 @@ class GH2730Test extends BaseTestCase
 
         // Re-persist the same document
         $this->dm->persist($document);
+        self::assertEquals($document->id, $id, 'ID not regenerated');
+        self::assertCount(0, $this->dm->getUnitOfWork()->getScheduledDocumentInsertions());
+        self::assertCount(1, $this->dm->getUnitOfWork()->getScheduledDocumentUpserts());
+
         $this->dm->flush();
 
         self::assertSame(1, $this->countDocuments());
@@ -55,15 +65,21 @@ class GH2730Test extends BaseTestCase
 
     public function testRemovePersist(): void
     {
-        $document = new GH2730Document();
+        $document = new GH2730();
         $this->dm->persist($document);
         $this->dm->flush();
+        $id = $document->id;
 
         // Remove the document
         $this->dm->remove($document);
 
         // Re-persist the same document
         $this->dm->persist($document);
+
+        self::assertEquals($document->id, $id, 'ID not regenerated');
+        self::assertCount(0, $this->dm->getUnitOfWork()->getScheduledDocumentInsertions());
+        self::assertCount(1, $this->dm->getUnitOfWork()->getScheduledDocumentUpserts());
+
         $this->dm->flush();
 
         self::assertSame(1, $this->countDocuments());
@@ -71,12 +87,12 @@ class GH2730Test extends BaseTestCase
 
     private function countDocuments(): int
     {
-        return $this->dm->getDocumentCollection(GH2730Document::class)->countDocuments();
+        return $this->dm->getDocumentCollection(GH2730::class)->countDocuments();
     }
 }
 
 #[ODM\Document]
-class GH2730Document
+class GH2730
 {
     #[ODM\Id]
     public ?string $id = null;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2730Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2730Test.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+
+use function spl_object_hash;
+
+class GH2730Test extends BaseTestCase
+{
+    public function testUniqueObjectIdentifier(): void
+    {
+        $document = new GH2730Document();
+        $oid      = spl_object_hash($document);
+        $this->dm->persist($document);
+        $this->dm->flush();
+
+        // Remove the document
+        $this->dm->remove($document);
+        $this->dm->flush();
+
+        // Remove the last reference to the document
+        unset($document);
+
+        // Create a new document
+        $document = new GH2730Document();
+        $this->dm->persist($document);
+        $this->dm->flush();
+
+        self::assertSame(1, $this->countDocuments());
+
+        // If this assertion fails in a future version of PHP, this test case can be skipped.
+        self::assertSame($oid, spl_object_hash($document), 'PHP created a new object wit the same object hash');
+    }
+
+    public function testRemoveFlushPersist(): void
+    {
+        $document = new GH2730Document();
+        $this->dm->persist($document);
+        $this->dm->flush();
+
+        // Remove the document
+        $this->dm->remove($document);
+        $this->dm->flush();
+
+        // Re-persist the same document
+        $this->dm->persist($document);
+        $this->dm->flush();
+
+        self::assertSame(1, $this->countDocuments());
+    }
+
+    public function testRemovePersist(): void
+    {
+        $document = new GH2730Document();
+        $this->dm->persist($document);
+        $this->dm->flush();
+
+        // Remove the document
+        $this->dm->remove($document);
+
+        // Re-persist the same document
+        $this->dm->persist($document);
+        $this->dm->flush();
+
+        self::assertSame(1, $this->countDocuments());
+    }
+
+    private function countDocuments(): int
+    {
+        return $this->dm->getDocumentCollection(GH2730Document::class)->countDocuments();
+    }
+}
+
+#[ODM\Document]
+class GH2730Document
+{
+    #[ODM\Id]
+    public ?string $id = null;
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | #2730

#### Summary

In think a document that has been "removed", need to be treated as a new document when persisted again. The only thing is that it's ID can be already initialized.

(I tried the WeakMap approach, but that's not going well. https://github.com/GromNaN/mongodb-odm/commit/8204cb0607c8ca1c10044efa495c6c9a2e35757a)
