### PR TITLE
Fix updates to embedded documents after removal

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
@@ -287,12 +287,23 @@ final class PersistenceBuilder
                 $updateData['$set'][$mapping['name']] = $this->prepareReferencedDocumentValue($mapping, $new);
 
             // @ReferenceMany, @EmbedMany
-            } elseif (
-                $mapping['type'] === ClassMetadata::MANY && ! $mapping['isInverseSide']
-                    && $new instanceof PersistentCollectionInterface && $new->isDirty()
-                    && CollectionHelper::isAtomic($mapping['strategy'])
-            ) {
-                $updateData['$set'][$mapping['name']] = $this->prepareAssociatedCollectionValue($new, true);
+            } elseif ($mapping['type'] === ClassMetadata::MANY) {
+                if (! $mapping['isInverseSide'] && $new instanceof PersistentCollectionInterface && $new->isDirty() && CollectionHelper::isAtomic($mapping['strategy'])) {
+                    $updateData['$set'][$mapping['name']] = $this->prepareAssociatedCollectionValue($new, true);
+                } elseif ($mapping['association'] === ClassMetadata::EMBED_MANY) {
+                    foreach ($new as $key => $embeddedDoc) {
+                        if ($this->uow->isScheduledForInsert($embeddedDoc)) {
+                            continue;
+                        }
+
+                        $update = $this->prepareUpsertData($embeddedDoc);
+                        foreach ($update as $cmd => $values) {
+                            foreach ($values as $name => $value) {
+                                $updateData[$cmd][$mapping['name'] . '.' . $key . '.' . $name] = $value;
+                            }
+                        }
+                    }
+                }
             }
             // @EmbedMany and @ReferenceMany are handled by CollectionPersister
         }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
@@ -283,7 +283,7 @@ final class PersistenceBuilder
                 }
 
             // @EmbedMany
-            } elseif ($mapping['association'] === ClassMetadata::EMBED_MANY) {
+            } elseif ($mapping['association'] === ClassMetadata::EMBED_MANY && ! CollectionHelper::isAtomic($mapping['strategy'])) {
                 foreach ($new as $key => $embeddedDoc) {
                     if ($this->uow->isScheduledForInsert($embeddedDoc)) {
                         continue;

--- a/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/PersistenceBuilder.php
@@ -282,30 +282,35 @@ final class PersistenceBuilder
                     }
                 }
 
+            // @EmbedMany
+            } elseif ($mapping['association'] === ClassMetadata::EMBED_MANY) {
+                foreach ($new as $key => $embeddedDoc) {
+                    if ($this->uow->isScheduledForInsert($embeddedDoc)) {
+                        continue;
+                    }
+
+                    $update = $this->prepareUpsertData($embeddedDoc);
+                    foreach ($update as $cmd => $values) {
+                        foreach ($values as $name => $value) {
+                            $updateData[$cmd][$mapping['name'] . '.' . $key . '.' . $name] = $value;
+                        }
+                    }
+                }
+
             // @ReferenceOne
             } elseif ($mapping['association'] === ClassMetadata::REFERENCE_ONE) {
                 $updateData['$set'][$mapping['name']] = $this->prepareReferencedDocumentValue($mapping, $new);
 
-            // @ReferenceMany, @EmbedMany
-            } elseif ($mapping['type'] === ClassMetadata::MANY) {
-                if (! $mapping['isInverseSide'] && $new instanceof PersistentCollectionInterface && $new->isDirty() && CollectionHelper::isAtomic($mapping['strategy'])) {
-                    $updateData['$set'][$mapping['name']] = $this->prepareAssociatedCollectionValue($new, true);
-                } elseif ($mapping['association'] === ClassMetadata::EMBED_MANY) {
-                    foreach ($new as $key => $embeddedDoc) {
-                        if ($this->uow->isScheduledForInsert($embeddedDoc)) {
-                            continue;
-                        }
-
-                        $update = $this->prepareUpsertData($embeddedDoc);
-                        foreach ($update as $cmd => $values) {
-                            foreach ($values as $name => $value) {
-                                $updateData[$cmd][$mapping['name'] . '.' . $key . '.' . $name] = $value;
-                            }
-                        }
-                    }
-                }
+            // @ReferenceMany
+            } elseif (
+                $mapping['type'] === ClassMetadata::MANY && ! $mapping['isInverseSide']
+                && $new instanceof PersistentCollectionInterface && $new->isDirty()
+                && CollectionHelper::isAtomic($mapping['strategy'])
+            ) {
+                $updateData['$set'][$mapping['name']] = $this->prepareAssociatedCollectionValue($new, true);
             }
-            // @EmbedMany and @ReferenceMany are handled by CollectionPersister
+
+            // @ReferenceMany is handled by CollectionPersister
         }
 
         // add discriminator if the class has one

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -1790,7 +1790,12 @@ final class UnitOfWork implements PropertyChangedListener
                 // Document becomes managed again
                 unset($this->scheduledDocumentDeletions[$oid]);
 
