### PR TITLE
[Encryption] Set master key when creating an encrypted collection

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -58,7 +58,8 @@ use function trim;
  * @phpstan-import-type CommitOptions from UnitOfWork
  * @phpstan-type AutoEncryptionOptions array{
  *     keyVaultNamespace: string,
- *     kmsProviders: array<string, array<string, string>>,
+ *     kmsProviders: array<string, array<string, mixed>>,
+ *     kmsProvider?: string,
  *     masterKey?: array<string, mixed>|null,
  *     tlsOptions?: array{kmip: array{tlsCAFile: string, tlsCertificateKeyFile: string}},
  * }
@@ -700,14 +701,20 @@ class Configuration
     public function setAutoEncryption(array $options): void
     {
         if (! isset($options['keyVaultNamespace']) || ! is_string($options['keyVaultNamespace'])) {
-            throw new InvalidArgumentException('The "keyVaultNamespace" option is required.');
+            throw new InvalidArgumentException('The "keyVaultNamespace" encryption option is required.');
         }
 
-        if (! is_array($options['kmsProviders'] ?? null) || count($options['kmsProviders']) !== 1) {
-            throw new InvalidArgumentException('AutoEncryption requires a single KMS provider.');
+        if (! is_array($options['kmsProviders'] ?? null) || count($options['kmsProviders']) === 0) {
+            throw new InvalidArgumentException('The "kmsProviders" encryption option is required and must be a non-empty.');
         }
 
-        if (array_key_first($options['kmsProviders']) !== 'local' && ! isset($options['masterKey'])) {
+        if (! isset($options['kmsProvider']) && count($options['kmsProviders']) > 1) {
+            throw new InvalidArgumentException('The "kmsProvider" encryption option is required when multiple KMS providers are specified.');
+        }
+
+        $options['kmsProvider'] ??= array_key_first($options['kmsProviders']);
+
+        if ($options['kmsProvider'] !== 'local' && ! isset($options['masterKey'])) {
             throw new InvalidArgumentException('The "masterKey" option is required when the KMS provider is not "local".');
         }
 
@@ -731,11 +738,7 @@ class Configuration
      */
     public function getKmsProvider(): ?string
     {
-        if (! isset($this->attributes['autoEncryption'])) {
-            return null;
-        }
-
-        return array_key_first($this->attributes['autoEncryption']['kmsProviders']);
+        return $this->attributes['autoEncryption']['kmsProvider'] ?? null;
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -59,6 +59,7 @@ use function trim;
  * @phpstan-type AutoEncryptionOptions array{
  *     keyVaultNamespace: string,
  *     kmsProviders: array<string, array<string, string>>,
+ *     masterKey?: array<string, mixed>|null,
  *     tlsOptions?: array{kmip: array{tlsCAFile: string, tlsCertificateKeyFile: string}},
  * }
  */
@@ -702,9 +703,12 @@ class Configuration
             throw new InvalidArgumentException('The "keyVaultNamespace" option is required.');
         }
 
-        // @todo Throw en exception if multiple KMS providers are defined. This is not supported yet and would require a setting for the KMS provider to use when creating a new collection
-        if (! isset($options['kmsProviders']) || ! is_array($options['kmsProviders']) || count($options['kmsProviders']) < 1) {
-            throw new InvalidArgumentException('The "kmsProviders" option is required.');
+        if (! is_array($options['kmsProviders'] ?? null) || count($options['kmsProviders']) !== 1) {
+            throw new InvalidArgumentException('AutoEncryption requires a single KMS provider.');
+        }
+
+        if (array_key_first($options['kmsProviders']) !== 'local' && ! isset($options['masterKey'])) {
+            throw new InvalidArgumentException('The "masterKey" option is required when the KMS provider is not "local".');
         }
 
         $this->attributes['autoEncryption'] = $options;
@@ -722,6 +726,9 @@ class Configuration
         return $this->attributes['autoEncryption'] ?? null;
     }
 
+    /**
+     * Get the KMS provider name used for auto-encryption.
+     */
     public function getKmsProvider(): ?string
     {
         if (! isset($this->attributes['autoEncryption'])) {
@@ -729,6 +736,16 @@ class Configuration
         }
 
         return array_key_first($this->attributes['autoEncryption']['kmsProviders']);
+    }
+
+    /**
+     * Get the master key used for auto-encryption.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getMasterKey(): ?array
+    {
+        return $this->attributes['autoEncryption']['masterKey'] ?? null;
     }
 
     private static function getVersion(): string

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -26,6 +26,8 @@ use Doctrine\Persistence\ObjectRepository;
 use InvalidArgumentException;
 use Jean85\PrettyVersions;
 use LogicException;
+use MongoDB\Client;
+use MongoDB\Driver\Manager;
 use MongoDB\Driver\WriteConcern;
 use ProxyManager\Configuration as ProxyManagerConfiguration;
 use ProxyManager\Factory\LazyLoadingGhostFactory;
@@ -36,12 +38,10 @@ use ReflectionClass;
 use Throwable;
 
 use function array_diff_key;
+use function array_intersect_key;
 use function array_key_exists;
-use function array_key_first;
 use function class_exists;
-use function count;
 use function interface_exists;
-use function is_array;
 use function is_string;
 use function sprintf;
 use function trigger_deprecation;
@@ -58,14 +58,7 @@ use function trim;
  *     $dm = DocumentManager::create(new Connection(), $config);
  *
  * @phpstan-import-type CommitOptions from UnitOfWork
- * @phpstan-type AutoEncryptionOptions array{
- *     keyVaultNamespace: string,
- *     kmsProviders: array<string, array<string, mixed>>,
- *     kmsProvider?: string,
- *     masterKey?: array<string, mixed>|null,
- *     tlsOptions?: array{kmip: array{tlsCAFile: string, tlsCertificateKeyFile: string}},
- *     ...
- * }
+ * @phpstan-type KmsProvider array{name: string, ...}
  */
 class Configuration
 {
@@ -138,7 +131,9 @@ class Configuration
      *      proxyDir?: string,
      *      proxyNamespace?: string,
      *      repositoryFactory?: RepositoryFactory,
-     *      autoEncryption?: AutoEncryptionOptions,
+     *      kmsProvider?: KmsProvider,
+     *      defaultMasterKey?: array<string, mixed>|null,
+     *      autoEncryption?: array<string, mixed>,
      * }
      */
     private array $attributes = [];
@@ -168,14 +163,32 @@ class Configuration
             ],
         ];
 
-        if (isset($this->attributes['autoEncryption'])) {
-            $driverOptions['autoEncryption'] = array_diff_key(
-                $this->attributes['autoEncryption'],
-                ['kmsProvider' => 0, 'masterKey' => 0],
-            );
+        if (isset($this->attributes['kmsProvider'])) {
+            $driverOptions['autoEncryption'] = $this->getAutoEncryptionOptions();
         }
 
         return $driverOptions;
+    }
+
+    /**
+     * Get options to create a ClientEncryption instance.
+     *
+     * @see https://www.php.net/manual/en/mongodb-driver-clientencryption.construct.php
+     *
+     * @return array{keyVaultClient?: Client|Manager, keyVaultNamespace: string, kmsProviders: array<string, mixed>, tlsOptions?: array<string, mixed>}
+     */
+    public function getClientEncryptionOptions(): array
+    {
+        if (! isset($this->attributes['kmsProvider'])) {
+            throw new ConfigurationException('MongoDB client encryption options are not set in configuration');
+        }
+
+        return array_intersect_key($this->getAutoEncryptionOptions(), [
+            'keyVaultClient' => 1,
+            'keyVaultNamespace' => 1,
+            'kmsProviders' => 1,
+            'tlsOptions' => 1,
+        ]);
     }
 
     /**
@@ -696,69 +709,72 @@ class Configuration
     }
 
     /**
-     * Set the options for auto-encryption.
+     * Set the KMS provider to use for auto-encryption. The name of the KMS provider
+     * must be specified in the 'name' key of the array.
      *
      * @see https://www.php.net/manual/en/mongodb-driver-clientencryption.construct.php
      *
-     * @phpstan-param AutoEncryptionOptions $options
+     * @param KmsProvider $kmsProvider
+     */
+    public function setKmsProvider(array $kmsProvider): void
+    {
+        if (! isset($kmsProvider['name'])) {
+            throw new ConfigurationException('The "name" KMS provider option is required.');
+        }
+
+        if (! is_string($kmsProvider['name'])) {
+            throw new ConfigurationException('The "name" KMS provider option must be a non-empty string.');
+        }
+
+        $this->attributes['kmsProvider'] = $kmsProvider;
+    }
+
+    /**
+     * Set the default master key to use when creating encrypted collections.
      *
-     * @throws InvalidArgumentException If the options are invalid.
+     * @param array<string, mixed>|null $masterKey
+     */
+    public function setDefaultMasterKey(?array $masterKey): void
+    {
+        $this->attributes['defaultMasterKey'] = $masterKey;
+    }
+
+    /**
+     * Set the options for auto-encryption.
+     *
+     * @see https://www.php.net/manual/en/mongodb-driver-manager.construct.php
+     *
+     * @param array{ keyVaultClient?: Client|Manager, keyVaultNamespace?: string, tlsOptions?: array<string, mixed>, schemaMap?: array<string, mixed>, encryptedFieldsMap?: array<string, mixed>, extraOptions?: array<string, mixed>} $options
      */
     public function setAutoEncryption(array $options): void
     {
-        if (! isset($options['keyVaultNamespace']) || ! is_string($options['keyVaultNamespace'])) {
-            throw new InvalidArgumentException('The "keyVaultNamespace" encryption option is required.');
-        }
-
-        if (! is_array($options['kmsProviders'] ?? null) || count($options['kmsProviders']) === 0) {
-            throw new InvalidArgumentException('The "kmsProviders" encryption option is required and must be a non-empty.');
-        }
-
-        if (! isset($options['kmsProvider']) && count($options['kmsProviders']) > 1) {
-            throw new InvalidArgumentException('The "kmsProvider" encryption option is required when multiple KMS providers are specified.');
-        }
-
-        $options['kmsProvider'] ??= array_key_first($options['kmsProviders']);
-
-        if (! array_key_exists($options['kmsProvider'], $options['kmsProviders'])) {
-            throw new InvalidArgumentException(sprintf('The "kmsProvider" encryption option "%s" is not defined in the "kmsProviders" option.', $options['kmsProvider']));
-        }
-
-        if ($options['kmsProvider'] !== 'local' && ! isset($options['masterKey'])) {
-            throw new InvalidArgumentException('The "masterKey" option is required when the KMS provider is not "local".');
+        if (isset($options['kmsProviders'])) {
+            throw new ConfigurationException('The "kmsProviders" encryption option must be set using the "setKmsProvider()" method.');
         }
 
         $this->attributes['autoEncryption'] = $options;
     }
 
     /**
-     * Get the options for auto-encryption.
-     *
-     * @see https://www.php.net/manual/en/mongodb-driver-clientencryption.construct.php
-     *
-     * @phpstan-return AutoEncryptionOptions
+     * Get the default KMS provider name used when creating encrypted collections.
      */
-    public function getAutoEncryption(): ?array
+    public function getDefaultKmsProvider(): ?string
     {
-        return $this->attributes['autoEncryption'] ?? null;
+        return $this->attributes['kmsProvider']['name'] ?? null;
     }
 
     /**
-     * Get the KMS provider name used for auto-encryption.
-     */
-    public function getKmsProvider(): ?string
-    {
-        return $this->attributes['autoEncryption']['kmsProvider'] ?? null;
-    }
-
-    /**
-     * Get the master key used for auto-encryption.
+     * Get the default master key used when creating encrypted collections.
      *
      * @return array<string, mixed>|null
      */
-    public function getMasterKey(): ?array
+    public function getDefaultMasterKey(): ?array
     {
-        return $this->attributes['autoEncryption']['masterKey'] ?? null;
+        if (! isset($this->attributes['kmsProvider']) || $this->attributes['kmsProvider']['name'] === 'local') {
+            return null;
+        }
+
+        return $this->attributes['defaultMasterKey'] ?? throw new ConfigurationException(sprintf('The "masterKey" configuration is required for the KMS provider "%s".', $this->attributes['kmsProvider']['name']));
     }
 
     private static function getVersion(): string
@@ -772,6 +788,16 @@ class Configuration
         }
 
         return self::$version;
+    }
+
+    /** @return array<string, mixed> */
+    private function getAutoEncryptionOptions(): array
+    {
+        return [
+            'kmsProviders' => [$this->attributes['kmsProvider']['name'] => array_diff_key($this->attributes['kmsProvider'], ['name' => 0])],
+            'keyVaultNamespace' => $this->getDefaultDB() . '.datakeys',
+            ...$this->attributes['autoEncryption'] ?? [],
+        ];
     }
 }
 

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -35,6 +35,7 @@ use Psr\Cache\CacheItemPoolInterface;
 use ReflectionClass;
 use Throwable;
 
