### PR TITLE
PHPORM-381 Add class metadata for vector search indexes

### DIFF
--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -1462,7 +1462,7 @@ Example:
         #[Field(type: Type::COLLECTION)]
         public array $plotEmbeddingVoyage3Large = [];
 
-        #[Field)]
+        #[Field]
         public string $category;
     }
 

--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -1167,6 +1167,10 @@ Optional arguments:
 This attribute is used to specify :ref:`search indexes <search_indexes>` for
 `MongoDB Atlas Search <https://www.mongodb.com/docs/atlas/atlas-search/>`__.
 
+.. note::
+
+    For vector search indexes, see :ref:`vector_search_index` below.
+
 The arguments correspond to arguments for
 `MongoDB\Collection::createSearchIndex() <https://www.mongodb.com/docs/php-library/current/reference/method/MongoDBCollection-createSearchIndex/>`__.
 Excluding ``name``, arguments are used to create the
@@ -1396,6 +1400,73 @@ for the related collection.
 
         // rest of the class code...
     }
+
+#[VectorSearchIndex]
+--------------------
+
+.. _vector_search_index:
+
+The ``#[VectorSearchIndex]`` attribute is used to define a vector search index
+on a document class. This enables efficient similarity search on vector fields,
+such as those used for machine learning embeddings.
+
+Optional arguments:
+
+- ``name``: (optional) The name of the vector search index. If omitted, a default name is used.
+- ``fields`` (required): A list of field definitions. Each field definition is an associative array describing a vector or filter field. For vector fields, the following keys are supported:
+
+  - ``type``: Must be set to ``'vector'`` for vector fields or ``'filter'`` for filter fields.
+  - ``path``: The name of the field in the document to index.
+  - ``numDimensions``: (vector fields only) The number of dimensions in the vector.
+  - ``similarity``: (vector fields only) The vector similarity function to use. Supported values include ``'euclidean'``, ``'cosine'``, and ``'dotProduct'``. Use the constants from ``Doctrine\ODM\MongoDB\Mapping\ClassMetadata::VECTOR_SIMILARITY_*`` for best compatibility.
+  - ``quantization``: (vector fields only, optional) The quantization method, e.g., ``'scalar'``.
+  - ``hnswOptions``: (vector fields only, optional) Options for the HNSW algorithm: ``maxEdges`` and ``numEdgeCandidates``.
+
+  For filter fields, only ``type: 'filter'`` and ``path`` are required.
+
+
+Example:
+
+.. code-block:: php
+
+    <?php
+    use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+    use Doctrine\ODM\MongoDB\Mapping\Annotations\Field;
+    use Doctrine\ODM\MongoDB\Mapping\Annotations\Id;
+    use Doctrine\ODM\MongoDB\Mapping\Annotations\VectorSearchIndex;
+    use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+    use Doctrine\ODM\MongoDB\Types\Type;
+
+    #[Document(collection: 'vector_embeddings')]
+    #[VectorSearchIndex(
+        fields: [
+            [
+                'type' => 'vector',
+                'path' => 'plotEmbeddingVoyage3Large',
+                'numDimensions' => 2048,
+                'similarity' => ClassMetadata::VECTOR_SIMILARITY_DOT_PRODUCT,
+                'quantization' => ClassMetadata::VECTOR_QUANTIZATION_SCALAR,
+            ],
+            [
+                'type' => 'filter',
+                'path' => 'category',
+            ],
+        ],
+    )]
+    class VectorEmbedding
+    {
+        #[Id]
+        public ?string $id = null;
+
+        /** @var list<float> */
+        #[Field(type: Type::COLLECTION)]
+        public array $plotEmbeddingVoyage3Large = [];
+
+        #[Field)]
+        public string $category;
+    }
+
+For more details, see the MongoDB documentation on `Atlas Vector Search <https://www.mongodb.com/docs/atlas/atlas-vector-search/>`_.
 
 #[Version]
 ----------

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -157,6 +157,7 @@
       <xs:element name="also-load-methods" type="odm:also-load-methods" minOccurs="0" />
       <xs:element name="indexes" type="odm:indexes" minOccurs="0" />
       <xs:element name="search-indexes" type="odm:search-indexes" minOccurs="0" />
+      <xs:element name="vector-search-indexes" type="odm:vector-search-indexes" minOccurs="0" />
       <xs:element name="shard-key" type="odm:shard-key" minOccurs="0" />
       <xs:element name="read-preference" type="odm:read-preference" minOccurs="0" />
       <xs:element name="schema-validation" type="odm:schema-validation" minOccurs="0" />
