### PR TITLE
Allow to paginate `$search` aggregation with `searchBefore` and `searchAfter` markers

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
@@ -34,6 +34,8 @@ use function strtolower;
  *             maxNumPassages?: int,
  *         },
  *         returnStoredSource?: bool,
+ *         searchBefore?: string,
+ *         searchAfter?: string,
  *         sort?: object,
  *         autocomplete?: object,
  *         compound?: object,
@@ -61,6 +63,8 @@ class Search extends Stage implements SupportsAllSearchOperators
     private ?object $count            = null;
     private ?object $highlight        = null;
     private ?bool $returnStoredSource = null;
+    private ?string $searchBefore     = null;
+    private ?string $searchAfter      = null;
     private ?SearchOperator $operator = null;
 
     /** @var array<string, -1|1|SortMeta> */
@@ -90,6 +94,14 @@ class Search extends Stage implements SupportsAllSearchOperators
 
         if ($this->returnStoredSource !== null) {
             $params->returnStoredSource = $this->returnStoredSource;
+        }
+
+        if ($this->searchBefore) {
+            $params->searchBefore = $this->searchBefore;
+        }
+
+        if ($this->searchAfter) {
+            $params->searchAfter = $this->searchAfter;
         }
 
         if ($this->sort) {
@@ -141,6 +153,20 @@ class Search extends Stage implements SupportsAllSearchOperators
     public function returnStoredSource(bool $returnStoredSource = true): static
     {
         $this->returnStoredSource = $returnStoredSource;
+
+        return $this;
+    }
+
+    public function searchBefore(string $searchBefore): static
+    {
+        $this->searchBefore = $searchBefore;
+
+        return $this;
+    }
+
+    public function searchAfter(string $searchAfter): static
+    {
+        $this->searchAfter = $searchAfter;
 
         return $this;
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -656,6 +656,16 @@ parameters:
 			path: tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
 
 		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Aggregation\\\\Stage\\\\SearchTest\\:\\:testSearchOperatorsWithSearchBefore\\(\\) has parameter \\$expectedOperator with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
+
+		-
+			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Aggregation\\\\Stage\\\\SearchTest\\:\\:testSearchOperatorsWithSearchAfter\\(\\) has parameter \\$expectedOperator with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
+
+		-
 			message: "#^Method Doctrine\\\\ODM\\\\MongoDB\\\\Tests\\\\Aggregation\\\\Stage\\\\SetWindowFieldsTest\\:\\:testOperators\\(\\) has parameter \\$args with no type specified\\.$#"
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SetWindowFieldsTest.php

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
@@ -1313,4 +1313,116 @@ class SearchTest extends BaseTestCase
             $searchStage->getExpression(),
         );
     }
