### PR TITLE
Upgrade CI: Ubuntu, MongoDB Server, Extension, Symfony

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -124,14 +124,14 @@ jobs:
       - name: "Remove phpbench/phpbench"
         run: composer remove --no-update --dev phpbench/phpbench
 
-      - name: "Configure Symfony ${{ matrix.php-version }}"
+      - name: "Configure Symfony ${{ matrix.symfony-version }}"
         if: "${{ matrix.symfony-version != 'stable' }}"
         run: |
           composer config minimum-stability dev
           # update symfony deps
-          composer require --no-update symfony/console:^${{ matrix.php-version }}
-          composer require --no-update symfony/var-dumper:^${{ matrix.php-version }}
-          composer require --no-update --dev symfony/cache:^${{ matrix.php-version }}
+          composer require --no-update symfony/console:^${{ matrix.symfony-version }}
+          composer require --no-update symfony/var-dumper:^${{ matrix.symfony-version }}
+          composer require --no-update --dev symfony/cache:^${{ matrix.symfony-version }}
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -69,13 +69,14 @@ jobs:
             dependencies: "highest"
             symfony-version: "stable"
             proxy: "proxy-manager"
-          # Test with ext-2.0
+          # Test with ext-1.21
           - topology: "server"
             php-version: "8.2"
             mongodb-version: "7.0"
-            driver-version: "mongodb/mongo-php-driver@v2.x"
+            driver-version: "1.21.0"
             dependencies: "highest"
             symfony-version: "7"
+            proxy: "lazy-ghost"
           # Test with a 5.0 sharded cluster
           # Currently disabled due to a bug where MongoDB reports "sharding status unknown"
 #          - topology: "sharded_cluster"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   phpunit:
     name: "PHPUnit"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
 
     strategy:
       fail-fast: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,9 +24,9 @@ jobs:
           - "8.3"
           - "8.4"
         mongodb-version:
+          - "8.0"
           - "7.0"
           - "6.0"
-          - "5.0"
         driver-version:
           - "stable"
         topology:
@@ -41,7 +41,7 @@ jobs:
           # Test against lowest dependencies
           - dependencies: "lowest"
             php-version: "8.1"
-            mongodb-version: "5.0"
+            mongodb-version: "6.0"
             driver-version: "1.21.0"
             topology: "server"
             symfony-version: "stable"
@@ -49,7 +49,7 @@ jobs:
           # Test with highest dependencies
           - topology: "server"
             php-version: "8.2"
-            mongodb-version: "7.0"
+            mongodb-version: "8.0"
             driver-version: "stable"
             dependencies: "highest"
             symfony-version: "7"
@@ -57,35 +57,35 @@ jobs:
           # Test with a 5.0 replica set
           - topology: "replica_set"
             php-version: "8.2"
-            mongodb-version: "5.0"
+            mongodb-version: "6.0"
             driver-version: "stable"
             dependencies: "highest"
             symfony-version: "stable"
             proxy: "lazy-ghost"
           # Test with ProxyManager
           - php-version: "8.2"
-            mongodb-version: "5.0"
+            mongodb-version: "6.0"
             driver-version: "stable"
             dependencies: "highest"
             symfony-version: "stable"
             proxy: "proxy-manager"
-          # Test with ext-1.21
+          # Test with extension 1.21
           - topology: "server"
             php-version: "8.2"
-            mongodb-version: "7.0"
+            mongodb-version: "8.0"
             driver-version: "1.21.0"
             dependencies: "highest"
             symfony-version: "7"
             proxy: "lazy-ghost"
-          # Test with a 5.0 sharded cluster
+          # Test with a sharded cluster
           # Currently disabled due to a bug where MongoDB reports "sharding status unknown"