@@ -639,6 +640,35 @@
       <xs:enumeration value="exclude" />
     </xs:restriction>
   </xs:simpleType>
+
+  <!-- https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/#atlas-vector-search-index-fields -->
+  <xs:complexType name="vector-search-indexes">
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="vector-search-index" type="odm:vector-search-index" maxOccurs="unbounded" />
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="vector-search-index">
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="vector-field" type="odm:vector-search-vector-field" />
+      <xs:element name="filter-field" type="odm:vector-search-filter-field" minOccurs="0" maxOccurs="unbounded" />
+    </xs:choice>
+
+    <xs:attribute name="name" type="xs:string" />
+  </xs:complexType>
+
+  <xs:complexType name="vector-search-vector-field">
+    <xs:attribute name="path" type="xs:string" use="required" />
+    <xs:attribute name="numDimensions" type="xs:int" use="required" />
+    <xs:attribute name="similarity" type="xs:string" use="required" />
+    <xs:attribute name="quantization" type="xs:string" />
+    <xs:attribute name="hnswMaxEdges" type="xs:int" />
+    <xs:attribute name="hnswNumEdgeCandidates" type="xs:int" />
+  </xs:complexType>
+
+  <xs:complexType name="vector-search-filter-field">
+    <xs:attribute name="path" type="xs:string" use="required" />
+  </xs:complexType>
 
   <xs:complexType name="shard-key">
     <xs:choice minOccurs="0" maxOccurs="unbounded">

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/SearchIndex.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/SearchIndex.php
@@ -11,6 +11,8 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 /**
  * Defines a search index on a class.
  *
+ * @see https://www.mongodb.com/docs/atlas/atlas-search/index-definitions/
+ *
  * @Annotation
  * @NamedArgumentConstructor
  * @phpstan-import-type SearchIndexStoredSource from ClassMetadata

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/VectorSearchIndex.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/VectorSearchIndex.php
@@ -9,7 +9,9 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 
 /**
- * Defines a search index on a class.
+ * Defines a vector search index on a class.
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/
  *
  * @Annotation
  * @NamedArgumentConstructor

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/VectorSearchIndex.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/VectorSearchIndex.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
+
+use Attribute;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+
+/**
+ * Defines a search index on a class.
+ *
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @phpstan-import-type VectorSearchIndexField from ClassMetadata
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class VectorSearchIndex implements Annotation
+{
+    /** @param list<VectorSearchIndexField> $fields */
+    public function __construct(
+        public array $fields,
+        public ?string $name = null,
+    ) {
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -35,6 +35,7 @@ use ReflectionEnum;
 use ReflectionNamedType;
 use ReflectionProperty;
 
+use function array_column;
 use function array_filter;
 use function array_key_exists;
 use function array_keys;
@@ -262,6 +263,17 @@ use function trigger_deprecation;
  *      name: string,
  *      definition: SearchIndexDefinition
  * }
