### PR TITLE
Add support for using `$text` operator in a aggregation with a filter

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -264,6 +264,11 @@ class Builder
      * @param bool $applyFilters Whether to apply filters on the aggregation
      * pipeline stage
      *
+     * For pipelines where the first stage is a $match stage, it will merge
+     * the document filters with the existing stage in a logical $and. This is
+     * required as $text operator can be used anywhere in the first $match stage
+     * or in the document filters.
+     *
      * For pipelines where the first stage is a $geoNear stage, it will apply
      * the document filters and discriminator queries to the query portion of
      * the geoNear operation. For all other pipelines, it prepends a $match stage
@@ -314,7 +319,17 @@ class Builder
 
         $matchExpression = $this->applyFilters([]);
         if ($matchExpression !== []) {
-            array_unshift($pipeline, ['$match' => $matchExpression]);
+            if (isset($pipeline[0]['$match'])) {
+                // Merge filters into the first $match stage with a logical $and
+                $pipeline[0]['$match'] = [
+                    '$and' => [
+                        $matchExpression,
+                        $pipeline[0]['$match'],
+                    ],
+                ];
+            } else {
+                array_unshift($pipeline, ['$match' => $matchExpression]);
+            }
         }
 
         return $pipeline;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -14,6 +14,7 @@ use Doctrine\ODM\MongoDB\Query\Expr as QueryExpr;
 use GeoJson\Geometry\Point;
 use MongoDB\Collection;
 use OutOfRangeException;
+use stdClass;
 use TypeError;
 
 use function array_map;
@@ -311,25 +312,21 @@ class Builder
             return $pipeline;
         }
 
-        if ($this->getStage(0) instanceof Stage\GeoNear) {
+        if (isset($pipeline[0]['$geoNear'])) {
             $pipeline[0]['$geoNear']['query'] = $this->applyFilters($pipeline[0]['$geoNear']['query']);
 
             return $pipeline;
         }
 
+        if (isset($pipeline[0]['$match'])) {
+            $pipeline[0]['$match'] = $this->applyFilters($pipeline[0]['$match']);
+
+            return $pipeline;
+        }
+
         $matchExpression = $this->applyFilters([]);
-        if ($matchExpression !== []) {
-            if (isset($pipeline[0]['$match'])) {
-                // Merge filters into the first $match stage with a logical $and
-                $pipeline[0]['$match'] = [
-                    '$and' => [
-                        $matchExpression,
-                        $pipeline[0]['$match'],
-                    ],
-                ];
-            } else {
-                array_unshift($pipeline, ['$match' => $matchExpression]);
-            }
+        if ((array) $matchExpression !== []) {
+            array_unshift($pipeline, ['$match' => $matchExpression]);
         }
 
         return $pipeline;
@@ -711,18 +708,22 @@ class Builder
     /**
      * Applies filters and discriminator queries to the pipeline
      *
-     * @param array<string, mixed> $query
+     * @param array<string, mixed>|stdClass $query
      *
-     * @return array<string, mixed>
+     * @return array<string, mixed>|stdClass
      */
-    private function applyFilters(array $query): array
+    private function applyFilters(array|stdClass $query): array|stdClass
     {
+        if (! is_array($query)) {
+            $query = (array) $query;
+        }
+
         $documentPersister = $this->getDocumentPersister();
 
         $query = $documentPersister->addDiscriminatorToPreparedQuery($query);
         $query = $documentPersister->addFilterToPreparedQuery($query);
 
-        return $query;
+        return $query === [] ? (object) $query : $query;
     }
 
     private function getDocumentPersister(): DocumentPersister

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -1029,9 +1029,6 @@ final class DocumentPersister
     {
         /* If filter criteria exists for this class, prepare it and merge
          * over the existing query.
-         *
-         * @todo Consider recursive merging in case the filter criteria and
-         * prepared query both contain top-level $and/$or operators.
          */
         $filterCriteria = $this->dm->getFilterCollection()->getFilterCriteria($this->class);
         if ($filterCriteria) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
@@ -368,6 +368,39 @@ class BuilderTest extends BaseTestCase
         self::assertEquals($expectedPipeline, $builder->getPipeline());
     }
 
+    public function testBuilderMergeFilterAndDiscriminatorWithMatchStage(): void
+    {
+        $this->dm->getFilterCollection()->enable('testFilter');
+        $filter = $this->dm->getFilterCollection()->getFilter('testFilter');
+        $filter->setParameter('class', GuestServer::class);
+        $filter->setParameter('field', 'filtered');
+        $filter->setParameter('value', true);
+
+        $builder = $this->dm->createAggregationBuilder(GuestServer::class);
+        $builder
+            ->match()
+                ->text('Paul');
+
+        $expectedPipeline = [
+            [
+                '$match' => [
+                    '$and' => [
+                        [
+                            '$and' => [
+                                ['stype' => 'server_guest'],
+                                ['filtered' => true],
+                            ],
+                        ],
+                        ['$text' => ['$search' => 'Paul']],
+                    ],
+                ],
+
+            ],
+        ];
+
+        self::assertEquals($expectedPipeline, $builder->getPipeline());
+    }
+
     public function testBuilderAppliesFilterAndDiscriminatorWithGeoNearStage(): void
     {
         $this->dm->getFilterCollection()->enable('testFilter');

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
@@ -386,15 +386,12 @@ class BuilderTest extends BaseTestCase
                 '$match' => [
                     '$and' => [
                         [
-                            '$and' => [
-                                ['stype' => 'server_guest'],
-                                ['filtered' => true],
-                            ],
+                            'stype' => 'server_guest',
+                            '$text' => ['$search' => 'Paul'],
                         ],
-                        ['$text' => ['$search' => 'Paul']],
+                        ['filtered' => true],
                     ],
                 ],
-
             ],
         ];
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GeoNearTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GeoNearTest.php
@@ -72,7 +72,7 @@ class GeoNearTest extends BaseTestCase
             ->geoNear(0, 0)
             ->limit(1);
 
-        $stage = ['near' => [0, 0], 'spherical' => false, 'distanceField' => null, 'query' => [], 'num' => 1];
-        self::assertSame([['$geoNear' => $stage]], $builder->getPipeline());
+        $stage = ['near' => [0, 0], 'spherical' => false, 'distanceField' => null, 'query' => (object) [], 'num' => 1];
+        self::assertEquals([['$geoNear' => $stage]], $builder->getPipeline());
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/FilterTest.php
@@ -334,4 +334,22 @@ class FilterTest extends BaseTestCase
          */
         self::assertEmpty($this->getUsernamesWithFindAll());
     }
+
+    public function testFilterOnMatchStageUsingTextOperator(): void
+    {
+        $this->dm->getDocumentCollection(User::class)->createIndex(['username' => 'text']);
+
+        $this->fc->enable('testFilter');
+        $testFilter = $this->fc->getFilter('testFilter');
+        $testFilter->setParameter('class', User::class);
+        $testFilter->setParameter('field', 'hits');
+        $testFilter->setParameter('value', 10);
+
+        $builder = $this->dm->createAggregationBuilder(User::class)
+            ->match()
+            ->field('username')
+            ->text('John');
+
+        self::assertCount(1, $builder->getAggregation()->execute());
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fix #2733

#### Summary

The `$text` operator [must be in the first](https://www.mongodb.com/docs/manual/reference/operator/query/text/#behavior) `$match` stage. Instead of prepending the pipeline with an other `$match` stage for the filter, the builder merge them using a logical `$and`. 

We cannot detect when `$text` is used as this can be deep in the `$match` query, so the behavior is for all the pipelines.
