### PR TITLE
Add test on Atlas Search features using an MongoDB Atlas Local Docker

### DIFF
--- a/.github/workflows/atlas-ci.yml
+++ b/.github/workflows/atlas-ci.yml
@@ -9,26 +9,20 @@ on:
 
 jobs:
   atlas-local:
-    runs-on: "${{ matrix.os }}"
-    name: "PHP/${{ matrix.php-version }} Symfony/${{ matrix.symfony }} Proxy/${{ matrix.proxy }}"
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - "ubuntu-latest"
         php-version:
-          - "8.2"
-          - "8.3"
           - "8.4"
         symfony:
           - "stable"
-          - "6.4"
         proxy:
           - "lazy-ghost"
         include:
           # Test with ProxyManager
-          - php-version: "8.2"
-            symfony: "stable"
+          - php-version: "8.1"
+            symfony: "6.4"
             proxy: "proxy-manager"
             os: "ubuntu-latest"
 
@@ -99,7 +93,7 @@ jobs:
           composer-options: "--prefer-dist"
 
       - name: "Run PHPUnit with Atlas Local"
-        run: "vendor/bin/phpunit"
+        run: "vendor/bin/phpunit --group atlas"
         env:
           DOCTRINE_MONGODB_SERVER: "mongodb://127.0.0.1:27017/?directConnection=true"
           USE_LAZY_GHOST_OBJECTS: ${{ matrix.proxy == 'lazy-ghost' && '1' || '0' }}

--- a/.github/workflows/atlas-ci.yml
+++ b/.github/workflows/atlas-ci.yml
@@ -1,0 +1,115 @@
+name: "Atlas CI"
+
+on:
+  push:
+    branches:
+      - "*.x"
+      - "feature/*"
+  pull_request:
+    branches:
+      - "*.x"
+      - "feature/*"
+
+env:
+  MONGODB_EXT_V1: mongodb-1.21.0
+  MONGODB_EXT_V2: stable
+
+jobs:
+  atlas-local:
+    runs-on: "${{ matrix.os }}"
+
+    name: "PHP/${{ matrix.php }} Symfony/${{ matrix.symfony }} Driver/${{ matrix.driver }} Proxy/${{ matrix.proxy }}"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - "ubuntu-latest"
+        php:
+          - "8.2"
+          - "8.3"
+          - "8.4"
+        symfony:
+          - "stable"
+          - "6.4"
+        driver:
+          - 1
+          - 2
+        proxy:
+          - "lazy-ghost"
+        include:
+          # Test with ProxyManager
+          - php: "8.2"
+            symfony: "stable"
+            driver: 2
+            proxy: "proxy-manager"
+            os: "ubuntu-latest"
+
+    steps:
+      - uses: "actions/checkout@v5"
+
+      - name: "Create MongoDB Atlas Local"
+        run: |
+          docker run --name mongodb -p 27017:27017 --detach mongodb/mongodb-atlas-local:latest
+          until docker exec --tty mongodb mongosh --eval "db.runCommand({ ping: 1 })"; do
+            sleep 1
+          done
+          until docker exec --tty mongodb mongosh --eval "db.createCollection('connection_test') && db.getCollection('connection_test').createSearchIndex({mappings:{dynamic: true}})"; do
+            sleep 1
+          done
+
+      - name: "Show MongoDB server status"
+        run: |
+          docker exec --tty mongodb mongosh --eval "db.runCommand({ serverStatus: 1 })"
+
+      - name: Setup cache environment
+        id: extcache
+        uses: shivammathur/cache-extensions@v1
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}
+          key: "extcache-v1"
+
+      - name: Cache extensions
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.extcache.outputs.dir }}
+          key: ${{ steps.extcache.outputs.key }}
+          restore-keys: ${{ steps.extcache.outputs.key }}
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ matrix.php }}"
+          tools: "pecl"
+          extensions: "bcmath,${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}"
+          coverage: "xdebug"
+          ini-values: "zend.assertions=1"
+
+      - name: "Show driver information"
+        run: "php --ri mongodb"
+
+      # Not used, skip transient dependencies
+      - name: "Remove phpbench/phpbench"
+        run: composer remove --no-update --dev phpbench/phpbench
+
+      - name: "Configure Symfony ${{ matrix.symfony }}"
+        if: "${{ matrix.symfony != 'stable' }}"
+        run: |
+          composer config minimum-stability dev
+          # update symfony deps
+          composer require --no-update symfony/console:^${{ matrix.symfony }}
+          composer require --no-update symfony/var-dumper:^${{ matrix.symfony }}
+          composer require --no-update --dev symfony/cache:^${{ matrix.symfony }}
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v3"
+        with:
+          dependency-versions: "highest"
+          composer-options: "--prefer-dist"
+
+      - name: "Run PHPUnit with Atlas Local"
+        run: "vendor/bin/phpunit --coverage-clover coverage.xml"
+        env:
+          DOCTRINE_MONGODB_SERVER: "mongodb://127.0.0.1:27017/?directConnection=true"
+          USE_LAZY_GHOST_OBJECTS: ${{ matrix.proxy == 'lazy-ghost' && '1' || '0' }}

