### PR TITLE
Feature: add support for `$filePaths`

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AnnotationDriver.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Driver;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\Reader;
+use Traversable;
 
 /**
  * The AnnotationDriver reads the mapping metadata from docblock annotations.
@@ -25,20 +26,21 @@ class AnnotationDriver extends AttributeDriver
      * Initializes a new AnnotationDriver that uses the given AnnotationReader for reading
      * docblock annotations.
      *
-     * @param Reader               $reader The AnnotationReader to use, duck-typed.
-     * @param string|string[]|null $paths  One or multiple paths where mapping classes can be found.
+     * @param Reader                                             $reader The AnnotationReader to use, duck-typed.
+     * @param string|string[]|Traversable<array-key,string>|null $paths  Iterable of source file paths (if {@see Traversable} is given),
+     *                                                                   or an array of directories where mapping classes can be found.
      */
     public function __construct($reader, $paths = null)
     {
         $this->reader = $reader;
 
-        $this->addPaths((array) $paths);
+        $this->initializePaths($paths);
     }
 
     /**
      * Factory method for the Annotation Driver
      *
-     * @param string[]|string $paths
+     * @param string|string[]|Traversable<array-key,string> $paths
      */
     public static function create($paths = [], ?Reader $reader = null): AnnotationDriver
     {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Mapping\Driver;
 
+use ArrayIterator;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
@@ -16,11 +17,13 @@ use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\ClassMetadata as PersistenceClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\ColocatedMappingDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use LogicException;
 use MongoDB\BSON\Document;
 use MongoDB\Driver\Exception\UnexpectedValueException;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
+use Traversable;
 
 use function array_merge;
 use function array_replace;
@@ -29,6 +32,9 @@ use function class_exists;
 use function constant;
 use function count;
 use function is_array;
+use function is_string;
+use function property_exists;
+use function sprintf;
 use function trigger_deprecation;
 
 /**
@@ -45,7 +51,10 @@ class AttributeDriver implements MappingDriver
      */
     protected $reader;
 
-    /** @param string|string[]|null $paths */
+    /**
+     * @param string|string[]|Traversable<array-key,string>|null $paths Iterable of source file paths (if {@see Traversable} is given),
+     *                                                                  or an array of directories where mapping classes can be found.
+     */
     public function __construct($paths = null, ?Reader $reader = null)
     {
         if ($reader !== null) {
@@ -59,7 +68,31 @@ class AttributeDriver implements MappingDriver
 
         $this->reader = $reader ?? new AttributeReader();
 
-        $this->addPaths((array) $paths);
+        $this->initializePaths($paths);
+    }
+
+    /** @param string|iterable<string>|null $paths */
+    final protected function initializePaths(string|iterable|null $paths): void
+    {
+        if (is_string($paths)) {
+            $paths = [$paths];
+        } elseif ($paths === null) {
+            $paths = new ArrayIterator([]);
+        }
+
+        $isFilePaths = $paths instanceof Traversable;
+
+        if (! $isFilePaths) {
+            $this->addPaths((array) $paths);
+
+            return;
+        }
+
+        if (! property_exists(self::class, 'filePaths')) {
+            throw new LogicException(sprintf('Source file paths support for %s is available since doctrine/persistence 4.1.', static::class));
+        }
+
+        $this->filePaths = $paths;
     }
 
     public function isTransient($className): bool
@@ -416,7 +449,7 @@ class AttributeDriver implements MappingDriver
     /**
      * Factory method for the Attribute Driver
      *
-     * @param string[]|string $paths
+     * @param string|string[]|Traversable<array-key,string> $paths
      *
      * @return AttributeDriver
      */

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
@@ -6,7 +6,6 @@ namespace Doctrine\ODM\MongoDB\Tests;
 
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use Doctrine\ODM\MongoDB\Proxy\InternalProxy;
 use Doctrine\ODM\MongoDB\Tests\Query\Filter\Filter;
 use Doctrine\ODM\MongoDB\UnitOfWork;
@@ -17,6 +16,7 @@ use MongoDB\Driver\Server;
 use MongoDB\Model\DatabaseInfo;
 use PHPUnit\Framework\TestCase;
 use ProxyManager\Proxy\LazyLoadingInterface;
+use Stubs\AttributeDriverFactory;
 
 use function array_key_exists;
 use function array_map;
@@ -124,7 +124,7 @@ abstract class BaseTestCase extends TestCase
 
     protected static function createMetadataDriverImpl(): MappingDriver
     {
-        return AttributeDriver::create(__DIR__ . '/../../../../Documents');
+        return AttributeDriverFactory::createAttributeDriver([__DIR__ . '/../../../../Documents']);
     }
 
     protected static function createTestDocumentManager(): DocumentManager

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractAnnotationDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractAnnotationDriverTestCase.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
@@ -15,6 +14,7 @@ use Documents\CmsUser;
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
+use Stubs\AnnotationDriverFactory;
 
 use function assert;
 
@@ -76,8 +76,7 @@ abstract class AbstractAnnotationDriverTestCase extends AbstractMappingDriverTes
     public function testLoadMetadataForNonDocumentThrowsException(): void
     {
         $cm               = new ClassMetadata('stdClass');
-        $reader           = new AnnotationReader();
-        $annotationDriver = new AnnotationDriver($reader);
+        $annotationDriver = AnnotationDriverFactory::createAnnotationDriver();
 
         $this->expectException(MappingException::class);
         $annotationDriver->loadMetadataForClass('stdClass', $cm);
@@ -87,8 +86,7 @@ abstract class AbstractAnnotationDriverTestCase extends AbstractMappingDriverTes
     public function testColumnWithMissingTypeDefaultsToString(): void
     {
         $cm               = new ClassMetadata(ColumnWithoutType::class);
-        $reader           = new AnnotationReader();
-        $annotationDriver = new AnnotationDriver($reader);
+        $annotationDriver = AnnotationDriverFactory::createAnnotationDriver();
 
         $annotationDriver->loadMetadataForClass(stdClass::class, $cm);
         self::assertEquals('id', $cm->fieldMappings['id']['type']);
@@ -255,9 +253,8 @@ abstract class AbstractAnnotationDriverTestCase extends AbstractMappingDriverTes
 
     protected function loadDriverForCMSDocuments(): MappingDriver
     {
-        $annotationDriver = static::loadDriver();
+        $annotationDriver = static::loadDriver([__DIR__ . '/../../../../../Documents']);
         assert($annotationDriver instanceof AnnotationDriver || $annotationDriver instanceof AttributeDriver);
-        $annotationDriver->addPaths([__DIR__ . '/../../../../../Documents']);
 
         return $annotationDriver;
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
@@ -34,7 +34,8 @@ use function usort;
 
 abstract class AbstractMappingDriverTestCase extends BaseTestCase
 {
-    abstract protected static function loadDriver(): MappingDriver;
+    /** @param list<string> $paths */
+    abstract protected static function loadDriver(array $paths = []): MappingDriver;
 
     protected static function createMetadataDriverImpl(): MappingDriver
     {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AnnotationDriverTest.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Stubs\AnnotationDriverFactory;
 
 use function call_user_func;
 use function restore_error_handler;
@@ -20,11 +19,9 @@ use const E_USER_DEPRECATED;
 
 class AnnotationDriverTest extends AbstractAnnotationDriverTestCase
 {
-    protected static function loadDriver(): MappingDriver
+    protected static function loadDriver(array $paths = []): MappingDriver
     {
-        $reader = new AnnotationReader();
-
-        return new AnnotationDriver($reader);
+        return AnnotationDriverFactory::createAnnotationDriver($paths);
     }
 
     public function testIndexesClassAnnotationEmitsDeprecationMessage(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AttributeDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AttributeDriverTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
-use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Stubs\AttributeDriverFactory;
 
 class AttributeDriverTest extends AbstractAnnotationDriverTestCase
 {
-    protected static function loadDriver(): MappingDriver
+    protected static function loadDriver(array $paths = []): MappingDriver
     {
-        return new AttributeDriver();
+        return AttributeDriverFactory::createAttributeDriver($paths);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/XmlMappingDriverTest.php
@@ -12,12 +12,16 @@ use ReflectionMethod;
 use SimpleXMLElement;
 use stdClass;
 
+use function assert;
+
 use const DIRECTORY_SEPARATOR;
 
 class XmlMappingDriverTest extends AbstractMappingDriverTestCase
 {
-    protected static function loadDriver(): MappingDriver
+    protected static function loadDriver(array $paths = []): MappingDriver
     {
+        assert($paths === []);
+
         return new XmlDriver(__DIR__ . DIRECTORY_SEPARATOR . 'xml');
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/Console/Command/Schema/UpdateCommandTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/Console/Command/Schema/UpdateCommandTest.php
@@ -8,6 +8,7 @@ use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\MongoDB\Tests\Tools\Console\Command\AbstractCommandTestCase;
 use Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\UpdateCommand;
 use Documents\SchemaValidated;
+use Stubs\AnnotationDriverFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -67,7 +68,7 @@ class UpdateCommandTest extends AbstractCommandTestCase
     public function testProcessValidators(): void
     {
         // Only load a subset of documents with legit annotations
-        $annotationDriver = AnnotationDriver::create(__DIR__ . '/../../../../../../../../Documents/Ecommerce');
+        $annotationDriver = $this->createDriver();
         $this->dm->getConfiguration()->setMetadataDriverImpl($annotationDriver);
         $this->commandTester->execute([]);
         $output = $this->commandTester->getDisplay();
@@ -77,10 +78,15 @@ class UpdateCommandTest extends AbstractCommandTestCase
     public function testDisabledValidatorsProcessing(): void
     {
         // Only load a subset of documents with legit annotations
-        $annotationDriver = AnnotationDriver::create(__DIR__ . '/../../../../../../../../Documents/Ecommerce');
+        $annotationDriver = $this->createDriver();
         $this->dm->getConfiguration()->setMetadataDriverImpl($annotationDriver);
         $this->commandTester->execute(['--disable-validators' => true]);
         $output = $this->commandTester->getDisplay();
         self::assertStringNotContainsString('Updated validation for all classes', $output);
+    }
+
+    private function createDriver(): AnnotationDriver
+    {
+        return AnnotationDriverFactory::createAnnotationDriver([__DIR__ . '/../../../../../../../../Documents/Ecommerce']);
     }
 }

--- a/tests/Stubs/AnnotationDriverFactory.php
+++ b/tests/Stubs/AnnotationDriverFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stubs;
+
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Doctrine\Persistence\Mapping\Driver\DirectoryFilesIterator;
+use Doctrine\Persistence\Mapping\Driver\FilePathNameIterator;
+
+final class AnnotationDriverFactory
+{
+    /** @param list<string> $paths */
+    public static function createAnnotationDriver(array $paths = [], ?Reader $reader = null): AnnotationDriver
+    {
+        if (! AttributeDriverFactory::isFilePathsSupported()) {
+            return AnnotationDriver::create($paths, $reader);
+        }
+
+        $filePaths = new FilePathNameIterator(new DirectoryFilesIterator($paths));
+
+        return AnnotationDriver::create($filePaths, $reader);
+    }
+}

--- a/tests/Stubs/AttributeDriverFactory.php
+++ b/tests/Stubs/AttributeDriverFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stubs;
+
+use Composer\InstalledVersions;
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
+use Doctrine\Persistence\Mapping\Driver\DirectoryFilesIterator;
+use Doctrine\Persistence\Mapping\Driver\FilePathNameIterator;
+
+use function version_compare;
+
+final class AttributeDriverFactory
+{
+    /** @param list<string> $paths */
+    public static function createAttributeDriver(array $paths = [], ?Reader $reader = null): AttributeDriver
+    {
+        if (! self::isFilePathsSupported()) {
+            return AttributeDriver::create($paths, $reader);
+        }
+
+        $filePaths = new FilePathNameIterator(new DirectoryFilesIterator($paths));
+
+        return AttributeDriver::create($filePaths, $reader);
+    }
+
+    public static function isFilePathsSupported(): bool
+    {
+        return version_compare(InstalledVersions::getVersion('doctrine/persistence'), '4.1', '>=');
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no

#### Summary

In the scope of https://github.com/doctrine/persistence/pull/432 (available from `doctrine/persistence` >= 4.1) there was added
`ColocatedMappingDriver::$filePaths`, which allows passing an `Traversable` of file paths for the mapping driver to use.
This commit integrates those changes into `AttributeDriver` (and `AnnotationDriver`).

Since `doctrine/orm` maintains the support for `doctrine/persistence` of older versions, the `AttributeDriver` ensures that `$filePaths` is actually defined. Tests use `InstalledVersions` to opt into new behaviour if `doctrine/persistence` is at least version 4.1.

The old behaviour can be adapted into a new one by using `DirectoryFilesIterator` and `FilePathNameIterator` on directory paths.