+ * @phpstan-type VectorSearchIndexField array{
+ *     type: 'vector'|'filter',
+ *     path: string,
+ *     numDimensions?: int,
+ *     similarity?: self::VECTOR_SIMILARITY_*,
+ *     quantization?: self::VECTOR_QUANTIZATION_*,
+ *     hnswOptions?: array{maxEdges?: int, numEdgeCandidates?: int}
+ * }
+ * @phpstan-type VectorSearchIndexDefinition array{
+ *     fields: list<VectorSearchIndexField>
+ * }
  * @phpstan-type ShardKeys array<string, mixed>
  * @phpstan-type ShardOptions array<string, mixed>
  * @phpstan-type ShardKey array{
@@ -458,6 +470,13 @@ use function trigger_deprecation;
      * @see https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/
      */
     public const DEFAULT_SEARCH_INDEX_NAME = 'default';
+
+    public const VECTOR_SIMILARITY_EUCLIDEAN   = 'euclidean';
+    public const VECTOR_SIMILARITY_COSINE      = 'cosine';
+    public const VECTOR_SIMILARITY_DOT_PRODUCT = 'dot_product';
+    public const VECTOR_QUANTIZATION_NONE      = 'none';
+    public const VECTOR_QUANTIZATION_SCALAR    = 'scalar';
+    public const VECTOR_QUANTIZATION_BINARY    = 'binary';
 
     private const ALLOWED_GRIDFS_FIELDS = ['_id', 'chunkSize', 'filename', 'length', 'metadata', 'uploadDate'];
 
@@ -1243,19 +1262,25 @@ use function trigger_deprecation;
     /**
      * Add a search index for this Document.
      *
-     * @phpstan-param SearchIndexDefinition $definition
+     * @phpstan-param SearchIndexDefinition|VectorSearchIndexDefinition $definition
+     * @phpstan-param 'search'|'vectorSearch' $type
      */
-    public function addSearchIndex(array $definition, ?string $name = null): void
+    public function addSearchIndex(array $definition, ?string $name = null, string $type = 'search'): void
     {
         $name ??= self::DEFAULT_SEARCH_INDEX_NAME;
 
-        if (empty($definition['mappings']['dynamic']) && empty($definition['mappings']['fields'])) {
+        if ($type === 'search' && empty($definition['mappings']['dynamic']) && empty($definition['mappings']['fields'])) {
             throw MappingException::emptySearchIndexDefinition($this->name, $name);
+        }
+
+        if ($type === 'vectorSearch' && ! in_array('vector', array_column($definition['fields'] ?? [], 'type'), true)) {
+            throw MappingException::emptyVectorSearchIndexDefinition($this->name, $name);
         }
 
         $this->searchIndexes[] = [
             'definition' => $definition,
             'name' => $name,
+            'type' => $type,
         ];
     }
 

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -1269,6 +1269,10 @@ use function trigger_deprecation;
     {
         $name ??= self::DEFAULT_SEARCH_INDEX_NAME;
 
+        if ($type !== 'search' && $type !== 'vectorSearch') {
+            throw new InvalidArgumentException(sprintf('Search index type must be either "search" or "vectorSearch", "%s" given.', $type));
+        }
+
         if ($type === 'search' && empty($definition['mappings']['dynamic']) && empty($definition['mappings']['fields'])) {
             throw MappingException::emptySearchIndexDefinition($this->name, $name);
         }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/AttributeDriver.php
@@ -8,7 +8,6 @@ use Doctrine\Common\Annotations\Reader;
 use Doctrine\ODM\MongoDB\Events;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\Annotations\AbstractIndex;
-use Doctrine\ODM\MongoDB\Mapping\Annotations\SearchIndex;
 use Doctrine\ODM\MongoDB\Mapping\Annotations\ShardKey;
 use Doctrine\ODM\MongoDB\Mapping\Annotations\TimeSeries;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
@@ -106,6 +105,10 @@ class AttributeDriver implements MappingDriver
 
             if ($attribute instanceof ODM\SearchIndex) {
                 $this->addSearchIndex($metadata, $attribute);
+            }
+
+            if ($attribute instanceof ODM\VectorSearchIndex) {
+                $this->addVectorSearchIndex($metadata, $attribute);
             }
 
             if ($attribute instanceof ODM\Indexes) {
@@ -370,7 +373,7 @@ class AttributeDriver implements MappingDriver
     }
 
     /** @param ClassMetadata<object> $class */
-    private function addSearchIndex(ClassMetadata $class, SearchIndex $index): void
+    private function addSearchIndex(ClassMetadata $class, ODM\SearchIndex $index): void
     {
         $definition = [];
 
@@ -386,7 +389,17 @@ class AttributeDriver implements MappingDriver
             }
         }
 
-        $class->addSearchIndex($definition, $index->name ?? null);
+        $class->addSearchIndex($definition, $index->name ?? null, 'search');
+    }
+
+    /** @param ClassMetadata<object> $class */
+    private function addVectorSearchIndex(ClassMetadata $class, ODM\VectorSearchIndex $index): void
+    {
+        $definition = [
+            'fields' => $index->fields,
+        ];
+
+        $class->addSearchIndex($definition, $index->name ?? null, 'vectorSearch');
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -210,6 +210,12 @@ class XmlDriver extends FileDriver
             }
         }
 
+        if (isset($xmlRoot->{'vector-search-indexes'})) {
+            foreach ($xmlRoot->{'vector-search-indexes'}->{'vector-search-index'} as $searchIndex) {
+                $this->addVectorSearchIndex($metadata, $searchIndex);
+            }
+        }
+
         if (isset($xmlRoot->{'shard-key'})) {
             $this->setShardKey($metadata, $xmlRoot->{'shard-key'}[0]);
         }
@@ -746,6 +752,45 @@ class XmlDriver extends FileDriver
         }
 
         return $fieldDefinition;
