### PR TITLE
[Encryption] Drop metadata collection when dropping encrypted collection

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -699,6 +699,14 @@ final class SchemaManager
 
         $options = $this->getWriteOptions($maxTimeMs, $writeConcern);
 
+        // When automatic encryption is enabled, we need to drop the metadata collections,
+        // we don't check if the class metadata has encrypted fields, because
+        // that does not mean that the existing collection is encrypted or not.
+        // "esc" and "ecoc" collections cannot be configured
+        if ($this->dm->getConfiguration()->getKmsProvider()) {
+            $options['encryptedFields'] = [];
+        }
+
         $this->dm->getDocumentCollection($documentName)->drop($options);
 
         if (! $class->isFile) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1687,6 +1687,12 @@ parameters:
 			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryableEncryptionTest.php
 
 		-
+			message: '#^Parameter \#1 \$value of function count expects array\|Countable, Iterator\<int, string\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryableEncryptionTest.php
+
+		-
 			message: '#^Parameter \$discriminatorMap of attribute class Doctrine\\ODM\\MongoDB\\Mapping\\Annotations\\ReferenceOne constructor expects array\<string, class\-string\>\|null, array\<string, string\> given\.$#'
 			identifier: argument.type
 			count: 1

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryableEncryptionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryableEncryptionTest.php
@@ -13,6 +13,7 @@ use MongoDB\BSON\Binary;
 use MongoDB\Client;
 use MongoDB\Model\BSONDocument;
 
+use function count;
 use function iterator_to_array;
 use function random_bytes;
 
@@ -80,6 +81,13 @@ class QueryableEncryptionTest extends BaseTestCase
         self::assertSame('Jon Doe', $result->patientName);
         self::assertSame('987-65-4320', $result->patientRecord->ssn);
         self::assertSame('4111111111111111', $result->patientRecord->billing->number);
+
+        // Drop the encrypted collection
+        $collectionCount = count($nonEncryptedDatabase->listCollectionNames());
+        $this->dm->getSchemaManager()->dropDocumentCollection(Patient::class);
+        $collectionNames = iterator_to_array($nonEncryptedDatabase->listCollectionNames());
+        self::assertNotContains('patients', $collectionNames);
+        self::assertSame($collectionCount - 3, count($collectionNames), 'The 2 metadata collections should also be dropped');
     }
 
     protected static function createTestDocumentManager(): DocumentManager


### PR DESCRIPTION
The option `encryptedFields` is required to trigger the deletion of metadata collections using the [`DropEncryptedCollection` operation](https://github.com/mongodb/mongo-php-library/blob/37440db813ad41e060a166a80088684d443b3403/src/Collection.php#L519-L521).

We don't support [custom `esc` and `ecoc` collection names](https://github.com/mongodb/mongo-php-library/blob/37440db813ad41e060a166a80088684d443b3403/src/Operation/DropEncryptedCollection.php#L76-L79). Therefore the array can be empty.

I chose to systematically try to delete metadata collections when autoencryption is enabled; not knowing if the collection was created encrypted and then the encrypted fields deleted from the metadata.