--- a/.github/workflows/atlas-ci.yml
+++ b/.github/workflows/atlas-ci.yml
@@ -7,35 +7,28 @@ on:
       - "feature/*"
   push:
 
-env:
-  MONGODB_EXT_V1: mongodb-1.21.0
-  MONGODB_EXT_V2: stable
-
 jobs:
   atlas-local:
     runs-on: "${{ matrix.os }}"
-    name: "PHP/${{ matrix.php }} Symfony/${{ matrix.symfony }} Driver/${{ matrix.driver-version }} Proxy/${{ matrix.proxy }}"
+    name: "PHP/${{ matrix.php-version }} Symfony/${{ matrix.symfony }} Proxy/${{ matrix.proxy }}"
     strategy:
       fail-fast: false
       matrix:
         os:
           - "ubuntu-latest"
-        php:
+        php-version:
           - "8.2"
           - "8.3"
           - "8.4"
         symfony:
           - "stable"
           - "6.4"
-        driver-version:
-          - "stable"
         proxy:
           - "lazy-ghost"
         include:
           # Test with ProxyManager
-          - php: "8.2"
+          - php-version: "8.2"
             symfony: "stable"
-            driver-version: "stable"
             proxy: "proxy-manager"
             os: "ubuntu-latest"
 
@@ -64,7 +57,7 @@ jobs:
         uses: shivammathur/cache-extensions@v1
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: "mongodb-${{ matrix.driver-version }}, bcmath"
+          extensions: "mongodb, bcmath"
           key: "extcache-v1"
 
       - name: Cache extensions
@@ -79,7 +72,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           tools: "pecl"
-          extensions: "mongodb-${{ matrix.driver-version }}, bcmath"
+          extensions: "mongodb, bcmath"
           coverage: "none"
           ini-values: "zend.assertions=1"
 

--- a/.github/workflows/atlas-ci.yml
+++ b/.github/workflows/atlas-ci.yml
@@ -1,14 +1,11 @@
 name: "Atlas CI"
 
 on:
-  push:
-    branches:
-      - "*.x"
-      - "feature/*"
   pull_request:
     branches:
       - "*.x"
       - "feature/*"
+  push:
 
 env:
   MONGODB_EXT_V1: mongodb-1.21.0
@@ -17,9 +14,7 @@ env:
 jobs:
   atlas-local:
     runs-on: "${{ matrix.os }}"
-
-    name: "PHP/${{ matrix.php }} Symfony/${{ matrix.symfony }} Driver/${{ matrix.driver }} Proxy/${{ matrix.proxy }}"
-
+    name: "PHP/${{ matrix.php }} Symfony/${{ matrix.symfony }} Driver/${{ matrix.driver-version }} Proxy/${{ matrix.proxy }}"
     strategy:
       fail-fast: false
       matrix:
@@ -32,25 +27,27 @@ jobs:
         symfony:
           - "stable"
           - "6.4"
-        driver:
-          - 1
-          - 2
+        driver-version:
+          - "stable"
         proxy:
           - "lazy-ghost"
         include:
           # Test with ProxyManager
           - php: "8.2"
             symfony: "stable"
