### PR TITLE
Improve detection of the type from a PHP variable

### DIFF
--- a/docs/en/reference/custom-mapping-types.rst
+++ b/docs/en/reference/custom-mapping-types.rst
@@ -9,6 +9,9 @@ In order to create a new mapping type you need to subclass
 ``Doctrine\ODM\MongoDB\Types\Type`` and implement/override
 the methods.
 
+Date Example: Mapping DateTimeImmutable with Timezone
+-----------------------------------------------------
+
 The following example defines a custom type that stores ``DateTimeInterface``
 instances as an embedded document containing a BSON date and accompanying
 timezone string. Those same embedded documents are then be translated back into
@@ -32,6 +35,7 @@ a ``DateTimeImmutable`` when the data is read from the database.
         // This trait provides default closureToPHP used during data hydration
         use ClosureToPHP;
 
+        /** @param array{utc: UTCDateTime, tz: string} $value */
         public function convertToPHPValue($value): DateTimeImmutable
         {
             if (!isset($value['utc'], $value['tz'])) {
@@ -46,6 +50,7 @@ a ``DateTimeImmutable`` when the data is read from the database.
             return DateTimeImmutable::createFromMutable($dateTime);
         }
 
+        /** @return array{utc: UTCDateTime, tz: string} */
         public function convertToDatabaseValue($value): array
         {
             if (!$value instanceof DateTimeImmutable) {
@@ -115,5 +120,114 @@ specify a unique name for the mapping type and map that to the corresponding
 
         <field field-name="field" type="date_with_timezone" />
 
+Custom Type Example: Mapping a UUID Class
+-----------------------------------------
+
+You can create a custom mapping type for your own value objects or classes. For
+example, to map a UUID value object using the `ramsey/uuid library`_, you can
+implement a type that converts between your class and the BSON Binary UUID format.
+
+This approach works for any custom class by adapting the conversion logic to your needs.
+
+Example Implementation (using ``Ramsey\Uuid\Uuid``)::
+
+.. code-block:: php
+
+    <?php
+
+    namespace My\Project\Types;
+
+    use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
+    use Doctrine\ODM\MongoDB\Types\Type;
+    use InvalidArgumentException;
+    use MongoDB\BSON\Binary;
+    use Ramsey\Uuid\Uuid;
+    use Ramsey\Uuid\UuidInterface;
+
+    final class UuidType extends Type
+    {
+        // This trait provides default closureToPHP used during data hydration
+        use ClosureToPHP;
+
+        public function convertToPHPValue(mixed $value): ?Uuid
+        {
+            if (null === $value) {
+                return null;
+            }
+
+            if ($value instanceof Uuid) {
+                return $value;
+            }
+
+            if ($value instanceof Binary) {
+                return Uuid::fromBytes($value->getData());
+            }
+
+            if (is_string($value) && Uuid::isValid($value)) {
+                return Uuid::fromString($value);
+            }
+
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Could not convert database value "%s" from "%s" to %s',
+                    $value,
+                    get_debug_type($value),
+                    UuidInterface::class
+                )
+            );
+        }
+
+        public function convertToDatabaseValue(mixed $value): ?Binary
+        {
+            if (null === $value || [] === $value) {
+                return null;
+            }
+
+            if ($value instanceof Binary) {
+                return $value;
+            }
+
+            if (is_string($value) && Uuid::isValid($value)) {
+                $value = Uuid::fromString($value)->getBytes();
+            }
+
+            if ($value instanceof Uuid) {
+                return new Binary($value->getBytes(), Binary::TYPE_UUID);
+            }
+
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Could not convert database value "%s" from "%s" to %s',
+                    $value,
+                    get_debug_type($value),
+                    Binary::class
+                )
+            );
+        }
+    }
+
+Register the type in your bootstrap code::
+
+.. code-block:: php
+
+    Type::addType(Ramsey\Uuid\Uuid::class, My\Project\Types\UuidType::class);
+
+Usage Example::
+
+.. code-block:: php
+
+    #[Field(type: Ramsey\Uuid\Uuid::class)]
+    public Ramsey\Uuid\Uuid $id;
+
+By using the |FQCN| of the value object class as the type name, the type is
+automatically used when encountering a property of that class. This means you
+can omit the ``type`` option when defining the field mapping::
+
+.. code-block:: php
+
+    #[Field]
+    public Ramsey\Uuid\Uuid $id;
+
+.. _`ramsey/uuid library`: https://github.com/ramsey/uuid
 .. |FQCN| raw:: html
   <abbr title="Fully-Qualified Class Name">FQCN</abbr>