+use function array_diff_key;
 use function array_key_exists;
 use function array_key_first;
 use function class_exists;
@@ -63,6 +64,7 @@ use function trim;
  *     kmsProvider?: string,
  *     masterKey?: array<string, mixed>|null,
  *     tlsOptions?: array{kmip: array{tlsCAFile: string, tlsCertificateKeyFile: string}},
+ *     ...
  * }
  */
 class Configuration

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -43,7 +43,6 @@ use function array_key_exists;
 use function class_exists;
 use function interface_exists;
 use function is_string;
-use function sprintf;
 use function trigger_deprecation;
 use function trim;
 
@@ -180,7 +179,7 @@ class Configuration
     public function getClientEncryptionOptions(): array
     {
         if (! isset($this->attributes['kmsProvider'])) {
-            throw new ConfigurationException('MongoDB client encryption options are not set in configuration');
+            throw ConfigurationException::clientEncryptionOptionsNotSet();
         }
 
         return array_intersect_key($this->getAutoEncryptionOptions(), [
@@ -719,11 +718,11 @@ class Configuration
     public function setKmsProvider(array $kmsProvider): void
     {
         if (! isset($kmsProvider['name'])) {
-            throw new ConfigurationException('The "name" KMS provider option is required.');
+            throw ConfigurationException::kmsProviderNameRequired();
         }
 
         if (! is_string($kmsProvider['name'])) {
-            throw new ConfigurationException('The "name" KMS provider option must be a non-empty string.');
+            throw ConfigurationException::kmsProviderNameMustBeString();
         }
 
         $this->attributes['kmsProvider'] = $kmsProvider;
@@ -749,7 +748,7 @@ class Configuration
     public function setAutoEncryption(array $options): void
     {
         if (isset($options['kmsProviders'])) {
-            throw new ConfigurationException('The "kmsProviders" encryption option must be set using the "setKmsProvider()" method.');
+            throw ConfigurationException::kmsProvidersOptionMustUseSetter();
         }
 
         $this->attributes['autoEncryption'] = $options;
@@ -774,7 +773,7 @@ class Configuration
             return null;
         }
 
-        return $this->attributes['defaultMasterKey'] ?? throw new ConfigurationException(sprintf('The "masterKey" configuration is required for the KMS provider "%s".', $this->attributes['kmsProvider']['name']));
+        return $this->attributes['defaultMasterKey'] ?? throw ConfigurationException::masterKeyRequired($this->attributes['kmsProvider']['name']);
     }
 
     private static function getVersion(): string

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -57,7 +57,7 @@ use function trim;
  *     $dm = DocumentManager::create(new Connection(), $config);
  *
  * @phpstan-import-type CommitOptions from UnitOfWork
- * @phpstan-type KmsProvider array{name: string, ...}
+ * @phpstan-type KmsProvider array{type: string, ...}
  */
 class Configuration
 {
@@ -709,7 +709,7 @@ class Configuration
 
     /**
      * Set the KMS provider to use for auto-encryption. The name of the KMS provider
-     * must be specified in the 'name' key of the array.
+     * must be specified in the 'type' key of the array.
      *
      * @see https://www.php.net/manual/en/mongodb-driver-clientencryption.construct.php
      *
@@ -717,12 +717,12 @@ class Configuration
      */
     public function setKmsProvider(array $kmsProvider): void
     {
-        if (! isset($kmsProvider['name'])) {
-            throw ConfigurationException::kmsProviderNameRequired();
+        if (! isset($kmsProvider['type'])) {
+            throw ConfigurationException::kmsProviderTypeRequired();
         }
 
-        if (! is_string($kmsProvider['name'])) {
-            throw ConfigurationException::kmsProviderNameMustBeString();
+        if (! is_string($kmsProvider['type'])) {
+            throw ConfigurationException::kmsProviderTypeMustBeString();
         }
 
         $this->attributes['kmsProvider'] = $kmsProvider;
@@ -759,7 +759,7 @@ class Configuration
      */
     public function getDefaultKmsProvider(): ?string
     {
-        return $this->attributes['kmsProvider']['name'] ?? null;
+        return $this->attributes['kmsProvider']['type'] ?? null;
     }
 
     /**
@@ -769,11 +769,11 @@ class Configuration
      */
     public function getDefaultMasterKey(): ?array
     {
-        if (! isset($this->attributes['kmsProvider']) || $this->attributes['kmsProvider']['name'] === 'local') {
+        if (! isset($this->attributes['kmsProvider']) || $this->attributes['kmsProvider']['type'] === 'local') {
             return null;
         }
 
-        return $this->attributes['defaultMasterKey'] ?? throw ConfigurationException::masterKeyRequired($this->attributes['kmsProvider']['name']);
+        return $this->attributes['defaultMasterKey'] ?? throw ConfigurationException::masterKeyRequired($this->attributes['kmsProvider']['type']);
     }
 
     private static function getVersion(): string
@@ -793,7 +793,7 @@ class Configuration
     private function getAutoEncryptionOptions(): array
     {
         return [
-            'kmsProviders' => [$this->attributes['kmsProvider']['name'] => array_diff_key($this->attributes['kmsProvider'], ['name' => 0])],
+            'kmsProviders' => [$this->attributes['kmsProvider']['type'] => array_diff_key($this->attributes['kmsProvider'], ['type' => 0])],
             'keyVaultNamespace' => $this->getDefaultDB() . '.datakeys',
             ...$this->attributes['autoEncryption'] ?? [],
         ];

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -167,7 +167,10 @@ class Configuration
         ];
 
         if (isset($this->attributes['autoEncryption'])) {
-            $driverOptions['autoEncryption'] = $this->attributes['autoEncryption'];
+            $driverOptions['autoEncryption'] = array_diff_key(
+                $this->attributes['autoEncryption'],
+                ['kmsProvider' => 0, 'masterKey' => 0],
+            );
         }
 
         return $driverOptions;

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -42,6 +42,7 @@ use function count;
 use function interface_exists;
 use function is_array;
 use function is_string;
+use function sprintf;
 use function trigger_deprecation;
 use function trim;
 
@@ -713,6 +714,10 @@ class Configuration
         }
 
         $options['kmsProvider'] ??= array_key_first($options['kmsProviders']);
+
+        if (! array_key_exists($options['kmsProvider'], $options['kmsProviders'])) {
+            throw new InvalidArgumentException(sprintf('The "kmsProvider" encryption option "%s" is not defined in the "kmsProviders" option.', $options['kmsProvider']));
+        }
 
         if ($options['kmsProvider'] !== 'local' && ! isset($options['masterKey'])) {
             throw new InvalidArgumentException('The "masterKey" option is required when the KMS provider is not "local".');

--- a/lib/Doctrine/ODM/MongoDB/ConfigurationException.php
+++ b/lib/Doctrine/ODM/MongoDB/ConfigurationException.php
@@ -6,6 +6,8 @@ namespace Doctrine\ODM\MongoDB;
 
 use Exception;
 
+use function sprintf;
+
 final class ConfigurationException extends Exception
 {
     public static function persistentCollectionDirMissing(): self
@@ -28,8 +30,28 @@ final class ConfigurationException extends Exception
         return new self('No proxy directory was configured. Please set a target directory first!');
     }
 
-    public static function kmsProvidersNotSupported(): self
+    public static function clientEncryptionOptionsNotSet(): self
     {
-        return new self('Setting multiple KMS providers is not supported. Please set a single KMS provider in your configuration.');
+        return new self('MongoDB client encryption options are not set in configuration');
+    }
+
+    public static function kmsProviderNameRequired(): self
+    {
+        return new self('The KMS provider "name" is required.');
+    }
+
+    public static function kmsProviderNameMustBeString(): self
+    {
+        return new self('The KMS provider "name" must be a non-empty string.');
+    }
+
+    public static function kmsProvidersOptionMustUseSetter(): self
+    {
+        return new self('The "kmsProviders" encryption option must be set using the "setKmsProvider()" method.');
+    }
+
+    public static function masterKeyRequired(string $provider): self
+    {
+        return new self(sprintf('The "masterKey" configuration is required for the KMS provider "%s".', $provider));
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/ConfigurationException.php
+++ b/lib/Doctrine/ODM/MongoDB/ConfigurationException.php
@@ -35,14 +35,14 @@ final class ConfigurationException extends Exception
         return new self('MongoDB client encryption options are not set in configuration');
     }
 
-    public static function kmsProviderNameRequired(): self
+    public static function kmsProviderTypeRequired(): self
     {
-        return new self('The KMS provider "name" is required.');
+        return new self('The KMS provider "type" is required.');
     }
 
-    public static function kmsProviderNameMustBeString(): self
+    public static function kmsProviderTypeMustBeString(): self
     {
-        return new self('The KMS provider "name" must be a non-empty string.');
+        return new self('The KMS provider "type" must be a non-empty string.');
     }
 
     public static function kmsProvidersOptionMustUseSetter(): self

--- a/lib/Doctrine/ODM/MongoDB/ConfigurationException.php
+++ b/lib/Doctrine/ODM/MongoDB/ConfigurationException.php
@@ -27,4 +27,9 @@ final class ConfigurationException extends Exception
     {
         return new self('No proxy directory was configured. Please set a target directory first!');
     }
+
+    public static function kmsProvidersNotSupported(): self
+    {
+        return new self('Setting multiple KMS providers is not supported. Please set a single KMS provider in your configuration.');
+    }
 }

--- a/lib/Doctrine/ODM/MongoDB/DocumentManager.php
+++ b/lib/Doctrine/ODM/MongoDB/DocumentManager.php
@@ -223,17 +223,17 @@ class DocumentManager implements ObjectManager
     /** @internal */
     public function getClientEncryption(): ClientEncryption
     {
-        $autoEncryptionOptions = $this->config->getAutoEncryption();
+        if (isset($this->clientEncryption)) {
+            return $this->clientEncryption;
+        }
 
-        if (! $autoEncryptionOptions) {
+        $options = $this->config->getClientEncryptionOptions();
+
+        if (! $options) {
             throw new RuntimeException('Auto-encryption is not enabled.');
         }
 
-        return $this->clientEncryption ??= $this->client->createClientEncryption([
-            'keyVaultNamespace' => $autoEncryptionOptions['keyVaultNamespace'],
-            'kmsProviders' => $autoEncryptionOptions['kmsProviders'],
-            'tlsOptions' => $autoEncryptionOptions['tlsOptions'] ?? [],
-        ]);
+        return $this->clientEncryption = $this->client->createClientEncryption($options);
     }
 
     /** Gets the metadata factory used to gather the metadata of classes. */

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -645,7 +645,7 @@ final class SchemaManager
         }
 
         // Encryption is enabled only if the KMS provider is set and at least one field is encrypted
-        if ($this->dm->getConfiguration()->getKmsProvider()) {
+        if ($this->dm->getConfiguration()->getAutoEncryption()) {
             $encryptedFields = (new EncryptionFieldMap($this->dm->getMetadataFactory()))->getEncryptionFieldMap($class->name);
 
             if ($encryptedFields) {
@@ -658,7 +658,7 @@ final class SchemaManager
                 $class->getCollection(),
                 $this->dm->getClientEncryption(),
                 $this->dm->getConfiguration()->getKmsProvider(),
-                null, // @todo when is it necessary to set the master key?
+                $this->dm->getConfiguration()->getMasterKey(),
                 $this->getWriteOptions($maxTimeMs, $writeConcern, $options),
             );
         } else {

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -645,7 +645,7 @@ final class SchemaManager
         }
 
         // Encryption is enabled only if the KMS provider is set and at least one field is encrypted
-        if ($this->dm->getConfiguration()->getAutoEncryption()) {
+        if ($this->dm->getConfiguration()->getDefaultKmsProvider()) {
             $encryptedFields = (new EncryptionFieldMap($this->dm->getMetadataFactory()))->getEncryptionFieldMap($class->name);
 
             if ($encryptedFields) {
@@ -657,8 +657,8 @@ final class SchemaManager
             $this->dm->getDocumentDatabase($documentName)->createEncryptedCollection(
                 $class->getCollection(),
                 $this->dm->getClientEncryption(),
-                $this->dm->getConfiguration()->getKmsProvider(),
-                $this->dm->getConfiguration()->getMasterKey(),
+                $this->dm->getConfiguration()->getDefaultKmsProvider(),
+                $this->dm->getConfiguration()->getDefaultMasterKey(),
                 $this->getWriteOptions($maxTimeMs, $writeConcern, $options),
             );
         } else {

--- a/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\ODM\MongoDB\ConfigurationException;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionFactory;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionGenerator;
-use Generator;
-use InvalidArgumentException;
-use PHPUnit\Framework\Attributes\DataProvider;
+use MongoDB\Driver\Manager;
+use PHPUnit\Framework\TestCase;
 
-class ConfigurationTest extends BaseTestCase
+class ConfigurationTest extends TestCase
 {
     public function testDefaultPersistentCollectionFactory(): void
     {
@@ -44,131 +44,88 @@ class ConfigurationTest extends BaseTestCase
         self::assertFalse($c->isTransactionalFlushEnabled(), 'Transactional flush is disabled after setTransactionalFlush(false)');
     }
 
-    public function testAutoEncryptionWithMultipleKmsProviders(): void
+    public function testLocalKmsProvider(): void
     {
-        $masterKey = ['region' => 'us-east-1', 'key' => 'arn:aws:kms:us-east-1:123456789012:key/abcd1234-ab12-cd34-ef56-1234567890ab'];
-        $c         = new Configuration();
-        $c->setAutoEncryption([
-            'keyVaultNamespace' => 'encryption.__keyVault',
-            'kmsProviders' => [
-                'azure' => [
-                    'tenantId' => 'TENANT_ID',
-                    'clientId' => 'CLIENT_ID',
-                    'clientSecret' => 'CLIENT_SECRET',
-                ],
-                'aws' => [
-                    'accessKeyId' => 'AKIA',
-                    'secretAccessKey' => 'SECRET',
-                ],
-            ],
-            'kmsProvider' => 'aws',
-            'masterKey' => $masterKey,
-        ]);
+        $c = new Configuration();
+        $c->setKmsProvider(['name' => 'local', 'key' => '1234567890123456789012345678901234567890123456789012345678901234']);
+        $c->setAutoEncryption(['extraOptions' => ['mongocryptdURI' => 'mongodb://localhost:27020']]);
+        $c->setDefaultDB('default_database');
 
-        self::assertSame($masterKey, $c->getMasterKey());
-        self::assertSame('aws', $c->getKmsProvider());
-        self::assertArrayHasKey('kmsProviders', $c->getAutoEncryption());
+        self::assertSame('local', $c->getDefaultKmsProvider());
+        self::assertNull($c->getDefaultMasterKey());
+        self::assertEquals([
+            'kmsProviders' => [
+                'local' => ['key' => '1234567890123456789012345678901234567890123456789012345678901234'],
+            ],
+            'extraOptions' => ['mongocryptdURI' => 'mongodb://localhost:27020'],
+            // Default key vault namespace
+            'keyVaultNamespace' => 'default_database.datakeys',
+        ], $c->getDriverOptions()['autoEncryption']);
     }
 
-    public function testAutoEncryptionSingleKmsProvider(): void
+    public function testKmsProvider(): void
     {
-        $masterKey = ['region' => 'us-east-1', 'key' => 'arn:aws:kms:us-east-1:123456789012:key/abcd1234-ab12-cd34-ef56-1234567890ab'];
-        $c         = new Configuration();
-        $c->setAutoEncryption([
-            'keyVaultNamespace' => 'encryption.__keyVault',
-            'kmsProviders' => [
-                'aws' => [
-                    'accessKeyId' => 'AKIA',
-                    'secretAccessKey' => 'SECRET',
-                ],
-            ],
-            'masterKey' => $masterKey,
-        ]);
+        $c = new Configuration();
+        $c->setKmsProvider(['name' => 'aws', 'accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET']);
+        $c->setAutoEncryption(['keyVaultNamespace' => 'keyvault.datakeys']);
+        $c->setDefaultMasterKey($masterKey = ['region' => 'us-east-1', 'key' => 'arn:aws:kms:us-east-1:123456789012:key/abcd1234-ab12-cd34-ef56-1234567890ab']);
 
-        self::assertSame($masterKey, $c->getMasterKey());
-        self::assertSame('aws', $c->getKmsProvider());
-        self::assertArrayHasKey('kmsProviders', $c->getAutoEncryption());
+        self::assertSame('aws', $c->getDefaultKmsProvider());
+        self::assertSame($masterKey, $c->getDefaultMasterKey());
+        self::assertEquals([
+            'kmsProviders' => [
+                'aws' => ['accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET'],
+            ],
+            // Key vault namespace from the configuration
+            'keyVaultNamespace' => 'keyvault.datakeys',
+        ], $c->getDriverOptions()['autoEncryption']);
     }
 
-    public function testAutoEncryptionWithLocalKmsProvider(): void
+    public function testAutoEncryptionOptions(): void
     {
         $c = new Configuration();
         $c->setAutoEncryption([
-            'keyVaultNamespace' => 'encryption.__keyVault',
-            'kmsProviders' => [
-                'local' => [
-                    'key' => ['key' => '1234567890123456789012345678901234567890123456789012345678901234'],
-                ],
-            ],
+            'keyVaultClient' => $keyVaultClient = new Manager(),
+            'keyVaultNamespace' => 'keyvault.datakeys',
+            'extraOptions' => ['mongocryptdURI' => 'mongodb://localhost:27020'],
+            'tlsOptions' => ['tlsDisableOCSPEndpointCheck' => true],
         ]);
+        $c->setKmsProvider(['name' => 'local', 'key' => '1234567890123456789012345678901234567890123456789012345678901234']);
 
-        self::assertNull($c->getMasterKey());
-        self::assertSame('local', $c->getKmsProvider());
-        self::assertArrayHasKey('kmsProviders', $c->getAutoEncryption());
+        self::assertSame([
+            'kmsProviders' => [
+                'local' => ['key' => '1234567890123456789012345678901234567890123456789012345678901234'],
+            ],
+            'keyVaultNamespace' => 'keyvault.datakeys',
+            'keyVaultClient' => $keyVaultClient,
+            'extraOptions' => ['mongocryptdURI' => 'mongodb://localhost:27020'],
+            'tlsOptions' => ['tlsDisableOCSPEndpointCheck' => true],
+        ], $c->getDriverOptions()['autoEncryption']);
+
+        self::assertSame([
+            'kmsProviders' => [
+                'local' => ['key' => '1234567890123456789012345678901234567890123456789012345678901234'],
+            ],
+            'keyVaultNamespace' => 'keyvault.datakeys',
+            'keyVaultClient' => $keyVaultClient,
+            'tlsOptions' => ['tlsDisableOCSPEndpointCheck' => true],
+        ], $c->getClientEncryptionOptions());
     }
 
-    /** @phpstan-ignore missingType.iterableValue */
-    #[DataProvider('provideInvalidAutoEncryptionConfigurations')]
-    public function testAutoEncryptionMissingConfiguration(string $message, array $config): void
+    public function testMissingDefaultMasterKey(): void
+    {
+        $c = new Configuration();
+        $c->setKmsProvider(['name' => 'aws', 'accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET']);
+
+        self::expectException(ConfigurationException::class);
+        $c->getDefaultMasterKey();
+    }
+
+    public function testKmsProvidersIsForbiddenInAutoEncryptionOptions(): void
     {
         $c = new Configuration();
 
-        self::expectException(InvalidArgumentException::class);
-        self::expectExceptionMessage($message);
-
-        // @phpstan-ignore argument.type
-        $c->setAutoEncryption($config);
-    }
-
-    public function provideInvalidAutoEncryptionConfigurations(): Generator
-    {
-        yield [
-            'The "kmsProviders" encryption option is required and must be a non-empty.',
-            [
-                'keyVaultNamespace' => 'encryption.__keyVault',
-                'kmsProviders' => [],
-            ],
-        ];
-
-        yield [
-            'The "keyVaultNamespace" encryption option is required.',
-            [
-                'kmsProviders' => [
-                    'local' => ['key' => ['key' => '1234567890123456789012345678901234567890123456789012345678901234']],
-                ],
-            ],
-        ];
-
-        yield [
-            'The "masterKey" option is required when the KMS provider is not "local".',
-            [
-                'keyVaultNamespace' => 'encryption.__keyVault',
-                'kmsProviders' => [
-                    'aws' => ['accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET'],
-                ],
-            ],
-        ];
-
-        yield [
-            'The "kmsProvider" encryption option is required when multiple KMS providers are specified.',
-            [
-                'keyVaultNamespace' => 'encryption.__keyVault',
-                'kmsProviders' => [
-                    'aws' => ['accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET'],
-                    'azure' => ['tenantId' => 'TENANT_ID', 'clientId' => 'CLIENT_ID', 'clientSecret' => 'CLIENT_SECRET'],
-                ],
-            ],
-        ];
-
-        yield [
-            'The "kmsProvider" encryption option "azure" is not defined in the "kmsProviders" option.',
-            [
-                'keyVaultNamespace' => 'encryption.__keyVault',
-                'kmsProviders' => [
-                    'aws' => ['accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET'],
-                ],
-                'kmsProvider' => 'azure',
-            ],
-        ];
+        self::expectException(ConfigurationException::class);
+        $c->setAutoEncryption(['kmsProviders' => ['aws' => ['accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET']]]);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
@@ -7,6 +7,9 @@ namespace Doctrine\ODM\MongoDB\Tests;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionFactory;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionGenerator;
+use Generator;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ConfigurationTest extends BaseTestCase
 {
@@ -39,5 +42,134 @@ class ConfigurationTest extends BaseTestCase
 
         $c->setUseTransactionalFlush(false);
         self::assertFalse($c->isTransactionalFlushEnabled(), 'Transactional flush is disabled after setTransactionalFlush(false)');
+    }
+
+    public function testAutoEncryptionWithMultipleKmsProviders(): void
+    {
+        $masterKey = ['region' => 'us-east-1', 'key' => 'arn:aws:kms:us-east-1:123456789012:key/abcd1234-ab12-cd34-ef56-1234567890ab'];
+        $c         = new Configuration();
+        $c->setAutoEncryption([
+            'keyVaultNamespace' => 'encryption.__keyVault',
+            'kmsProviders' => [
+                'azure' => [
+                    'tenantId' => 'TENANT_ID',
+                    'clientId' => 'CLIENT_ID',
+                    'clientSecret' => 'CLIENT_SECRET',
+                ],
+                'aws' => [
+                    'accessKeyId' => 'AKIA',
+                    'secretAccessKey' => 'SECRET',
+                ],
+            ],
+            'kmsProvider' => 'aws',
+            'masterKey' => $masterKey,
+        ]);
+
+        self::assertSame($masterKey, $c->getMasterKey());
+        self::assertSame('aws', $c->getKmsProvider());
+        self::assertArrayHasKey('kmsProviders', $c->getAutoEncryption());
+    }
+
+    public function testAutoEncryptionSingleKmsProvider(): void
+    {
+        $masterKey = ['region' => 'us-east-1', 'key' => 'arn:aws:kms:us-east-1:123456789012:key/abcd1234-ab12-cd34-ef56-1234567890ab'];
+        $c         = new Configuration();
+        $c->setAutoEncryption([
+            'keyVaultNamespace' => 'encryption.__keyVault',
+            'kmsProviders' => [
+                'aws' => [
+                    'accessKeyId' => 'AKIA',
+                    'secretAccessKey' => 'SECRET',
+                ],
+            ],
+            'masterKey' => $masterKey,
+        ]);
+
+        self::assertSame($masterKey, $c->getMasterKey());
+        self::assertSame('aws', $c->getKmsProvider());
+        self::assertArrayHasKey('kmsProviders', $c->getAutoEncryption());
+    }
+
+    public function testAutoEncryptionWithLocalKmsProvider(): void
+    {
+        $c = new Configuration();
+        $c->setAutoEncryption([
+            'keyVaultNamespace' => 'encryption.__keyVault',
+            'kmsProviders' => [
+                'local' => [
+                    'key' => ['key' => '1234567890123456789012345678901234567890123456789012345678901234'],
+                ],
+            ],
+        ]);
+
+        self::assertNull($c->getMasterKey());
+        self::assertSame('local', $c->getKmsProvider());
+        self::assertArrayHasKey('kmsProviders', $c->getAutoEncryption());
+    }
+
+    /** @phpstan-ignore missingType.iterableValue */
+    #[DataProvider('provideInvalidAutoEncryptionConfigurations')]
+    public function testAutoEncryptionMissingConfiguration(string $message, array $config): void
+    {
+        $c = new Configuration();
+
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage($message);
+
+        // @phpstan-ignore argument.type
+        $c->setAutoEncryption($config);
+    }
+
+    public function provideInvalidAutoEncryptionConfigurations(): Generator
+    {
+        yield [
+            'The "kmsProviders" encryption option is required and must be a non-empty.',
+            [
+                'keyVaultNamespace' => 'encryption.__keyVault',
+                'kmsProviders' => [],
+            ],
+        ];
+
+        yield [
+            'The "keyVaultNamespace" encryption option is required.',
+            [
+                'kmsProviders' => [
+                    'local' => [
+                        'key' => ['key' => '1234567890123456789012345678901234567890123456789012345678901234'],
+                    ],
+                ],
+            ],
+        ];
+
+        yield [
+            'The "masterKey" option is required when the KMS provider is not "local".',
+            [
+                'keyVaultNamespace' => 'encryption.__keyVault',
+                'kmsProviders' => [
+                    'aws' => [
+                        'accessKeyId' => 'AKIA',
+                        'secretAccessKey' => 'SECRET',
+                    ],
+                ],
+            ],
+        ];
+
+        yield [
+            'The "kmsProvider" encryption option is required when multiple KMS providers are specified.',
+            [
+                'keyVaultNamespace' => 'encryption.__keyVault',
+                'kmsProviders' => [
+                    'aws' => [
+                        'accessKeyId' => 'AKIA',
+                        'secretAccessKey' => 'SECRET',
+                    ],
+                    'azure' => [
+                        'tenantId' => 'TENANT_ID',
+                        'clientId' => 'CLIENT_ID',
+                        'clientSecret' => 'CLIENT_SECRET',
+                    ],
+                ],
+            ],
+        ];
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
@@ -134,9 +134,7 @@ class ConfigurationTest extends BaseTestCase
             'The "keyVaultNamespace" encryption option is required.',
             [
                 'kmsProviders' => [
-                    'local' => [
-                        'key' => ['key' => '1234567890123456789012345678901234567890123456789012345678901234'],
-                    ],
+                    'local' => ['key' => ['key' => '1234567890123456789012345678901234567890123456789012345678901234']],
                 ],
             ],
         ];
@@ -146,10 +144,7 @@ class ConfigurationTest extends BaseTestCase
             [
                 'keyVaultNamespace' => 'encryption.__keyVault',
                 'kmsProviders' => [
-                    'aws' => [
-                        'accessKeyId' => 'AKIA',
-                        'secretAccessKey' => 'SECRET',
-                    ],
+                    'aws' => ['accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET'],
                 ],
             ],
         ];
@@ -159,16 +154,20 @@ class ConfigurationTest extends BaseTestCase
             [
                 'keyVaultNamespace' => 'encryption.__keyVault',
                 'kmsProviders' => [
-                    'aws' => [
-                        'accessKeyId' => 'AKIA',
-                        'secretAccessKey' => 'SECRET',
-                    ],
-                    'azure' => [
-                        'tenantId' => 'TENANT_ID',
-                        'clientId' => 'CLIENT_ID',
-                        'clientSecret' => 'CLIENT_SECRET',
-                    ],
+                    'aws' => ['accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET'],
+                    'azure' => ['tenantId' => 'TENANT_ID', 'clientId' => 'CLIENT_ID', 'clientSecret' => 'CLIENT_SECRET'],
                 ],
+            ],
+        ];
+
+        yield [
+            'The "kmsProvider" encryption option "azure" is not defined in the "kmsProviders" option.',
+            [
+                'keyVaultNamespace' => 'encryption.__keyVault',
+                'kmsProviders' => [
+                    'aws' => ['accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET'],
+                ],
+                'kmsProvider' => 'azure',
             ],
         ];
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
@@ -118,6 +118,7 @@ class ConfigurationTest extends TestCase
         $c->setKmsProvider(['name' => 'aws', 'accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET']);
 
         self::expectException(ConfigurationException::class);
+        self::expectExceptionMessage('The "masterKey" configuration is required for the KMS provider "aws".');
         $c->getDefaultMasterKey();
     }
 
@@ -126,6 +127,35 @@ class ConfigurationTest extends TestCase
         $c = new Configuration();
 
         self::expectException(ConfigurationException::class);
+        self::expectExceptionMessage('The "kmsProviders" encryption option must be set using the "setKmsProvider()" method.');
         $c->setAutoEncryption(['kmsProviders' => ['aws' => ['accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET']]]);
+    }
+
+    public function testClientEncryptionOptionsNotSet(): void
+    {
+        $c = new Configuration();
+        self::expectException(ConfigurationException::class);
+        self::expectExceptionMessage('MongoDB client encryption options are not set in configuration');
+        $c->getClientEncryptionOptions();
+    }
+
+    public function testKmsProviderNameRequired(): void
+    {
+        $c = new Configuration();
+        self::expectException(ConfigurationException::class);
+        self::expectExceptionMessage('The KMS provider "name" is required.');
+
+        // @phpstan-ignore argument.type
+        $c->setKmsProvider(['foo' => 'bar']);
+    }
+
+    public function testKmsProviderNameMustBeString(): void
+    {
+        $c = new Configuration();
+        self::expectException(ConfigurationException::class);
+        self::expectExceptionMessage('The KMS provider "name" must be a non-empty string.');
+
+        // @phpstan-ignore argument.type
+        $c->setKmsProvider(['name' => ['not', 'a', 'string']]);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
@@ -47,7 +47,7 @@ class ConfigurationTest extends TestCase
     public function testLocalKmsProvider(): void
     {
         $c = new Configuration();
-        $c->setKmsProvider(['name' => 'local', 'key' => '1234567890123456789012345678901234567890123456789012345678901234']);
+        $c->setKmsProvider(['type' => 'local', 'key' => '1234567890123456789012345678901234567890123456789012345678901234']);
         $c->setAutoEncryption(['extraOptions' => ['mongocryptdURI' => 'mongodb://localhost:27020']]);
         $c->setDefaultDB('default_database');
 
@@ -66,7 +66,7 @@ class ConfigurationTest extends TestCase
     public function testKmsProvider(): void
     {
         $c = new Configuration();
-        $c->setKmsProvider(['name' => 'aws', 'accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET']);
+        $c->setKmsProvider(['type' => 'aws', 'accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET']);
         $c->setAutoEncryption(['keyVaultNamespace' => 'keyvault.datakeys']);
         $c->setDefaultMasterKey($masterKey = ['region' => 'us-east-1', 'key' => 'arn:aws:kms:us-east-1:123456789012:key/abcd1234-ab12-cd34-ef56-1234567890ab']);
 
@@ -90,7 +90,7 @@ class ConfigurationTest extends TestCase
             'extraOptions' => ['mongocryptdURI' => 'mongodb://localhost:27020'],
             'tlsOptions' => ['tlsDisableOCSPEndpointCheck' => true],
         ]);
-        $c->setKmsProvider(['name' => 'local', 'key' => '1234567890123456789012345678901234567890123456789012345678901234']);
+        $c->setKmsProvider(['type' => 'local', 'key' => '1234567890123456789012345678901234567890123456789012345678901234']);
 
         self::assertSame([
             'kmsProviders' => [
@@ -115,7 +115,7 @@ class ConfigurationTest extends TestCase
     public function testMissingDefaultMasterKey(): void
     {
         $c = new Configuration();
-        $c->setKmsProvider(['name' => 'aws', 'accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET']);
+        $c->setKmsProvider(['type' => 'aws', 'accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET']);
 
         self::expectException(ConfigurationException::class);
         self::expectExceptionMessage('The "masterKey" configuration is required for the KMS provider "aws".');
@@ -139,23 +139,23 @@ class ConfigurationTest extends TestCase
         $c->getClientEncryptionOptions();
     }
 
-    public function testKmsProviderNameRequired(): void
+    public function testKmsProviderTypeRequired(): void
     {
         $c = new Configuration();
         self::expectException(ConfigurationException::class);
-        self::expectExceptionMessage('The KMS provider "name" is required.');
+        self::expectExceptionMessage('The KMS provider "type" is required.');
 
         // @phpstan-ignore argument.type
         $c->setKmsProvider(['foo' => 'bar']);
     }
 
-    public function testKmsProviderNameMustBeString(): void
+    public function testKmsProviderTypeMustBeString(): void
     {
         $c = new Configuration();
         self::expectException(ConfigurationException::class);
-        self::expectExceptionMessage('The KMS provider "name" must be a non-empty string.');
+        self::expectExceptionMessage('The KMS provider "type" must be a non-empty string.');
 
         // @phpstan-ignore argument.type
-        $c->setKmsProvider(['name' => ['not', 'a', 'string']]);
+        $c->setKmsProvider(['type' => ['not', 'a', 'string']]);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryableEncryptionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryableEncryptionTest.php
@@ -87,7 +87,7 @@ class QueryableEncryptionTest extends BaseTestCase
         $config = static::getConfiguration();
         $config->setDefaultDB(DOCTRINE_MONGODB_DATABASE);
         $config->setKmsProvider([
-            'name' => 'local',
+            'type' => 'local',
             'key' => new Binary(random_bytes(96)),
         ]);
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryableEncryptionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryableEncryptionTest.php
@@ -85,11 +85,10 @@ class QueryableEncryptionTest extends BaseTestCase
     protected static function createTestDocumentManager(): DocumentManager
     {
         $config = static::getConfiguration();
-        $config->setAutoEncryption([
-            'keyVaultNamespace' => DOCTRINE_MONGODB_DATABASE . '.datakeys',
-            'kmsProviders' => [
-                'local' => ['key' => new Binary(random_bytes(96))],
-            ],
+        $config->setDefaultDB(DOCTRINE_MONGODB_DATABASE);
+        $config->setKmsProvider([
+            'name' => 'local',
+            'key' => new Binary(random_bytes(96)),
         ]);
 
         $client = new Client(self::getUri(), [], $config->getDriverOptions());

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryableEncryptionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryableEncryptionTest.php
@@ -92,7 +92,7 @@ class QueryableEncryptionTest extends BaseTestCase
             ],
         ]);
 
-        $client = new Client(self::getUri(), [], ['autoEncryption' => $config->getAutoEncryption()]);
+        $client = new Client(self::getUri(), [], $config->getDriverOptions());
 
         return DocumentManager::create($client, $config);
     }


### PR DESCRIPTION
The master key is required for all KMS exception "local" ([doc](https://www.mongodb.com/docs/php-library/current/reference/method/MongoDBDatabase-createEncryptedCollection/#parameters)).

The `masterKey` and `kmsProvider` configurations as set independently from the other `autoEncryption` options so that we can validate and transform them.
A single `kmsProvider` is allowed, and used as default when an encrypted collection is created.