### PR TITLE
Deprecate `APM\Command::getServer()`, add `getPort()` and `getHost()` instead

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/APM/Command.php
+++ b/lib/Doctrine/ODM/MongoDB/APM/Command.php
@@ -11,6 +11,8 @@ use MongoDB\Driver\Monitoring\CommandSucceededEvent;
 use MongoDB\Driver\Server;
 use Throwable;
 
+use function method_exists;
+
 final class Command
 {
     private CommandStartedEvent $startedEvent;
@@ -70,9 +72,24 @@ final class Command
         return $this->startedEvent->getRequestId();
     }
 
+    /** @deprecated This method is failing with MongoDB Extension v2.0+, use getHost and getPort instead. */
     public function getServer(): Server
     {
+        if (! method_exists($this->finishedEvent, 'getServer')) {
+            throw new LogicException('getServer() is not available in MongoDB Extension v2.0+');
+        }
+
         return $this->finishedEvent->getServer();
+    }
+
+    public function getPort(): int
+    {
+        return $this->finishedEvent->getPort();
+    }
+
+    public function getHost(): string
+    {
+        return $this->finishedEvent->getHost();
     }
 
     public function getReply(): object


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

`CommandSucceededEvent|CommandFailedEvent::getServer()` has been deprecated in ext-mongodb [1.20](https://github.com/mongodb/mongo-php-driver/releases/tag/1.20.0) and removed in [2.0.0](https://github.com/mongodb/mongo-php-driver/releases/tag/2.0.0).
For backward compatibility: we keep this method in MongoDB ODM, but throw an exception the extension is not compatible. I'm not adding a `trigger_deprecation` as this is already triggered by the extension method call.

The new methods `getPort()` and `getHost()` are added as proxy to extension methods that are always available in the required ext-mongodb 1.21+.

This is not covered by tests, I can add tests on `CommandLogger` before merging.

