### PR TITLE
[Encryption] Add Int64 type

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -145,6 +145,7 @@ Here is a quick overview of the built-in mapping types:
 -  ``hash``
 -  ``id``
 -  ``int``
+-  ``int64``
 -  ``key``
 -  ``object_id``
 -  ``raw``

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -2386,6 +2386,16 @@ use function trigger_deprecation;
             $mapping['nullable'] = false;
         }
 
+        if (isset($mapping['encrypt']['queryType'])) {
+            // The encrypted range query options min and max must be converted to the database type
+            $type = Type::getType($mapping['type']);
+            foreach (['min', 'max'] as $option) {
+                if (isset($mapping['encrypt'][$option])) {
+                    $mapping['encrypt'][$option] = $type->convertToDatabaseValue($mapping['encrypt'][$option]);
+                }
+            }
+        }
+
         if (
             isset($mapping['reference'])
             && isset($mapping['storeAs'])

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -940,7 +940,7 @@ class XmlDriver extends FileDriver
         foreach ($encrypt->attributes() as $key => $value) {
             $encryptMapping[$key] = match ($key) {
                 'queryType' => EncryptQuery::from((string) $value),
-                'min', 'max' => $value,
+                'min', 'max' => (string) $value,
                 'sparsity', 'precision', 'trimFactor', 'contention' => (int) $value,
             };
         }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -9,7 +9,6 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations\TimeSeries;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Mapping\TimeSeries\Granularity;
-use Doctrine\ODM\MongoDB\Types\Type;
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 use Doctrine\Persistence\Mapping\Driver\FileDriver;
 use DOMDocument;
@@ -941,7 +940,7 @@ class XmlDriver extends FileDriver
         foreach ($encrypt->attributes() as $key => $value) {
             $encryptMapping[$key] = match ($key) {
                 'queryType' => EncryptQuery::from((string) $value),
-                'min', 'max' => Type::getType($type)->convertToDatabaseValue((string) $value),
+                'min', 'max' => $value,
                 'sparsity', 'precision', 'trimFactor', 'contention' => (int) $value,
             };
         }

--- a/lib/Doctrine/ODM/MongoDB/Types/Int64Type.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/Int64Type.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Types;
+
+use MongoDB\BSON\Int64;
+
+/**
+ * The Int64 type (long)
+ */
+class Int64Type extends IntType implements Incrementable, Versionable
+{
+    public function convertToDatabaseValue($value)
+    {
+        return $value !== null ? new Int64($value) : null;
+    }
+
+    public function closureToMongo(): string
+    {
+        return '$return = new \MongoDB\BSON\Int64($value);';
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Types/Int64Type.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/Int64Type.php
@@ -13,7 +13,11 @@ class Int64Type extends IntType implements Incrementable, Versionable
 {
     public function convertToDatabaseValue($value)
     {
-        return $value !== null ? new Int64($value) : null;
+        if ($value instanceof Int64 || $value === null) {
+            return $value;
+        }
+
+        return new Int64($value);
     }
 
     public function closureToMongo(): string

--- a/lib/Doctrine/ODM/MongoDB/Types/Type.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/Type.php
@@ -26,6 +26,7 @@ abstract class Type
     public const CUSTOMID           = 'custom_id';
     public const BOOL               = 'bool';
     public const INT                = 'int';
+    public const INT64              = 'int64';
     public const FLOAT              = 'float';
     public const STRING             = 'string';
     public const DATE               = 'date';
@@ -66,6 +67,7 @@ abstract class Type
         self::BOOLEAN => Types\BooleanType::class,
         self::INT => Types\IntType::class,
         self::INTEGER => Types\IntType::class,
+        self::INT64 => Types\Int64Type::class,
         self::FLOAT => Types\FloatType::class,
         self::STRING => Types\StringType::class,
         self::DATE => Types\DateType::class,

--- a/lib/Doctrine/ODM/MongoDB/Utility/EncryptedFieldsMapGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Utility/EncryptedFieldsMapGenerator.php
@@ -140,12 +140,6 @@ final class EncryptedFieldsMapGenerator
             if (isset($mapping['encrypt']['queryType'])) {
                 $field['queries']              = array_filter($mapping['encrypt'], static fn ($v) => $v !== null);
                 $field['queries']['queryType'] = $field['queries']['queryType']->value;
-
-                foreach (['min', 'max'] as $option) {
-                    if (isset($field['queries'][$option])) {
-                        $field['queries'][$option] = Type::getType($mapping['type'])->convertToDatabaseValue($field['queries'][$option]);
-                    }
-                }
             }
 
             yield $field;

--- a/lib/Doctrine/ODM/MongoDB/Utility/EncryptedFieldsMapGenerator.php
+++ b/lib/Doctrine/ODM/MongoDB/Utility/EncryptedFieldsMapGenerator.php
@@ -122,6 +122,7 @@ final class EncryptedFieldsMapGenerator
                     ClassMetadata::ONE, Type::HASH => 'object',
                     ClassMetadata::MANY, Type::COLLECTION => 'array',
                     Type::INT, Type::INTEGER => 'int',
+                    Type::INT64 => 'long',
                     Type::FLOAT => 'double',
                     Type::DECIMAL128 => 'decimal',
                     Type::DATE, Type::DATE_IMMUTABLE => 'date',
@@ -139,6 +140,12 @@ final class EncryptedFieldsMapGenerator
             if (isset($mapping['encrypt']['queryType'])) {
                 $field['queries']              = array_filter($mapping['encrypt'], static fn ($v) => $v !== null);
                 $field['queries']['queryType'] = $field['queries']['queryType']->value;
+
+                foreach (['min', 'max'] as $option) {
+                    if (isset($field['queries'][$option])) {
+                        $field['queries'][$option] = Type::getType($mapping['type'])->convertToDatabaseValue($field['queries'][$option]);
+                    }
+                }
             }
 
             yield $field;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,30 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Call to an undefined method MongoDB\\Driver\\Monitoring\\CommandFailedEvent\|MongoDB\\Driver\\Monitoring\\CommandSucceededEvent\:\:getServer\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/APM/Command.php
-
-		-
-			message: '#^Call to function assert\(\) with true will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 2
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
-
-		-
-			message: '#^Instanceof between MongoDB\\Driver\\CursorInterface and Iterator will always evaluate to true\.$#'
-			identifier: instanceof.alwaysTrue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
-
-		-
-			message: '#^Instanceof between MongoDB\\Driver\\CursorInterface and MongoDB\\Driver\\CursorInterface will always evaluate to true\.$#'
-			identifier: instanceof.alwaysTrue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
-
-		-
 			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Aggregation\:\:__construct\(\) has parameter \$classMetadata with generic class Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
@@ -1117,32 +1093,8 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
 
 		-
-			message: '#^Call to function assert\(\) with true will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 2
-			path: lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
-
-		-
 			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
-
-		-
-			message: '#^Instanceof between MongoDB\\Collection and MongoDB\\Collection will always evaluate to true\.$#'
-			identifier: instanceof.alwaysTrue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
-
-		-
-			message: '#^Instanceof between MongoDB\\Driver\\CursorInterface and Iterator will always evaluate to true\.$#'
-			identifier: instanceof.alwaysTrue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
-
-		-
-			message: '#^Instanceof between MongoDB\\Driver\\CursorInterface and MongoDB\\Driver\\CursorInterface will always evaluate to true\.$#'
-			identifier: instanceof.alwaysTrue
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
 
@@ -1233,12 +1185,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$array \(non\-empty\-list\) of array_values is already a list, call has no effect\.$#'
 			identifier: arrayValues.list
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
-
-		-
-			message: '#^Result of && is always true\.$#'
-			identifier: booleanAnd.alwaysTrue
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,30 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Call to an undefined method MongoDB\\Driver\\Monitoring\\CommandFailedEvent\|MongoDB\\Driver\\Monitoring\\CommandSucceededEvent\:\:getServer\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/APM/Command.php
+
+		-
+			message: '#^Call to function assert\(\) with true will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
+
+		-
+			message: '#^Instanceof between MongoDB\\Driver\\CursorInterface and Iterator will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
+
+		-
+			message: '#^Instanceof between MongoDB\\Driver\\CursorInterface and MongoDB\\Driver\\CursorInterface will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
+
+		-
 			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Aggregation\:\:__construct\(\) has parameter \$classMetadata with generic class Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
@@ -1093,8 +1117,32 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
 
 		-
+			message: '#^Call to function assert\(\) with true will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+
+		-
 			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+
+		-
+			message: '#^Instanceof between MongoDB\\Collection and MongoDB\\Collection will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+
+		-
+			message: '#^Instanceof between MongoDB\\Driver\\CursorInterface and Iterator will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+
+		-
+			message: '#^Instanceof between MongoDB\\Driver\\CursorInterface and MongoDB\\Driver\\CursorInterface will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
 
@@ -1185,6 +1233,12 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$array \(non\-empty\-list\) of array_values is already a list, call has no effect\.$#'
 			identifier: arrayValues.list
+			count: 1
+			path: lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+
+		-
+			message: '#^Result of && is always true\.$#'
+			identifier: booleanAnd.alwaysTrue
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
 
@@ -1945,43 +1999,43 @@ parameters:
 			path: tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest.php
 
 		-
-			message: '#^Method Doctrine\\Persistence\\Mapping\\AbstractClassMetadataFactory@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest\.php\:199\:\:__construct\(\) has parameter \$classNames with no value type specified in iterable type array\.$#'
+			message: '#^Method Doctrine\\Persistence\\Mapping\\AbstractClassMetadataFactory@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest\.php\:212\:\:__construct\(\) has parameter \$classNames with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest.php
 
 		-
-			message: '#^Method Doctrine\\Persistence\\Mapping\\AbstractClassMetadataFactory@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest\.php\:199\:\:doLoadMetadata\(\) has parameter \$class with generic interface Doctrine\\Persistence\\Mapping\\ClassMetadata but does not specify its types\: T$#'
+			message: '#^Method Doctrine\\Persistence\\Mapping\\AbstractClassMetadataFactory@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest\.php\:212\:\:doLoadMetadata\(\) has parameter \$class with generic interface Doctrine\\Persistence\\Mapping\\ClassMetadata but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest.php
 
 		-
-			message: '#^Method Doctrine\\Persistence\\Mapping\\AbstractClassMetadataFactory@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest\.php\:199\:\:doLoadMetadata\(\) has parameter \$parent with generic interface Doctrine\\Persistence\\Mapping\\ClassMetadata but does not specify its types\: T$#'
+			message: '#^Method Doctrine\\Persistence\\Mapping\\AbstractClassMetadataFactory@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest\.php\:212\:\:doLoadMetadata\(\) has parameter \$parent with generic interface Doctrine\\Persistence\\Mapping\\ClassMetadata but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest.php
 
 		-
-			message: '#^Method Doctrine\\Persistence\\Mapping\\AbstractClassMetadataFactory@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest\.php\:199\:\:getAllMetadata\(\) return type with generic interface Doctrine\\Persistence\\Mapping\\ClassMetadata does not specify its types\: T$#'
+			message: '#^Method Doctrine\\Persistence\\Mapping\\AbstractClassMetadataFactory@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest\.php\:212\:\:getAllMetadata\(\) return type with generic interface Doctrine\\Persistence\\Mapping\\ClassMetadata does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest.php
 
 		-
-			message: '#^Method Doctrine\\Persistence\\Mapping\\AbstractClassMetadataFactory@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest\.php\:199\:\:initializeReflection\(\) has parameter \$class with generic interface Doctrine\\Persistence\\Mapping\\ClassMetadata but does not specify its types\: T$#'
+			message: '#^Method Doctrine\\Persistence\\Mapping\\AbstractClassMetadataFactory@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest\.php\:212\:\:initializeReflection\(\) has parameter \$class with generic interface Doctrine\\Persistence\\Mapping\\ClassMetadata but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest.php
 
 		-
-			message: '#^Method Doctrine\\Persistence\\Mapping\\AbstractClassMetadataFactory@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest\.php\:199\:\:isEntity\(\) has parameter \$class with generic interface Doctrine\\Persistence\\Mapping\\ClassMetadata but does not specify its types\: T$#'
+			message: '#^Method Doctrine\\Persistence\\Mapping\\AbstractClassMetadataFactory@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest\.php\:212\:\:isEntity\(\) has parameter \$class with generic interface Doctrine\\Persistence\\Mapping\\ClassMetadata but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest.php
 
 		-
-			message: '#^Method Doctrine\\Persistence\\Mapping\\AbstractClassMetadataFactory@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest\.php\:199\:\:wakeupReflection\(\) has parameter \$class with generic interface Doctrine\\Persistence\\Mapping\\ClassMetadata but does not specify its types\: T$#'
+			message: '#^Method Doctrine\\Persistence\\Mapping\\AbstractClassMetadataFactory@anonymous/tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest\.php\:212\:\:wakeupReflection\(\) has parameter \$class with generic interface Doctrine\\Persistence\\Mapping\\ClassMetadata but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
 			path: tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest.php

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/AbstractDriverTestCase.php
@@ -17,6 +17,7 @@ use Documents\Group;
 use Documents\Phonenumber;
 use Documents\Profile;
 use MongoDB\BSON\Decimal128;
+use MongoDB\BSON\Int64;
 use MongoDB\BSON\UTCDateTime;
 use PHPUnit\Framework\TestCase;
 use TestDocuments\EmbeddedDocument;
@@ -25,6 +26,8 @@ use TestDocuments\PartialFilterDocument;
 use TestDocuments\PrimedCollectionDocument;
 use TestDocuments\QueryResultDocument;
 use TestDocuments\User;
+
+use const PHP_INT_MAX;
 
 abstract class AbstractDriverTestCase extends TestCase
 {
@@ -572,6 +575,12 @@ abstract class AbstractDriverTestCase extends TestCase
             'min' => 5,
             'max' => 10,
         ], $classMetadata->fieldMappings['intField']['encrypt']);
+
+        self::assertEquals([
+            'queryType' => EncryptQuery::Range,
+            'min' => new Int64(5),
+            'max' => new Int64(PHP_INT_MAX - 5),
+        ], $classMetadata->fieldMappings['int64Field']['encrypt']);
 
         self::assertEquals([
             'queryType' => EncryptQuery::Range,

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/Documents.Encryption.RangeTypes.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Driver/fixtures/xml/Documents.Encryption.RangeTypes.dcm.xml
@@ -10,6 +10,9 @@
         <field name="intField" type="int">
             <encrypt queryType="range" min="5" max="10"/>
         </field>
+        <field name="int64Field" type="int64">
+            <encrypt queryType="range" min="5" max="9223372036854775802"/>
+        </field>
         <field name="floatField" type="float">
             <encrypt queryType="range" min="5.5" max="10.5"/>
         </field>

--- a/tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Tools/EncryptedFieldsMapGeneratorTest.php
@@ -23,9 +23,12 @@ use Documents\Encryption\Patient;
 use Documents\Encryption\PatientRecord;
 use Documents\Encryption\RangeTypes;
 use MongoDB\BSON\Decimal128;
+use MongoDB\BSON\Int64;
 use MongoDB\BSON\UTCDateTime;
 
 use function array_map;
+
+use const PHP_INT_MAX;
 
 class EncryptedFieldsMapGeneratorTest extends BaseTestCase
 {
@@ -89,6 +92,16 @@ class EncryptedFieldsMapGeneratorTest extends BaseTestCase
                 'bsonType' => 'int',
                 'keyId' => null,
                 'queries' => ['queryType' => 'range', 'min' => 5, 'max' => 10],
+            ],
+            [
+                'path' => 'int64Field',
+                'bsonType' => 'long',
+                'keyId' => null,
+                'queries' => [
+                    'queryType' => 'range',
+                    'min' => new Int64(5),
+                    'max' => new Int64(PHP_INT_MAX - 5),
+                ],
             ],
             [
                 'path' => 'floatField',

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
@@ -18,6 +18,7 @@ use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+use function get_debug_type;
 use function md5;
 use function str_pad;
 use function str_repeat;
@@ -33,14 +34,12 @@ class TypeTest extends BaseTestCase
         $bsonValue ??= $phpValue;
         $type        = Type::getType($typeName);
 
-        self::assertEquals($phpValue, $type->convertToPHPValue($bsonValue));
-        self::assertEquals($bsonValue, $type->convertToDatabaseValue($phpValue));
+        self::assertSameTypeAndValue($phpValue, $type->convertToPHPValue($bsonValue));
+        self::assertSameTypeAndValue($bsonValue, $type->convertToDatabaseValue($phpValue));
     }
 
     public static function provideTypes(): array
     {
-        $array = ['foo' => 'bar'];
-
         return [
             'id' => [Type::ID, '507f1f77bcf86cd799439011', new ObjectId('507f1f77bcf86cd799439011')],
             'intId' => [Type::INTID, 1],
@@ -49,24 +48,24 @@ class TypeTest extends BaseTestCase
             'boolean' => [Type::BOOLEAN, false],
             'int' => [Type::INT, 69],
             'integer' => [Type::INTEGER, 42],
-            'int64' => [Type::INT64, 9223372036854775807, new Int64(9223372036854775807)],
+            'int64' => [Type::INT64, 100, new Int64(100)],
             'float' => [Type::FLOAT, 3.14],
             'string' => [Type::STRING, 'ohai'],
             'minKey' => [Type::KEY, 0, new MinKey()],
             'maxKey' => [Type::KEY, 1, new MaxKey()],
             'timestamp' => [Type::TIMESTAMP, $t = time(), new Timestamp(0, $t)],
-            'binData' => [Type::BINDATA, 'foobarbaz'],
-            'binDataFunc' => [Type::BINDATAFUNC, 'foobarbaz'],
-            'binDataByteArray' => [Type::BINDATABYTEARRAY, 'foobarbaz'],
-            'binDataUuid' => [Type::BINDATAUUID, 'testtesttesttest'],
-            'binDataUuidRFC4122' => [Type::BINDATAUUIDRFC4122, str_repeat('a', 16)],
-            'binDataMD5' => [Type::BINDATAMD5, md5('ODM')],
-            'binDataCustom' => [Type::BINDATACUSTOM, 'foobarbaz'],
+            'binData' => [Type::BINDATA, 'foobarbaz', new Binary('foobarbaz', Binary::TYPE_GENERIC)],
+            'binDataFunc' => [Type::BINDATAFUNC, 'foobarbaz', new Binary('foobarbaz', Binary::TYPE_FUNCTION)],
+            'binDataByteArray' => [Type::BINDATABYTEARRAY, 'foobarbaz', new Binary('foobarbaz', Binary::TYPE_OLD_BINARY)],
+            'binDataUuid' => [Type::BINDATAUUID, 'testtesttesttest', new Binary('testtesttesttest', Binary::TYPE_OLD_UUID)],
+            'binDataUuidRFC4122' => [Type::BINDATAUUIDRFC4122, str_repeat('a', 16), new Binary(str_repeat('a', 16), Binary::TYPE_UUID)],
+            'binDataMD5' => [Type::BINDATAMD5, md5('ODM'), new Binary(md5('ODM'), Binary::TYPE_MD5)],
+            'binDataCustom' => [Type::BINDATACUSTOM, 'foobarbaz', new Binary('foobarbaz', Binary::TYPE_USER_DEFINED)],
             'hash' => [Type::HASH, ['foo' => 'bar'], (object) ['foo' => 'bar']],
             'collection' => [Type::COLLECTION, ['foo', 'bar']],
-            'objectId' => [Type::OBJECTID, '507f1f77bcf86cd799439011'],
+            'objectId' => [Type::OBJECTID, '507f1f77bcf86cd799439011', new ObjectId('507f1f77bcf86cd799439011')],
             'raw' => [Type::RAW, (object) ['foo' => 'bar']],
-            'decimal128' => [Type::DECIMAL128, '4.20'],
+            'decimal128' => [Type::DECIMAL128, '4.20', new Decimal128('4.20')],
         ];
     }
 
@@ -74,7 +73,7 @@ class TypeTest extends BaseTestCase
     #[DataProvider('provideTypesForIdempotent')]
     public function testConversionIsIdempotent(Type $type, $test): void
     {
-        self::assertEquals($test, $type->convertToDatabaseValue($test));
+        self::assertSameTypeAndValue($test, $type->convertToDatabaseValue($test));
     }
 
     public static function provideTypesForIdempotent(): array
@@ -83,6 +82,7 @@ class TypeTest extends BaseTestCase
             'id' => [Type::getType(Type::ID), new ObjectId()],
             'date' => [Type::getType(Type::DATE), new UTCDateTime()],
             'dateImmutable' => [Type::getType(Type::DATE_IMMUTABLE), new UTCDateTime()],
+            'int64' => [Type::getType(Type::INT64), new Int64(100)],
             'timestamp' => [Type::getType(Type::TIMESTAMP), new Timestamp(0, time())],
             'binData' => [Type::getType(Type::BINDATA), new Binary('foobarbaz', Binary::TYPE_GENERIC)],
             'binDataFunc' => [Type::getType(Type::BINDATAFUNC), new Binary('foobarbaz', Binary::TYPE_FUNCTION)],
@@ -124,5 +124,11 @@ class TypeTest extends BaseTestCase
         $date = new DateTimeImmutable('now');
 
         self::assertInstanceOf(UTCDateTime::class, Type::convertPHPToDatabaseValue($date));
+    }
+
+    private static function assertSameTypeAndValue(mixed $expected, mixed $actual): void
+    {
+        self::assertSame(get_debug_type($expected), get_debug_type($actual));
+        self::assertEquals($expected, $actual);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/TypeTest.php
@@ -10,6 +10,9 @@ use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
+use MongoDB\BSON\Int64;
+use MongoDB\BSON\MaxKey;
+use MongoDB\BSON\MinKey;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
@@ -24,40 +27,46 @@ use const STR_PAD_LEFT;
 
 class TypeTest extends BaseTestCase
 {
-    /** @param mixed $test */
     #[DataProvider('provideTypes')]
-    public function testConversion(Type $type, $test): void
+    public function testConversion(string $typeName, mixed $phpValue, mixed $bsonValue = null): void
     {
-        self::assertEquals($test, $type->convertToPHPValue($type->convertToDatabaseValue($test)));
+        $bsonValue ??= $phpValue;
+        $type        = Type::getType($typeName);
+
+        self::assertEquals($phpValue, $type->convertToPHPValue($bsonValue));
+        self::assertEquals($bsonValue, $type->convertToDatabaseValue($phpValue));
     }
 
     public static function provideTypes(): array
     {
+        $array = ['foo' => 'bar'];
+
         return [
-            'id' => [Type::getType(Type::ID), '507f1f77bcf86cd799439011'],
-            'intId' => [Type::getType(Type::INTID), 1],
-            'customId' => [Type::getType(Type::CUSTOMID), (object) ['foo' => 'bar']],
-            'bool' => [Type::getType(Type::BOOL), true],
-            'boolean' => [Type::getType(Type::BOOLEAN), false],
-            'int' => [Type::getType(Type::INT), 69],
-            'integer' => [Type::getType(Type::INTEGER), 42],
-            'float' => [Type::getType(Type::FLOAT), 3.14],
-            'string' => [Type::getType(Type::STRING), 'ohai'],
-            'minKey' => [Type::getType(Type::KEY), 0],
-            'maxKey' => [Type::getType(Type::KEY), 1],
-            'timestamp' => [Type::getType(Type::TIMESTAMP), time()],
-            'binData' => [Type::getType(Type::BINDATA), 'foobarbaz'],
-            'binDataFunc' => [Type::getType(Type::BINDATAFUNC), 'foobarbaz'],
-            'binDataByteArray' => [Type::getType(Type::BINDATABYTEARRAY), 'foobarbaz'],
-            'binDataUuid' => [Type::getType(Type::BINDATAUUID), 'testtesttesttest'],
-            'binDataUuidRFC4122' => [Type::getType(Type::BINDATAUUIDRFC4122), str_repeat('a', 16)],
-            'binDataMD5' => [Type::getType(Type::BINDATAMD5), md5('ODM')],
-            'binDataCustom' => [Type::getType(Type::BINDATACUSTOM), 'foobarbaz'],
-            'hash' => [Type::getType(Type::HASH), ['foo' => 'bar']],
-            'collection' => [Type::getType(Type::COLLECTION), ['foo', 'bar']],
-            'objectId' => [Type::getType(Type::OBJECTID), '507f1f77bcf86cd799439011'],
-            'raw' => [Type::getType(Type::RAW), (object) ['foo' => 'bar']],
-            'decimal128' => [Type::getType(Type::DECIMAL128), '4.20'],
+            'id' => [Type::ID, '507f1f77bcf86cd799439011', new ObjectId('507f1f77bcf86cd799439011')],
+            'intId' => [Type::INTID, 1],
+            'customId' => [Type::CUSTOMID, (object) ['foo' => 'bar']],
+            'bool' => [Type::BOOL, true],
+            'boolean' => [Type::BOOLEAN, false],
+            'int' => [Type::INT, 69],
+            'integer' => [Type::INTEGER, 42],
+            'int64' => [Type::INT64, 9223372036854775807, new Int64(9223372036854775807)],
+            'float' => [Type::FLOAT, 3.14],
+            'string' => [Type::STRING, 'ohai'],
+            'minKey' => [Type::KEY, 0, new MinKey()],
+            'maxKey' => [Type::KEY, 1, new MaxKey()],
+            'timestamp' => [Type::TIMESTAMP, $t = time(), new Timestamp(0, $t)],
+            'binData' => [Type::BINDATA, 'foobarbaz'],
+            'binDataFunc' => [Type::BINDATAFUNC, 'foobarbaz'],
+            'binDataByteArray' => [Type::BINDATABYTEARRAY, 'foobarbaz'],
+            'binDataUuid' => [Type::BINDATAUUID, 'testtesttesttest'],
+            'binDataUuidRFC4122' => [Type::BINDATAUUIDRFC4122, str_repeat('a', 16)],
+            'binDataMD5' => [Type::BINDATAMD5, md5('ODM')],
+            'binDataCustom' => [Type::BINDATACUSTOM, 'foobarbaz'],
+            'hash' => [Type::HASH, ['foo' => 'bar'], (object) ['foo' => 'bar']],
+            'collection' => [Type::COLLECTION, ['foo', 'bar']],
+            'objectId' => [Type::OBJECTID, '507f1f77bcf86cd799439011'],
+            'raw' => [Type::RAW, (object) ['foo' => 'bar']],
+            'decimal128' => [Type::DECIMAL128, '4.20'],
         ];
     }
 

--- a/tests/Documents/Encryption/RangeTypes.php
+++ b/tests/Documents/Encryption/RangeTypes.php
@@ -13,6 +13,8 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations\Id;
 use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\Decimal128;
 
+use const PHP_INT_MAX;
+
 /**
  * Test all supported types for range encrypted queries.
  *
@@ -27,6 +29,10 @@ class RangeTypes
     #[Field(type: Type::INT)]
     #[Encrypt(EncryptQuery::Range, min: 5, max: 10)]
     public int $intField;
+
+    #[Field(type: Type::INT64)]
+    #[Encrypt(EncryptQuery::Range, min: 5, max: PHP_INT_MAX - 5)]
+    public int $int64Field;
 
     #[Field(type: Type::FLOAT)]
     #[Encrypt(EncryptQuery::Range, min: 5.5, max: 10.5, precision: 1)]


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | https://github.com/doctrine/mongodb-odm/pull/2779#discussion_r2278161437

#### Summary

Queryable Encryption is more strict. While the PHP driver automatically switch the type of the BSON value between `int` (32 bits) or `long` (64 bits) depending on the actual value, the encrypted fields configuration requires a unique type.

This new `Int64` type is only useful for very large int encrypted fields.