-            driver: 2
+            driver-version: "stable"
             proxy: "proxy-manager"
             os: "ubuntu-latest"
 
     steps:
-      - uses: "actions/checkout@v5"
+      - name: "Checkout"
+        uses: "actions/checkout@v5"
+        with:
+          fetch-depth: 2
 
       - name: "Create MongoDB Atlas Local"
         run: |
-          docker run --name mongodb -p 27017:27017 --detach mongodb/mongodb-atlas-local:latest
+          docker run --name mongodb -p 27017:27017 --detach mongodb/mongodb-atlas-local:8.2
           until docker exec --tty mongodb mongosh --eval "db.runCommand({ ping: 1 })"; do
             sleep 1
           done
@@ -66,8 +63,8 @@ jobs:
         id: extcache
         uses: shivammathur/cache-extensions@v1
         with:
-          php-version: ${{ matrix.php }}
-          extensions: ${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}
+          php-version: ${{ matrix.php-version }}
+          extensions: "mongodb-${{ matrix.driver-version }}, bcmath"
           key: "extcache-v1"
 
       - name: Cache extensions
@@ -80,10 +77,10 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "${{ matrix.php }}"
+          php-version: "${{ matrix.php-version }}"
           tools: "pecl"
-          extensions: "bcmath,${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}"
-          coverage: "xdebug"
+          extensions: "mongodb-${{ matrix.driver-version }}, bcmath"
+          coverage: "none"
           ini-values: "zend.assertions=1"
 
       - name: "Show driver information"
@@ -109,7 +106,7 @@ jobs:
           composer-options: "--prefer-dist"
 
       - name: "Run PHPUnit with Atlas Local"
