### PR TITLE
Add vector search type to atlas search indexes

### DIFF
--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -566,11 +566,19 @@
     </xs:choice>
 
     <xs:attribute name="name" type="xs:string" />
+    <xs:attribute name="type" type="odm:search-index-type" />
     <xs:attribute name="dynamic" type="xs:boolean" />
     <xs:attribute name="analyzer" type="xs:string" />
     <xs:attribute name="searchAnalyzer" type="xs:string" />
     <xs:attribute name="storedSource" type="xs:boolean" />
   </xs:complexType>
+
+  <xs:simpleType name="search-index-type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="search" />
+      <xs:enumeration value="vectorSearch" />
+    </xs:restriction>
+  </xs:simpleType>
 
   <!-- https://www.mongodb.com/docs/atlas/atlas-search/define-field-mappings/ -->
   <xs:complexType name="search-index-field">

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/SearchIndex.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/SearchIndex.php
@@ -24,6 +24,7 @@ class SearchIndex implements Annotation
      * @param list<array>|null              $analyzers
      * @param SearchIndexStoredSource|null  $storedSource
      * @param list<SearchIndexSynonym>|null $synonyms
+     * @param string|null                   $type         Type of index: 'search' (default) or 'vectorSearch'
      */
     public function __construct(
         public ?string $name = null,
@@ -34,6 +35,7 @@ class SearchIndex implements Annotation
         public ?array $analyzers = null,
         public $storedSource = null,
         public ?array $synonyms = null,
+        public ?string $type = null,
     ) {
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -1245,7 +1245,7 @@ use function trigger_deprecation;
      *
      * @phpstan-param SearchIndexDefinition $definition
      */
-    public function addSearchIndex(array $definition, ?string $name = null): void
+    public function addSearchIndex(array $definition, ?string $name = null, ?string $type): void
     {
         $name ??= self::DEFAULT_SEARCH_INDEX_NAME;
 
@@ -1256,6 +1256,7 @@ use function trigger_deprecation;
         $this->searchIndexes[] = [
             'definition' => $definition,
             'name' => $name,
+            'type' => $type,
         ];
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
@@ -386,7 +386,7 @@ class AttributeDriver implements MappingDriver
             }
         }
 
-        $class->addSearchIndex($definition, $index->name ?? null);
+        $class->addSearchIndex($definition, $index->name, $index->type);
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

Enable creation of vector search index: https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-overview/