--- a/docs/en/reference/custom-mapping-types.rst
+++ b/docs/en/reference/custom-mapping-types.rst
@@ -135,74 +135,43 @@ Example Implementation (using ``Ramsey\Uuid\Uuid``)::
 
     <?php
 
-    namespace My\Project\Types;
+    namespace App\MongoDB\Types;
 
     use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
     use Doctrine\ODM\MongoDB\Types\Type;
     use InvalidArgumentException;
-    use MongoDB\BSON\Binary;
-    use Ramsey\Uuid\Uuid;
-    use Ramsey\Uuid\UuidInterface;
+    use MongoDB\BSON\Binary as BsonBinary;
+    use Ramsey\Uuid\Uuid as RamseyUuid;
 
-    final class UuidType extends Type
+    final class RamseyUuidType extends Type
     {
         // This trait provides default closureToPHP used during data hydration
         use ClosureToPHP;
 
-        public function convertToPHPValue(mixed $value): ?Uuid
+        public function convertToPHPValue(mixed $value): ?RamseyUuid
         {
             if (null === $value) {
                 return null;
             }
 
-            if ($value instanceof Uuid) {
-                return $value;
+            if ($value instanceof BsonBinary && $value->getType() === BsonBinary::TYPE_UUID) {
+                return RamseyUuid::fromBytes($value->getData());
             }
 
-            if ($value instanceof Binary) {
-                return Uuid::fromBytes($value->getData());
-            }
-
-            if (is_string($value) && Uuid::isValid($value)) {
-                return Uuid::fromString($value);
-            }
-
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Could not convert database value "%s" from "%s" to %s',
-                    $value,
-                    get_debug_type($value),
-                    UuidInterface::class
-                )
-            );
+            throw new \InvalidArgumentException(\sprintf('Could not convert database value from "%s" to %s',get_debug_type($value),RamseyUuid::class));
         }
 
-        public function convertToDatabaseValue(mixed $value): ?Binary
+        public function convertToDatabaseValue(mixed $value): ?BsonBinary
         {
-            if (null === $value || [] === $value) {
+            if (null === $value) {
                 return null;
             }
 
-            if ($value instanceof Binary) {
-                return $value;
+            if ($value instanceof RamseyUuid) {
+                return new BsonBinary($value->getBytes(), BsonBinary::TYPE_UUID);
             }
 
-            if (is_string($value) && Uuid::isValid($value)) {
-                $value = Uuid::fromString($value)->getBytes();
-            }
-
-            if ($value instanceof Uuid) {
-                return new Binary($value->getBytes(), Binary::TYPE_UUID);
-            }
-
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Could not convert database value "%s" from "%s" to %s',
-                    $value,
-                    get_debug_type($value),
-                    Binary::class
-                )
-            );
+            throw new \InvalidArgumentException(\sprintf('Could not convert database value from "%s" to %s', get_debug_type($value), Binary::class));
         }
     }
 
@@ -210,14 +179,14 @@ Register the type in your bootstrap code::
 
 .. code-block:: php
 
-    Type::addType(Ramsey\Uuid\Uuid::class, My\Project\Types\UuidType::class);
+    Type::addType(Ramsey\Uuid\Uuid::class, App\MongoDB\Types\RamseyUuidType::class);
 
 Usage Example::
 
 .. code-block:: php
 
-    #[Field(type: Ramsey\Uuid\Uuid::class)]
-    public Ramsey\Uuid\Uuid $id;
+    #[Field(type: \Ramsey\Uuid\Uuid::class)]
+    public ?\Ramsey\Uuid\Uuid $id;
 
 By using the |FQCN| of the value object class as the type name, the type is
 automatically used when encountering a property of that class. This means you
@@ -226,7 +195,13 @@ can omit the ``type`` option when defining the field mapping::
 .. code-block:: php
 
     #[Field]
-    public Ramsey\Uuid\Uuid $id;
+    public ?\Ramsey\Uuid\Uuid $id;
+
+.. note::
+
+    This implementation of ``RamseyUuidType`` is volontary simple and does not
+    handle all edge cases, but it should give you a good starting point for
+    implementing your own custom types.
 
 .. _`ramsey/uuid library`: https://github.com/ramsey/uuid
 .. |FQCN| raw:: html

