### PR TITLE
Add `Type::getBSONType()`

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Types/BinDataType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/BinDataType.php
@@ -22,6 +22,11 @@ class BinDataType extends Type
      */
     protected $binDataType = Binary::TYPE_GENERIC;
 
+    public function getBSONType(): BsonType
+    {
+        return BsonType::BinaryData;
+    }
+
     public function convertToDatabaseValue($value)
     {
         if ($value === null) {

--- a/lib/Doctrine/ODM/MongoDB/Types/BooleanType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/BooleanType.php
@@ -9,6 +9,11 @@ namespace Doctrine\ODM\MongoDB\Types;
  */
 class BooleanType extends Type
 {
+    public function getBSONType(): BsonType
+    {
+        return BsonType::Boolean;
+    }
+
     public function convertToDatabaseValue($value)
     {
         return $value !== null ? (bool) $value : null;

--- a/lib/Doctrine/ODM/MongoDB/Types/BsonType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/BsonType.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Types;
+
+enum BsonType: string
+{
+    case Double            = 'double';
+    case String            = 'string';
+    case Object            = 'object';
+    case Array             = 'array';
+    case BinaryData        = 'binData';
+    case ObjectId          = 'objectId';
+    case Boolean           = 'bool';
+    case Date              = 'date';
+    case Null              = 'null';
+    case RegularExpression = 'regex';
+    case JavaScript        = 'javascript';
+    case Int32             = 'int';
+    case Timestamp         = 'timestamp';
+    case Int64             = 'long';
+    case Decimal128        = 'decimal';
+    case MinKey            = 'minKey';
+    case MaxKey            = 'maxKey';
+}

--- a/lib/Doctrine/ODM/MongoDB/Types/CollectionType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/CollectionType.php
@@ -14,6 +14,11 @@ use function is_array;
  */
 class CollectionType extends Type
 {
+    public function getBSONType(): BsonType
+    {
+        return BsonType::Array;
+    }
+
     public function convertToDatabaseValue($value)
     {
         if ($value !== null && ! is_array($value)) {

--- a/lib/Doctrine/ODM/MongoDB/Types/CustomIdType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/CustomIdType.php
@@ -4,11 +4,20 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Types;
 
+use LogicException;
+
+use function sprintf;
+
 /**
  * The Id type.
  */
 class CustomIdType extends Type
 {
+    public function getBSONType(): BsonType
+    {
+        throw new LogicException(sprintf('Cannot determine BSON type for "%s".', self::class));
+    }
+
     public function convertToDatabaseValue($value)
     {
         return $value;

--- a/lib/Doctrine/ODM/MongoDB/Types/DateType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/DateType.php
@@ -28,6 +28,11 @@ use const STR_PAD_LEFT;
  */
 class DateType extends Type implements Versionable
 {
+    public function getBSONType(): BsonType
+    {
+        return BsonType::Date;
+    }
+
     /**
      * Converts a value to a DateTime.
      * Supports microseconds

--- a/lib/Doctrine/ODM/MongoDB/Types/Decimal128Type.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/Decimal128Type.php
@@ -13,6 +13,11 @@ class Decimal128Type extends Type implements Incrementable, Versionable
 {
     use ClosureToPHP;
 
+    public function getBSONType(): BsonType
+    {
+        return BsonType::Decimal128;
+    }
+
     public function convertToDatabaseValue($value)
     {
         if ($value === null) {

--- a/lib/Doctrine/ODM/MongoDB/Types/FloatType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/FloatType.php
@@ -9,6 +9,11 @@ namespace Doctrine\ODM\MongoDB\Types;
  */
 class FloatType extends Type implements Incrementable
 {
+    public function getBSONType(): BsonType
+    {
+        return BsonType::Double;
+    }
+
     public function convertToDatabaseValue($value)
     {
         return $value !== null ? (float) $value : null;

--- a/lib/Doctrine/ODM/MongoDB/Types/HashType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/HashType.php
@@ -13,6 +13,11 @@ use function is_array;
  */
 class HashType extends Type
 {
+    public function getBSONType(): BsonType
+    {
+        return BsonType::Object;
+    }
+
     public function convertToDatabaseValue($value)
     {
         if ($value !== null && ! is_array($value)) {

--- a/lib/Doctrine/ODM/MongoDB/Types/IdType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/IdType.php
@@ -12,6 +12,11 @@ use MongoDB\Driver\Exception\InvalidArgumentException;
  */
 class IdType extends Type
 {
+    public function getBSONType(): BsonType
+    {
+        return BsonType::ObjectId;
+    }
+
     public function convertToDatabaseValue($value)
     {
         if ($value === null) {

--- a/lib/Doctrine/ODM/MongoDB/Types/IntType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/IntType.php
@@ -11,6 +11,11 @@ use function max;
  */
 class IntType extends Type implements Incrementable, Versionable
 {
+    public function getBSONType(): BsonType
+    {
+        return BsonType::Int32;
+    }
+
     public function convertToDatabaseValue($value)
     {
         return $value !== null ? (int) $value : null;

--- a/lib/Doctrine/ODM/MongoDB/Types/KeyType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/KeyType.php
@@ -4,14 +4,22 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Types;
 
+use LogicException;
 use MongoDB\BSON\MaxKey;
 use MongoDB\BSON\MinKey;
+
+use function sprintf;
 
 /**
  * The Key type.
  */
 class KeyType extends Type
 {
+    public function getBSONType(): BsonType
+    {
+        throw new LogicException(sprintf('Cannot determine BSON type for "%s".', self::class));
+    }
+
     public function convertToDatabaseValue($value)
     {
         if ($value === null) {

--- a/lib/Doctrine/ODM/MongoDB/Types/ObjectIdType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/ObjectIdType.php
@@ -11,6 +11,11 @@ use MongoDB\BSON\ObjectId;
  */
 class ObjectIdType extends Type
 {
+    public function getBSONType(): BsonType
+    {
+        return BsonType::ObjectId;
+    }
+
     public function convertToDatabaseValue($value)
     {
         if ($value === null) {

--- a/lib/Doctrine/ODM/MongoDB/Types/RawType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/RawType.php
@@ -4,11 +4,20 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Types;
 
+use LogicException;
+
+use function sprintf;
+
 /**
  * Raw data type.
  */
 class RawType extends Type
 {
+    public function getBSONType(): BsonType
+    {
+        throw new LogicException(sprintf('Cannot determine BSON type for "%s".', self::class));
+    }
+
     public function convertToDatabaseValue($value)
     {
         return $value;

--- a/lib/Doctrine/ODM/MongoDB/Types/StringType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/StringType.php
@@ -11,6 +11,11 @@ use MongoDB\BSON\Regex;
  */
 class StringType extends Type
 {
+    public function getBSONType(): BsonType
+    {
+        return BsonType::String;
+    }
+
     public function convertToDatabaseValue($value)
     {
         return $value === null || $value instanceof Regex ? $value : (string) $value;

--- a/lib/Doctrine/ODM/MongoDB/Types/TimestampType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/TimestampType.php
@@ -14,6 +14,11 @@ use function substr;
  */
 class TimestampType extends Type
 {
+    public function getBSONType(): BsonType
+    {
+        return BsonType::Timestamp;
+    }
+
     public function convertToDatabaseValue($value)
     {
         if ($value instanceof Timestamp) {

--- a/lib/Doctrine/ODM/MongoDB/Types/Type.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/Type.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Types;
 
+use BadMethodCallException;
 use DateTimeInterface;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Types;
@@ -89,6 +90,17 @@ abstract class Type
     /** Prevent instantiation and force use of the factory method. */
     final private function __construct()
     {
+    }
+
+    /**
+     * Returns the alias name of the BSON type.
+     *
+     * @link https://www.mongodb.com/docs/manual/reference/bson-types/
+     */
+    public function getBSONType(): BsonType
+    {
+        // This method will be abstract in the next major version.
+        throw new BadMethodCallException(sprintf('The method "%s::getBSONType" is not implemented. You must implement this method in the concrete type class.', static::class));
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | [PHPORM-358](https://jira.mongodb.org/browse/PHPORM-358)

#### Summary

While working on `encryptedFieldsMap` (https://github.com/doctrine/mongodb-odm/pull/2785#discussion_r2163749423), we found that it would be useful if every ODM Type could indicate its [BSON type](https://www.mongodb.com/docs/manual/reference/bson-types/).

It's possible to assign 1 BSON type for most of the ODM types, but there are some exception with some ODM types that can return multiple BSON types (see comments).
