### PR TITLE
[Encryption] Support encrypted mappings of embedded documents in XML mappings

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -279,6 +279,7 @@
       <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0" />
       <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0" />
       <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0" />
+      <xs:element name="encrypt" type="odm:encrypt-field" minOccurs="0" maxOccurs="1" />
     </xs:choice>
 
     <xs:attribute name="target-document" type="xs:string" />
@@ -294,6 +295,7 @@
       <xs:element name="discriminator-field" type="odm:discriminator-field" minOccurs="0" />
       <xs:element name="discriminator-map" type="odm:discriminator-map" minOccurs="0" />
       <xs:element name="default-discriminator-value" type="odm:default-discriminator-value" minOccurs="0" />
+      <xs:element name="encrypt" type="odm:encrypt-field" minOccurs="0" maxOccurs="1" />
     </xs:choice>
 
     <xs:attribute name="target-document" type="xs:string" />

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Mapping\Driver;
 
+use Doctrine\ODM\MongoDB\Mapping\Annotations\EncryptQuery;
 use Doctrine\ODM\MongoDB\Mapping\Annotations\TimeSeries;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
@@ -937,7 +938,7 @@ class XmlDriver extends FileDriver
         $encryptMapping = [];
         foreach ($encrypt->attributes() as $encryptKey => $encryptValue) {
             $encryptMapping[$encryptKey] = match ($encryptKey) {
-                'queryType' => (string) $encryptValue,
+                'queryType' => EncryptQuery::from((string) $encryptValue),
                 'min', 'max' => Type::getType($type)->convertToDatabaseValue((string) $encryptValue),
                 'sparsity', 'precision', 'trimFactor', 'contention' => (int) $encryptValue,
             };

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -312,14 +312,7 @@ class XmlDriver extends FileDriver
                 }
 
                 if (isset($field->encrypt)) {
-                    $mapping['encrypt'] = [];
-                    foreach ($field->encrypt->attributes() as $encryptKey => $encryptValue) {
-                        $mapping['encrypt'][$encryptKey] = match ($encryptKey) {
-                            'queryType' => (string) $encryptValue,
-                            'min', 'max' => Type::getType($mapping['type'])->convertToDatabaseValue((string) $encryptValue),
-                            'sparsity', 'precision', 'trimFactor', 'contention' => (int) $encryptValue,
-                        };
-                    }
+                    $mapping['encrypt'] = $this->addEncryptionMapping($field->encrypt, $mapping['type']);
                 }
 
                 $this->addFieldMapping($metadata, $mapping);