--- a/docs/en/reference/custom-mapping-types.rst
+++ b/docs/en/reference/custom-mapping-types.rst
@@ -120,16 +120,16 @@ specify a unique name for the mapping type and map that to the corresponding
 
         <field field-name="field" type="date_with_timezone" />
 
-Custom Type Example: Mapping a UUID Class
------------------------------------------
+Custom Type Example: Mapping a Money Value Object
+-------------------------------------------------
 
 You can create a custom mapping type for your own value objects or classes. For
-example, to map a UUID value object using the `ramsey/uuid library`_, you can
-implement a type that converts between your class and the BSON Binary UUID format.
+example, to map a ``Money`` value object using the `moneyphp/money library`_, you can
+implement a type that converts between this class and a BSON embedded document format.
 
 This approach works for any custom class by adapting the conversion logic to your needs.
 
-Example Implementation (using ``Ramsey\Uuid\Uuid``)::
+Example Implementation (using ``Money\Money``)::
 
 .. code-block:: php
 
@@ -140,38 +140,41 @@ Example Implementation (using ``Ramsey\Uuid\Uuid``)::
     use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
     use Doctrine\ODM\MongoDB\Types\Type;
     use InvalidArgumentException;
-    use MongoDB\BSON\Binary as BsonBinary;
-    use Ramsey\Uuid\Uuid as RamseyUuid;
+    use Money\Money;
+    use Money\Currency;
 
