### PR TITLE
Make XSD more strict for other Document types

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -16,9 +16,9 @@
     <xs:complexType>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:element name="document" type="odm:document" minOccurs="0" maxOccurs="unbounded" />
-        <xs:element name="embedded-document" type="odm:document" minOccurs="0" maxOccurs="unbounded" />
-        <xs:element name="mapped-superclass" type="odm:document" minOccurs="0" maxOccurs="unbounded" />
-        <xs:element name="query-result-document" type="odm:document" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="embedded-document" type="odm:embedded-document" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="mapped-superclass" type="odm:mapped-superclass" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="query-result-document" type="odm:query-result-document" minOccurs="0" maxOccurs="unbounded" />
         <xs:element name="view" type="odm:view" minOccurs="0" maxOccurs="unbounded" />
         <xs:element name="gridfs-file" type="odm:gridfs-file" minOccurs="0" maxOccurs="unbounded" />
       </xs:choice>
@@ -26,15 +26,51 @@
   </xs:element>
 
   <xs:complexType name="embedded-document">
-    <xs:attribute name="name" type="xs:NMTOKEN" />
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="id" type="odm:id" minOccurs="0" />
+      <xs:element name="field" type="odm:field" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="embed-one" type="odm:embed-one" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="embed-many" type="odm:embed-many" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="reference-one" type="odm:reference-one" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="reference-many" type="odm:reference-many" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="also-load-methods" type="odm:also-load-methods" minOccurs="0" />
+      <xs:element name="indexes" type="odm:indexes" minOccurs="0" />
+    </xs:choice>
+
+    <xs:attribute name="name" type="xs:string" />
+    <xs:attribute name="inheritance-type" type="odm:inheritance-type" />
   </xs:complexType>
 
   <xs:complexType name="mapped-superclass">
-    <xs:attribute name="name" type="xs:NMTOKEN" />
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="id" type="odm:id" minOccurs="0" />
+      <xs:element name="field" type="odm:field" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="embed-one" type="odm:embed-one" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="embed-many" type="odm:embed-many" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="reference-one" type="odm:reference-one" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="reference-many" type="odm:reference-many" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="also-load-methods" type="odm:also-load-methods" minOccurs="0" />
+      <xs:element name="indexes" type="odm:indexes" minOccurs="0" />
+    </xs:choice>
+
+    <xs:attribute name="name" type="xs:string" />
+    <xs:attribute name="inheritance-type" type="odm:inheritance-type" />
   </xs:complexType>
 
   <xs:complexType name="query-result-document">
-    <xs:attribute name="name" type="xs:NMTOKEN" />
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="id" type="odm:id" minOccurs="0" />
+      <xs:element name="field" type="odm:field" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="embed-one" type="odm:embed-one" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="embed-many" type="odm:embed-many" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="reference-one" type="odm:reference-one" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="reference-many" type="odm:reference-many" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="also-load-methods" type="odm:also-load-methods" minOccurs="0" />
+      <xs:element name="indexes" type="odm:indexes" minOccurs="0" />
+    </xs:choice>
+
+    <xs:attribute name="name" type="xs:string" />
+    <xs:attribute name="inheritance-type" type="odm:inheritance-type" />
   </xs:complexType>
 
   <xs:complexType name="view">

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -33,6 +33,10 @@
       <xs:element name="embed-many" type="odm:embed-many" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="reference-one" type="odm:reference-one" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="reference-many" type="odm:reference-many" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0" />
+      <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0" />
+      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0" />
+      <xs:element name="lifecycle-callbacks" type="odm:lifecycle-callbacks" minOccurs="0" />
       <xs:element name="also-load-methods" type="odm:also-load-methods" minOccurs="0" />
       <xs:element name="indexes" type="odm:indexes" minOccurs="0" />
     </xs:choice>
@@ -49,12 +53,25 @@
       <xs:element name="embed-many" type="odm:embed-many" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="reference-one" type="odm:reference-one" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="reference-many" type="odm:reference-many" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0" />
+      <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0" />
+      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0" />
+      <xs:element name="lifecycle-callbacks" type="odm:lifecycle-callbacks" minOccurs="0" />
       <xs:element name="also-load-methods" type="odm:also-load-methods" minOccurs="0" />
       <xs:element name="indexes" type="odm:indexes" minOccurs="0" />
     </xs:choice>
 
+    <xs:attribute name="db" type="xs:NMTOKEN" />
     <xs:attribute name="name" type="xs:string" />
+    <xs:attribute name="write-concern" type="xs:string" />
+    <xs:attribute name="collection" type="xs:NMTOKEN" />
+    <xs:attribute name="capped-collection" type="xs:boolean" />
+    <xs:attribute name="capped-collection-size" type="xs:integer" />
+    <xs:attribute name="capped-collection-max" type="xs:integer" />
+    <xs:attribute name="repository-class" type="xs:string" />
     <xs:attribute name="inheritance-type" type="odm:inheritance-type" />
+    <xs:attribute name="change-tracking-policy" type="odm:change-tracking-policy" />
+    <xs:attribute name="read-only" type="xs:boolean" />
   </xs:complexType>
 
   <xs:complexType name="query-result-document">
@@ -65,12 +82,14 @@
       <xs:element name="embed-many" type="odm:embed-many" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="reference-one" type="odm:reference-one" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="reference-many" type="odm:reference-many" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0" />
