### PR TITLE
[Encryption] Cast KMS provider to object to support AWS empty config

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -793,7 +793,8 @@ class Configuration
     private function getAutoEncryptionOptions(): array
     {
         return [
-            'kmsProviders' => [$this->attributes['kmsProvider']['type'] => array_diff_key($this->attributes['kmsProvider'], ['type' => 0])],
+            // Each kmsProvider must be an object, it can be empty
+            'kmsProviders' => [$this->attributes['kmsProvider']['type'] => (object) array_diff_key($this->attributes['kmsProvider'], ['type' => 0])],
             'keyVaultNamespace' => $this->getDefaultDB() . '.datakeys',
             ...$this->attributes['autoEncryption'] ?? [],
         ];

--- a/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/ConfigurationTest.php
@@ -55,7 +55,7 @@ class ConfigurationTest extends TestCase
         self::assertNull($c->getDefaultMasterKey());
         self::assertEquals([
             'kmsProviders' => [
-                'local' => ['key' => '1234567890123456789012345678901234567890123456789012345678901234'],
+                'local' => (object) ['key' => '1234567890123456789012345678901234567890123456789012345678901234'],
             ],
             'extraOptions' => ['mongocryptdURI' => 'mongodb://localhost:27020'],
             // Default key vault namespace
@@ -74,7 +74,7 @@ class ConfigurationTest extends TestCase
         self::assertSame($masterKey, $c->getDefaultMasterKey());
         self::assertEquals([
             'kmsProviders' => [
-                'aws' => ['accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET'],
+                'aws' => (object) ['accessKeyId' => 'AKIA', 'secretAccessKey' => 'SECRET'],
             ],
             // Key vault namespace from the configuration
             'keyVaultNamespace' => 'keyvault.datakeys',
@@ -88,27 +88,27 @@ class ConfigurationTest extends TestCase
             'keyVaultClient' => $keyVaultClient = new Manager(),
             'keyVaultNamespace' => 'keyvault.datakeys',
             'extraOptions' => ['mongocryptdURI' => 'mongodb://localhost:27020'],
-            'tlsOptions' => ['tlsDisableOCSPEndpointCheck' => true],
+            'tlsOptions' => ['local' => ['tlsDisableOCSPEndpointCheck' => true]],
         ]);
         $c->setKmsProvider(['type' => 'local', 'key' => '1234567890123456789012345678901234567890123456789012345678901234']);
 
-        self::assertSame([
+        self::assertEquals([
             'kmsProviders' => [
-                'local' => ['key' => '1234567890123456789012345678901234567890123456789012345678901234'],
+                'local' => (object) ['key' => '1234567890123456789012345678901234567890123456789012345678901234'],
             ],
             'keyVaultNamespace' => 'keyvault.datakeys',
             'keyVaultClient' => $keyVaultClient,
             'extraOptions' => ['mongocryptdURI' => 'mongodb://localhost:27020'],
-            'tlsOptions' => ['tlsDisableOCSPEndpointCheck' => true],
+            'tlsOptions' => ['local' => ['tlsDisableOCSPEndpointCheck' => true]],
         ], $c->getDriverOptions()['autoEncryption']);
 
-        self::assertSame([
+        self::assertEquals([
             'kmsProviders' => [
-                'local' => ['key' => '1234567890123456789012345678901234567890123456789012345678901234'],
+                'local' => (object) ['key' => '1234567890123456789012345678901234567890123456789012345678901234'],
             ],
             'keyVaultNamespace' => 'keyvault.datakeys',
             'keyVaultClient' => $keyVaultClient,
-            'tlsOptions' => ['tlsDisableOCSPEndpointCheck' => true],
+            'tlsOptions' => ['local' => ['tlsDisableOCSPEndpointCheck' => true]],
         ], $c->getClientEncryptionOptions());
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | [DoctrineMongoDBBundle#897](https://github.com/doctrine/DoctrineMongoDBBundle/pull/897/#discussion_r2270005305)

#### Summary

For some KMS providers, all options can be omitted. The authentication is done using the env var or the system.
https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.md#credentialproviders


