### PR TITLE
[Encryption] Update test on dropping encrypted collection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "doctrine/persistence": "^3.2 || ^4",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "jean85/pretty-package-versions": "^1.3.0 || ^2.0.1",
-        "mongodb/mongodb": "^1.21 || ^2.0@dev",
+        "mongodb/mongodb": "~1.21.2 || ^2.1.1@dev",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1671,13 +1671,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property MongoDB\\Model\\BSONDocument\:\:\$patientRecord\.$#'
 			identifier: property.notFound
-			count: 3
-			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryableEncryptionTest.php
-
-		-
-			message: '#^Parameter \#1 \$value of function count expects array\|Countable, Iterator\<int, string\> given\.$#'
-			identifier: argument.type
-			count: 1
+			count: 6
 			path: tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryableEncryptionTest.php
 
 		-

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryableEncryptionTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/QueryableEncryptionTest.php
@@ -10,10 +10,10 @@ use Documents\Encryption\Patient;
 use Documents\Encryption\PatientBilling;
 use Documents\Encryption\PatientRecord;
 use MongoDB\BSON\Binary;
+use MongoDB\BSON\Regex;
 use MongoDB\Client;
 use MongoDB\Model\BSONDocument;
 
-use function count;
 use function getenv;
 use function iterator_to_array;
 use function random_bytes;
@@ -25,6 +25,13 @@ class QueryableEncryptionTest extends BaseTestCase
         parent::setUp();
 
         $this->skipTestIfQueryableEncryptionNotSupported();
+    }
+
+    public function tearDown(): void
+    {
+        $this->dm?->getDocumentCollection(Patient::class)?->drop(['encryptedFields' => []]);
+
+        parent::tearDown();
     }
 
     public function testCreateAndQueryEncryptedCollection(): void
@@ -64,8 +71,11 @@ class QueryableEncryptionTest extends BaseTestCase
         self::assertSame('Jon Doe', $document->patientName);
         self::assertSame(12345678, $document->patientId);
         self::assertInstanceOf(Binary::class, $document->patientRecord->ssn);
+        self::assertSame(Binary::TYPE_ENCRYPTED, $document->patientRecord->ssn->getType());
         self::assertInstanceOf(Binary::class, $document->patientRecord->billing);
+        self::assertSame(Binary::TYPE_ENCRYPTED, $document->patientRecord->billing->getType());
         self::assertInstanceOf(Binary::class, $document->patientRecord->billingAmount);
+        self::assertSame(Binary::TYPE_ENCRYPTED, $document->patientRecord->billingAmount->getType());
 
         // Queryable with equality
         $result = $this->dm->getRepository(Patient::class)->findOneBy(['patientRecord.ssn' => '987-65-4320']);
@@ -84,11 +94,9 @@ class QueryableEncryptionTest extends BaseTestCase
         self::assertSame('4111111111111111', $result->patientRecord->billing->number);
 
         // Drop the encrypted collection
-        $collectionCount = count($nonEncryptedDatabase->listCollectionNames());
         $this->dm->getSchemaManager()->dropDocumentCollection(Patient::class);
-        $collectionNames = iterator_to_array($nonEncryptedDatabase->listCollectionNames());
-        self::assertNotContains('patients', $collectionNames);
-        self::assertSame($collectionCount - 3, count($collectionNames), 'The 2 metadata collections should also be dropped');
+        $collectionNames = iterator_to_array($nonEncryptedDatabase->listCollectionNames(['filter' => ['name' => new Regex('patients')]]));
+        self::assertSame([], $collectionNames, 'The 2 metadata collections should also be dropped');
     }
 
     protected static function createTestDocumentManager(): DocumentManager


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

Update related to the fix in `mongodb/mongodb` [2.1.1](https://github.com/mongodb/mongo-php-library/releases/tag/2.1.1) and [1.21.2](https://github.com/mongodb/mongo-php-library/releases/tag/2.1.1)
