### PR TITLE
Fix duplicate slug in .doctrine-project.json

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -8,7 +8,7 @@
         {
             "name": "2.13",
             "branchName": "2.13.x",
-            "slug": "latest",
+            "slug": "2.13",
             "upcoming": true
         },
         {


### PR DESCRIPTION
Currently https://www.doctrine-project.org/projects/doctrine-mongodb-odm/en/latest/index.html shows the version 2.13 of the documentation. There is no way to access 2.12.