### PR TITLE
Remove unnecessary `assert` calls

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
@@ -56,14 +56,11 @@ final class Aggregation implements IterableResult
         $options = array_merge($this->options, ['cursor' => true]);
 
         $cursor = $this->collection->aggregate($this->pipeline, $options);
-        // This assertion can be dropped when requiring mongodb/mongodb 1.17.0
-        assert($cursor instanceof CursorInterface);
-        assert($cursor instanceof SPLIterator);
 
         return $this->prepareIterator($cursor);
     }
 
-    private function prepareIterator(CursorInterface&SPLIterator $cursor): Iterator
+    private function prepareIterator(CursorInterface $cursor): Iterator
     {
         if ($this->classMetadata) {
             $cursor = new HydratingIterator($cursor, $this->dm->getUnitOfWork(), $this->classMetadata);

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
@@ -11,12 +11,10 @@ use Doctrine\ODM\MongoDB\Iterator\IterableResult;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Iterator\UnrewindableIterator;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use Iterator as SPLIterator;
 use MongoDB\Collection;
 use MongoDB\Driver\CursorInterface;
 
 use function array_merge;
-use function assert;
 
 /** @phpstan-import-type PipelineExpression from Builder */
 final class Aggregation implements IterableResult

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -333,8 +333,8 @@ final class DocumentPersister
             $data  = ['$set' => ['_id' => $criteria['_id']]];
         }
 
+        assert($this->collection instanceof Collection);
         try {
-            assert($this->collection instanceof Collection);
             $this->collection->updateOne($criteria, $data, $options);
 
             return;
@@ -344,7 +344,6 @@ final class DocumentPersister
             }
         }
 
-        assert($this->collection instanceof Collection);
         $this->collection->updateOne($criteria, ['$set' => new stdClass()], $options);
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -29,7 +29,6 @@ use Doctrine\ODM\MongoDB\UnitOfWork;
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 use Doctrine\Persistence\Mapping\MappingException;
 use InvalidArgumentException;
-use Iterator as SplIterator;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
 use MongoDB\Driver\CursorInterface;

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -544,8 +544,6 @@ final class DocumentPersister
         assert($this->collection instanceof Collection);
         $baseCursor = $this->collection->find($criteria, $options);
 
-        assert($baseCursor instanceof CursorInterface && $baseCursor instanceof SplIterator);
-
         return $this->wrapCursor($baseCursor);
     }
 
@@ -592,7 +590,7 @@ final class DocumentPersister
     /**
      * Wraps the supplied base cursor in the corresponding ODM class.
      */
-    private function wrapCursor(SplIterator&CursorInterface $baseCursor): Iterator
+    private function wrapCursor(CursorInterface $baseCursor): Iterator
     {
         return new CachingIterator(new HydratingIterator($baseCursor, $this->dm->getUnitOfWork(), $this->class));
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

Fix errors reported by PHPStan.

```
 ------ ---------------------------------------------------------------------------------------- 
  Line   lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php                                    
 ------ ---------------------------------------------------------------------------------------- 
  60     Ignored error pattern #^Call to function assert\(\) with true will                      
         always evaluate to true\.$# (function.alreadyNarrowedType) in path                      
         /Users/jerome/Develop/mongodb-odm/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php  
         is expected to occur 1 time, but occurred 2 times.                                      
  61     Call to function assert() with true will always evaluate to true.                       
         🪪 function.alreadyNarrowedType                                                         
  61     Instanceof between MongoDB\Driver\CursorInterface and Iterator will                     
         always evaluate to true.                                                                
         🪪 instanceof.alwaysTrue                                                                
 ------ ---------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------- 
  Line   lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php                                    
 ------ --------------------------------------------------------------------------------------------- 
  347    Ignored error pattern #^Call to function assert\(\) with true will                           
         always evaluate to true\.$# (function.alreadyNarrowedType) in path                           
         /Users/jerome/Develop/mongodb-odm/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php  
         is expected to occur 1 time, but occurred 2 times.                                           
  547    Call to function assert() with true will always evaluate to true.                            
         🪪 function.alreadyNarrowedType                                                              
  547    Instanceof between MongoDB\Driver\CursorInterface and Iterator will                          
         always evaluate to true.                                                                     
         🪪 instanceof.alwaysTrue                                                                     
  547    Result of && is always true.                                                                 
         🪪 booleanAnd.alwaysTrue                                                                     
 ------ --------------------------------------------------------------------------------------------- 
```