### PR TITLE
`DocumentPersister::$collection` is never `null`

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -89,7 +89,7 @@ use function trigger_deprecation;
  */
 final class DocumentPersister
 {
-    private ?Collection $collection = null;
+    private Collection $collection;
 
     private ?Bucket $bucket = null;
 
@@ -226,7 +226,6 @@ final class DocumentPersister
         }
 
         try {
-            assert($this->collection instanceof Collection);
             $this->collection->insertMany($inserts, $options);
         } catch (DriverException $e) {
             $this->queuedInserts = [];
@@ -334,7 +333,6 @@ final class DocumentPersister
         }
 
         try {
-            assert($this->collection instanceof Collection);
             $this->collection->updateOne($criteria, $data, $options);
 
             return;
@@ -344,7 +342,6 @@ final class DocumentPersister
             }
         }
 
-        assert($this->collection instanceof Collection);
         $this->collection->updateOne($criteria, ['$set' => new stdClass()], $options);
     }
 
@@ -398,7 +395,6 @@ final class DocumentPersister
 
             $options = $this->getWriteOptions($options);
 
-            assert($this->collection instanceof Collection);
             $result = $this->collection->updateOne($query, $update, $options);
 
             if (($this->class->isVersioned || $this->class->isLockable) && $result->getModifiedCount() !== 1) {
@@ -439,7 +435,6 @@ final class DocumentPersister
 
         $options = $this->getWriteOptions($options);
 
-        assert($this->collection instanceof Collection);
         $result = $this->collection->deleteOne($query, $options);
 
         if (($this->class->isVersioned || $this->class->isLockable) && ! $result->getDeletedCount()) {
@@ -452,7 +447,6 @@ final class DocumentPersister
      */
     public function refresh(object $document): void
     {
-        assert($this->collection instanceof Collection);
         $query = $this->getQueryForDocument($document);
         $data  = $this->collection->findOne($query);
         if ($data === null) {
@@ -498,7 +492,6 @@ final class DocumentPersister
             $options['sort'] = $this->prepareSort($sort);
         }
 
-        assert($this->collection instanceof Collection);
         $result = $this->collection->findOne($criteria, $options);
         $result = $result !== null ? (array) $result : null;
 
@@ -541,7 +534,6 @@ final class DocumentPersister
             $options['skip'] = $skip;
         }
 
-        assert($this->collection instanceof Collection);
         $baseCursor = $this->collection->find($criteria, $options);
 
         assert($baseCursor instanceof CursorInterface && $baseCursor instanceof SplIterator);
@@ -603,7 +595,6 @@ final class DocumentPersister
     public function exists(object $document): bool
     {
         $id = $this->class->getIdentifierObject($document);
-        assert($this->collection instanceof Collection);
 
         return (bool) $this->collection->findOne(['_id' => $id], ['_id']);
     }
@@ -616,7 +607,7 @@ final class DocumentPersister
         $id          = $this->uow->getDocumentIdentifier($document);
         $criteria    = ['_id' => $this->class->getDatabaseIdentifierValue($id)];
         $lockMapping = $this->class->fieldMappings[$this->class->lockField];
-        assert($this->collection instanceof Collection);
+
         $this->collection->updateOne($criteria, ['$set' => [$lockMapping['name'] => $lockMode]]);
         $this->class->reflFields[$this->class->lockField]->setValue($document, $lockMode);
     }
@@ -629,7 +620,7 @@ final class DocumentPersister
         $id          = $this->uow->getDocumentIdentifier($document);
         $criteria    = ['_id' => $this->class->getDatabaseIdentifierValue($id)];
         $lockMapping = $this->class->fieldMappings[$this->class->lockField];
-        assert($this->collection instanceof Collection);
+
         $this->collection->updateOne($criteria, ['$unset' => [$lockMapping['name'] => true]]);
         $this->class->reflFields[$this->class->lockField]->setValue($document, null);
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

`DocumentPersister::$collection` is set in the constructor for root document types that use it. It doesn't have to be nullable, so that all the `assert` can be removed.

https://github.com/doctrine/mongodb-odm/blob/9cc829197581df02c227f00cfa789b077949dffa/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php#L115-L130