+    }
+
+    /** @param ClassMetadata<object> $class */
+    private function addVectorSearchIndex(ClassMetadata $class, SimpleXMLElement $searchIndex): void
+    {
+        $definition = ['fields' => []];
+
+        foreach ($searchIndex->{'vector-field'} as $vectorField) {
+            $field = [
+                'type' => 'vector',
+                'path' => (string) $vectorField['path'],
+                'numDimensions' => (int) $vectorField['numDimensions'],
+                'similarity' => (string) $vectorField['similarity'],
+            ];
+            if (isset($vectorField['quantization'])) {
+                $field['quantization'] = (string) $vectorField['quantization'];
+            }
+
+            if (isset($vectorField['hnswMaxEdges'])) {
+                $field['hnswOptions']['maxEdges'] = (int) $vectorField['hnswMaxEdges'];
+            }
+
+            if (isset($vectorField['hnswNumEdgeCandidates'])) {
+                $field['hnswOptions']['numEdgeCandidates'] = (int) $vectorField['hnswNumEdgeCandidates'];
+            }
+
+            $definition['fields'][] = $field;
+        }
+
+        foreach ($searchIndex->{'filter-field'} as $filterField) {
+            $definition['fields'][] = [
+                'type' => 'filter',
+                'path' => (string) $filterField['path'],
+            ];
+        }
+
+        $name = isset($searchIndex['name']) ? (string) $searchIndex['name'] : null;
+
+        $class->addSearchIndex($definition, $name, 'vectorSearch');
     }
 
     /** @return array<string, array<string, mixed>|scalar|null> */

--- a/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/MappingException.php
@@ -297,6 +297,11 @@ final class MappingException extends BaseMappingException
         return new self(sprintf('%s search index "%s" must be dynamic or specify a field mapping', $className, $indexName));
     }
 