@@ -462,6 +455,10 @@ class XmlDriver extends FileDriver
 
         if (isset($embed->{'default-discriminator-value'})) {
             $mapping['defaultDiscriminatorValue'] = (string) $embed->{'default-discriminator-value'}['value'];
+        }
+
+        if (isset($embed->encrypt)) {
+            $mapping['encrypt'] = $this->addEncryptionMapping($embed->encrypt, $mapping['type']);
         }
 
         if (isset($attributes['not-saved'])) {
@@ -933,6 +930,20 @@ class XmlDriver extends FileDriver
 
         $xmlRoot->metadata->addAttribute('field', 'metadata');
         $this->addEmbedMapping($class, $xmlRoot->metadata, ClassMetadata::ONE);
+    }
+
+    private function addEncryptionMapping(?SimpleXMLElement $encrypt, $type): array
+    {
+        $encryptMapping = [];
+        foreach ($encrypt->attributes() as $encryptKey => $encryptValue) {
+            $encryptMapping[$encryptKey] = match ($encryptKey) {
+                'queryType' => (string) $encryptValue,
+                'min', 'max' => Type::getType($type)->convertToDatabaseValue((string) $encryptValue),
+                'sparsity', 'precision', 'trimFactor', 'contention' => (int) $encryptValue,
+            };
+        }
+
+        return $encryptMapping;
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/XmlMappingQueryableEncryptionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/XmlMappingQueryableEncryptionTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\Mapping\Driver\XmlDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+
+class XmlMappingQueryableEncryptionTest extends QueryableEncryptionTest
+{
+    protected static function createMetadataDriverImpl(): MappingDriver
+    {
+        return new XmlDriver(__DIR__ . '/../Mapping/Driver/fixtures/xml');
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Mapping\Driver;
 
 use DateTimeImmutable;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\EncryptQuery;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Documents\Account;
@@ -17,7 +18,6 @@ use Documents\Phonenumber;
 use Documents\Profile;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\UTCDateTime;
-use MongoDB\Driver\ClientEncryption;
 use PHPUnit\Framework\TestCase;
 use TestDocuments\EmbeddedDocument;
 use TestDocuments\NullableFieldsDocument;
@@ -537,13 +537,13 @@ abstract class AbstractDriverTestCase extends TestCase
         self::assertFalse($classMetadata->isEncrypted);
 
         self::assertSame([
-            'queryType' => ClientEncryption::QUERY_TYPE_EQUALITY,
+            'queryType' => EncryptQuery::Equality,
         ], $classMetadata->fieldMappings['ssn']['encrypt']);
 
         self::assertSame([], $classMetadata->fieldMappings['billing']['encrypt']);
 
         self::assertSame([
-            'queryType' => ClientEncryption::QUERY_TYPE_RANGE,
+            'queryType' => EncryptQuery::Range,
             'sparsity' => 1,
             'trimFactor' => 4,
             'min' => 100,
@@ -568,25 +568,25 @@ abstract class AbstractDriverTestCase extends TestCase
         $this->driver->loadMetadataForClass(RangeTypes::class, $classMetadata);
 
         self::assertEquals([
-            'queryType' => ClientEncryption::QUERY_TYPE_RANGE,
+            'queryType' => EncryptQuery::Range,
             'min' => 5,
             'max' => 10,
         ], $classMetadata->fieldMappings['intField']['encrypt']);
 
         self::assertEquals([
-            'queryType' => ClientEncryption::QUERY_TYPE_RANGE,
+            'queryType' => EncryptQuery::Range,
             'min' => 5.5,
             'max' => 10.5,
         ], $classMetadata->fieldMappings['floatField']['encrypt']);
 
         self::assertEquals([
-            'queryType' => ClientEncryption::QUERY_TYPE_RANGE,
+            'queryType' => EncryptQuery::Range,
             'min' => new Decimal128('0.1'),
             'max' => new Decimal128('0.2'),
         ], $classMetadata->fieldMappings['decimalField']['encrypt']);
 
         self::assertEquals([
-            'queryType' => ClientEncryption::QUERY_TYPE_RANGE,
+            'queryType' => EncryptQuery::Range,
             'min' => new UTCDateTime(new DateTimeImmutable('2000-01-01 00:00:00')),
             'max' => new UTCDateTime(new DateTimeImmutable('2100-01-01 00:00:00')),
         ], $classMetadata->fieldMappings['dateField']['encrypt']);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/Documents.Encryption.Patient.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/Documents.Encryption.Patient.dcm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="Documents\Encryption\Patient" collection="patients">
+        <id/>
+        <field name="patientName" type="string" />
+        <field name="patientId" type="int" />
+        <embed-one target-document="Documents\Encryption\PatientRecord" field="patientRecord"/>
+    </document>
+
+</doctrine-mongo-mapping>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/Documents.Encryption.PatientBilling.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/Documents.Encryption.PatientBilling.dcm.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                  http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <embedded-document name="Documents\Encryption\PatientBilling">
+        <field name="type" type="string"/>
+        <field name="number" type="string"/>
+    </embedded-document>
+
+</doctrine-mongo-mapping>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/Documents.Encryption.PatientRecord.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/Documents.Encryption.PatientRecord.dcm.xml
@@ -9,7 +9,7 @@
         <field name="ssn" type="string">
             <encrypt queryType="equality"/>
         </field>
-        <embed-one target-document="Documents\Encryption\Billing" field="billing">
+        <embed-one target-document="Documents\Encryption\PatientBilling" field="billing">
             <encrypt/>
         </embed-one>
         <field name="billingAmount" type="int">


### PR DESCRIPTION
This fixes a bug exposed by Copilot review. It complained that a field was mapped as `string` when it was mapped as an embedded document in the attribute mapping. After changing it to an embedded document mapping, I noticed there was no way to mark an embedded document as encrypted through the XML mapping, where it's possible to do so using attribute.

This PR updates the schema to support an `encrypt` element within `embed-one` and `embed-many`. A couple of notes:
- `encrypt` retains its attributes, even though none of them make sense for embedded documents at the moment. Future versions of QE may change this
- There's an `encrypt-embedded-document` type in the XSD, which is never used. Was that intended for that purpose?
- Should we opt for a simpler `encrypt` attribute to `embed-one` and `embed-many` and only add support for an `encrypt` element once QE supports queries on encrypted embedded documents?