### PR TITLE
Remove calls to `ReflectionMethod::setAccessible` in tests

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DocumentPersisterTest.php
@@ -638,7 +638,6 @@ class DocumentPersisterTest extends BaseTestCase
             ->with($this->isType('array'), $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern($writeConcern))));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
-        $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($documentPersister, $collection);
 
         $testDocument = new $class();
@@ -660,7 +659,6 @@ class DocumentPersisterTest extends BaseTestCase
             ->with($this->isType('array'), $this->logicalNot($this->arrayHasKey('writeConcern')));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
-        $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($documentPersister, $collection);
 
         $testDocument = new $class();
@@ -682,7 +680,6 @@ class DocumentPersisterTest extends BaseTestCase
             ->with($this->isType('array'), $this->isType('array'), $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern($writeConcern))));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
-        $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($documentPersister, $collection);
 
         $testDocument     = new $class();
@@ -705,7 +702,6 @@ class DocumentPersisterTest extends BaseTestCase
             ->with($this->isType('array'), $this->logicalNot($this->arrayHasKey('writeConcern')));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
-        $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($documentPersister, $collection);
 
         $testDocument     = new $class();
@@ -728,7 +724,6 @@ class DocumentPersisterTest extends BaseTestCase
             ->with($this->isType('array'), $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern($writeConcern))));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
-        $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($documentPersister, $collection);
 
         $testDocument = new $class();
@@ -753,7 +748,6 @@ class DocumentPersisterTest extends BaseTestCase
             ->with($this->isType('array'), $this->logicalNot($this->arrayHasKey('writeConcern')));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
-        $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($documentPersister, $collection);
 
         $testDocument = new $class();
@@ -777,7 +771,6 @@ class DocumentPersisterTest extends BaseTestCase
             ->with($this->isType('array'), $this->equalTo(['writeConcern' => new WriteConcern(0)]));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
-        $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($documentPersister, $collection);
 
         $this->dm->getConfiguration()->setDefaultCommitOptions(['writeConcern' => new WriteConcern(0)]);
@@ -800,7 +793,6 @@ class DocumentPersisterTest extends BaseTestCase
             ->with($this->isType('array'), $this->logicalNot($this->arrayHasKey('writeConcern')));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
-        $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($documentPersister, $collection);
 
         $this->dm->getConfiguration()->setDefaultCommitOptions(['writeConcern' => new WriteConcern(1)]);
@@ -823,7 +815,6 @@ class DocumentPersisterTest extends BaseTestCase
             ->with($this->isType('array'), $this->equalTo(['writeConcern' => new WriteConcern(0)]));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
-        $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($documentPersister, $collection);
 
         $this->dm->getConfiguration()->setDefaultCommitOptions(['w' => 0]);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SplObjectHashCollisionsTest.php
@@ -77,7 +77,6 @@ class SplObjectHashCollisionsTest extends BaseTestCase
     {
         $ro = new ReflectionObject($this->uow);
         $rp = $ro->getProperty($prop);
-        $rp->setAccessible(true);
         self::assertCount($expected, $rp->getValue($this->uow));
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
@@ -29,7 +29,6 @@ class XmlMappingDriverTest extends AbstractMappingDriverTestCase
 
         /** @uses XmlDriver::setShardKey */
         $m = new ReflectionMethod($driver::class, 'setShardKey');
-        $m->setAccessible(true);
         $m->invoke($driver, $class, $element);
 
         self::assertTrue($class->isSharded());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
@@ -26,7 +26,6 @@ class DocumentPersisterGetShardKeyQueryTest extends BaseTestCase
         $persister = $this->uow->getDocumentPersister($o::class);
 
         $method = new ReflectionMethod($persister, 'getShardKeyQuery');
-        $method->setAccessible(true);
 
         self::assertSame(
             ['int' => $o->int, 'string' => $o->string, 'bool' => $o->bool, 'float' => $o->float],
@@ -43,8 +42,7 @@ class DocumentPersisterGetShardKeyQueryTest extends BaseTestCase
 
         $persister = $this->uow->getDocumentPersister($o::class);
 
-        $method = new ReflectionMethod($persister, 'getShardKeyQuery');
-        $method->setAccessible(true);
+        $method        = new ReflectionMethod($persister, 'getShardKeyQuery');
         $shardKeyQuery = $method->invoke($persister, $o);
 
         self::assertInstanceOf(ObjectId::class, $shardKeyQuery['oid']);
@@ -69,8 +67,7 @@ class DocumentPersisterGetShardKeyQueryTest extends BaseTestCase
 
         $persister = $this->uow->getDocumentPersister($o::class);
 
-        $method = new ReflectionMethod($persister, 'getShardKeyQuery');
-        $method->setAccessible(true);
+        $method        = new ReflectionMethod($persister, 'getShardKeyQuery');
         $shardKeyQuery = $method->invoke($persister, $o);
 
         self::assertSame(['_id' => $o->identifier], $shardKeyQuery);
@@ -88,8 +85,7 @@ class DocumentPersisterGetShardKeyQueryTest extends BaseTestCase
 
         $persister = $this->uow->getDocumentPersister($o::class);
 
-        $method = new ReflectionMethod($persister, 'getShardKeyQuery');
-        $method->setAccessible(true);
+        $method        = new ReflectionMethod($persister, 'getShardKeyQuery');
         $shardKeyQuery = $method->invoke($persister, $o);
 
         self::assertSame(['reference.$id' => $userId], $shardKeyQuery);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Query/BuilderTest.php
@@ -479,7 +479,6 @@ class BuilderTest extends BaseTestCase
 
         $qb                 = $this->getTestQueryBuilder();
         $reflectionProperty = new ReflectionProperty($qb, 'expr');
-        $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($qb, $expr);
 
         self::assertSame($qb, $qb->$method(...$args));

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTest.php
@@ -535,7 +535,6 @@ class UnitOfWorkTest extends BaseTestCase
         $documentPersister = $this->uow->getDocumentPersister(ForumUser::class);
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
-        $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($documentPersister, $collection);
 
         $user           = new ForumUser();


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | minor
| BC Break     | no
| Fixed issues | -

> Note: As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

