### PR TITLE
Skip empty `$match` from pipeline builder

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -17,7 +17,6 @@ use OutOfRangeException;
 use stdClass;
 use TypeError;
 
-use function array_map;
 use function array_unshift;
 use function func_get_arg;
 use function func_num_args;
@@ -295,10 +294,15 @@ class Builder
             ));
         }
 
-        $pipeline = array_map(
-            static fn (Stage $stage) => $stage->getExpression(),
-            $this->stages,
-        );
+        $pipeline = [];
+        foreach ($this->stages as $stage) {
+            $stage = $stage->getExpression();
+            if (! $stage) {
+                continue;
+            }
+
+            $pipeline[] = $stage;
+        }
 
         if ($this->getStage(0) instanceof Stage\IndexStats) {
             // Don't apply any filters when using an IndexStats stage: since it

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -297,7 +297,7 @@ class Builder
         $pipeline = [];
         foreach ($this->stages as $stage) {
             $stage = $stage->getExpression();
-            if (! $stage) {
+            if ($stage === null) {
                 continue;
             }
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -33,7 +33,7 @@ abstract class Stage
      * @return array<string, mixed>
      * @phpstan-return StageExpression
      */
-    abstract public function getExpression(): array;
+    abstract public function getExpression(): ?array;
 
     /**
      * Executes the aggregation pipeline

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/MatchStage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/MatchStage.php
@@ -279,11 +279,15 @@ class MatchStage extends Stage
         return $this;
     }
 
-    public function getExpression(): array
+    public function getExpression(): ?array
     {
-        return [
-            '$match' => $this->query->getQuery() ?: (object) [],
-        ];
+        $query = $this->query->getQuery();
+
+        if (! $query) {
+            return null;
+        }
+
+        return ['$match' => $query];
     }
 
     /**

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
@@ -450,7 +450,7 @@ class BuilderTest extends BaseTestCase
         self::assertSame('$indexStats', array_keys($builder->getPipeline()[0])[0]);
     }
 
-    public function testEmptyMatchStage(): void
+    public function testEmptyMatchStageIsSkipped(): void
     {
         $builder = $this->dm
             ->createAggregationBuilder(BlogPost::class)

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/BuilderTest.php
@@ -450,6 +450,20 @@ class BuilderTest extends BaseTestCase
         self::assertSame('$indexStats', array_keys($builder->getPipeline()[0])[0]);
     }
 
+    public function testEmptyMatchStage(): void
+    {
+        $builder = $this->dm
+            ->createAggregationBuilder(BlogPost::class)
+            ->match()->field('foo')->equals('bar')
+            ->match()
+            ->match()->field('baz')->equals('qux');
+
+        self::assertSame([
+            ['$match' => ['foo' => 'bar']],
+            ['$match' => ['baz' => 'qux']],
+        ], $builder->getPipeline());
+    }
+
     public function testNonRewindableBuilder(): void
     {
         $builder = $this->dm


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no-ish
| Fixed issues | -

#### Summary

Don't send an unnecessary stage to the server.

Might be considered as a breaking change is someone manipulate the generated pipeline.