-        run: "vendor/bin/phpunit --coverage-clover coverage.xml"
+        run: "vendor/bin/phpunit"
         env:
           DOCTRINE_MONGODB_SERVER: "mongodb://127.0.0.1:27017/?directConnection=true"
           USE_LAZY_GHOST_OBJECTS: ${{ matrix.proxy == 'lazy-ghost' && '1' || '0' }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -159,7 +159,7 @@ jobs:
           topology: ${{ matrix.topology }}
 
       - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit"
+        run: "vendor/bin/phpunit --exclude-group=atlas"
         env:
           DOCTRINE_MONGODB_SERVER: ${{ steps.setup-mongodb.outputs.cluster-uri }}
           USE_LAZY_GHOST_OBJECTS: ${{ matrix.proxy == 'lazy-ghost' && '1' || '0' }}"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: '3.8'
+
+services:
+  mongodb-atlas-local:
+    image: mongodb/mongodb-atlas-local
+    ports:
+      - "27018:27017"

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -473,7 +473,7 @@ use function trigger_deprecation;
 
     public const VECTOR_SIMILARITY_EUCLIDEAN   = 'euclidean';
     public const VECTOR_SIMILARITY_COSINE      = 'cosine';
-    public const VECTOR_SIMILARITY_DOT_PRODUCT = 'dot_product';
+    public const VECTOR_SIMILARITY_DOT_PRODUCT = 'dotProduct';
     public const VECTOR_QUANTIZATION_NONE      = 'none';
     public const VECTOR_QUANTIZATION_SCALAR    = 'scalar';
     public const VECTOR_QUANTIZATION_BINARY    = 'binary';

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
@@ -14,6 +14,7 @@ use Doctrine\Persistence\Mapping\Driver\FileClassLocator;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use MongoDB\Client;
 use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\CommandException;
 use MongoDB\Driver\Manager;
 use MongoDB\Driver\Server;
 use MongoDB\Model\DatabaseInfo;
@@ -45,6 +46,7 @@ abstract class BaseTestCase extends TestCase
     protected static bool $allowsTransactions = true;
     protected ?DocumentManager $dm;
     protected UnitOfWork $uow;
+    private bool $disableFailPoints = false;
 
     protected function setUp(): void
     {
@@ -52,16 +54,26 @@ abstract class BaseTestCase extends TestCase
         $this->uow = $this->dm->getUnitOfWork();
     }
 
-    protected  function tearDown(): void
+    protected function tearDown(): void
     {
         if (! $this->dm) {
             return;
         }
 
+        $client = $this->dm->getClient();
+
+        // Remove any fail points that may have been set
+        if ($this->disableFailPoints) {
+            $client->getDatabase('admin')->command([
+                'configureFailPoint' => 'failCommand',
+                'mode' => 'off',
+            ]);
+            $this->disableFailPoints = false;
+        }
+
         // Check if the database exists. Calling listCollections on a non-existing
         // database in a sharded setup will cause an invalid command cursor to be
         // returned
-        $client        = $this->dm->getClient();
         $databases     = iterator_to_array($client->listDatabases());
         $databaseNames = array_map(static fn (DatabaseInfo $database) => $database->getName(), $databases);
         if (! in_array(DOCTRINE_MONGODB_DATABASE, $databaseNames)) {
@@ -213,10 +225,6 @@ abstract class BaseTestCase extends TestCase
             new Command(['buildInfo' => 1]),
         )->toArray()[0];
 
-        if (! in_array('enterprise', $buildInfo->modules ?? [])) {
-            $this->markTestSkipped('Queryable Encryption test requires MongoDB Atlas or Enterprise');
-        }
-
         $this->requireVersion($buildInfo->version, '7.0', '<', 'Queryable Encryption test requires MongoDB 7.0 or higher');
     }
 
@@ -293,5 +301,28 @@ abstract class BaseTestCase extends TestCase
         $manager = new Manager(self::getUri());
 
         return $manager->selectServer()->getType() !== Server::TYPE_STANDALONE;
+    }
+
+    protected function createFailPoint(string $failCommand, bool $transient = false, int $times = 1): void
+    {
+        try {
+            $this->dm->getClient()->getManager()->executeCommand(
+                'admin',
+                new Command([
+                    'configureFailPoint' => 'failCommand',
+                    'mode'               => ['times' => $times],
+                    'data' => [
+                        'errorCode' => 192, // FailPointEnabled
+                        'errorLabels' => $transient ? ['TransientTransactionError'] : [],
+                        'failCommands' => [$failCommand],
+                    ],
+                ]),
+            );
+            $this->disableFailPoints = true;
+        } catch (CommandException $commandException) {
+            if ($commandException->getCode() === 59) {
+                self::markTestSkipped('Test skipped because the server does not support fail points');
+            }
+        }
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
@@ -46,13 +46,13 @@ abstract class BaseTestCase extends TestCase
     protected ?DocumentManager $dm;
     protected UnitOfWork $uow;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->dm  = static::createTestDocumentManager();
         $this->uow = $this->dm->getUnitOfWork();
     }
 
-    public function tearDown(): void
+    protected  function tearDown(): void
     {
         if (! $this->dm) {
             return;

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
@@ -323,8 +323,9 @@ abstract class BaseTestCase extends TestCase
                 ]),
             );
             $this->disableFailPoints = true;
-        } catch (CommandException $commandException) {
-            if ($commandException->getCode() === 59) {
+        } catch (CommandException $exception) {
+            // no such command: 'configureFailPoint'
+            if ($exception->getCode() === 59) {
                 self::markTestSkipped('Test skipped because the server does not support fail points');
             }
         }

--- a/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/BaseTestCase.php
@@ -225,6 +225,10 @@ abstract class BaseTestCase extends TestCase
             new Command(['buildInfo' => 1]),
         )->toArray()[0];
 
+        if (! in_array('enterprise', $buildInfo->modules ?? [])) {
+            $this->markTestSkipped('Queryable Encryption test requires MongoDB Atlas or Enterprise');
+        }
+
         $this->requireVersion($buildInfo->version, '7.0', '<', 'Queryable Encryption test requires MongoDB 7.0 or higher');
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Events/TransactionalLifecycleEventsTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Events/TransactionalLifecycleEventsTest.php
@@ -23,16 +23,6 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
         $this->skipTestIfTransactionalFlushDisabled();
     }
 