+      <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0" />
+      <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0" />
+      <xs:element name="lifecycle-callbacks" type="odm:lifecycle-callbacks" minOccurs="0" />
       <xs:element name="also-load-methods" type="odm:also-load-methods" minOccurs="0" />
-      <xs:element name="indexes" type="odm:indexes" minOccurs="0" />
     </xs:choice>
 
     <xs:attribute name="name" type="xs:string" />
-    <xs:attribute name="inheritance-type" type="odm:inheritance-type" />
   </xs:complexType>
 
   <xs:complexType name="view">

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/XmlDriverTest.php
@@ -10,6 +10,7 @@ use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use MongoDB\BSON\Document;
 use TestDocuments\AlsoLoadDocument;
 use TestDocuments\CustomIdGenerator;
+use TestDocuments\InvalidEmbeddedDocument;
 use TestDocuments\InvalidPartialFilterDocument;
 use TestDocuments\SchemaInvalidDocument;
 use TestDocuments\SchemaValidatedDocument;
@@ -73,6 +74,16 @@ class XmlDriverTest extends AbstractDriverTestCase
         $this->expectExceptionMessageMatches('#The mapping file .+ is invalid#');
 
         $this->driver->loadMetadataForClass(InvalidPartialFilterDocument::class, $classMetadata);
+    }
+
+    public function testInvalidEmbeddedDocument(): void
+    {
+        $classMetadata = new ClassMetadata(InvalidEmbeddedDocument::class);
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessageMatches('#The mapping file .+ is invalid#');
+
+        $this->driver->loadMetadataForClass(InvalidEmbeddedDocument::class, $classMetadata);
     }
 
     public function testWildcardIndexName(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/InvalidEmbeddedDocument.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/InvalidEmbeddedDocument.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestDocuments;
+
+class InvalidEmbeddedDocument
+{
+    public string $id;
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.InvalidEmbeddedDocument.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/TestDocuments.InvalidEmbeddedDocument.dcm.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <embedded-document name="TestDocuments\InvalidEmbeddedDocument" collection="embeddedDocument">
+        <id />
+    </embedded-document>
+</doctrine-mongo-mapping>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | -

#### Summary

The goal of this change is to detect earlier when an XML attribute is used while it's not supported by Doctrine ODM.

BC Break: previously, the XSD schema allowed some attributes or child elements that were not used in the metadata. Example: "collection" name for embedded documents.

| **Element**                       | **document** | **embedded-document**  | **mapped-superclass**  | **query-result-document** | **view** |
|-----------------------------------|--------------|------------------------|------------------------|---------------------------|----------|
| **id**                            | Yes          | Yes                    | Yes                    | Yes                       | Yes      |
| **field**                         | Yes          | Yes                    | Yes                    | Yes                       | Yes      |
| **embed-one**                     | Yes          | Yes                    | Yes                    | Yes                       | Yes      |
| **embed-many**                    | Yes          | Yes                    | Yes                    | Yes                       | Yes      |
| **reference-one**                 | Yes          | Yes                    | Yes                    | Yes                       | Yes      |
| **reference-many**                | Yes          | Yes                    | Yes                    | Yes                       | Yes      |
| **discriminator-field**           | Yes          | Yes                    | Yes                    | Yes                       | Yes      |
| **discriminator-map**             | Yes          | Yes                    | Yes                    | Yes                       | Yes      |
| **default-discriminator-value**   | Yes          | Yes                    | Yes                    | Yes                       | Yes      |
| **lifecycle-callbacks**           | Yes          | Yes                    | Yes                    | Yes                       | Yes      |
| **also-load-methods**             | Yes          | Yes                    | Yes                    | Yes                       | Yes      |
| **indexes**                       | Yes          | Yes                    | Yes                    |                           |          |
| **search-indexes**                | Yes          |                        |                        |                           |          |
| **shard-key**                     | Yes          |                        |                        |                           |          |
| **read-preference**               | Yes          |                        |                        |                           |          |
| **schema-validation**             | Yes          |                        |                        |                           |          |
| **time-series**                   | Yes          |                        |                        |                           |          |
| **Attibute**                      | **document** | **embedded-document**  | **mapped-superclass**  | **query-result-document** | **view** |
| **db**                            | Yes          |                        | Yes                    |                           | Yes      |
| **name**                          | Yes          | Yes                    | Yes                    | Yes                       | Yes      |
| **write-concern**                 | Yes          |                        | Yes                    |                           |          |
| **collection**                    | Yes          |                        | Yes                    |                           |          |
| **capped-collection**             | Yes          |                        | Yes                    |                           |          |
| **capped-collection-size**        | Yes          |                        | Yes                    |                           |          |
| **capped-collection-max**         | Yes          |                        | Yes                    |                           |          |
| **repository-class**              | Yes          |                        | Yes                    |                           | Yes      |
| **inheritance-type**              | Yes          | Yes                    | Yes                    | Yes                       | Yes      |
| **change-tracking-policy**        | Yes          |                        | Yes                    |                           | Yes      |
| **read-only**                     | Yes          |                        | Yes                    |                           |          |
| **view**                          |              |                        |                        |                           | Yes      |
| **root-class**                    |              |                        |                        |                           | Yes      |