### PR TITLE
Symfony 8.0 support

### DIFF
--- a/.github/workflows/atlas-ci.yml
+++ b/.github/workflows/atlas-ci.yml
@@ -18,8 +18,13 @@ jobs:
         symfony:
           - "stable"
         proxy:
-          - "lazy-ghost"
+          - "native"
         include:
+          # Test with LazyGhostObject
+          - php-version: "8.2"
+            symfony: "7.4"
+            proxy: "lazy-ghost"
+            os: "ubuntu-latest"
           # Test with ProxyManager
           - php-version: "8.1"
             symfony: "6.4"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,7 +34,7 @@ jobs:
         dependencies:
           - "highest"
         symfony-version:
-          - "stable"
+          - "locked"
         proxy:
           - "lazy-ghost"
         include:
@@ -44,7 +44,7 @@ jobs:
             mongodb-version: "6.0"
             driver-version: "1.21.0"
             topology: "server"
-            symfony-version: "stable"
+            symfony-version: "locked"
             proxy: "lazy-ghost"
           # Test with Symfony 6.4
           - topology: "server"
@@ -60,7 +60,7 @@ jobs:
             mongodb-version: "6.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: "stable"
+            symfony-version: "locked"
             proxy: "lazy-ghost"
           # Test with a 8.0 replica set
           - topology: "replica_set"
@@ -68,21 +68,21 @@ jobs:
             mongodb-version: "8.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: "stable"
+            symfony-version: "locked"
             proxy: "lazy-ghost"
           # Test with ProxyManager
           - php-version: "8.2"
             mongodb-version: "6.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: "stable"
+            symfony-version: "locked"
             proxy: "proxy-manager"
           # Test with Native Lazy Objects
           - php-version: "8.4"
             mongodb-version: "8.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: "stable"
+            symfony-version: "locked"
             proxy: "native"
           # Test with extension 1.21
           - topology: "server"
@@ -90,9 +90,9 @@ jobs:
             mongodb-version: "8.0"
             driver-version: "1.21.0"
             dependencies: "highest"
-            symfony-version: "stable"
+            symfony-version: "locked"
             proxy: "lazy-ghost"
-          # Test with upcoming Symfony 7.4
+          # Test with Symfony 7.4 LTS
           - topology: "server"
             php-version: "8.2"
             mongodb-version: "8.0"
@@ -100,13 +100,13 @@ jobs:
             dependencies: "highest"
             symfony-version: "7.4"
             proxy: "lazy-ghost"
-          # Test with upcoming Symfony 8.0
+          # Test with Symfony 8
           - topology: "server"
             php-version: "8.4"
             mongodb-version: "8.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: "8.0"
+            symfony-version: false
             proxy: "native"
           # Test with a sharded cluster
           # Currently disabled due to a bug where MongoDB reports "sharding status unknown"
@@ -115,7 +115,7 @@ jobs:
 #            mongodb-version: "6.0"
 #            driver-version: "stable"
 #            dependencies: "highest"
-#            symfony-version: "stable"
+#            symfony-version: "locked"
 #            proxy: "lazy-ghost"
 
     steps:
@@ -150,28 +150,17 @@ jobs:
       - name: "Show driver information"
         run: "php --ri mongodb"
 
-      # Not used, skip transient dependencies
+      # Not used for tests, skip transient dependencies
       - name: "Remove phpbench/phpbench"
         run: composer remove --no-update --dev phpbench/phpbench
-
-      - name: "Configure Symfony ${{ matrix.symfony-version }}"
-        if: "${{ matrix.symfony-version != 'stable' }}"
-        run: |
-          composer config minimum-stability dev
-          # update symfony deps
-          composer require --no-update symfony/console:^${{ matrix.symfony-version }}
-          composer require --no-update symfony/var-dumper:^${{ matrix.symfony-version }}
-          composer require --no-update --dev symfony/cache:^${{ matrix.symfony-version }}
-          if dpkg --compare-versions "${{ matrix.symfony-version }}" lt "8.0"; then
-            # LazyGhostTrait was removed from symfony/var-exporter >= 8.0
-            composer require --dev symfony/var-exporter:^${{ matrix.symfony-version }}
-          fi
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
           composer-options: "--prefer-dist"
+        env:
+          SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
 
       - name: "Install latest Python version"
         uses: actions/setup-python@v6

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -92,6 +92,22 @@ jobs:
             dependencies: "highest"
             symfony-version: "stable"
             proxy: "lazy-ghost"
+          # Test with upcoming Symfony 7.4
+          - topology: "server"
+            php-version: "8.2"
+            mongodb-version: "8.0"
+            driver-version: "stable"
+            dependencies: "highest"
+            symfony-version: "7.4"
+            proxy: "lazy-ghost"
+          # Test with upcoming Symfony 8.0
+          - topology: "server"
+            php-version: "8.4"
+            mongodb-version: "8.0"
+            driver-version: "stable"
+            dependencies: "highest"
+            symfony-version: "8.0"
+            proxy: "native"
           # Test with a sharded cluster
           # Currently disabled due to a bug where MongoDB reports "sharding status unknown"
 #          - topology: "sharded_cluster"