-    public function tearDown(): void
-    {
-        $this->dm->getClient()->getDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => 'off',
-        ]);
-
-        parent::tearDown();
-    }
-
     public function testPersistEvents(): void
     {
         $root       = new RootEventDocument();
@@ -41,7 +31,7 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
         $root->embedded       = new EmbeddedEventDocument();
         $root->embedded->name = 'embedded';
 
-        $this->createFailPoint('insert');
+        $this->createFailPoint('insert', transient: true);
 
         $this->dm->persist($root);
         $this->dm->flush();
@@ -61,7 +51,7 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
         $this->dm->persist($root);
         $this->dm->flush();
 
-        $this->createFailPoint('update');
+        $this->createFailPoint('update', transient: true);
 
         $root->name           = 'updated';
         $root->embedded->name = 'updated';
@@ -85,7 +75,7 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
         $this->dm->persist($root);
         $this->dm->flush();
 
-        $this->createFailPoint('update');
+        $this->createFailPoint('update', transient: true);
 
         $root->name = 'updated';
 
@@ -108,7 +98,7 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
         $this->dm->persist($root);
         $this->dm->flush();
 
-        $this->createFailPoint('update');
+        $this->createFailPoint('update', transient: true);
 
         $root->embedded->name = 'updated';
 
@@ -136,7 +126,7 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
         $this->dm->persist($root);
         $this->dm->flush();
 
-        $this->createFailPoint('update');
+        $this->createFailPoint('update', transient: true);
 
         $root->name     = 'updated';
         $root->embedded = $secondEmbedded;
@@ -168,7 +158,7 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
         $this->dm->persist($root);
         $this->dm->flush();
 
-        $this->createFailPoint('delete');
+        $this->createFailPoint('delete', transient: true);
 
         $this->dm->remove($root);
         $this->dm->flush();
@@ -184,19 +174,6 @@ class TransactionalLifecycleEventsTest extends BaseTestCase
         $client = new Client(self::getUri(false), [], ['typeMap' => ['root' => 'array', 'document' => 'array']]);
 
         return DocumentManager::create($client, $config);
-    }
-
-    private function createFailPoint(string $failCommand): void
-    {
-        $this->dm->getClient()->getDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => ['times' => 1],
-            'data' => [
-                'errorCode' => 192, // FailPointEnabled
-                'errorLabels' => ['TransientTransactionError'],
-                'failCommands' => [$failCommand],
-            ],
-        ]);
     }
 }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtlasSearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtlasSearchTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\CmsArticle;