+    public static function emptyVectorSearchIndexDefinition(string $className, string $indexName): self
+    {
+        return new self(sprintf('%s vector search index "%s" must have a vector field', $className, $indexName));
+    }
+
     public static function timeSeriesFieldNotFound(string $className, string $fieldName, string $field): self
     {
         return new self(sprintf(

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1867,6 +1867,18 @@ parameters:
 			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataLoadEventTest.php
 
 		-
+			message: '#^Method Doctrine\\ODM\\MongoDB\\Tests\\Mapping\\ClassMetadataTest\:\:testEmptyVectorSearchIndexDefinition\(\) has parameter \$definition with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+
+		-
+			message: '#^Method Doctrine\\ODM\\MongoDB\\Tests\\Mapping\\ClassMetadataTest\:\:testSearchIndexDefinition\(\) has parameter \$definition with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+
+		-
 			message: '#^Property DoctrineGlobal_User\:\:\$email is unused\.$#'
 			identifier: property.unused
 			count: 1

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
@@ -115,13 +115,14 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
     #[Depends('testDocumentLevelWriteConcern')]
     public function testFieldMappings(ClassMetadata $class): ClassMetadata
     {
-        self::assertCount(14, $class->fieldMappings);
+        self::assertCount(15, $class->fieldMappings);
         self::assertTrue(isset($class->fieldMappings['identifier']));
         self::assertTrue(isset($class->fieldMappings['version']));
         self::assertTrue(isset($class->fieldMappings['lock']));
         self::assertTrue(isset($class->fieldMappings['name']));
         self::assertTrue(isset($class->fieldMappings['email']));
         self::assertTrue(isset($class->fieldMappings['roles']));
+        self::assertTrue(isset($class->fieldMappings['embedding']));
 
         return $class;
     }
@@ -237,7 +238,7 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
     #[Depends('testIdentifier')]
     public function testAssocations(ClassMetadata $class): ClassMetadata
     {
-        self::assertCount(14, $class->fieldMappings);
+        self::assertCount(15, $class->fieldMappings);
 
         return $class;
     }
@@ -433,6 +434,7 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
         $expectedIndexes = [
             [
                 'name' => 'default',
+                'type' => 'search',
                 'definition' => [
                     'mappings' => ['dynamic' => true],
                     'analyzer' => 'lucene.standard',
@@ -442,6 +444,7 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
             ],
             [
                 'name' => 'usernameAndPhoneNumbers',
+                'type' => 'search',
                 'definition' => [
                     'mappings' => [
                         'fields' => [
@@ -469,6 +472,30 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
                             'name' => 'mySynonyms',
                             'analyzer' => 'lucene.english',
                             'source' => ['collection' => 'synonyms'],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type' => 'vectorSearch',
+                'name' => 'embeddingIndex',
+                'definition' => [
+                    'fields' => [
+                        [
+                            'type' => 'vector',
+                            'path' => 'embedding',
+                            'numDimensions' => 1536,
+                            'similarity' => 'euclidean',
+                            'quantization' => 'scalar',
+                            'hnswOptions' => ['maxEdges' => 16, 'numEdgeCandidates' => 200],
+                        ],
+                        [
+                            'type' => 'filter',
+                            'path' => 'name',
+                        ],
+                        [
+                            'type' => 'filter',
+                            'path' => 'email',
                         ],
                     ],
                 ],
@@ -729,6 +756,19 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
  *     {"name"="mySynonyms", "analyzer"="lucene.english", "source"={"collection"="synonyms"}},
  *   },
  * )
+ * @ODM\VectorSearchIndex(
+ *   fields={
+ *     {"type"="vector",
+ *      "path"="embedding",
+ *      "numDimensions"=1536,
+ *      "similarity"="euclidean",
+ *      "quantization"="scalar",
+ *      "hnswOptions"={"maxEdges"=16, "numEdgeCandidates"=200, },
+ *     },
+ *     {"type"="filter", "path"="name"}
+ *   },
+ *   name="embeddingIndex",
+ * )
  * @ODM\ShardKey(keys={"name"="asc"},unique=true,numInitialChunks=4096)
  * @ODM\ReadPreference("primaryPreferred", tags={
  *   { "dc"="east" },
@@ -763,6 +803,27 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
     synonyms: [
         ['name' => 'mySynonyms', 'analyzer' => 'lucene.english', 'source' => ['collection' => 'synonyms']],
     ],
+)]
+#[ODM\VectorSearchIndex(
+    fields: [
+        [
+            'type' => 'vector',
+            'path' => 'embedding',
+            'numDimensions' => 1536,
+            'similarity' => ClassMetadata::VECTOR_SIMILARITY_EUCLIDEAN,
+            'quantization' => ClassMetadata::VECTOR_QUANTIZATION_SCALAR,
+            'hnswOptions' => ['maxEdges' => 16, 'numEdgeCandidates' => 200],
+        ],
+        [
+            'type' => 'filter',
+            'path' => 'name',
+        ],
+        [
+            'type' => 'filter',
+            'path' => 'email',
+        ],
+    ],
+    name: 'embeddingIndex',
 )]
 #[ODM\ShardKey(keys: ['name' => 'asc'], unique: true, numInitialChunks: 4096)]
 #[ODM\ReadPreference('primaryPreferred', tags: [['dc' => 'east'], ['dc' => 'west'], []])]
@@ -889,6 +950,14 @@ class AbstractMappingDriverUser
      */
     #[ODM\Field(type: 'collection')]
     public $roles = [];
+
+    /**
+     * @ODM\Field(type="collection")
+     *
+     * @var int[]
+     */
+    #[ODM\Field(type: 'collection')]
+    public $embedding = [];
 
     /** @ODM\PrePersist */
     #[ODM\PrePersist]

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractMappingDriverTestCase.php
@@ -758,14 +758,16 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
  * )
  * @ODM\VectorSearchIndex(
  *   fields={
- *     {"type"="vector",
- *      "path"="embedding",
- *      "numDimensions"=1536,
- *      "similarity"="euclidean",
- *      "quantization"="scalar",
- *      "hnswOptions"={"maxEdges"=16, "numEdgeCandidates"=200, },
+ *     {
+ *       "type"="vector",
+ *       "path"="embedding",
+ *       "numDimensions"=1536,
+ *       "similarity"="euclidean",
+ *       "quantization"="scalar",
+ *       "hnswOptions"={"maxEdges"=16, "numEdgeCandidates"=200, },
  *     },
- *     {"type"="filter", "path"="name"}
+ *     {"type"="filter", "path"="name"},
+ *     {"type"="filter", "path"="email"},
  *   },
  *   name="embeddingIndex",
  * )

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -39,6 +39,7 @@ use Generator;
 use InvalidArgumentException;
 use MongoDB\BSON\Document;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use ReflectionClass;
 use ReflectionException;
 use stdClass;
@@ -980,6 +981,34 @@ class ClassMetadataTest extends BaseTestCase
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage('stdClass search index "default" must be dynamic or specify a field mapping');
         $cm->addSearchIndex(['mappings' => []]);
+    }
+
+    #[TestWith([null, ClassMetadata::DEFAULT_SEARCH_INDEX_NAME, ['mappings' => ['dynamic' => true]]])]
+    #[TestWith(['custom_name', 'custom_name', ['mappings' => ['fields' => ['title' => ['type' => 'string']]]]])]
+    public function testSearchIndexDefinition(?string $name, string $expectedName, array $definition): void
+    {
+        $cm = new ClassMetadata('stdClass');
+        $cm->addSearchIndex($definition, $name);
+
+        self::assertSame([
+            [
+                'definition' => $definition,
+                'name' => $expectedName,
+                'type' => 'search',
+            ],
+        ], $cm->getSearchIndexes());
+    }
+
+    #[TestWith([[]])]
+    #[TestWith([['fields' => []]])]
+    #[TestWith([['fields' => [['type' => 'filter', 'path' => 'foo']]]])]
+    public function testEmptyVectorSearchIndexDefinition(array $definition): void
+    {
+        $cm = new ClassMetadata('stdClass');
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('stdClass vector search index "default" must have a vector field');
+        $cm->addSearchIndex($definition, name: 'default', type: 'vector');
     }
 
     public function testTimeSeriesMappingOnlyWithTimeField(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -1008,7 +1008,35 @@ class ClassMetadataTest extends BaseTestCase
 
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage('stdClass vector search index "default" must have a vector field');
-        $cm->addSearchIndex($definition, name: 'default', type: 'vector');
+        $cm->addSearchIndex($definition, 'default', 'vectorSearch');
+    }
+
+    public function testVectorSearchIndexDefinition(): void
+    {
+        $definition = [
+            'fields' => [
+                [
+                    'type' => 'vector',
+                    'path' => 'embedding',
+                    'numDimensions' => 85,
+                    'similarity' => ClassMetadata::VECTOR_SIMILARITY_COSINE,
+                ],
+                [
+                    'type' => 'filter',
+                    'path' => 'category',
+                ],
+            ],
+        ];
+        $cm         = new ClassMetadata('stdClass');
+        $cm->addSearchIndex($definition, 'embeddings_index', 'vectorSearch');
+
+        self::assertSame([
+            [
+                'definition' => $definition,
+                'name' => 'embeddings_index',
+                'type' => 'vectorSearch',
+            ],
+        ], $cm->getSearchIndexes());
     }
 
     public function testTimeSeriesMappingOnlyWithTimeField(): void

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
@@ -28,6 +28,7 @@
         <field field-name="mysqlProfileId" type="int" unique="true" drop-dups="true" order="desc" />
         <field field-name="createdAt" type="date" />
         <field field-name="roles" type="collection" />
+        <field field-name="embedding" type="collection" />
         <indexes>
             <index unique="true">
                 <key name="username" order="desc" />
@@ -59,6 +60,13 @@
                 <synonym name="mySynonyms" analyzer="lucene.english" sourceCollection="synonyms" />
             </search-index>
         </search-indexes>
+        <vector-search-indexes>
+            <vector-search-index name="embeddingIndex">
+                <vector-field path="embedding" numDimensions="1536" similarity="euclidean" quantization="scalar" hnswMaxEdges="16" hnswNumEdgeCandidates="200" />
+                <filter-field path="name" />
+                <filter-field path="email" />
+            </vector-search-index>
+        </vector-search-indexes>
         <reference-one target-document="Doctrine\ODM\MongoDB\Tests\Mapping\Address" field="address">
             <cascade>
                 <remove />

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -25,6 +25,7 @@ use Documents\SimpleReferenceUser;
 use Documents\TimeSeries\TimeSeriesDocument;
 use Documents\Tournament\Tournament;
 use Documents\UserName;
+use Documents\VectorEmbedding;
 use InvalidArgumentException;
 use Iterator;
 use MongoDB\BSON\Document;
@@ -48,6 +49,7 @@ use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\MockObject\MockObject;
 
 use function array_count_values;
+use function array_key_exists;
 use function array_map;
 use function assert;
 use function in_array;
@@ -72,10 +74,11 @@ class SchemaManagerTest extends BaseTestCase
         ShardedOneWithDifferentKey::class,
     ];
 
-    /** @var list<class-string> */
+    /** @var array<class-string, list<string>> */
     private array $searchIndexedClasses = [
-        CmsAddress::class,
-        CmsArticle::class,
+        CmsAddress::class => ['default'],
+        CmsArticle::class => ['search_articles'],
+        VectorEmbedding::class => ['default', 'vector_int'],
     ];
 
     /** @var list<class-string> */
@@ -112,12 +115,7 @@ class SchemaManagerTest extends BaseTestCase
                 $this->documentCollections[$cm->getCollection()] = $this->getMockCollection($cm->getCollection());
             }
 
-            $db = $this->getDatabaseName($cm);
-            if (isset($this->documentDatabases[$db])) {
-                continue;
-            }
-
-            $this->documentDatabases[$db] = $this->getMockDatabase();
+            $this->documentDatabases[$this->getDatabaseName($cm)] ??= $this->getMockDatabase();
         }
 
         $client->method('getDatabase')->willReturnCallback(fn (string $db) => $this->documentDatabases[$db]);
@@ -392,17 +390,18 @@ class SchemaManagerTest extends BaseTestCase
 
     public function testCreateSearchIndexes(): void
     {
-        $searchIndexedCollections = array_map(
-            fn (string $fqcn) => $this->dm->getClassMetadata($fqcn)->getCollection(),
-            $this->searchIndexedClasses,
-        );
+        $searchIndexesPerCollectionName = [];
+        foreach ($this->searchIndexedClasses as $fqcn => $indexes) {
+            $searchIndexesPerCollectionName[$this->dm->getClassMetadata($fqcn)->getCollection()] = $indexes;
+        }
+
         foreach ($this->documentCollections as $collectionName => $collection) {
-            if (in_array($collectionName, $searchIndexedCollections)) {
+            if (array_key_exists($collectionName, $searchIndexesPerCollectionName)) {
                 $collection
                     ->expects($this->once())
                     ->method('createSearchIndexes')
                     ->with($this->anything())
-                    ->willReturn(['default']);
+                    ->willReturn($searchIndexesPerCollectionName[$collectionName]);
             } else {
                 $collection->expects($this->never())->method('createSearchIndexes');
             }
@@ -413,14 +412,58 @@ class SchemaManagerTest extends BaseTestCase
 
     public function testCreateDocumentSearchIndexes(): void
     {
-        $cmsArticleCollectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
+        $expectedCollectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
         foreach ($this->documentCollections as $collectionName => $collection) {
-            if ($collectionName === $cmsArticleCollectionName) {
+            if ($collectionName === $expectedCollectionName) {
                 $collection
                     ->expects($this->once())
                     ->method('createSearchIndexes')
-                    ->with($this->anything())
-                    ->willReturn(['default']);
+                    ->with([
+                        [
+                            'definition' => ['mappings' => ['dynamic' => true]],
+                            'name' => 'search_articles',
+                            'type' => 'search',
+                        ],
+                    ])
+                    ->willReturn(['search_articles']);
+            } else {
+                $collection->expects($this->never())->method('createSearchIndexes');
+            }
+        }
+
+        $this->schemaManager->createDocumentSearchIndexes(CmsArticle::class);
+    }
+
+    public function testCreateDocumentVectorSearchIndexes(): void
+    {
+        $expectedCollectionName = $this->dm->getClassMetadata(VectorEmbedding::class)->getCollection();
+        foreach ($this->documentCollections as $collectionName => $collection) {
+            if ($collectionName === $expectedCollectionName) {
+                $collection
+                    ->expects($this->once())
+                    ->method('createSearchIndexes')
+                    ->with([
+                        [
+                            'definition' => [
+                                'fields' => [
+                                    ['type' => 'vector', 'path' => 'vectorFloat', 'numDimensions' => 3, 'similarity' => 'dot_product'],
+                                ],
+                            ],
+                            'name' => 'default',
+                            'type' => 'vectorSearch',
+                        ],
+                        [
+                            'definition' => [
+                                'fields' => [
+                                    ['type' => 'vector', 'path' => 'vectorInt', 'numDimensions' => 3, 'similarity' => 'cosine'],
+                                    ['type' => 'filter', 'path' => 'filterField'],
+                                ],
+                            ],
+                            'name' => 'vector_int',
+                            'type' => 'vectorSearch',
+                        ],
+                    ])
+                    ->willReturn(['default', 'vector_int']);
             } else {
                 $collection->expects($this->never())->method('createSearchIndexes');
             }

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -434,44 +434,6 @@ class SchemaManagerTest extends BaseTestCase
         $this->schemaManager->createDocumentSearchIndexes(CmsArticle::class);
     }
 
-    public function testCreateDocumentVectorSearchIndexes(): void
-    {
-        $expectedCollectionName = $this->dm->getClassMetadata(VectorEmbedding::class)->getCollection();
-        foreach ($this->documentCollections as $collectionName => $collection) {
-            if ($collectionName === $expectedCollectionName) {
-                $collection
-                    ->expects($this->once())
-                    ->method('createSearchIndexes')
-                    ->with([
-                        [
-                            'definition' => [
-                                'fields' => [
-                                    ['type' => 'vector', 'path' => 'vectorFloat', 'numDimensions' => 3, 'similarity' => 'dot_product'],
-                                ],
-                            ],
-                            'name' => 'default',
-                            'type' => 'vectorSearch',
-                        ],
-                        [
-                            'definition' => [
-                                'fields' => [
-                                    ['type' => 'vector', 'path' => 'vectorInt', 'numDimensions' => 3, 'similarity' => 'cosine'],
-                                    ['type' => 'filter', 'path' => 'filterField'],
-                                ],
-                            ],
-                            'name' => 'vector_int',
-                            'type' => 'vectorSearch',
-                        ],
-                    ])
-                    ->willReturn(['default', 'vector_int']);
-            } else {
-                $collection->expects($this->never())->method('createSearchIndexes');
-            }
-        }
-
-        $this->schemaManager->createDocumentSearchIndexes(CmsArticle::class);
-    }
-
     public function testCreateDocumentSearchIndexesNotSupported(): void
     {
         $exception = $this->createSearchIndexCommandException();
@@ -501,7 +463,7 @@ class SchemaManagerTest extends BaseTestCase
             ->expects($this->once())
             ->method('listSearchIndexes')
             ->willReturn(new ArrayIterator([
-                ['name' => 'default'],
+                ['name' => 'search_articles'],
                 ['name' => 'foo'],
             ]));
         $collection
@@ -511,7 +473,7 @@ class SchemaManagerTest extends BaseTestCase
         $collection
             ->expects($this->once())
             ->method('updateSearchIndex')
-            ->with('default', $this->anything());
+            ->with('search_articles', $this->anything());
 
         $this->schemaManager->updateDocumentSearchIndexes(CmsArticle::class);
     }

--- a/tests/Documents/CmsArticle.php
+++ b/tests/Documents/CmsArticle.php
@@ -8,7 +8,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 #[ODM\Index(keys: ['topic' => 'asc'])]
-#[ODM\SearchIndex(dynamic: true)]
+#[ODM\SearchIndex(name: 'search_articles', dynamic: true)]
 #[ODM\Document]
 class CmsArticle
 {

--- a/tests/Documents/VectorEmbedding.php
+++ b/tests/Documents/VectorEmbedding.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Field;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Id;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\VectorSearchIndex;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Types\Type;
+
+#[Document(collection: 'vector_embeddings')]
+#[VectorSearchIndex(
+    fields: [
+        ['type' => 'vector', 'path' => 'vectorFloat', 'numDimensions' => 3, 'similarity' => ClassMetadata::VECTOR_SIMILARITY_DOT_PRODUCT],
+    ],
+)]
+#[VectorSearchIndex(
+    name: 'vector_int',
+    fields: [
+        ['type' => 'vector', 'path' => 'vectorInt', 'numDimensions' => 3, 'similarity' => ClassMetadata::VECTOR_SIMILARITY_COSINE],
+        ['type' => 'filter', 'path' => 'filterField'],
+    ],
+)]
+class VectorEmbedding
+{
+    #[Id]
+    public ?string $id = null;
+
+    /** @var list<float> */
+    #[Field(type: Type::COLLECTION)]
+    public array $vectorFloat = [];
+
+    /** @var list<int> */
+    #[Field(type: Type::COLLECTION)]
+    public array $vectorInt = [];
+
+    #[Field(type: Type::STRING)]
+    public string $filterField;
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | [PHPORM-381](https://jira.mongodb.org/browse/PHPORM-381)

#### Summary

Add a new `#[ODM\VectorSearchIndex]` attribute to create [Atlas Vector Search Indexes](https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/?deployment-type=atlas&interface=driver&language=php).

In XML, attribute and annotations, this is a new type of object. But they create Search Indexes in the class metadata with the type `vectorSearch`. The index management is exactly the same for search and vector search indexes.