+
+    #[DataProvider('provideAutocompleteBuilders')]
+    #[DataProvider('provideCompoundBuilders')]
+    #[DataProvider('provideEmbeddedDocumentBuilders')]
+    #[DataProvider('provideEmbeddedDocumentCompoundBuilders')]
+    #[DataProvider('provideEqualsBuilders')]
+    #[DataProvider('provideExistsBuilders')]
+    #[DataProvider('provideGeoShapeBuilders')]
+    #[DataProvider('provideGeoWithinBuilders')]
+    #[DataProvider('provideMoreLikeThisBuilders')]
+    #[DataProvider('provideNearBuilders')]
+    #[DataProvider('providePhraseBuilders')]
+    #[DataProvider('provideQueryStringBuilders')]
+    #[DataProvider('provideRangeBuilders')]
+    #[DataProvider('provideRegexBuilders')]
+    #[DataProvider('provideTextBuilders')]
+    #[DataProvider('provideWildcardBuilders')]
+    public function testSearchOperatorsWithSearchBefore(array $expectedOperator, Closure $createOperator): void
+    {
+        $baseExpected = [
+            'index' => 'my_search_index',
+            'highlight' => (object) [
+                'path' => 'content',
+                'maxCharsToExamine' => 2,
+                'maxNumPassages' => 3,
+            ],
+            'count' => (object) [
+                'type' => 'lowerBound',
+                'threshold' => 1000,
+            ],
+            'returnStoredSource' => true,
+            'searchBefore' => 'marker',
+        ];
+
+        $searchStage = new Search($this->getTestAggregationBuilder());
+        $searchStage
+            ->index('my_search_index')
+            ->searchBefore('marker');
+
+        $result = $createOperator($searchStage);
+
+        self::logicalOr(
+            new IsInstanceOf(AbstractSearchOperator::class),
+            new IsInstanceOf(Search::class),
+        );
+
+        $result
+            ->highlight('content', 2, 3)
+            ->countDocuments('lowerBound', 1000)
+            ->returnStoredSource();
+
+        self::assertEquals(
+            ['$search' => (object) array_merge($baseExpected, $expectedOperator)],
+            $searchStage->getExpression(),
+        );
+    }
+
+    #[DataProvider('provideAutocompleteBuilders')]
+    #[DataProvider('provideCompoundBuilders')]
+    #[DataProvider('provideEmbeddedDocumentBuilders')]
+    #[DataProvider('provideEmbeddedDocumentCompoundBuilders')]
+    #[DataProvider('provideEqualsBuilders')]
+    #[DataProvider('provideExistsBuilders')]
+    #[DataProvider('provideGeoShapeBuilders')]
+    #[DataProvider('provideGeoWithinBuilders')]
+    #[DataProvider('provideMoreLikeThisBuilders')]
+    #[DataProvider('provideNearBuilders')]
+    #[DataProvider('providePhraseBuilders')]
+    #[DataProvider('provideQueryStringBuilders')]
+    #[DataProvider('provideRangeBuilders')]
+    #[DataProvider('provideRegexBuilders')]
+    #[DataProvider('provideTextBuilders')]
+    #[DataProvider('provideWildcardBuilders')]
+    public function testSearchOperatorsWithSearchAfter(array $expectedOperator, Closure $createOperator): void
+    {
+        $baseExpected = [
+            'index' => 'my_search_index',
+            'highlight' => (object) [
+                'path' => 'content',
+                'maxCharsToExamine' => 2,
+                'maxNumPassages' => 3,
+            ],
+            'count' => (object) [
+                'type' => 'lowerBound',
+                'threshold' => 1000,
+            ],
+            'returnStoredSource' => true,
+            'searchAfter' => 'marker',
+        ];
+
+        $searchStage = new Search($this->getTestAggregationBuilder());
+        $searchStage
+            ->index('my_search_index')
+            ->searchAfter('marker');
+
+        $result = $createOperator($searchStage);
+
+        self::logicalOr(
+            new IsInstanceOf(AbstractSearchOperator::class),
+            new IsInstanceOf(Search::class),
+        );
+
+        $result
+            ->highlight('content', 2, 3)
+            ->countDocuments('lowerBound', 1000)
+            ->returnStoredSource();
+
+        self::assertEquals(
+            ['$search' => (object) array_merge($baseExpected, $expectedOperator)],
+            $searchStage->getExpression(),
+        );
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
@@ -1315,21 +1315,6 @@ class SearchTest extends BaseTestCase
     }
 
     #[DataProvider('provideAutocompleteBuilders')]
-    #[DataProvider('provideCompoundBuilders')]
-    #[DataProvider('provideEmbeddedDocumentBuilders')]
-    #[DataProvider('provideEmbeddedDocumentCompoundBuilders')]
-    #[DataProvider('provideEqualsBuilders')]
-    #[DataProvider('provideExistsBuilders')]
-    #[DataProvider('provideGeoShapeBuilders')]
-    #[DataProvider('provideGeoWithinBuilders')]
-    #[DataProvider('provideMoreLikeThisBuilders')]
-    #[DataProvider('provideNearBuilders')]
-    #[DataProvider('providePhraseBuilders')]
-    #[DataProvider('provideQueryStringBuilders')]
-    #[DataProvider('provideRangeBuilders')]
-    #[DataProvider('provideRegexBuilders')]
-    #[DataProvider('provideTextBuilders')]
-    #[DataProvider('provideWildcardBuilders')]
     public function testSearchOperatorsWithSearchBefore(array $expectedOperator, Closure $createOperator): void
     {
         $baseExpected = [
@@ -1371,21 +1356,6 @@ class SearchTest extends BaseTestCase
     }
 
     #[DataProvider('provideAutocompleteBuilders')]
-    #[DataProvider('provideCompoundBuilders')]
-    #[DataProvider('provideEmbeddedDocumentBuilders')]
-    #[DataProvider('provideEmbeddedDocumentCompoundBuilders')]
-    #[DataProvider('provideEqualsBuilders')]
-    #[DataProvider('provideExistsBuilders')]
-    #[DataProvider('provideGeoShapeBuilders')]
-    #[DataProvider('provideGeoWithinBuilders')]
-    #[DataProvider('provideMoreLikeThisBuilders')]
-    #[DataProvider('provideNearBuilders')]
-    #[DataProvider('providePhraseBuilders')]
-    #[DataProvider('provideQueryStringBuilders')]
-    #[DataProvider('provideRangeBuilders')]
-    #[DataProvider('provideRegexBuilders')]
-    #[DataProvider('provideTextBuilders')]
-    #[DataProvider('provideWildcardBuilders')]
     public function testSearchOperatorsWithSearchAfter(array $expectedOperator, Closure $createOperator): void
     {
         $baseExpected = [


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | NA

#### Summary

feat: allow to paginate search aggregation with searchBefore and searchAfter markers