+use Documents\CmsUser;
+use PHPUnit\Framework\Attributes\Group;
+
+use function sleep;
+
+#[Group('atlas')]
+class AtlasSearchTest extends BaseTestCase
+{
+    public function testAtlasSearch(): void
+    {
+        $schemaManager = $this->dm->getSchemaManager();
+        $schemaManager->createDocumentCollection(CmsArticle::class);
+        $schemaManager->createDocumentSearchIndexes(CmsArticle::class);
+
+        $user         = new CmsUser();
+        $user->status = 'active';
+        $this->dm->persist($user);
+
+        $article1        = new CmsArticle();
+        $article1->topic = 'Technology';
+        $article1->title = 'Introduction to MongoDB Atlas Search';
+        $article1->text  = 'MongoDB Atlas Search provides full-text search capabilities with advanced features like autocomplete and fuzzy matching.';
+        $article1->setAuthor($user);
+
+        $article2        = new CmsArticle();
+        $article2->topic = 'Database';
+        $article2->title = 'Working with Document Databases';
+        $article2->text  = 'Document databases like MongoDB offer flexible schema design and powerful query capabilities for modern applications.';
+        $article2->setAuthor($user);
+
+        $article3        = new CmsArticle();
+        $article3->topic = 'Programming';
+        $article3->title = 'PHP and MongoDB Integration';
+        $article3->text  = 'The MongoDB ODM for PHP provides an easy way to work with MongoDB documents using object-oriented programming.';
+        $article3->setAuthor($user);
+
+        $this->dm->persist($article1);
+        $this->dm->persist($article2);
+        $this->dm->persist($article3);
+        $this->dm->flush();
+
+        // Wait for the search index to be ready (Atlas Local needs time to build the index)
+        sleep(2);
+
+        $results = $this->dm->createAggregationBuilder(CmsArticle::class)
+            ->search()
+                ->index('search_articles')
+                ->text()
+                    ->query('Mongo')
+                    ->path('title')
+                    ->fuzzy(2, 2)
+            ->limit(5)
+            ->getAggregation()->execute()->toArray();
+
+        $this->assertNotEmpty($results, 'Autocomplete search should return results');
+
+        $results = $this->dm->createAggregationBuilder(CmsArticle::class)
+            ->search()
+                ->index('search_articles')
+                ->compound()
+                    ->must()
+                        ->text()
+                            ->query('database')
+                            ->path('text')
+                    ->should()
+                        ->text()
+                            ->query('MongoDB')
+                            ->path('title')
+            ->addFields()
+                ->field('score')
+                ->expression(['$meta' => 'searchScore'])
+            ->sort(['score' => 'searchScore'])
+            ->getAggregation()->execute()->toArray();
+
+        foreach ($results as $result) {
+            $this->assertIsArray($result);
+            $this->assertStringContainsStringIgnoringCase('database', $result['text']);
+        }
+
+        $results = $this->dm->createAggregationBuilder(CmsArticle::class)
+            ->search()
+                ->index('search_articles')
+                ->text()
+                    ->query('Atlas Search')
+                    ->path('text')
+                ->highlight('text', 100, 1)
+            ->addFields()
+                ->field('highlights')
+                ->expression(['$meta' => 'searchHighlights'])
+            ->getAggregation()->execute()->toArray();
+
+        foreach ($results as $result) {
+            $this->assertIsArray($result);
+            $this->assertIsArray($result['highlights']);
+        }
+
+        $results = $this->dm->createAggregationBuilder(CmsArticle::class)
+            ->search()
+                ->index('search_articles')
+                ->text()
+                    ->query('MongoDB')
+                    ->path('title', 'text')
+                ->countDocuments('total')
+            ->getAggregation()->execute()->toArray();
+
+        $this->assertNotEmpty($results, 'Count search should return results');
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/VectorSearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/VectorSearchTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\VectorEmbedding;
+use PHPUnit\Framework\Attributes\Group;
+
+use function iterator_to_array;
+use function sleep;
+
+#[Group('atlas')]
+class VectorSearchTest extends BaseTestCase
+{
+    protected function tearDown(): void
+    {
+        $this->dm->getDocumentCollection(VectorEmbedding::class)->drop();
+    }
+
+    public function testAtlasVectorSearch(): void
+    {
+        // Create the collection by ensuring the schema
+        $schemaManager = $this->dm->getSchemaManager();
+
+        // Create the collection and vector search indexes
+        $schemaManager->createDocumentCollection(VectorEmbedding::class);
+        $schemaManager->createDocumentSearchIndexes(VectorEmbedding::class);
+
+        // Insert some test documents with vector embeddings
+        $doc1              = new VectorEmbedding();
+        $doc1->vectorFloat = [1.0, 2.0, 3.0];
+        $doc1->vectorInt   = [1, 2, 3];
+        $doc1->filterField = 'active';
+
+        $doc2              = new VectorEmbedding();
+        $doc2->vectorFloat = [4.0, 5.0, 6.0];
+        $doc2->vectorInt   = [4, 5, 6];
+        $doc2->filterField = 'inactive';
+
+        $doc3              = new VectorEmbedding();
+        $doc3->vectorFloat = [1.5, 2.5, 3.5];
+        $doc3->vectorInt   = [2, 3, 4];
+        $doc3->filterField = 'active';
+
+        $this->dm->persist($doc1);
+        $this->dm->persist($doc2);
+        $this->dm->persist($doc3);
+        $this->dm->flush();
+
+        // Wait for search index to be ready (Atlas Local needs time to build the index)
+        sleep(2);
+
+        $results = $this->dm->createAggregationBuilder(VectorEmbedding::class)
+            ->vectorSearch()
+                ->index('default')
+                ->queryVector([1.1, 2.1, 3.1])
+                ->path('vectorFloat')
+                ->numCandidates(10)
+                ->limit(5)
+            ->set()
+                ->field('score')
+                ->expression(['$meta' => 'vectorSearchScore'])
+            ->getAggregation()->execute()->toArray();
+
+        $this->assertCount(3, $results);
+        foreach ($results as $result) {
+            $this->assertIsArray($result);
+            $this->assertIsFloat($result['score'], 'Result should have a score');
+        }
+
+        // Test with filter
+        $results = ($builder = $this->dm->createAggregationBuilder(VectorEmbedding::class))
+            ->vectorSearch()
+                ->index('vector_int')
+                ->queryVector([1, 1, 3])
+                ->path('vectorInt')
+                ->numCandidates(10)
+                ->limit(5)
+                ->filter($builder->matchExpr()->field('filterField')->equals('active'))
+            ->getAggregation()->execute()->toArray();
+
+        $this->assertCount(2, $results);
+        foreach ($results as $result) {
+            $this->assertIsArray($result);
+            $this->assertEquals('active', $result['filterField'], 'Filtered results should only contain active documents');
+        }
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/VectorSearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/VectorSearchTest.php
@@ -8,17 +8,11 @@ use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\VectorEmbedding;
 use PHPUnit\Framework\Attributes\Group;
 
-use function iterator_to_array;
 use function sleep;
 
 #[Group('atlas')]
 class VectorSearchTest extends BaseTestCase
 {
-    protected function tearDown(): void
-    {
-        $this->dm->getDocumentCollection(VectorEmbedding::class)->drop();
-    }
-
     public function testAtlasVectorSearch(): void
     {
         // Create the collection by ensuring the schema

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkCommitConsistencyTest.php
@@ -18,16 +18,6 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
     // This test requires transactions to be disabled
     protected static bool $allowsTransactions = false;
 
-    public function tearDown(): void
-    {
-        $this->dm->getClient()->getDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => 'off',
-        ]);
-
-        parent::tearDown();
-    }
-
     public function testInsertErrorKeepsFailingInsertions(): void
     {
         $firstUser           = new ForumUser();
@@ -445,17 +435,5 @@ class UnitOfWorkCommitConsistencyTest extends BaseTestCase
         $client = new Client(self::getUri(false), [], ['typeMap' => ['root' => 'array', 'document' => 'array']]);
 
         return DocumentManager::create($client, $config);
-    }
-
-    private function createFailpoint(string $commandName): void
-    {
-        $this->dm->getClient()->getDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => ['times' => 1],
-            'data' => [
-                'errorCode' => 192, // FailPointEnabled
-                'failCommands' => [$commandName],
-            ],
-        ]);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTransactionalCommitConsistencyTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/UnitOfWorkTransactionalCommitConsistencyTest.php
@@ -25,16 +25,6 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
         $this->skipTestIfNoTransactionSupport();
     }
 
-    public function tearDown(): void
-    {
-        $this->dm->getClient()->getDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => 'off',
-        ]);
-
-        parent::tearDown();
-    }
-
     public function testFatalInsertError(): void
     {
         $firstUser           = new ForumUser();
@@ -48,7 +38,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
         $friendUser = new FriendUser('GromNaN');
         $this->uow->persist($friendUser);
 
-        $this->createFatalFailPoint('insert');
+        $this->createFailPoint('insert');
 
         try {
             $this->uow->commit();
@@ -92,7 +82,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
         $this->uow->persist($friendUser);
 
         // Add a failpoint that triggers a transient error. The transaction will be retried and succeeds
-        $this->createTransientFailPoint('insert');
+        $this->createFailPoint('insert', transient: true);
 
         $this->uow->commit();
 
@@ -130,7 +120,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
         $this->uow->persist($friendUser);
 
         // Add a failpoint that triggers multiple transient errors. The transaction is expected to fail
-        $this->createTransientFailPoint('insert', 2);
+        $this->createFailPoint('insert', transient: true, times: 2);
 
         try {
             $this->uow->commit();
@@ -251,7 +241,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
         $user->username = 'alcaeus';
         $this->uow->persist($user);
 
-        $this->createFatalFailPoint('update');
+        $this->createFailPoint('update');
 
         try {
             $this->uow->commit();
@@ -278,7 +268,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
         $user->username = 'alcaeus';
         $this->uow->persist($user);
 
-        $this->createTransientFailPoint('update');
+        $this->createFailPoint('update', transient: true);
 
         $this->uow->commit();
 
@@ -300,7 +290,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
 
         $user->username = 'jmikola';
 
-        $this->createFatalFailPoint('update');
+        $this->createFailPoint('update');
 
         try {
             $this->uow->commit();
@@ -328,7 +318,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
 
         $user->username = 'jmikola';
 
-        $this->createTransientFailPoint('update');
+        $this->createFailPoint('update', transient: true);
 
         $this->uow->commit();
 
@@ -353,7 +343,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
         $address->setCity('Olching');
         $user->setAddress($address);
 
-        $this->createFatalFailPoint('update');
+        $this->createFailPoint('update');
 
         try {
             $this->uow->commit();
@@ -381,7 +371,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
         $address->setCity('Olching');
         $user->setAddress($address);
 
-        $this->createTransientFailPoint('update');
+        $this->createFailPoint('update', transient: true);
 
         $this->uow->commit();
 
@@ -405,7 +395,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
 
         $address->setCity('Munich');
 
-        $this->createFatalFailPoint('update');
+        $this->createFailPoint('update');
 
         try {
             $this->uow->commit();
@@ -435,7 +425,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
 
         $address->setCity('Munich');
 
-        $this->createTransientFailPoint('update');
+        $this->createFailPoint('update', transient: true);
 
         $this->uow->commit();
 
@@ -459,7 +449,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
 
         $user->removeAddress();
 
-        $this->createFatalFailPoint('update');
+        $this->createFailPoint('update');
 
         try {
             $this->uow->commit();
@@ -491,7 +481,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
 
         $user->removeAddress();
 
-        $this->createTransientFailPoint('update');
+        $this->createFailPoint('update', transient: true);
 
         $this->uow->commit();
 
@@ -515,7 +505,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
 
         $this->uow->remove($user);
 
-        $this->createFatalFailPoint('delete');
+        $this->createFailPoint('delete');
 
         try {
             $this->uow->commit();
@@ -549,7 +539,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
 
         $this->uow->remove($user);
 
-        $this->createTransientFailPoint('delete');
+        $this->createFailPoint('delete', transient: true);
 
         $this->uow->commit();
 
@@ -582,7 +572,7 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
         // Remove fooUser and create a transient failpoint to force the deletion
         // to fail. This exposes the issue with collections
         $this->uow->remove($fooUser);
-        $this->createTransientFailPoint('delete');
+        $this->createFailPoint('delete', transient: true);
 
         $this->uow->commit();
 
@@ -607,30 +597,5 @@ class UnitOfWorkTransactionalCommitConsistencyTest extends BaseTestCase
         $configuration->setUseTransactionalFlush(true);
 
         return $configuration;
-    }
-
-    private function createTransientFailPoint(string $failCommand, int $times = 1): void
-    {
-        $this->dm->getClient()->getDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => ['times' => $times],
-            'data' => [
-                'errorCode' => 192, // FailPointEnabled
-                'errorLabels' => ['TransientTransactionError'],
-                'failCommands' => [$failCommand],
-            ],
-        ]);
-    }
-
-    private function createFatalFailPoint(string $failCommand): void
-    {
-        $this->dm->getClient()->getDatabase('admin')->command([
-            'configureFailPoint' => 'failCommand',
-            'mode' => ['times' => 1],
-            'data' => [
-                'errorCode' => 192, // FailPointEnabled
-                'failCommands' => [$failCommand],
-            ],
-        ]);
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | [PHPORM-390](https://jira.mongodb.org/browse/PHPORM-390)

#### Summary

- Run Atlas tests with MongoDB Atlas Local
- Add integration test for Vector Search
- Add integration test for Search

The `configureFailPoint` command is not available in Atlas Local. I mark the tests as skipped instead of adding a group to exclude them from atlas.
