### PR TITLE
[Encryption] Remove `encryptedFields` option when dropping collection

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -699,14 +699,6 @@ final class SchemaManager
 
         $options = $this->getWriteOptions($maxTimeMs, $writeConcern);
 
-        // When automatic encryption is enabled, we need to drop the metadata collections,
-        // we don't check if the class metadata has encrypted fields, because
-        // that does not mean that the existing collection is encrypted or not.
-        // "esc" and "ecoc" collections cannot be configured
-        if ($this->dm->getConfiguration()->getDefaultKmsProvider()) {
-            $options['encryptedFields'] = [];
-        }
-
         $this->dm->getDocumentCollection($documentName)->drop($options);
 
         if (! $class->isFile) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

#### Summary

No need to do ["best-guess effort"](https://github.com/doctrine/mongodb-odm/pull/2781#discussion_r2149278848): 
The driver already detects encrypted collections: https://github.com/mongodb/mongo-php-library/blob/0058bc008028d91f5f9e032e80daa094b31ef9a9/src/Collection.php#L514-L517

