### PR TITLE
Deprecate `Stage::search()` because the `$search` stage must be the first of the pipeline

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage.php
@@ -368,10 +368,14 @@ abstract class Stage
      * The $search stage performs a full-text search on the specified field or
      * fields which must be covered by an Atlas Search index.
      *
+     * @deprecated Since doctrine/mongodb-odm 2.13. This $search stage must be the first of the pipeline, use Builder::search() instead.
+     *
      * @see https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#mongodb-pipeline-pipe.-search
      */
     public function search(): Stage\Search
     {
+        trigger_deprecation('doctrine/mongodb-odm', '2.13', 'Using "%s" is deprecated because the $search stage must be the first of the pipeline, use "%s::search()" instead.', __METHOD__, Builder::class);
+
         return $this->builder->search();
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | -

#### Summary

> [$search](https://www.mongodb.com/docs/atlas/atlas-search/aggregation-stages/search/#mongodb-pipeline-pipe.-search) must be the first stage of any pipeline it appears in.

And mentioned in the ODM doc: https://github.com/doctrine/mongodb-odm/blob/e3352c0783886e525d2b8accb8bc7984148017bf/docs/en/reference/aggregation-stage-reference.rst?plain=1#L679-L685