### PR TITLE
Catch `BulkWriteException`, since `WriteException` is removed from extension v2

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -33,8 +33,8 @@ use Iterator as SplIterator;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
 use MongoDB\Driver\CursorInterface;
+use MongoDB\Driver\Exception\BulkWriteException;
 use MongoDB\Driver\Exception\Exception as DriverException;
-use MongoDB\Driver\Exception\WriteException;
 use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\GridFS\Bucket;
@@ -266,7 +266,7 @@ final class DocumentPersister
                 $this->executeUpsert($document, $options);
                 $this->handleCollections($document, $options);
                 unset($this->queuedUpserts[$oid]);
-            } catch (WriteException $e) {
+            } catch (BulkWriteException $e) {
                 unset($this->queuedUpserts[$oid]);
 
                 throw $e;
@@ -338,7 +338,7 @@ final class DocumentPersister
             $this->collection->updateOne($criteria, $data, $options);
 
             return;
-        } catch (WriteException $e) {
+        } catch (BulkWriteException $e) {
             if (empty($retry) || strpos($e->getMessage(), 'Mod on _id not allowed') === false) {
                 throw $e;
             }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

#### Summary

Probably forgotten in https://github.com/doctrine/mongodb-odm/pull/2683

The `WriteException` was removed in MongoDB Extension v2.0. It was never thrown itself; and only its child class `BulkWriteException` is thrown.

Spotted by PHPStan.
