### PR TITLE
Enable optimistic locking using an `ObjectId` as version field

### DIFF
--- a/docs/en/reference/transactions-and-concurrency.rst
+++ b/docs/en/reference/transactions-and-concurrency.rst
@@ -191,6 +191,7 @@ Choosing the Field Type
 
 When using the date-based type in a high-concurrency environment, it is still possible to create multiple documents
 with the same version and cause a conflict. This can be avoided by using the ``int``, ``decimal128``, or ``object_id`` type.
+The ``object_id`` type contains the timestamp of its creation, but also a random value to ensure uniqueness.
 
 Usage
 """""

--- a/docs/en/reference/transactions-and-concurrency.rst
+++ b/docs/en/reference/transactions-and-concurrency.rst
@@ -105,7 +105,7 @@ a ``LockException`` is thrown, which indicates that the document was already mod
 .. note::
 
     Only types implementing the ``\Doctrine\ODM\MongoDB\Types\Versionable`` interface can be used for versioning.
-    Following ODM types can be used for versioning: ``int``, ``decimal128``, ``date``, and ``date_immutable``.
+    Following ODM types can be used for versioning: ``int``, ``decimal128``, ``date``, ``date_immutable``, and ``object_id``.
 
 Document Configuration
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -190,7 +190,7 @@ Choosing the Field Type
 """""""""""""""""""""""
 
 When using the date-based type in a high-concurrency environment, it is still possible to create multiple documents
-with the same version and cause a conflict. This can be avoided by using the ``int`` or ``decimal128`` type.
+with the same version and cause a conflict. This can be avoided by using the ``int``, ``decimal128``, or ``object_id`` type.
 
 Usage
 """""

--- a/lib/Doctrine/ODM/MongoDB/Types/ObjectIdType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/ObjectIdType.php
@@ -9,7 +9,7 @@ use MongoDB\BSON\ObjectId;
 /**
  * The ObjectId type.
  */
-class ObjectIdType extends Type
+class ObjectIdType extends Type implements Versionable
 {
     public function convertToDatabaseValue($value)
     {
@@ -37,5 +37,10 @@ class ObjectIdType extends Type
     public function closureToPHP(): string
     {
         return '$return = (string) $value;';
+    }
+
+    public function getNextVersion($current): ObjectId
+    {
+        return new ObjectId();
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/VersionableTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/VersionableTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Types;
+
+use DateTime;
+use DateTimeImmutable;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Doctrine\ODM\MongoDB\Types\Type;
+use Doctrine\ODM\MongoDB\Types\Versionable;
+use MongoDB\BSON\ObjectId;
+
+class VersionableTest extends BaseTestCase
+{
+    public function testIntNextVersion(): void
+    {
+        $type = $this->getType(Type::INT);
+        self::assertSame(1, $type->getNextVersion(null));
+        self::assertSame(2, $type->getNextVersion(1));
+    }
+
+    public function testDecimal128NextVersion(): void
+    {
+        $type = $this->getType(Type::DECIMAL128);
+        self::assertSame('1', $type->getNextVersion(null));
+        self::assertSame('2', $type->getNextVersion('1'));
+    }
+
+    public function testDateTimeNextVersion(): void
+    {
+        $type    = $this->getType(Type::DATE);
+        $current = new DateTime();
+        $next    = $type->getNextVersion(null);
+        self::assertInstanceOf(DateTime::class, $next);
+        self::assertGreaterThanOrEqual($current, $next);
+        self::assertLessThanOrEqual(new DateTime(), $next);
+
+        $next = $type->getNextVersion(new DateTime('2000-01-01'));
+        self::assertInstanceOf(DateTime::class, $next);
+        self::assertGreaterThanOrEqual($current, $next);
+        self::assertLessThanOrEqual(new DateTime(), $next);
+    }
+
+    public function testDateTimeImmutableNextVersion(): void
+    {
+        $type    = $this->getType(Type::DATE_IMMUTABLE);
+        $current = new DateTime();
+        $next    = $type->getNextVersion(null);
+        self::assertInstanceOf(DateTimeImmutable::class, $next);
+        self::assertGreaterThanOrEqual($current, $next);
+        self::assertLessThanOrEqual(new DateTimeImmutable(), $next);
+
+        $next = $type->getNextVersion(new DateTimeImmutable('2000-01-01'));
+        self::assertInstanceOf(DateTimeImmutable::class, $next);
+        self::assertGreaterThanOrEqual($current, $next);
+        self::assertLessThanOrEqual(new DateTimeImmutable(), $next);
+    }
+
+    public function testObjectIdNextVersion(): void
+    {
+        $type    = $this->getType(Type::OBJECTID);
+        $current = new ObjectId();
+        $next    = $type->getNextVersion(null);
+        self::assertInstanceOf(ObjectId::class, $next);
+        self::assertGreaterThan($current, $next);
+        self::assertLessThan(new ObjectId(), $next);
+
+        $next = $type->getNextVersion($current);
+        self::assertInstanceOf(ObjectId::class, $next);
+        self::assertGreaterThan($current, $next);
+        self::assertLessThan(new ObjectId(), $next);
+    }
+
+    private function getType(string $name): Versionable
+    {
+        $type = Type::getType($name);
+
+        self::assertInstanceOf(Versionable::class, $type);
+
+        return $type;
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | Related to https://github.com/doctrine/mongodb-odm/issues/2789

#### Summary

Optimistic Locking use a `version` field that is incremented on each version.
- Using a `int` field is safe but doesn't provide any information about the last update
- Using a `date` field provides the last update date, but is not safe if updates occurs during the same millisecond.
- Using an a MongoDB `ObjectId` is perfect as it is both safe, sortable and provide the update date using [`ObjectId::getTimestamp()`](https://www.php.net/manual/en/mongodb-bson-objectid.gettimestamp.php)