-                $this->persistNew($class, $document);
+                if ($class->isEmbeddedDocument) {
+                    $this->documentStates[$oid] = self::STATE_MANAGED;
+                } else {
+                    $this->persistNew($class, $document);
+                }
+
                 break;
 
             case self::STATE_DETACHED:

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2767Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2767Test.php
@@ -14,7 +14,7 @@ class GH2767Test extends BaseTestCase
     public function testRemovePersistEmbedded(): void
     {
         // Start with a parent document and 1 embedded document, both with removedCount = 0
-        $document = new TestDocument([new TestEmbeddedDocument()]);
+        $document = new GH2767TestDocument([new GH2767TestEmbeddedDocument()]);
         $this->dm->persist($document);
         $this->dm->flush();
         $id = $document->id;
@@ -31,7 +31,7 @@ class GH2767Test extends BaseTestCase
         $this->dm->flush();
         $this->dm->clear();
 
-        $repository = $this->dm->getRepository(TestDocument::class);
+        $repository = $this->dm->getRepository(GH2767TestDocument::class);
         $result     = $repository->find($id);
 
         self::assertEquals(1, $result->removedCount);
@@ -40,7 +40,7 @@ class GH2767Test extends BaseTestCase
 }
 
 #[ODM\Document]
-class TestDocument
+class GH2767TestDocument
 {
     #[ODM\Id]
     public ?string $id = null;
@@ -48,11 +48,11 @@ class TestDocument
     #[ODM\Field(type: 'int')]
     public int $removedCount = 0;
 
-    /** @var Collection<int, TestEmbeddedDocument> */
-    #[ODM\EmbedMany(targetDocument: TestEmbeddedDocument::class)]
+    /** @var Collection<int, GH2767TestEmbeddedDocument> */
+    #[ODM\EmbedMany(targetDocument: GH2767TestEmbeddedDocument::class)]
     public $embeddedDocuments;
 
-    /** @param TestEmbeddedDocument[] $embeddedDocuments */
+    /** @param GH2767TestEmbeddedDocument[] $embeddedDocuments */
     public function __construct(array $embeddedDocuments)
     {
         $this->embeddedDocuments = new ArrayCollection($embeddedDocuments);
@@ -68,7 +68,7 @@ class TestDocument
 }
 
 #[ODM\EmbeddedDocument]
-class TestEmbeddedDocument
+class GH2767TestEmbeddedDocument
 {
     #[ODM\Field(type: 'int')]
     public int $removedCount = 0;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2767Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH2767Test.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+
+class GH2767Test extends BaseTestCase
+{
+    public function testRemovePersistEmbedded(): void
+    {
+        // Start with a parent document and 1 embedded document, both with removedCount = 0
+        $document = new TestDocument([new TestEmbeddedDocument()]);
+        $this->dm->persist($document);
+        $this->dm->flush();
+        $id = $document->id;
+
+        // Remove the document
+        $this->dm->remove($document);
+
+        // Increase the removedCount of the parent document and the embedded document by 1
+        $document->incrementRemovedCount();
+
+        // Re-persist the same document
+        $this->dm->persist($document);
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $repository = $this->dm->getRepository(TestDocument::class);
+        $result     = $repository->find($id);
+
+        self::assertEquals(1, $result->removedCount);
+        self::assertEquals(1, $result->embeddedDocuments[0]->removedCount);
+    }
+}
+
+#[ODM\Document]
+class TestDocument
+{
+    #[ODM\Id]
+    public ?string $id = null;
+
+    #[ODM\Field(type: 'int')]
+    public int $removedCount = 0;
+
+    /** @var Collection<int, TestEmbeddedDocument> */
+    #[ODM\EmbedMany(targetDocument: TestEmbeddedDocument::class)]
+    public $embeddedDocuments;
+
+    /** @param TestEmbeddedDocument[] $embeddedDocuments */
+    public function __construct(array $embeddedDocuments)
+    {
+        $this->embeddedDocuments = new ArrayCollection($embeddedDocuments);
+    }
+
+    public function incrementRemovedCount(): void
+    {
+        $this->removedCount++;
+        foreach ($this->embeddedDocuments as $embeddedDocument) {
+            $embeddedDocument->removedCount++;
+        }
+    }
+}
+
+#[ODM\EmbeddedDocument]
+class TestEmbeddedDocument
+{
+    #[ODM\Field(type: 'int')]
+    public int $removedCount = 0;
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #2767 

#### Summary

<!-- Provide a summary your change. -->

After a parent document and its embeds are removed and then subsequently persisted, the embedded documents didn't get updated. This happened because the parent document goes through an upsert operation, but `PersistenceBuilder->prepareUpsertData()` did not handle embedded associations in the same way that
`PersistenceBuilder->prepareUpdateData()` does. This fixes that issue so that an upserted parent document handles embed-many's the same was as an updated parent document.

Fixes doctrine#2767
