### PR TITLE
Support nullable date field in HydratorFactory #2753

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -188,10 +188,8 @@ EOF
         if (array_key_exists('%1$s', $data) && ($data['%1$s'] !== null || ($this->class->fieldMappings['%2$s']['nullable'] ?? false))) {
             $value = $data['%1$s'];
             %3$s
-            if (\is_object($return)) {
-              $return = clone $return;
-            }
-            $this->class->reflFields['%2$s']->setValue($document, $return);
+            $field = $this->class->reflFields['%2$s'];
+            if (null !== $return) { $field->setValue($document, clone $return); } else { $field->setValue($document, null); }
             $hydratedData['%2$s'] = $return;
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -188,8 +188,7 @@ EOF
         if (array_key_exists('%1$s', $data) && ($data['%1$s'] !== null || ($this->class->fieldMappings['%2$s']['nullable'] ?? false))) {
             $value = $data['%1$s'];
             %3$s
-            $field = $this->class->reflFields['%2$s'];
-            if (null !== $return) { $field->setValue($document, clone $return); } else { $field->setValue($document, null); }
+            $this->class->reflFields['%2$s']->setValue($document, $return === null ? null : clone $return);
             $hydratedData['%2$s'] = $return;
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -185,10 +185,13 @@ EOF
                     <<<'EOF'
 
         // Field(type: "date")
-        if (isset($data['%1$s'])) {
+        if (isset($data['%1$s']) || (! empty($this->class->fieldMappings['%2$s']['nullable']) && array_key_exists('%1$s', $data))) {
             $value = $data['%1$s'];
             %3$s
-            $this->class->reflFields['%2$s']->setValue($document, clone $return);
+            if (\is_object($return)) {
+              $return = clone $return;
+            }
+            $this->class->reflFields['%2$s']->setValue($document, $return);
             $hydratedData['%2$s'] = $return;
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
+++ b/lib/Doctrine/ODM/MongoDB/Hydrator/HydratorFactory.php
@@ -185,7 +185,7 @@ EOF
                     <<<'EOF'
 
         // Field(type: "date")
-        if (isset($data['%1$s']) || (! empty($this->class->fieldMappings['%2$s']['nullable']) && array_key_exists('%1$s', $data))) {
+        if (array_key_exists('%1$s', $data) && ($data['%1$s'] !== null || ($this->class->fieldMappings['%2$s']['nullable'] ?? false))) {
             $value = $data['%1$s'];
             %3$s
             if (\is_object($return)) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,8 +27,8 @@
     </groups>
     <php>
         <ini name="error_reporting" value="-1"/>
-        <const name="DOCTRINE_MONGODB_SERVER" value="mongodb://localhost:27017" />
-        <const name="DOCTRINE_MONGODB_DATABASE" value="doctrine_odm_tests" />
+        <const name="DOCTRINE_MONGODB_SERVER" value="mongodb://teknoo_user:teknoo_pwd@db/teknoo" />
+        <const name="DOCTRINE_MONGODB_DATABASE" value="teknoo" />
         <env name="USE_LAZY_GHOST_OBJECTS" value="1"/>
     </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,8 +27,8 @@
     </groups>
     <php>
         <ini name="error_reporting" value="-1"/>
-        <const name="DOCTRINE_MONGODB_SERVER" value="mongodb://teknoo_user:teknoo_pwd@db/teknoo" />
-        <const name="DOCTRINE_MONGODB_DATABASE" value="teknoo" />
+        <const name="DOCTRINE_MONGODB_SERVER" value="mongodb://localhost:27017" />
+        <const name="DOCTRINE_MONGODB_DATABASE" value="doctrine_odm_tests" />
         <env name="USE_LAZY_GHOST_OBJECTS" value="1"/>
     </php>
 </phpunit>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
@@ -84,7 +84,6 @@ class DateTest extends BaseTestCase
         self::assertNotEmpty($changeset);
     }
 
-    // Test Issue #2753
     public function testNullableDateInstanceValue(): void
     {
         $user = new User();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/DateTest.php
@@ -84,6 +84,20 @@ class DateTest extends BaseTestCase
         self::assertNotEmpty($changeset);
     }
 
+    // Test Issue #2753
+    public function testNullableDateInstanceValue(): void
+    {
+        $user = new User();
+        $user->setCreatedAt(new DateTime('1985-09-01'));
+        $this->dm->persist($user);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $user = $this->dm->getRepository($user::class)->findOneBy([]);
+        self::assertInstanceOf(DateTime::class, $user->getCreatedAt());
+        self::assertNull($user->getDisabledAt());
+    }
+
     public function testDateInstanceValueChangeDoesCauseUpdateIfValueIsTheSame(): void
     {
         $user = new User();

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -34,9 +34,9 @@ class User extends BaseDocument
     #[ODM\Field(type: 'date')]
     protected $createdAt;
 
-    /** @var UTCDateTime|DateTimeInterface|string */
+    /** @var ?DateTimeInterface */
     #[ODM\Field(type: 'date', nullable: true, name: 'disable-at')]
-    protected ?\DateTimeInterface $disabledAt;
+    protected ?DateTimeInterface $disabledAt;
 
     /** @var Address|null */
     #[ODM\EmbedOne(targetDocument: Address::class)]
@@ -215,7 +215,7 @@ class User extends BaseDocument
         return $this->createdAt;
     }
 
-    public function getDisabledAt(): ?\DateTimeInterface
+    public function getDisabledAt(): ?DateTimeInterface
     {
         return $this->disabledAt;
     }

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -34,6 +34,10 @@ class User extends BaseDocument
     #[ODM\Field(type: 'date')]
     protected $createdAt;
 
+    /** @var UTCDateTime|DateTimeInterface|string */
+    #[ODM\Field(type: 'date', nullable: true, name: 'disable-at')]
+    protected ?\DateTimeInterface $disabledAt;
+
     /** @var Address|null */
     #[ODM\EmbedOne(targetDocument: Address::class)]
     protected $address;
@@ -209,6 +213,11 @@ class User extends BaseDocument
     public function getCreatedAt()
     {
         return $this->createdAt;
+    }
+
+    public function getDisabledAt(): ?\DateTimeInterface
+    {
+        return $this->disabledAt;
     }
 
     public function getAddress(): ?Address

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -34,7 +34,6 @@ class User extends BaseDocument
     #[ODM\Field(type: 'date')]
     protected $createdAt;
 
-    /** @var ?DateTimeInterface */
     #[ODM\Field(type: 'date', nullable: true, name: 'disable-at')]
     protected ?DateTimeInterface $disabledAt;
 


### PR DESCRIPTION
Update code generated by the HydratorFactory for date to support nullable datetime field.

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2753 

#### Summary

These PR update only the HydratorFactory class to update the if condition to support nullable field like for other type.
It will update also the clone $return value, because $return can be 'null' and we can not clone null value in PHP.