### PR TITLE
Update test using deprecated field type `integer`

### DIFF
--- a/tests/Documents/GH2310Container.php
+++ b/tests/Documents/GH2310Container.php
@@ -25,6 +25,6 @@ class GH2310Container
 #[ODM\EmbeddedDocument]
 class GH2310Embedded
 {
-    #[ODM\Field(type: 'integer')]
+    #[ODM\Field(type: 'int')]
     public int $value;
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | task
| BC Break     | no
| Fixed issues | -

#### Summary

The `integer` type is deprecated in favor of `int`. Update the test so that we don't use this type. There is no other usage of a deprecated type in the tests. I found it while removing deprecated types for 3.0
https://github.com/doctrine/mongodb-odm/blob/afb565e6246d2dcdaa81636e5a0020d21c1d6fe5/lib/Doctrine/ODM/MongoDB/Types/Type.php#L49-L56