### PR TITLE
PHPORM-356: Skip search indexes not enabled exception

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -47,6 +47,7 @@ final class SchemaManager
 
     private const CODE_SHARDING_ALREADY_INITIALIZED = 23;
     private const CODE_COMMAND_NOT_SUPPORTED        = 115;
+    private const CODE_SEARCH_NOT_ENABLED           = 31082;
 
     private const ALLOWED_MISSING_INDEX_OPTIONS = [
         'background',
@@ -1079,6 +1080,11 @@ final class SchemaManager
 
     private function isSearchIndexCommandException(CommandException $e): bool
     {
+        // MongoDB 8.0+: "Using Atlas Search Database Commands and the $listSearchIndexes aggregation stage requires additional configuration."
+        if ($e->getCode() === self::CODE_SEARCH_NOT_ENABLED) {
+            return true;
+        }
+
         // MongoDB 6.0.7+ and 7.0+: "Search indexes are only available on Atlas"
         if ($e->getCode() === self::CODE_COMMAND_NOT_SUPPORTED && str_contains($e->getMessage(), 'Search index')) {
             return true;
@@ -1090,7 +1096,7 @@ final class SchemaManager
         }
 
         // Older server versions don't support $listSearchIndexes
-        // We don't check for an error code here as the code is not documented and we can't rely on it
+        // We don't check for an error code here as the code is not documented, and we can't rely on it
         return str_contains($e->getMessage(), 'Unrecognized pipeline stage name: \'$listSearchIndexes\'');
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -492,6 +492,25 @@ class SchemaManagerTest extends BaseTestCase
         $this->schemaManager->updateDocumentSearchIndexes(CmsProduct::class);
     }
 
+    public function testUpdateDocumentWhenSearchNotEnabled(): void
+    {
+        // Class has no search indexes, so if the server doesn't support them we assume everything is fine
+        $collectionName = $this->dm->getClassMetadata(CmsProduct::class)->getCollection();
+        $collection     = $this->documentCollections[$collectionName];
+        $collection
+            ->expects($this->once())
+            ->method('listSearchIndexes')
+            ->willThrowException($this->createSearchNotEnabledCommandException());
+        $collection
+            ->expects($this->never())
+            ->method('dropSearchIndex');
+        $collection
+            ->expects($this->never())
+            ->method('updateSearchIndex');
+
+        $this->schemaManager->updateDocumentSearchIndexes(CmsProduct::class);
+    }
+
     public function testUpdateDocumentSearchIndexesNotSupportedForClassWithoutSearchIndexesOnOlderServers(): void
     {
         // Class has no search indexes, so if the server doesn't support them we assume everything is fine
@@ -1373,6 +1392,11 @@ EOT;
     private function createSearchIndexCommandException(): CommandException
     {
         return new CommandException('PlanExecutor error during aggregation :: caused by :: Search index commands are only supported with Atlas.', 115);
+    }
+
+    private function createSearchNotEnabledCommandException(): CommandException
+    {
+        return new CommandException('Using Atlas Search Database Commands and the $listSearchIndexes aggregation stage requires additional configuration.', 31082);
     }
 
     private function createSearchIndexCommandExceptionForOlderServers(): CommandException


### PR DESCRIPTION
If search indexes are not enabled on the server, we should simply skip any search index operation. This commit adds an error code to the search index error check already in place.

Closes PHPORM-356