### PR TITLE
Drop metadata collection when an encrypted collection is dropped but encryptedFieldsMap is not configured

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -62,6 +62,14 @@ jobs:
             dependencies: "highest"
             symfony-version: "stable"
             proxy: "lazy-ghost"
+          # Test with a 8.0 replica set (Queryable Encryption requirement)
+          - topology: "replica_set"
+            php-version: "8.2"
+            mongodb-version: "8.0"
+            driver-version: "stable"
+            dependencies: "highest"
+            symfony-version: "stable"
+            proxy: "lazy-ghost"
           # Test with ProxyManager
           - php-version: "8.2"
             mongodb-version: "6.0"

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -699,7 +699,16 @@ final class SchemaManager
 
         $options = $this->getWriteOptions($maxTimeMs, $writeConcern);
 
-        $this->dm->getDocumentCollection($documentName)->drop($options);
+        $collection    = $this->dm->getDocumentCollection($documentName);
+        $driverOptions = $this->dm->getConfiguration()->getDriverOptions();
+        // Ensure that metadata collections are dropped if the collection is encrypted
+        // This should be automatically handled by the driver
+        // @see https://jira.mongodb.org/browse/PHPLIB-1702
+        if (isset($driverOptions['autoEncryption']) && ! isset($driverOptions['encryptedFieldsMap'][$collection->getNamespace()])) {
+            $options['encryptedFields'] = [];
+        }
+
+        $collection->drop($options);
 
         if (! $class->isFile) {
             return;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

#### Summary

Patch for https://jira.mongodb.org/browse/PHPLIB-1702
