### PR TITLE
Replace `spl_object_hash` with `spl_object_id`

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -61,7 +61,7 @@ use function is_array;
 use function is_object;
 use function is_scalar;
 use function is_string;
-use function spl_object_hash;
+use function spl_object_id;
 use function sprintf;
 use function strpos;
 use function strtolower;
@@ -96,14 +96,14 @@ final class DocumentPersister
     /**
      * Array of queued inserts for the persister to insert.
      *
-     * @var array<string, object>
+     * @var array<int, object>
      */
     private array $queuedInserts = [];
 
     /**
      * Array of queued inserts for the persister to insert.
      *
-     * @var array<string, object>
+     * @var array<int, object>
      */
     private array $queuedUpserts = [];
 
@@ -136,7 +136,7 @@ final class DocumentPersister
         $this->bucket = $dm->getDocumentBucket($class->name);
     }
 
-    /** @return array<string, object> */
+    /** @return array<int, object> */
     public function getInserts(): array
     {
         return $this->queuedInserts;
@@ -144,7 +144,7 @@ final class DocumentPersister
 
     public function isQueuedForInsert(object $document): bool
     {
-        return isset($this->queuedInserts[spl_object_hash($document)]);
+        return isset($this->queuedInserts[spl_object_id($document)]);
     }
 
     /**
@@ -153,10 +153,10 @@ final class DocumentPersister
      */
     public function addInsert(object $document): void
     {
-        $this->queuedInserts[spl_object_hash($document)] = $document;
+        $this->queuedInserts[spl_object_id($document)] = $document;
     }
 
-    /** @return array<string, object> */
+    /** @return array<int, object> */
     public function getUpserts(): array
     {
         return $this->queuedUpserts;
@@ -164,7 +164,7 @@ final class DocumentPersister
 
     public function isQueuedForUpsert(object $document): bool
     {
-        return isset($this->queuedUpserts[spl_object_hash($document)]);
+        return isset($this->queuedUpserts[spl_object_id($document)]);
     }
 
     /**
@@ -173,7 +173,7 @@ final class DocumentPersister
      */
     public function addUpsert(object $document): void
     {
-        $this->queuedUpserts[spl_object_hash($document)] = $document;
+        $this->queuedUpserts[spl_object_id($document)] = $document;
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Repository/AbstractRepositoryFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Repository/AbstractRepositoryFactory.php
@@ -11,7 +11,7 @@ use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\Persistence\ObjectRepository;
 
 use function is_a;
-use function spl_object_hash;
+use function spl_object_id;
 
 /**
  * Abstract factory for creating document repositories.
@@ -35,7 +35,7 @@ abstract class AbstractRepositoryFactory implements RepositoryFactory
     public function getRepository(DocumentManager $documentManager, string $documentName): ObjectRepository
     {
         $metadata = $documentManager->getClassMetadata($documentName);
-        $hashKey  = $metadata->getName() . spl_object_hash($documentManager);
+        $hashKey  = $metadata->getName() . '_' . spl_object_id($documentManager);
 
         if (isset($this->repositoryList[$hashKey])) {
             return $this->repositoryList[$hashKey];

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -48,7 +48,7 @@ use function is_object;
 use function method_exists;
 use function preg_match;
 use function serialize;
-use function spl_object_hash;
+use function spl_object_id;
 use function sprintf;
 use function trigger_deprecation;
 
@@ -125,38 +125,38 @@ final class UnitOfWork implements PropertyChangedListener
 
     /**
      * Map of all identifiers of managed documents.
-     * Keys are object ids (spl_object_hash).
+     * Keys are object ids (spl_object_id).
      *
-     * @var array<string, mixed>
+     * @var array<int, mixed>
      */
     private array $documentIdentifiers = [];
 
     /**
      * Map of the original document data of managed documents.
-     * Keys are object ids (spl_object_hash). This is used for calculating changesets
+     * Keys are object ids (spl_object_id). This is used for calculating changesets
      * at commit time.
      *
      * @internal Note that PHPs "copy-on-write" behavior helps a lot with memory usage.
      *           A value will only really be copied if the value in the document is modified
      *           by the user.
      *
-     * @var array<string, array<string, mixed>>
+     * @var array<int, array<string, mixed>>
      */
     private array $originalDocumentData = [];
 
     /**
-     * Map of document changes. Keys are object ids (spl_object_hash).
+     * Map of document changes. Keys are object ids (spl_object_id).
      * Filled at the beginning of a commit of the UnitOfWork and cleaned at the end.
      *
-     * @var array<string, array<string, ChangeSet>>
+     * @var array<int, array<string, ChangeSet>>
      */
     private array $documentChangeSets = [];
 
     /**
      * The (cached) states of any known documents.
-     * Keys are object ids (spl_object_hash).
+     * Keys are object ids (spl_object_id).
      *
-     * @var array<string, self::STATE_*>
+     * @var array<int, self::STATE_*>
      */
     private array $documentStates = [];
 
@@ -167,56 +167,56 @@ final class UnitOfWork implements PropertyChangedListener
      * object hash. This is only used for documents with a change tracking
      * policy of DEFERRED_EXPLICIT.
      *
-     * @var array<class-string, array<string, object>>
+     * @var array<class-string, array<int, object>>
      */
     private array $scheduledForSynchronization = [];
 
     /**
      * A list of all pending document insertions.
      *
-     * @var array<string, object>
+     * @var array<int, object>
      */
     private array $scheduledDocumentInsertions = [];
 
     /**
      * A list of all pending document updates.
      *
-     * @var array<string, object>
+     * @var array<int, object>
      */
     private array $scheduledDocumentUpdates = [];
 
     /**
      * A list of all pending document upserts.
      *
-     * @var array<string, object>
+     * @var array<int, object>
      */
     private array $scheduledDocumentUpserts = [];
 
     /**
      * A list of all pending document deletions.
      *
-     * @var array<string, object>
+     * @var array<int, object>
      */
     private array $scheduledDocumentDeletions = [];
 
     /**
      * All pending collection deletions.
      *
-     * @var array<string, PersistentCollectionInterface<array-key, object>>
+     * @var array<int, PersistentCollectionInterface<array-key, object>>
      */
     private array $scheduledCollectionDeletions = [];
 
     /**
      * All pending collection updates.
      *
-     * @var array<string, PersistentCollectionInterface<array-key, object>>
+     * @var array<int, PersistentCollectionInterface<array-key, object>>
      */
     private array $scheduledCollectionUpdates = [];
 
     /**
      * A list of documents related to collections scheduled for update or deletion
      *
-     * @var array<string, array<string, PersistentCollectionInterface<array-key, object>>>
+     * @var array<int, array<int, PersistentCollectionInterface<array-key, object>>>
      */
     private array $hasScheduledCollections = [];
 
@@ -225,7 +225,7 @@ final class UnitOfWork implements PropertyChangedListener
      * At the end of the UnitOfWork all these collections will make new snapshots
      * of their data.
      *
-     * @var array<string, array<PersistentCollectionInterface<array-key, object>>>
+     * @var array<int, array<PersistentCollectionInterface<array-key, object>>>
      */
     private array $visitedCollections = [];
 
@@ -242,7 +242,7 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Additional documents that are scheduled for removal.
      *
-     * @var array<string, object>
+     * @var array<int, object>
      */
     private array $orphanRemovals = [];
 
@@ -271,7 +271,7 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Array of parent associations between embedded documents.
      *
-     * @var array<string, array{0: AssociationFieldMapping, 1: object|null, 2: string}>
+     * @var array<int, array{0: AssociationFieldMapping, 1: object|null, 2: string}>
      */
     private array $parentAssociations = [];
 
@@ -280,11 +280,11 @@ final class UnitOfWork implements PropertyChangedListener
     private ReflectionService $reflectionService;
 
     /**
-     * Array of embedded documents known to UnitOfWork. We need to hold them to prevent spl_object_hash
+     * Array of embedded documents known to UnitOfWork. We need to hold them to prevent spl_object_id
      * collisions in case already managed object is lost due to GC (so now it won't). Embedded documents
      * found during doDetach are removed from the registry, to empty it altogether clear() can be utilized.
      *
-     * @var array<string, object>
+     * @var array<int, object>
      */
     private array $embeddedDocumentsRegistry = [];
 
@@ -326,7 +326,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function setParentAssociation(object $document, array $mapping, ?object $parent, string $propertyPath): void
     {
-        $oid                                   = spl_object_hash($document);
+        $oid                                   = spl_object_id($document);
         $this->embeddedDocumentsRegistry[$oid] = $document;
         $this->parentAssociations[$oid]        = [$mapping, $parent, $propertyPath];
     }
@@ -342,7 +342,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function getParentAssociation(object $document): ?array
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
 
         return $this->parentAssociations[$oid] ?? null;
     }
@@ -502,9 +502,9 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Groups a list of scheduled documents by their class.
      *
-     * @param array<string, object> $documents
+     * @param array<int, object> $documents
      *
-     * @phpstan-return array<class-string, array{0: ClassMetadata<object>, 1: array<string, object>}>
+     * @phpstan-return array<class-string, array{0: ClassMetadata<object>, 1: array<int, object>}>
      */
     private function getClassesForCommitAction(array $documents, bool $includeEmbedded = false): array
     {
@@ -587,7 +587,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function getDocumentChangeSet(object $document): array
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
 
         return $this->documentChangeSets[$oid] ?? [];
     }
@@ -601,7 +601,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function setDocumentChangeSet(object $document, array $changeset): void
     {
-        $this->documentChangeSets[spl_object_hash($document)] = $changeset;
+        $this->documentChangeSets[spl_object_id($document)] = $changeset;
     }
 
     /**
@@ -700,7 +700,7 @@ final class UnitOfWork implements PropertyChangedListener
             return;
         }
 
-        $oid           = spl_object_hash($document);
+        $oid           = spl_object_id($document);
         $actualData    = $this->getDocumentActualData($document);
         $isNewDocument = ! isset($this->originalDocumentData[$oid]);
         if ($isNewDocument) {
@@ -877,7 +877,7 @@ final class UnitOfWork implements PropertyChangedListener
             $values = $mapping['type'] === ClassMetadata::ONE ? [$value] : $value->unwrap();
 
             foreach ($values as $obj) {
-                $oid2 = spl_object_hash($obj);
+                $oid2 = spl_object_id($obj);
 
                 if (! isset($this->documentChangeSets[$oid2])) {
                     continue;
@@ -942,7 +942,7 @@ final class UnitOfWork implements PropertyChangedListener
                 }
 
                 // Only MANAGED documents that are NOT SCHEDULED FOR INSERTION, UPSERT OR DELETION are processed here.
-                $oid = spl_object_hash($document);
+                $oid = spl_object_id($document);
                 if (
                     isset($this->scheduledDocumentInsertions[$oid])
                     || isset($this->scheduledDocumentUpserts[$oid])
@@ -967,7 +967,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     private function computeAssociationChanges(object $parentDocument, array $assoc, $value): void
     {
-        $isNewParentDocument   = isset($this->scheduledDocumentInsertions[spl_object_hash($parentDocument)]);
+        $isNewParentDocument   = isset($this->scheduledDocumentInsertions[spl_object_id($parentDocument)]);
         $class                 = $this->dm->getClassMetadata($parentDocument::class);
         $topOrExistingDocument = ( ! $isNewParentDocument || ! $class->isEmbeddedDocument);
 
@@ -984,8 +984,8 @@ final class UnitOfWork implements PropertyChangedListener
                 $this->scheduleCollectionUpdate($value);
             }
 
-            $topmostOwner                                               = $this->getOwningDocument($value->getOwner());
-            $this->visitedCollections[spl_object_hash($topmostOwner)][] = $value;
+            $topmostOwner                                             = $this->getOwningDocument($value->getOwner());
+            $this->visitedCollections[spl_object_id($topmostOwner)][] = $value;
             if (! empty($assoc['orphanRemoval']) || isset($assoc['embedded'])) {
                 $value->initialize();
                 foreach ($value->getDeletedDocuments() as $orphan) {
@@ -1038,8 +1038,8 @@ final class UnitOfWork implements PropertyChangedListener
                             $entry = clone $entry;
                             if ($assoc['type'] === ClassMetadata::ONE) {
                                 $class->setFieldValue($parentDocument, $assoc['fieldName'], $entry);
-                                $this->setOriginalDocumentProperty(spl_object_hash($parentDocument), $assoc['fieldName'], $entry);
-                                $poid = spl_object_hash($parentDocument);
+                                $this->setOriginalDocumentProperty(spl_object_id($parentDocument), $assoc['fieldName'], $entry);
+                                $poid = spl_object_id($parentDocument);
                                 if (isset($this->documentChangeSets[$poid][$assoc['fieldName']])) {
                                     $this->documentChangeSets[$poid][$assoc['fieldName']][1] = $entry;
                                 }
@@ -1101,7 +1101,7 @@ final class UnitOfWork implements PropertyChangedListener
             return;
         }
 
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
 
         if (! isset($this->documentStates[$oid]) || $this->documentStates[$oid] !== self::STATE_MANAGED) {
             throw new InvalidArgumentException('Document must be managed.');
@@ -1125,7 +1125,7 @@ final class UnitOfWork implements PropertyChangedListener
     private function persistNew(ClassMetadata $class, object $document): void
     {
         $this->lifecycleEventManager->prePersist($class, $document);
-        $oid    = spl_object_hash($document);
+        $oid    = spl_object_id($document);
         $upsert = false;
         if ($class->identifier) {
             $idValue = $class->getIdentifierValue($document);
@@ -1301,7 +1301,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function scheduleForInsert(ClassMetadata $class, object $document): void
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
 
         if (isset($this->scheduledDocumentUpdates[$oid])) {
             throw new InvalidArgumentException('Dirty document can not be scheduled for insertion.');
@@ -1339,7 +1339,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function scheduleForUpsert(ClassMetadata $class, object $document): void
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
 
         if ($class->isEmbeddedDocument) {
             throw new InvalidArgumentException('Embedded document can not be scheduled for upsert.');
@@ -1367,7 +1367,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function isScheduledForInsert(object $document): bool
     {
-        return isset($this->scheduledDocumentInsertions[spl_object_hash($document)]);
+        return isset($this->scheduledDocumentInsertions[spl_object_id($document)]);
     }
 
     /**
@@ -1375,7 +1375,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function isScheduledForUpsert(object $document): bool
     {
-        return isset($this->scheduledDocumentUpserts[spl_object_hash($document)]);
+        return isset($this->scheduledDocumentUpserts[spl_object_id($document)]);
     }
 
     /**
@@ -1387,7 +1387,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function scheduleForUpdate(object $document): void
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
         if (! isset($this->documentIdentifiers[$oid])) {
             throw new InvalidArgumentException('Document has no identity.');
         }
@@ -1414,7 +1414,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function isScheduledForUpdate(object $document): bool
     {
-        return isset($this->scheduledDocumentUpdates[spl_object_hash($document)]);
+        return isset($this->scheduledDocumentUpdates[spl_object_id($document)]);
     }
 
     /**
@@ -1424,7 +1424,7 @@ final class UnitOfWork implements PropertyChangedListener
     {
         $class = $this->dm->getClassMetadata($document::class);
 
-        return isset($this->scheduledForSynchronization[$class->name][spl_object_hash($document)]);
+        return isset($this->scheduledForSynchronization[$class->name][spl_object_id($document)]);
     }
 
     /**
@@ -1434,7 +1434,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function scheduleForDelete(object $document, bool $isView = false): void
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
 
         if (isset($this->scheduledDocumentInsertions[$oid])) {
             if ($this->isInIdentityMap($document)) {
@@ -1478,7 +1478,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function isScheduledForDelete(object $document): bool
     {
-        return isset($this->scheduledDocumentDeletions[spl_object_hash($document)]);
+        return isset($this->scheduledDocumentDeletions[spl_object_id($document)]);
     }
 
     /**
@@ -1488,7 +1488,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function isDocumentScheduled(object $document): bool
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
 
         return isset($this->scheduledDocumentInsertions[$oid]) ||
             isset($this->scheduledDocumentUpserts[$oid]) ||
@@ -1533,7 +1533,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function getDocumentState(object $document, ?int $assume = null): int
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
 
         if (isset($this->documentStates[$oid])) {
             return $this->documentStates[$oid];
@@ -1592,7 +1592,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function removeFromIdentityMap(object $document): bool
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
 
         // Check if id is registered first
         if (! isset($this->documentIdentifiers[$oid])) {
@@ -1673,8 +1673,8 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function scheduleForSynchronization(object $document): void
     {
-        $class                                                                       = $this->dm->getClassMetadata($document::class);
-        $this->scheduledForSynchronization[$class->name][spl_object_hash($document)] = $document;
+        $class                                                                     = $this->dm->getClassMetadata($document::class);
+        $this->scheduledForSynchronization[$class->name][spl_object_id($document)] = $document;
     }
 
     /**
@@ -1684,7 +1684,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function isInIdentityMap(object $document): bool
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
 
         if (! isset($this->documentIdentifiers[$oid])) {
             return false;
@@ -1701,9 +1701,9 @@ final class UnitOfWork implements PropertyChangedListener
         $class = $this->dm->getClassMetadata($document::class);
 
         if (! $class->identifier) {
-            $id = spl_object_hash($document);
+            $id = (string) spl_object_id($document);
         } else {
-            $id = $this->documentIdentifiers[spl_object_hash($document)];
+            $id = $this->documentIdentifiers[spl_object_id($document)];
             $id = serialize($class->getDatabaseIdentifierValue($id));
         }
 
@@ -1756,7 +1756,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     private function doPersist(object $document, array &$visited): void
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
         if (isset($visited[$oid])) {
             return; // Prevent infinite recursion
         }
@@ -1822,13 +1822,13 @@ final class UnitOfWork implements PropertyChangedListener
      * This method is internally called during delete() cascades as it tracks
      * the already visited documents to prevent infinite recursions.
      *
-     * @param array<string, object> $visited
+     * @param array<int, object> $visited
      *
      * @throws MongoDBException
      */
     private function doRemove(object $document, array &$visited): void
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
         if (isset($visited[$oid])) {
             return; // Prevent infinite recursion
         }
@@ -1875,7 +1875,7 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Executes a merge operation on a document.
      *
-     * @param array<string, object> $visited
+     * @param array<int, object> $visited
      * @phpstan-param AssociationFieldMapping|null $assoc
      *
      * @throws InvalidArgumentException If the entity instance is NEW.
@@ -1885,7 +1885,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     private function doMerge(object $document, array &$visited, ?object $prevManagedCopy = null, ?array $assoc = null): object
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
 
         if (isset($visited[$oid])) {
             return $visited[$oid]; // Prevent infinite recursion
@@ -2064,7 +2064,7 @@ final class UnitOfWork implements PropertyChangedListener
         }
 
         // Mark the managed copy visited as well
-        $visited[spl_object_hash($managedCopy)] = $managedCopy;
+        $visited[spl_object_id($managedCopy)] = $managedCopy;
 
         $this->cascadeMerge($document, $managedCopy, $visited);
 
@@ -2086,11 +2086,11 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Executes a detach operation on the given document.
      *
-     * @param array<string, object> $visited
+     * @param array<int, object> $visited
      */
     private function doDetach(object $document, array &$visited): void
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
         if (isset($visited[$oid])) {
             return; // Prevent infinite recursion
         }
@@ -2138,13 +2138,13 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Executes a refresh operation on a document.
      *
-     * @param array<string, object> $visited
+     * @param array<int, object> $visited
      *
      * @throws InvalidArgumentException If the document is not MANAGED.
      */
     private function doRefresh(object $document, array &$visited): void
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
         if (isset($visited[$oid])) {
             return; // Prevent infinite recursion
         }
@@ -2167,7 +2167,7 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Cascades a refresh operation to associated documents.
      *
-     * @param array<string, object> $visited
+     * @param array<int, object> $visited
      */
     private function cascadeRefresh(object $document, array &$visited): void
     {
@@ -2198,7 +2198,7 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Cascades a detach operation to associated documents.
      *
-     * @param array<string, object> $visited
+     * @param array<int, object> $visited
      */
     private function cascadeDetach(object $document, array &$visited): void
     {
@@ -2227,7 +2227,7 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Cascades a merge operation to associated documents.
      *
-     * @param array<string, object> $visited
+     * @param array<int, object> $visited
      */
     private function cascadeMerge(object $document, object $managedCopy, array &$visited): void
     {
@@ -2259,7 +2259,7 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Cascades the save operation to associated documents.
      *
-     * @param array<string, object> $visited
+     * @param array<int, object> $visited
      */
     private function cascadePersist(object $document, array &$visited): void
     {
@@ -2317,7 +2317,7 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Cascades the delete operation to associated documents.
      *
-     * @param array<string, object> $visited
+     * @param array<int, object> $visited
      */
     private function cascadeRemove(object $document, array &$visited): void
     {
@@ -2444,7 +2444,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function scheduleOrphanRemoval(object $document): void
     {
-        $this->orphanRemovals[spl_object_hash($document)] = $document;
+        $this->orphanRemovals[spl_object_id($document)] = $document;
     }
 
     /**
@@ -2454,7 +2454,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function unscheduleOrphanRemoval(object $document): void
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
         unset($this->orphanRemovals[$oid]);
     }
 
@@ -2485,7 +2485,7 @@ final class UnitOfWork implements PropertyChangedListener
             $class->reflFields[$propName]->setValue($document, $newValue);
             if ($this->isScheduledForUpdate($document)) {
                 // @todo following line should be superfluous once collections are stored in change sets
-                $this->setOriginalDocumentProperty(spl_object_hash($document), $propName, $newValue);
+                $this->setOriginalDocumentProperty(spl_object_id($document), $propName, $newValue);
             }
 
             return $newValue;
@@ -2503,7 +2503,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function scheduleCollectionDeletion(PersistentCollectionInterface $coll): void
     {
-        $oid = spl_object_hash($coll);
+        $oid = spl_object_id($coll);
         unset($this->scheduledCollectionUpdates[$oid]);
         if (isset($this->scheduledCollectionDeletions[$oid])) {
             return;
@@ -2522,7 +2522,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function isCollectionScheduledForDeletion(PersistentCollectionInterface $coll): bool
     {
-        return isset($this->scheduledCollectionDeletions[spl_object_hash($coll)]);
+        return isset($this->scheduledCollectionDeletions[spl_object_id($coll)]);
     }
 
     /**
@@ -2538,14 +2538,14 @@ final class UnitOfWork implements PropertyChangedListener
             return;
         }
 
-        $oid = spl_object_hash($coll);
+        $oid = spl_object_id($coll);
         if (! isset($this->scheduledCollectionDeletions[$oid])) {
             return;
         }
 
         $topmostOwner = $this->getOwningDocument($coll->getOwner());
         unset($this->scheduledCollectionDeletions[$oid]);
-        unset($this->hasScheduledCollections[spl_object_hash($topmostOwner)][$oid]);
+        unset($this->hasScheduledCollections[spl_object_id($topmostOwner)][$oid]);
     }
 
     /**
@@ -2565,7 +2565,7 @@ final class UnitOfWork implements PropertyChangedListener
             $this->unscheduleCollectionDeletion($coll);
         }
 
-        $oid = spl_object_hash($coll);
+        $oid = spl_object_id($coll);
         if (isset($this->scheduledCollectionUpdates[$oid])) {
             return;
         }
@@ -2587,14 +2587,14 @@ final class UnitOfWork implements PropertyChangedListener
             return;
         }
 
-        $oid = spl_object_hash($coll);
+        $oid = spl_object_id($coll);
         if (! isset($this->scheduledCollectionUpdates[$oid])) {
             return;
         }
 
         $topmostOwner = $this->getOwningDocument($coll->getOwner());
         unset($this->scheduledCollectionUpdates[$oid]);
-        unset($this->hasScheduledCollections[spl_object_hash($topmostOwner)][$oid]);
+        unset($this->hasScheduledCollections[spl_object_id($topmostOwner)][$oid]);
     }
 
     /**
@@ -2606,7 +2606,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function isCollectionScheduledForUpdate(PersistentCollectionInterface $coll): bool
     {
-        return isset($this->scheduledCollectionUpdates[spl_object_hash($coll)]);
+        return isset($this->scheduledCollectionUpdates[spl_object_id($coll)]);
     }
 
     /**
@@ -2620,7 +2620,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function getVisitedCollections(object $document): array
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
 
         return $this->visitedCollections[$oid] ?? [];
     }
@@ -2630,11 +2630,11 @@ final class UnitOfWork implements PropertyChangedListener
      *
      * @internal
      *
-     * @return array<string, PersistentCollectionInterface<array-key, object>>
+     * @return array<int, PersistentCollectionInterface<array-key, object>>
      */
     public function getScheduledCollections(object $document): array
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
 
         return $this->hasScheduledCollections[$oid] ?? [];
     }
@@ -2647,7 +2647,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function hasScheduledCollections(object $document): bool
     {
-        return isset($this->hasScheduledCollections[spl_object_hash($document)]);
+        return isset($this->hasScheduledCollections[spl_object_id($document)]);
     }
 
     /**
@@ -2669,8 +2669,8 @@ final class UnitOfWork implements PropertyChangedListener
             return;
         }
 
-        $document                                                                          = $this->getOwningDocument($coll->getOwner());
-        $this->hasScheduledCollections[spl_object_hash($document)][spl_object_hash($coll)] = $coll;
+        $document                                                                      = $this->getOwningDocument($coll->getOwner());
+        $this->hasScheduledCollections[spl_object_id($document)][spl_object_id($coll)] = $coll;
 
         if ($document !== $coll->getOwner()) {
             $parent  = $coll->getOwner();
@@ -2780,7 +2780,7 @@ final class UnitOfWork implements PropertyChangedListener
         if ($isManagedObject) {
             /** @phpstan-var T $document */
             $document = $this->identityMap[$class->name][$serializedId];
-            $oid      = spl_object_hash($document);
+            $oid      = spl_object_id($document);
             if ($this->isUninitializedObject($document)) {
                 if ($document instanceof InternalProxy) {
                     $document->__setInitialized(true);
@@ -2810,7 +2810,7 @@ final class UnitOfWork implements PropertyChangedListener
 
             if (! $class->isQueryResultDocument) {
                 $this->registerManaged($document, $id, $data);
-                $oid                                            = spl_object_hash($document);
+                $oid                                            = spl_object_id($document);
                 $this->documentStates[$oid]                     = self::STATE_MANAGED;
                 $this->identityMap[$class->name][$serializedId] = $document;
             }
@@ -2862,7 +2862,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function getOriginalDocumentData(object $document): array
     {
-        $oid = spl_object_hash($document);
+        $oid = spl_object_id($document);
 
         return $this->originalDocumentData[$oid] ?? [];
     }
@@ -2874,7 +2874,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function setOriginalDocumentData(object $document, array $data): void
     {
-        $oid                              = spl_object_hash($document);
+        $oid                              = spl_object_id($document);
         $this->originalDocumentData[$oid] = $data;
         unset($this->documentChangeSets[$oid]);
     }
@@ -2886,7 +2886,7 @@ final class UnitOfWork implements PropertyChangedListener
      *
      * @param mixed $value
      */
-    public function setOriginalDocumentProperty(string $oid, string $property, $value): void
+    public function setOriginalDocumentProperty(int $oid, string $property, $value): void
     {
         $this->originalDocumentData[$oid][$property] = $value;
     }
@@ -2898,7 +2898,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function getDocumentIdentifier(object $document)
     {
-        return $this->documentIdentifiers[spl_object_hash($document)] ?? null;
+        return $this->documentIdentifiers[spl_object_id($document)] ?? null;
     }
 
     /**
@@ -2946,7 +2946,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function registerManaged(object $document, $id, array $data): void
     {
-        $oid   = spl_object_hash($document);
+        $oid   = spl_object_id($document);
         $class = $this->dm->getClassMetadata($document::class);
 
         if (! $class->identifier || $id === null) {
@@ -2965,7 +2965,7 @@ final class UnitOfWork implements PropertyChangedListener
      *
      * @internal
      */
-    public function clearDocumentChangeSet(string $oid): void
+    public function clearDocumentChangeSet(int $oid): void
     {
         $this->documentChangeSets[$oid] = [];
     }
@@ -2982,7 +2982,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     public function propertyChanged($sender, $propertyName, $oldValue, $newValue): void
     {
-        $oid   = spl_object_hash($sender);
+        $oid   = spl_object_id($sender);
         $class = $this->dm->getClassMetadata($sender::class);
 
         if (! isset($class->fieldMappings[$propertyName])) {
@@ -3001,7 +3001,7 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Gets the currently scheduled document insertions in this UnitOfWork.
      *
-     * @return array<string, object>
+     * @return array<int, object>
      */
     public function getScheduledDocumentInsertions(): array
     {
@@ -3011,7 +3011,7 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Gets the currently scheduled document upserts in this UnitOfWork.
      *
-     * @return array<string, object>
+     * @return array<int, object>
      */
     public function getScheduledDocumentUpserts(): array
     {
@@ -3021,7 +3021,7 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Gets the currently scheduled document updates in this UnitOfWork.
      *
-     * @return array<string, object>
+     * @return array<int, object>
      */
     public function getScheduledDocumentUpdates(): array
     {
@@ -3031,7 +3031,7 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Gets the currently scheduled document deletions in this UnitOfWork.
      *
-     * @return array<string, object>
+     * @return array<int, object>
      */
     public function getScheduledDocumentDeletions(): array
     {
@@ -3043,7 +3043,7 @@ final class UnitOfWork implements PropertyChangedListener
      *
      * @internal
      *
-     * @return array<string, PersistentCollectionInterface<array-key, object>>
+     * @return array<int, PersistentCollectionInterface<array-key, object>>
      */
     public function getScheduledCollectionDeletions(): array
     {
@@ -3055,7 +3055,7 @@ final class UnitOfWork implements PropertyChangedListener
      *
      * @internal
      *
-     * @return array<string, PersistentCollectionInterface<array-key, object>>
+     * @return array<int, PersistentCollectionInterface<array-key, object>>
      */
     public function getScheduledCollectionUpdates(): array
     {
@@ -3104,7 +3104,7 @@ final class UnitOfWork implements PropertyChangedListener
 
     private function objToStr(object $obj): string
     {
-        return method_exists($obj, '__toString') ? (string) $obj : $obj::class . '@' . spl_object_hash($obj);
+        return method_exists($obj, '__toString') ? (string) $obj : $obj::class . '@' . spl_object_id($obj);
     }
 
     /** @phpstan-param CommitOptions $options */

--- a/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
+++ b/lib/Doctrine/ODM/MongoDB/Utility/LifecycleEventManager.php
@@ -18,7 +18,7 @@ use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use MongoDB\Driver\Session;
 
-use function spl_object_hash;
+use function spl_object_id;
 
 /** @internal */
 final class LifecycleEventManager
@@ -27,7 +27,7 @@ final class LifecycleEventManager
 
     private ?Session $session = null;
 
-    /** @var array<string, array<string, true>> */
+    /** @var array<int, array<string, true>> */
     private array $transactionalEvents = [];
 
     public function __construct(private DocumentManager $dm, private UnitOfWork $uow, private EventManager $evm)
@@ -314,10 +314,10 @@ final class LifecycleEventManager
         }
 
         // Check whether the event has already been dispatched.
-        $hasDispatched = isset($this->transactionalEvents[spl_object_hash($document)][$eventName]);
+        $hasDispatched = isset($this->transactionalEvents[spl_object_id($document)][$eventName]);
 
         // Mark the event as dispatched - no problem doing this if it already was dispatched
-        $this->transactionalEvents[spl_object_hash($document)][$eventName] = true;
+        $this->transactionalEvents[spl_object_id($document)][$eventName] = true;
 
         return ! $hasDispatched;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1017Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1017Test.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 
 use function in_array;
-use function spl_object_hash;
+use function spl_object_id;
 
 class GH1017Test extends BaseTestCase
 {
@@ -28,7 +28,7 @@ class GH1017Test extends BaseTestCase
             unset($owner->embedded);
 
             $owner->embedded = new GH1017EmbeddedDocument();
-            $oid             = spl_object_hash($owner->embedded);
+            $oid             = spl_object_id($owner->embedded);
             if (in_array($oid, $usedHashes)) {
                 // Collision found, let's test state of embedded doc
                 self::assertEquals(

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mocks/PreUpdateListenerMock.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mocks/PreUpdateListenerMock.php
@@ -8,7 +8,7 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\Event\OnFlushEventArgs;
 use Doctrine\ODM\MongoDB\Event\PreUpdateEventArgs;
 
-use function spl_object_hash;
+use function spl_object_id;
 
 class PreUpdateListenerMock implements EventSubscriber
 {
@@ -24,7 +24,7 @@ class PreUpdateListenerMock implements EventSubscriber
     {
         $uow = $args->getDocumentManager()->getUnitOfWork();
         foreach ($uow->getScheduledDocumentUpdates() as $document) {
-            $uow->clearDocumentChangeSet(spl_object_hash($document));
+            $uow->clearDocumentChangeSet(spl_object_id($document));
         }
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -32,7 +32,7 @@ use ReflectionProperty;
 use Throwable;
 
 use function end;
-use function spl_object_hash;
+use function spl_object_id;
 use function sprintf;
 
 class UnitOfWorkTest extends BaseTestCase
@@ -74,7 +74,7 @@ class UnitOfWorkTest extends BaseTestCase
         $user->id = new ObjectId();
         self::assertEmpty($this->uow->getScheduledDocumentUpserts());
         $this->uow->scheduleForUpsert($class, $user);
-        self::assertEquals([spl_object_hash($user) => $user], $this->uow->getScheduledDocumentUpserts());
+        self::assertEquals([spl_object_id($user) => $user], $this->uow->getScheduledDocumentUpserts());
     }
 
     public function testScheduleForEmbeddedUpsert(): void
@@ -216,7 +216,7 @@ class UnitOfWorkTest extends BaseTestCase
             'uploadDate' => new DateTime(),
         ];
 
-        $this->uow->registerManaged($file, spl_object_hash($file), $data);
+        $this->uow->registerManaged($file, spl_object_id($file), $data);
 
         $this->uow->computeChangeSets();
         $changeset = $this->uow->getDocumentChangeSet($file);
@@ -242,7 +242,7 @@ class UnitOfWorkTest extends BaseTestCase
             'filename' => 'file.txt',
         ];
 
-        $this->uow->registerManaged($file, spl_object_hash($file), $data);
+        $this->uow->registerManaged($file, spl_object_id($file), $data);
 
         $this->uow->computeChangeSets();
         $changeset = $this->uow->getDocumentChangeSet($file);
@@ -326,7 +326,7 @@ class UnitOfWorkTest extends BaseTestCase
     public function testRegisterManagedEmbeddedDocumentWithMappedIdAndNullValue(): void
     {
         $document = new EmbeddedDocumentWithId();
-        $oid      = spl_object_hash($document);
+        $oid      = spl_object_id($document);
 
         $this->uow->registerManaged($document, null, []);
 
@@ -336,7 +336,7 @@ class UnitOfWorkTest extends BaseTestCase
     public function testRegisterManagedEmbeddedDocumentWithoutMappedId(): void
     {
         $document = new EmbeddedDocumentWithoutId();
-        $oid      = spl_object_hash($document);
+        $oid      = spl_object_id($document);
 
         $this->uow->registerManaged($document, null, []);
 
@@ -346,7 +346,7 @@ class UnitOfWorkTest extends BaseTestCase
     public function testRegisterManagedEmbeddedDocumentWithMappedIdStrategyNoneAndNullValue(): void
     {
         $document = new EmbeddedDocumentWithIdStrategyNone();
-        $oid      = spl_object_hash($document);
+        $oid      = spl_object_id($document);
 
         $this->uow->registerManaged($document, null, []);
 
@@ -441,7 +441,7 @@ class UnitOfWorkTest extends BaseTestCase
         self::assertEquals(UnitOfWork::STATE_MANAGED, $this->uow->getDocumentState($user->getAddress()));
         self::assertTrue($this->uow->isInIdentityMap($address));
         self::assertTrue($this->uow->isScheduledForInsert($address));
-        self::assertEquals(spl_object_hash($address), $this->uow->getDocumentIdentifier($address));
+        self::assertEquals(spl_object_id($address), $this->uow->getDocumentIdentifier($address));
 
         $this->uow->commit();
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | -

#### Summary

Same as https://github.com/doctrine/orm/pull/8837, but we don't have the same [breaking change](https://github.com/doctrine/orm/pull/8837/files#r751297402) because the method is internal. I haven't redone the perf benchmarks, but it seems obvious to me that they're of the same order of magnitude.

The updated public methods:

- **BC break:** `DocumentPersister::getInserts()` and `DocumentPersister::getUpserts()` return `array<int, object>` instead of `array<string, object>`.
- Internal: `UoW::clearDocumentChangeSet()` type of the first argument is modified from `string` to `int`.
