### PR TITLE
Fix: Cast numeric write-concern values from XML mapping to integers

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -162,7 +162,7 @@ class XmlDriver extends FileDriver
             if (is_numeric($writeConcern)) {
                 $writeConcern = (int) $writeConcern;
             }
-            
+
             $metadata->setWriteConcern($writeConcern);
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -159,9 +159,10 @@ class XmlDriver extends FileDriver
 
         if (isset($xmlRoot['write-concern'])) {
             $writeConcern = (string) $xmlRoot['write-concern'];
-            if(is_numeric($writeConcern)) {
+            if (is_numeric($writeConcern)) {
                 $writeConcern = (int) $writeConcern;
             }
+            
             $metadata->setWriteConcern($writeConcern);
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -158,7 +158,11 @@ class XmlDriver extends FileDriver
         }
 
         if (isset($xmlRoot['write-concern'])) {
-            $metadata->setWriteConcern((string) $xmlRoot['write-concern']);
+            $writeConcern = (string) $xmlRoot['write-concern'];
+            if(is_numeric($writeConcern)) {
+                $writeConcern = (int) $writeConcern;
+            }
+            $metadata->setWriteConcern($writeConcern);
         }
 
         if (isset($xmlRoot['inheritance-type'])) {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractAnnotationDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractAnnotationDriverTestCase.php
@@ -148,7 +148,7 @@ abstract class AbstractAnnotationDriverTestCase extends AbstractMappingDriverTes
     public function testDocumentAnnotationCanSpecifyWriteConcern(): void
     {
         $cm = $this->dm->getClassMetadata(AnnotationDriverTestWriteConcernMajority::class);
-        self::assertEquals('majority', $cm->writeConcern);
+        self::assertSame('majority', $cm->writeConcern);
 
         $cm = $this->dm->getClassMetadata(AnnotationDriverTestWriteConcernUnacknowledged::class);
         self::assertSame(0, $cm->writeConcern);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
@@ -101,7 +101,7 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
     #[Depends('testDocumentCollectionNameAndInheritance')]
     public function testDocumentLevelWriteConcern(ClassMetadata $class): ClassMetadata
     {
-        self::assertEquals(1, $class->getWriteConcern());
+        self::assertSame(1, $class->getWriteConcern());
 
         return $class;
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fix #2749

#### Summary

<!-- Provide a summary your change. -->

When using write-concern="1" in XML mapping, the value was being cast to string, causing MongoDB to interpret it as a named write concern mode instead of a numeric level. This led to errors like: "No write concern mode named '1' found in replica set configuration".

This commit ensures that numeric write concern values are properly cast to integers, while still allowing named modes such as "majority" to be used as strings.