@@ -127,7 +143,6 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: "pecl"
           extensions: "mongodb-${{ matrix.driver-version }}, bcmath"
           coverage: "none"
           ini-values: "zend.assertions=1"
@@ -147,6 +162,10 @@ jobs:
           composer require --no-update symfony/console:^${{ matrix.symfony-version }}
           composer require --no-update symfony/var-dumper:^${{ matrix.symfony-version }}
           composer require --no-update --dev symfony/cache:^${{ matrix.symfony-version }}
+          if dpkg --compare-versions "${{ matrix.symfony-version }}" lt "8.0"; then
+            # LazyGhostTrait was removed from symfony/var-exporter >= 8.0
+            composer require --dev symfony/var-exporter:^${{ matrix.symfony-version }}
+          fi
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"

--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,10 @@
         "jean85/pretty-package-versions": "^1.3.0 || ^2.0.1",
         "mongodb/mongodb": "^1.21.2 || ^2.1.1",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
-        "symfony/console": "^5.4 || ^6.0 || ^7.0",
+        "symfony/console": "^5.4 || ^6.4 || ^7.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0",
-        "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0",
-        "symfony/var-exporter": "^6.2 || ^7.0"
+        "symfony/var-dumper": "^5.4 || ^6.4 || ^7.0",
+        "symfony/var-exporter": "^6.4 || ^7.0"
     },
     "require-dev": {
         "ext-bcmath": "*",
@@ -52,8 +52,8 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^10.5.58",
         "squizlabs/php_codesniffer": "^4",
-        "symfony/cache": "^5.4 || ^6.0 || ^7.0",
-        "symfony/uid": "^5.4 || ^6.0 || ^7.0"
+        "symfony/cache": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/uid": "^5.4 || ^6.0 || ^7.0 || ^8.0"
     },
     "conflict": {
         "doctrine/annotations": "<1.12 || >=3.0"

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,8 @@
         "mapping",
         "object"
     ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "homepage": "https://www.doctrine-project.org/projects/mongodb-odm.html",
     "license": "MIT",
     "authors": [
@@ -35,9 +37,9 @@
         "jean85/pretty-package-versions": "^1.3.0 || ^2.0.1",
         "mongodb/mongodb": "^1.21.2 || ^2.1.1",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
-        "symfony/console": "^5.4 || ^6.4 || ^7.0",
+        "symfony/console": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0",
-        "symfony/var-dumper": "^5.4 || ^6.4 || ^7.0",
+        "symfony/var-dumper": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/var-exporter": "^6.4 || ^7.0"
     },
     "require-dev": {

--- a/docs/en/reference/console-commands.rst
+++ b/docs/en/reference/console-commands.rst
@@ -1,7 +1,7 @@
 Console Commands
 ================
 
-Doctrine MongoDB ODM offers some console commands, which utilize Symfony2's
+Doctrine MongoDB ODM offers some console commands, which utilize Symfony's
 Console component, to ease your development process:
 
 - ``odm:clear-cache:metadata`` - Clear all metadata cache of the various cache drivers.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -68,6 +68,7 @@
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>src/Mapping/Driver/CompatibilityAnnotationDriver.php</exclude-pattern>
         <exclude-pattern>src/Tools/Console/Command/CommandCompatibility.php</exclude-pattern>
+        <exclude-pattern>src/Tools/Console/Command/Schema/AbstractCommandCompatibility.php</exclude-pattern>
         <exclude-pattern>src/Tools/Console/Helper/DocumentManagerHelper.php</exclude-pattern>
         <exclude-pattern>tests/*</exclude-pattern>
     </rule>

--- a/src/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/src/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -22,8 +22,7 @@ class MetadataCommand extends Command
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this
         ->setName('odm:clear-cache:metadata')

--- a/src/Tools/Console/Command/CommandCompatibility.php
+++ b/src/Tools/Console/Command/CommandCompatibility.php
@@ -9,10 +9,32 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-if ((new ReflectionMethod(Command::class, 'execute'))->hasReturnType()) {
+// Symfony 8
+if ((new ReflectionMethod(Command::class, 'configure'))->hasReturnType()) {
     /** @internal */
     trait CommandCompatibility
     {
+        protected function configure(): void
+        {
+            $this->doConfigure();
+        }
+
+        protected function execute(InputInterface $input, OutputInterface $output): int
+        {
+            return $this->doExecute($input, $output);
+        }
+    }
+// Symfony 7
+} elseif ((new ReflectionMethod(Command::class, 'execute'))->hasReturnType()) {
+    /** @internal */
+    trait CommandCompatibility
+    {
+        /** @return void */
+        protected function configure()
+        {
+            $this->doConfigure();
+        }
+
         protected function execute(InputInterface $input, OutputInterface $output): int
         {
             return $this->doExecute($input, $output);
@@ -22,6 +44,12 @@ if ((new ReflectionMethod(Command::class, 'execute'))->hasReturnType()) {
     /** @internal */
     trait CommandCompatibility
     {
+        /** @return void */
+        protected function configure()
+        {
+            $this->doConfigure();
+        }
+
         /**
          * {@inheritDoc}
          *

--- a/src/Tools/Console/Command/GenerateHydratorsCommand.php
+++ b/src/Tools/Console/Command/GenerateHydratorsCommand.php
@@ -31,8 +31,7 @@ class GenerateHydratorsCommand extends Command
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this
         ->setName('odm:generate:hydrators')

--- a/src/Tools/Console/Command/GeneratePersistentCollectionsCommand.php
+++ b/src/Tools/Console/Command/GeneratePersistentCollectionsCommand.php
@@ -31,8 +31,7 @@ class GeneratePersistentCollectionsCommand extends Command
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this
             ->setName('odm:generate:persistent-collections')

--- a/src/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/src/Tools/Console/Command/GenerateProxiesCommand.php
@@ -35,8 +35,7 @@ class GenerateProxiesCommand extends Command
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this
         ->setName('odm:generate:proxies')

--- a/src/Tools/Console/Command/QueryCommand.php
+++ b/src/Tools/Console/Command/QueryCommand.php
@@ -27,8 +27,7 @@ class QueryCommand extends Command
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this
         ->setName('odm:query')

--- a/src/Tools/Console/Command/Schema/AbstractCommand.php
+++ b/src/Tools/Console/Command/Schema/AbstractCommand.php
@@ -19,16 +19,15 @@ use function is_string;
 
 abstract class AbstractCommand extends Command
 {
+    use AbstractCommandCompatibility;
+
     public const DB           = 'db';
     public const COLLECTION   = 'collection';
     public const INDEX        = 'index';
     public const SEARCH_INDEX = 'search-index';
 
-    /** @return void */
-    protected function configure()
+    private function configureCommonOptions(): void
     {
-        parent::configure();
-
         $this
             ->addOption('maxTimeMs', null, InputOption::VALUE_REQUIRED, 'An optional maxTimeMs that will be used for all schema operations.')
             ->addOption('w', null, InputOption::VALUE_REQUIRED, 'An optional w option for the write concern that will be used for all schema operations.')

--- a/src/Tools/Console/Command/Schema/AbstractCommandCompatibility.php
+++ b/src/Tools/Console/Command/Schema/AbstractCommandCompatibility.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tools\Console\Command\Schema;
+
+use ReflectionMethod;
+use Symfony\Component\Console\Command\Command;
+
+// Symfony 8
+if ((new ReflectionMethod(Command::class, 'configure'))->hasReturnType()) {
+    /** @internal */
+    trait AbstractCommandCompatibility
+    {
+        protected function configure(): void
+        {
+            $this->configureCommonOptions();
+        }
+    }
+} else {
+    /** @internal */
+    trait AbstractCommandCompatibility
+    {
+        /** @return void */
+        protected function configure()
+        {
+            $this->configureCommonOptions();
+        }
+    }
+}

--- a/src/Tools/Console/Command/Schema/CreateCommand.php
+++ b/src/Tools/Console/Command/Schema/CreateCommand.php
@@ -30,8 +30,7 @@ class CreateCommand extends AbstractCommand
         self::SEARCH_INDEX => ['search index(es)', 'search indexes'],
     ];
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         parent::configure();
 

--- a/src/Tools/Console/Command/Schema/DropCommand.php
+++ b/src/Tools/Console/Command/Schema/DropCommand.php
@@ -31,8 +31,7 @@ class DropCommand extends AbstractCommand
         self::SEARCH_INDEX => ['search index(es)', 'search indexes'],
     ];
 
-    /** @return void */
-    protected function configure()
+    protected function doConfigure(): void
     {
         parent::configure();
 

--- a/src/Tools/Console/Command/Schema/ShardCommand.php
+++ b/src/Tools/Console/Command/Schema/ShardCommand.php
@@ -19,8 +19,7 @@ class ShardCommand extends AbstractCommand
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         parent::configure();
 

--- a/src/Tools/Console/Command/Schema/UpdateCommand.php
+++ b/src/Tools/Console/Command/Schema/UpdateCommand.php
@@ -19,8 +19,7 @@ class UpdateCommand extends AbstractCommand
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         parent::configure();
 

--- a/src/Tools/Console/Command/Schema/ValidateCommand.php
+++ b/src/Tools/Console/Command/Schema/ValidateCommand.php
@@ -19,8 +19,7 @@ class ValidateCommand extends Command
 {
     use CommandCompatibility;
 
-    /** @return void */
-    protected function configure()
+    private function doConfigure(): void
     {
         $this
             ->setName('odm:schema:validate')


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | [PHPORM-375](https://jira.mongodb.org/browse/PHPORM-375)

#### Summary

Dependencies blocking Symfony upgrade:

- [x] `doctrine/orm` https://github.com/doctrine/orm/pull/12102
- [x] `friendsofphp/proxy-manager-lts`
- [x] `phpbench/phpbench`

Support for Native Lazy objects is required, as [Symfony 8.0 drops support for lazy ghost objects](https://github.com/symfony/symfony/blob/8.0/UPGRADE-8.0.md#varexporter). This version will never be compatible with `symfony/var-exporter:8`