### PR TITLE
Fix `$geoNear` stage with empty query

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -723,6 +723,7 @@ class Builder
         $query = $documentPersister->addDiscriminatorToPreparedQuery($query);
         $query = $documentPersister->addFilterToPreparedQuery($query);
 
+        // An empty array is encoded as a BSON array. We need a BSON document.
         return $query === [] ? (object) $query : $query;
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GeoNear.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/GeoNear.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use GeoJson\Geometry\Point;
+use stdClass;
 
 use function is_array;
 
@@ -50,7 +51,7 @@ class GeoNear extends MatchStage
             'near' => $this->near,
             'spherical' => $this->spherical,
             'distanceField' => $this->distanceField,
-            'query' => $this->query->getQuery(),
+            'query' => $this->query->getQuery() ?: new stdClass(),
             'distanceMultiplier' => $this->distanceMultiplier,
             'includeLocs' => $this->includeLocs,
             'maxDistance' => $this->maxDistance,

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GeoNearTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/GeoNearTest.php
@@ -8,6 +8,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\GeoNear;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use stdClass;
 
 class GeoNearTest extends BaseTestCase
 {
@@ -72,7 +73,11 @@ class GeoNearTest extends BaseTestCase
             ->geoNear(0, 0)
             ->limit(1);
 
-        $stage = ['near' => [0, 0], 'spherical' => false, 'distanceField' => null, 'query' => (object) [], 'num' => 1];
-        self::assertEquals([['$geoNear' => $stage]], $builder->getPipeline());
+        $stage = $builder->getPipeline()[0];
+        self::assertSame([0, 0], $stage['$geoNear']['near']);
+        self::assertFalse($stage['$geoNear']['spherical']);
+        self::assertNull($stage['$geoNear']['distanceField']);
+        self::assertEquals(new stdClass(), $stage['$geoNear']['query']);
+        self::assertSame(1, $stage['$geoNear']['num']);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/GeoTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/GeoTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\Place;
+
+class GeoTest extends BaseTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dm->getSchemaManager()->ensureDocumentIndexes(Place::class);
+        $this->dm->persist(new Place(
+            name: 'Central Park',
+            location: ['type' => 'Point', 'coordinates' => [-73.97, 40.77]],
+            category: 'Parks',
+        ));
+        $this->dm->persist(new Place(
+            name: 'Sara D. Roosevelt Park',
+            location: ['type' => 'Point', 'coordinates' => [-73.9928, 40.7193]],
+            category: 'Parks',
+        ));
+        $this->dm->persist(new Place(
+            name: 'Polo Grounds',
+            location: ['type' => 'Point', 'coordinates' => [-73.9928, 40.7193]],
+            category: 'Stadiums',
+        ));
+        $this->dm->flush();
+    }
+
+    public function testGeoNearWithQuery(): void
+    {
+        $pipeline = $this->dm->createAggregationBuilder(Place::class)
+            ->geoNear(-73.99279, 40.719296)
+                ->field('category')->equals('Parks')
+                ->distanceField('calculated')
+                ->maxDistance(2)
+                ->spherical(true)
+            ->getAggregation();
+
+        $results = $pipeline->execute()->toArray();
+        self::assertCount(2, $results);
+        self::assertSame('Sara D. Roosevelt Park', $results[0]['name']);
+        self::assertIsFloat($results[0]['calculated']);
+    }
+
+    public function testGeoNearWithEmptyQuery(): void
+    {
+        $pipeline = $this->dm->createAggregationBuilder(Place::class)
+            ->geoNear(-73.99279, 40.719296)
+                ->distanceField('dist.calculated')
+                ->maxDistance(2)
+                ->includeLocs('dist.location')
+                ->spherical(true)
+            ->getAggregation();
+
+        $results = $pipeline->execute()->toArray();
+        self::assertCount(3, $results);
+        self::assertSame('Sara D. Roosevelt Park', $results[0]['name']);
+        self::assertIsArray($results[0]['dist']);
+        self::assertIsArray($results[0]['dist']['location']);
+        self::assertIsFloat($results[0]['dist']['calculated']);
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -17,6 +17,7 @@ use Documents\CmsComment;
 use Documents\CmsProduct;
 use Documents\Comment;
 use Documents\File;
+use Documents\Place;
 use Documents\SchemaValidated;
 use Documents\Sharded\ShardedOne;
 use Documents\Sharded\ShardedOneWithDifferentKey;
@@ -60,6 +61,7 @@ class SchemaManagerTest extends BaseTestCase
         CmsComment::class,
         CmsProduct::class,
         Comment::class,
+        Place::class,
         SimpleReferenceUser::class,
         ShardedOne::class,
         ShardedOneWithDifferentKey::class,

--- a/tests/Documents/Place.php
+++ b/tests/Documents/Place.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/** For testing $geoNear and other geographic operators */
+#[ODM\Document(collection: 'places')]
+#[ODM\Index(keys: ['location' => '2dsphere'])]
+class Place
+{
+    #[ODM\Id]
+    public ?string $id;
+
+    /** @param array{type:string, coordinates: list<float|int>} $location Geometry */
+    public function __construct(
+        #[ODM\Field]
+        public string $name,
+        #[ODM\Field]
+        public array $location,
+        #[ODM\Field]
+        public string $category,
+    ) {
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | https://github.com/doctrine/mongodb-odm/pull/2739#discussion_r1978342677

#### Summary

The `$geoNear` stage property `query` requires a document. When nothing is set, an empty array is currently sent; which is invalid.