### PR TITLE
[Encryption] Fix `getDefaultKmsProvider` method name

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -703,7 +703,7 @@ final class SchemaManager
         // we don't check if the class metadata has encrypted fields, because
         // that does not mean that the existing collection is encrypted or not.
         // "esc" and "ecoc" collections cannot be configured
-        if ($this->dm->getConfiguration()->getKmsProvider()) {
+        if ($this->dm->getConfiguration()->getDefaultKmsProvider()) {
             $options['encryptedFields'] = [];
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

- Part of feature https://github.com/doctrine/mongodb-odm/pull/2779

The method was renamed in https://github.com/doctrine/mongodb-odm/pull/2780