-    final class RamseyUuidType extends Type
+    final class MoneyType extends Type
     {
-        // This trait provides default closureToPHP used during data hydration
+        // This trait provides a default closureToPHP used during data hydration
         use ClosureToPHP;
 
-        public function convertToPHPValue(mixed $value): ?RamseyUuid
+        public function convertToPHPValue(mixed $value): ?Money
         {
             if (null === $value) {
                 return null;
             }
 
-            if ($value instanceof BsonBinary && $value->getType() === BsonBinary::TYPE_UUID) {
-                return RamseyUuid::fromBytes($value->getData());
+            if (is_array($value) && isset($value['amount'], $value['currency'])) {
+                return new Money($value['amount'], new Currency($value['currency']));
             }
 
-            throw new \InvalidArgumentException(\sprintf('Could not convert database value from "%s" to %s',get_debug_type($value),RamseyUuid::class));
+            throw new InvalidArgumentException(sprintf('Could not convert database value from "%s" to %s', get_debug_type($value), Money::class));
         }
 
-        public function convertToDatabaseValue(mixed $value): ?BsonBinary
+        public function convertToDatabaseValue(mixed $value): ?array
         {
             if (null === $value) {
                 return null;
             }
 
-            if ($value instanceof RamseyUuid) {
-                return new BsonBinary($value->getBytes(), BsonBinary::TYPE_UUID);
+            if ($value instanceof Money) {
+                return [
+                    'amount' => $value->getAmount(),
+                    'currency' => $value->getCurrency()->getCode(),
+                ];
             }
 
-            throw new \InvalidArgumentException(\sprintf('Could not convert database value from "%s" to %s', get_debug_type($value), Binary::class));
+            throw new InvalidArgumentException(sprintf('Could not convert database value from "%s" to array', get_debug_type($value)));
         }
     }
 
@@ -179,14 +182,7 @@ Register the type in your bootstrap code::
 
 .. code-block:: php
 
-    Type::addType(Ramsey\Uuid\Uuid::class, App\MongoDB\Types\RamseyUuidType::class);
-
-Usage Example::
-
-.. code-block:: php
-
-    #[Field(type: \Ramsey\Uuid\Uuid::class)]
-    public ?\Ramsey\Uuid\Uuid $id;
+    Type::addType(Money::class, App\MongoDB\Types\MoneyType::class);
 
 By using the |FQCN| of the value object class as the type name, the type is
 automatically used when encountering a property of that class. This means you
@@ -195,14 +191,14 @@ can omit the ``type`` option when defining the field mapping::
 .. code-block:: php
 
     #[Field]
-    public ?\Ramsey\Uuid\Uuid $id;
+    public ?\Money\Money $price;
 
 .. note::
 
-    This implementation of ``RamseyUuidType`` is volontary simple and does not
-    handle all edge cases, but it should give you a good starting point for
-    implementing your own custom types.
+    This implementation of ``MoneyType`` is kept simple for illustration purposes
+    and does not handle all edge cases, but it should give you a good starting
+    point for implementing your own custom types.
 
-.. _`ramsey/uuid library`: https://github.com/ramsey/uuid
+.. _`moneyphp/money library`: https://github.com/moneyphp/money
 .. |FQCN| raw:: html
   <abbr title="Fully-Qualified Class Name">FQCN</abbr>

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -2823,9 +2823,19 @@ use const PHP_VERSION_ID;
      */
     private function validateAndCompleteTypedFieldMapping(array $mapping): array
     {
+        if (isset($mapping['type'])) {
+            return $mapping;
+        }
+
         $type = $this->reflClass->getProperty($mapping['fieldName'])->getType();
 
-        if (! $type instanceof ReflectionNamedType || isset($mapping['type'])) {
+        if (! $type instanceof ReflectionNamedType) {
+            return $mapping;
+        }
+
+        if (! $type->isBuiltin() && Type::hasType($type->getName())) {
+            $mapping['type'] = $type->getName();
+
             return $mapping;
         }
 
@@ -2836,6 +2846,7 @@ use const PHP_VERSION_ID;
                 throw MappingException::nonBackedEnumMapped($this->name, $mapping['fieldName'], $reflection->getName());
             }
 
+            // Use the backing type of the enum for the mapping type
             $type = $reflection->getBackingType();
             assert($type instanceof ReflectionNamedType);
             $mapping['enumType'] = $reflection->getName();

--- a/src/Types/InvalidTypeException.php
+++ b/src/Types/InvalidTypeException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Types;
+
+use InvalidArgumentException;
+
+use function sprintf;
+
+final class InvalidTypeException extends InvalidArgumentException
+{
+    public static function invalidTypeName(string $name): self
+    {
+        return new self(sprintf('Invalid type specified: "%s"', $name));
+    }
+}

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -4,18 +4,16 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Types;
 
+use DateTimeImmutable;
 use DateTimeInterface;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Types;
-use InvalidArgumentException;
-use MongoDB\BSON\ObjectId;
 use Symfony\Component\Uid\Uuid;
 
 use function end;
 use function explode;
 use function gettype;
 use function is_object;
-use function sprintf;
 use function str_replace;
 
 /**
@@ -157,52 +155,52 @@ abstract class Type
     /**
      * Get a Type instance.
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidTypeException
      */
     public static function getType(string $type): Type
     {
         if (! isset(self::$typesMap[$type])) {
-            throw new InvalidArgumentException(sprintf('Invalid type specified "%s".', $type));
+            throw InvalidTypeException::invalidTypeName($type);
         }
 
-        if (! isset(self::$typeObjects[$type])) {
-            $className                = self::$typesMap[$type];
-            self::$typeObjects[$type] = new $className();
-        }
-
-        return self::$typeObjects[$type];
+        return self::$typeObjects[$type] ??= new (self::$typesMap[$type]);
     }
 
     /**
      * Get a Type instance based on the type of the passed php variable.
      *
      * @param mixed $variable
-     *
-     * @throws InvalidArgumentException
      */
     public static function getTypeFromPHPVariable($variable): ?Type
     {
         if (is_object($variable)) {
-            if ($variable instanceof DateTimeInterface) {
-                return self::getType(self::DATE);
+            if ($variable instanceof DateTimeImmutable) {
+                return self::getType(self::DATE_IMMUTABLE);
             }
 
-            if ($variable instanceof ObjectId) {
-                return self::getType(self::ID);
+            if ($variable instanceof DateTimeInterface) {
+                return self::getType(self::DATE);
             }
 
             if ($variable instanceof Uuid) {
                 return self::getType(self::UUID);
             }
-        } else {
-            $type = gettype($variable);
-            switch ($type) {
-                case 'integer':
-                    return self::getType('int');
+
+            // Try the variable class as type name
+            if (self::hasType($variable::class)) {
+                return self::getType($variable::class);
             }
+
+            return null;
         }
 
-        return null;
+        return match (gettype($variable)) {
+            'integer' => self::getType(self::INT),
+            'boolean' => self::getType(self::BOOL),
+            'double' => self::getType(self::FLOAT),
+            'string' => self::getType(self::STRING),
+            default => null,
+        };
     }
 
     /**

--- a/tests/Documentation/CustomMapping/DateTimeWithTimezoneType.php
+++ b/tests/Documentation/CustomMapping/DateTimeWithTimezoneType.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Documentation\CustomMapping;
 
 use DateTimeImmutable;
-use DateTimeInterface;
 use DateTimeZone;
 use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\UTCDateTime;
 use RuntimeException;
+
+use function gettype;
+use function sprintf;
 
 class DateTimeWithTimezoneType extends Type
 {
@@ -32,13 +34,18 @@ class DateTimeWithTimezoneType extends Type
         return DateTimeImmutable::createFromMutable($dateTime);
     }
 
-    /**
-     * @param DateTimeInterface $value
-     *
-     * @return array{utc: UTCDateTime, tz: string}
-     */
+    /** @return array{utc: UTCDateTime, tz: string} */
     public function convertToDatabaseValue($value): array
     {
+        if (! $value instanceof DateTimeImmutable) {
+            throw new RuntimeException(
+                sprintf(
+                    'Expected instance of \DateTimeImmutable, got %s',
+                    gettype($value),
+                ),
+            );
+        }
+
         return [
             'utc' => new UTCDateTime($value),
             'tz' => $value->getTimezone()->getName(),

--- a/tests/Tests/Functional/CustomTypeTest.php
+++ b/tests/Tests/Functional/CustomTypeTest.php
@@ -163,7 +163,7 @@ class Country
 
     /** The field type is detected from the property type */
     #[ODM\Field(/* type: Language::class */)]
-    public Language $lang;
+    public ?Language $lang;
 }
 
 class Language

--- a/tests/Tests/Functional/CustomTypeTest.php
+++ b/tests/Tests/Functional/CustomTypeTest.php
@@ -10,16 +10,34 @@ use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Exception;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
+use ReflectionProperty;
 
 use function array_map;
 use function array_values;
+use function assert;
 use function is_array;
 
 class CustomTypeTest extends BaseTestCase
 {
-    public static function setUpBeforeClass(): void
+    /** @var string[] */
+    private array $originalTypeMap = [];
+
+    #[Before]
+    public function backupTypeMap(): void
     {
+        $this->originalTypeMap = (new ReflectionProperty(Type::class, 'typesMap'))->getValue();
+
         Type::addType('date_collection', DateCollectionType::class);
+        Type::addType(Language::class, LanguageType::class);
+    }
+
+    #[After]
+    public function restoreTypeMap(): void
+    {
+        (new ReflectionProperty(Type::class, 'typesMap'))->setValue($this->originalTypeMap);
+        unset($this->originalTypeMap);
     }
 
     public function testCustomTypeValueConversions(): void
@@ -45,6 +63,36 @@ class CustomTypeTest extends BaseTestCase
         $this->dm->persist($country);
         $this->expectException(CustomTypeException::class);
         $this->dm->flush();
+    }
+
+    public function testCustomTypeDetection(): void
+    {
+        $typeOfField = $this->dm->getClassMetadata(Country::class)->getTypeOfField('lang');
+        self::assertSame(Language::class, $typeOfField, 'The custom type should be detected on the field');
+
+        $country       = new Country();
+        $country->lang = new Language('French', 'fr');
+
+        $this->dm->persist($country);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $country = $this->dm->find(Country::class, $country->id);
+
+        self::assertNotNull($country);
+        self::assertInstanceOf(Language::class, $country->lang);
+        self::assertSame('French', $country->lang->name);
+        self::assertSame('fr', $country->lang->code);
+    }
+
+    public function testTypeFromPHPVariable(): void
+    {
+        $lang = new Language('French', 'fr');
+        $type = Type::getTypeFromPHPVariable($lang);
+        self::assertInstanceOf(LanguageType::class, $type);
+
+        $databaseValue = Type::convertPHPToDatabaseValue($lang);
+        self::assertSame(['name' => 'French', 'code' => 'fr'], $databaseValue);
     }
 }
 
@@ -106,11 +154,52 @@ class CustomTypeException extends Exception
 #[ODM\Document]
 class Country
 {
-    /** @var string|null */
     #[ODM\Id]
-    public $id;
+    public ?string $id;
 
     /** @var DateTime[]|DateTime|null */
     #[ODM\Field(type: 'date_collection')]
     public $nationalHolidays;
+
+    /** The field type is detected from the property type */
+    #[ODM\Field(/* type: Language::class */)]
+    public Language $lang;
+}
+
+class Language
+{
+    public function __construct(
+        public string $name,
+        public string $code,
+    ) {
+    }
+}
+
+class LanguageType extends Type
+{
+    use ClosureToPHP;
+
+    /** @return array{name:string,code:string}|null */
+    public function convertToDatabaseValue($value): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        assert($value instanceof Language);
+
+        return ['name' => $value->name, 'code' => $value->code];
+    }
+
+    /** @param array{name:string,code:string}|null $value */
+    public function convertToPHPValue($value): ?Language
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        assert(is_array($value) && isset($value['name'], $value['code']));
+
+        return new Language($value['name'], $value['code']);
+    }
 }

--- a/tests/Tests/Functional/Ticket/GH2789Test.php
+++ b/tests/Tests/Functional/Ticket/GH2789Test.php
@@ -9,17 +9,35 @@ use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Doctrine\ODM\MongoDB\Types\Versionable;
 use MongoDB\BSON\Binary;
-use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
+use ReflectionProperty;
 
 use function assert;
 use function is_int;
 
-#[BackupGlobals(true)]
 class GH2789Test extends BaseTestCase
 {
+    /** @var string[] */
+    private array $originalTypeMap = [];
+
+    #[Before]
+    public function backupTypeMap(): void
+    {
+        $this->originalTypeMap = (new ReflectionProperty(Type::class, 'typesMap'))->getValue();
+
+        Type::addType(GH2789CustomType::class, GH2789CustomType::class);
+    }
+
+    #[After]
+    public function restoreTypeMap(): void
+    {
+        (new ReflectionProperty(Type::class, 'typesMap'))->setValue($this->originalTypeMap);
+        unset($this->originalTypeMap);
+    }
+
     public function testVersionWithCustomType(): void
     {
-        Type::addType(GH2789CustomType::class, GH2789CustomType::class);
         $doc = new GH2789VersionedUuid('original message');
 
         $this->dm->persist($doc);

--- a/tests/Tests/Types/TypeTest.php
+++ b/tests/Tests/Types/TypeTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Types;
 use DateTime;
 use DateTimeImmutable;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Doctrine\ODM\MongoDB\Types\InvalidTypeException;
 use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
@@ -22,6 +23,7 @@ use Symfony\Component\Uid\UuidV4;
 use function get_debug_type;
 use function hex2bin;
 use function md5;
+use function sprintf;
 use function str_pad;
 use function str_repeat;
 use function time;
@@ -127,6 +129,46 @@ class TypeTest extends BaseTestCase
         $date = new DateTimeImmutable('now');
 
         self::assertInstanceOf(UTCDateTime::class, Type::convertPHPToDatabaseValue($date));
+    }
+
+    #[DataProvider('provideTypeFromPHPVariable')]
+    public function testGetTypeFromPHPVariable(?Type $expectedType, mixed $variable): void
+    {
+        $type = Type::getTypeFromPHPVariable($variable);
+
+        if ($expectedType === null) {
+            self::assertNull($type);
+        } elseif ($type === null) {
+            self::fail(sprintf('Type is null, expected "%s"', $expectedType::class));
+        } else {
+            self::assertInstanceOf($expectedType::class, $type, $type::class);
+        }
+    }
+
+    public static function provideTypeFromPHPVariable(): array
+    {
+        return [
+            'null' => [null, null],
+            'bool' => [Type::getType(Type::BOOL), true],
+            'int' => [Type::getType(Type::INT), 1],
+            'float' => [Type::getType(Type::FLOAT), 3.14],
+            'string' => [Type::getType(Type::STRING), 'ohai'],
+            'DateTime' => [Type::getType(Type::DATE), new DateTime()],
+            'DateTimeImmutable' => [Type::getType(Type::DATE_IMMUTABLE), new DateTimeImmutable()],
+            'unknown object' => [
+                null,
+                new class () {
+                },
+            ],
+        ];
+    }
+
+    public function testInvalidType(): void
+    {
+        self::expectException(InvalidTypeException::class);
+        self::expectExceptionMessage('Invalid type specified: "foo"');
+
+        Type::getType('foo');
     }
 
     private static function assertSameTypeAndValue(mixed $expected, mixed $actual): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | Related to https://github.com/doctrine/mongodb-odm/issues/2789

#### Summary

The method `getTypeFromPHPVariable` is used only by `convertPHPToDatabaseValue`. Which is used to process expressions in the aggregation builder. 

With this new feature, we try to find the type for object class name; assuming custom types are registered using the FQCN of the objects they store.