-#          - topology: "sharded_cluster"
-#            php-version: "8.2"
-#            mongodb-version: "5.0"
-#            driver-version: "stable"
-#            dependencies: "highest"
-#            symfony-version: "stable"
-#            proxy: "lazy-ghost"
+          - topology: "sharded_cluster"
+            php-version: "8.2"
+            mongodb-version: "6.0"
+            driver-version: "stable"
+            dependencies: "highest"
+            symfony-version: "stable"
+            proxy: "lazy-ghost"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -79,13 +79,13 @@ jobs:
             proxy: "lazy-ghost"
           # Test with a sharded cluster
           # Currently disabled due to a bug where MongoDB reports "sharding status unknown"
-          - topology: "sharded_cluster"
-            php-version: "8.2"
-            mongodb-version: "6.0"
-            driver-version: "stable"
-            dependencies: "highest"
-            symfony-version: "stable"
-            proxy: "lazy-ghost"
+#          - topology: "sharded_cluster"
+#            php-version: "8.2"
+#            mongodb-version: "6.0"
+#            driver-version: "stable"
+#            dependencies: "highest"
+#            symfony-version: "stable"
+#            proxy: "lazy-ghost"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -46,15 +46,15 @@ jobs:
             topology: "server"
             symfony-version: "stable"
             proxy: "lazy-ghost"
-          # Test with highest dependencies
+          # Test with Symfony 6.4
           - topology: "server"
-            php-version: "8.2"
-            mongodb-version: "8.0"
+            php-version: "8.1"
+            mongodb-version: "6.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: "7"
+            symfony-version: "6.4"
             proxy: "lazy-ghost"
-          # Test with a 5.0 replica set
+          # Test with a 6.0 replica set
           - topology: "replica_set"
             php-version: "8.2"
             mongodb-version: "6.0"
@@ -75,7 +75,7 @@ jobs:
             mongodb-version: "8.0"
             driver-version: "1.21.0"
             dependencies: "highest"
-            symfony-version: "7"
+            symfony-version: "stable"
             proxy: "lazy-ghost"
           # Test with a sharded cluster
           # Currently disabled due to a bug where MongoDB reports "sharding status unknown"
@@ -120,18 +120,18 @@ jobs:
       - name: "Show driver information"
         run: "php --ri mongodb"
 
-      # This allows installing symfony/console 3.4 and 6
+      # Not used, skip transient dependencies
       - name: "Remove phpbench/phpbench"
         run: composer remove --no-update --dev phpbench/phpbench
 
-      - name: "Configure Symfony v7@dev"
-        if: "${{ matrix.symfony-version == '7' }}"
+      - name: "Configure Symfony ${{ matrix.php-version }}"
+        if: "${{ matrix.symfony-version != 'stable' }}"
         run: |
           composer config minimum-stability dev
           # update symfony deps
-          composer require --no-update symfony/console:^7@dev
-          composer require --no-update symfony/var-dumper:^7@dev
-          composer require --no-update --dev symfony/cache:^7@dev
+          composer require --no-update symfony/console:^${{ matrix.php-version }}
+          composer require --no-update symfony/var-dumper:^${{ matrix.php-version }}
+          composer require --no-update --dev symfony/cache:^${{ matrix.php-version }}
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   validate-with-guides:
     name: "Validate documentation with phpDocumentor/guides"
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
 
     steps:
       - name: "Checkout code"

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   performance-tests:
     name: "Performance Tests"
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
 
     strategy:
       matrix:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   static-analysis-phpstan:
     name: "Static Analysis with PHPStan"
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
 
     strategy:
       matrix:


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

Follow https://github.com/doctrine/mongodb-odm/pull/2683

- Since `mongodb` extension [v2.0.0](https://github.com/mongodb/mongo-php-library/releases/tag/2.0.0) has been released, we need to explicitly install the version `1.21.0` to test this version
- Ubuntu 20.04 Image is disabled by Github, upgraded to 22.04 for unit tests that need to setup MongoDB Server. 24.04 for other tests.
- MongoDB 5.0 is [not supported](https://www.mongodb.com/legal/support-policy/lifecycles) by on Ubuntu 22.04, so the minimum MongoDB server tested is 6.0.
- Adding test on MongoDB 8.0
- Adding test on Symfony 6.4: `lowest` dependencies installs 5.4 and `highest` installs 7.2+
