### PR TITLE
Add `SchemaManager::waitForSearchIndexes()`

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/SchemaException.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB;
+
+use RuntimeException;
+
+use function implode;
+use function sprintf;
+
+/**
+ * Exception for schema-related issues.
+ */
+final class SchemaException extends RuntimeException
+{
+    /**
+     * @internal
+     *
+     * @param string[] $missingIndexes
+     */
+    public static function missingSearchIndex(string $documentClass, array $missingIndexes): self
+    {
+        return new self(sprintf('The document class "%s" is missing the following search index(es): "%s"', $documentClass, implode('", "', $missingIndexes)));
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -20,12 +20,14 @@ use function array_diff;
 use function array_diff_key;
 use function array_filter;
 use function array_keys;
+use function array_map;
 use function array_merge;
 use function array_search;
 use function array_unique;
 use function array_values;
 use function assert;
 use function count;
+use function hrtime;
 use function implode;
 use function in_array;
 use function is_array;
@@ -35,6 +37,7 @@ use function iterator_to_array;
 use function ksort;
 use function sprintf;
 use function str_contains;
+use function usleep;
 
 /**
  * @phpstan-import-type IndexMapping from ClassMetadata
@@ -338,6 +341,65 @@ final class SchemaManager
     }
 
     /**
+     * Wait until all search indexes are queryable for the given document classes.
+     *
+     * @param list<class-string>|null $classNames List of class names to check, or null to check all mapped classes
+     * @param positive-int            $maxTimeMs  Maximum time to wait in milliseconds (default: 10,000 ms)
+     * @param positive-int            $waitTimeMs Time to wait between checks in milliseconds (default: 100 ms)
+     */
+    public function waitForSearchIndexes(?array $classNames = null, int $maxTimeMs = 10_000, int $waitTimeMs = 100): void
+    {
+        if ($maxTimeMs < 1) {
+            throw new InvalidArgumentException('$maxTimeMs must be a positive number of milliseconds.');
+        }
+
+        if ($waitTimeMs < 1) {
+            throw new InvalidArgumentException('$waitTimeMs must be a positive number of milliseconds.');
+        }
+
+        $classes = $classNames === null ? $this->metadataFactory->getAllMetadata() : array_map($this->metadataFactory->getMetadataFor(...), $classNames);
+
+        /** @var array<class-string, string[]> $indexesToCheck Search indexes for each class */
+        $indexesToCheck = [];
+        foreach ($classes as $class) {
+            if (! $class->hasSearchIndexes()) {
+                continue;
+            }
+
+            $indexesToCheck[$class->getName()] = array_column($class->getSearchIndexes(), 'name');
+        }
+
+        $start = hrtime(true);
+        while ($indexesToCheck) {
+            if (hrtime(true) > $start + $maxTimeMs * 1_000_000) {
+                throw new MongoDBException(sprintf('Timed out waiting for search indexes to become queryable after %d ms. Search indexes are not ready for the following class(es): %s', $maxTimeMs, implode(', ', array_keys($indexesToCheck))));
+            }
+
+            foreach ($indexesToCheck as $className => $indexNames) {
+                $collection = $this->dm->getDocumentCollection($className);
+
+                /** @var array<string, bool> $indexStatus Queryable status for each index name */
+                $indexStatus = array_column(iterator_to_array($collection->listSearchIndexes([
+                    'filter' => ['name' => ['$in' => array_keys($indexNames)]],
+                    'typeMap' => ['root' => 'array'],
+                ])), 'queryable', 'name');
+
+                // Check that all indexes exist
+                $missingIndexes = array_diff_key($indexNames, array_keys($indexStatus));
+                if ($missingIndexes) {
+                    throw SchemaException::missingSearchIndex($className, $missingIndexes);
+                }
+
+                // Remove the indexes that are ready from the list of indexes to check
+                $indexesToCheck[$className] = array_keys(array_filter($indexStatus, static fn ($queryable) => ! $queryable));
+            }
+
+            // Remove empty arrays and wait before checking again
+            ($indexesToCheck = array_filter($indexesToCheck)) && usleep($waitTimeMs * 1_000);
+        }
+    }
+
+    /**
      * Create search indexes for the given document class.
      *
      * @param class-string $documentName
@@ -368,7 +430,7 @@ final class SchemaManager
         $unprocessedNames = array_diff($definedNames, $createdNames);
 
         if (! empty($unprocessedNames)) {
-            throw new InvalidArgumentException(sprintf('The following search indexes for %s were not created: %s', $class->name, implode(', ', $unprocessedNames)));
+            throw SchemaException::missingSearchIndex($class->name, $unprocessedNames);
         }
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -385,18 +385,6 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
 
 		-
-			message: '#^Class Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata has type alias SearchIndexDefinition with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 2
-			path: lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
-
-		-
-			message: '#^Class Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata has type alias SearchIndexMapping with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 2
-			path: lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
-
-		-
 			message: '#^Instanceof between Doctrine\\Persistence\\Reflection\\RuntimeReflectionProperty and ReflectionProperty will always evaluate to true\.$#'
 			identifier: instanceof.alwaysTrue
 			count: 1
@@ -409,21 +397,9 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
 
 		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata\:\:addSearchIndex\(\) has parameter \$definition with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 2
-			path: lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
-
-		-
 			message: '#^Method Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata\:\:getBucketName\(\) never returns null so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata\:\:getSearchIndexes\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 2
 			path: lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
 
 		-
@@ -454,12 +430,6 @@ parameters:
 			message: '#^Property Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata\:\:\$rootClass \(class\-string\|null\) is never assigned null so it can be removed from the property type\.$#'
 			identifier: property.unusedType
 			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
-
-		-
-			message: '#^Property Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata\:\:\$searchIndexes type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 2
 			path: lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
 
 		-

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtlasSearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtlasSearchTest.php
@@ -7,9 +7,8 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsArticle;
 use Documents\CmsUser;
+use MongoDB\Driver\WriteConcern;
 use PHPUnit\Framework\Attributes\Group;
-
-use function sleep;
 
 #[Group('atlas')]
 class AtlasSearchTest extends BaseTestCase
@@ -18,7 +17,6 @@ class AtlasSearchTest extends BaseTestCase
     {
         $schemaManager = $this->dm->getSchemaManager();
         $schemaManager->createDocumentCollection(CmsArticle::class);
-        $schemaManager->createDocumentSearchIndexes(CmsArticle::class);
 
         $user         = new CmsUser();
         $user->status = 'active';
@@ -45,10 +43,15 @@ class AtlasSearchTest extends BaseTestCase
         $this->dm->persist($article1);
         $this->dm->persist($article2);
         $this->dm->persist($article3);
-        $this->dm->flush();
+
+        // Write with majority concern to ensure data is visible for search
+        $this->dm->flush(['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)]);
+
+        // Index must be created after data insertion, so the index status is not immediately "READY"
+        $schemaManager->createDocumentSearchIndexes(CmsArticle::class);
 
         // Wait for the search index to be ready (Atlas Local needs time to build the index)
-        sleep(2);
+        $schemaManager->waitForSearchIndexes([CmsArticle::class, CmsUser::class]);
 
         $results = $this->dm->createAggregationBuilder(CmsArticle::class)
             ->search()

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/SchemaManagerWaitForSearchIndexesTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/SchemaManagerWaitForSearchIndexesTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\MongoDBException;
+use Doctrine\ODM\MongoDB\SchemaException;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\CmsArticle;
+use MongoDB\Driver\BulkWrite;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\TestWith;
+
+use function hrtime;
+
+#[Group('atlas')]
+class SchemaManagerWaitForSearchIndexesTest extends BaseTestCase
+{
+    #[TestWith([0])]
+    #[TestWith([50_000])]
+    public function testWait(int $nbDocuments): void
+    {
+        $schemaManager = $this->dm->getSchemaManager();
+        $collection    = $this->dm->getDocumentCollection(CmsArticle::class);
+
+        $schemaManager->createDocumentCollection(CmsArticle::class);
+
+        if ($nbDocuments) {
+            $bulk = new BulkWrite();
+            for ($i = 0; $i < $nbDocuments; $i++) {
+                $bulk->insert(['topic' => 'topic ' . $i, 'title' => 'title ' . $i, 'text' => 'text ' . $i]);
+            }
+
+            $collection->getManager()->executeBulkWrite($collection->getNamespace(), $bulk);
+        }
+
+        // The index must be created after data insertion, so the index status is not immediately "READY"
+        $schemaManager->createDocumentSearchIndexes(CmsArticle::class);
+
+        $this->assertNotSame('READY', $collection->listSearchIndexes(['name' => 'search_articles'])->current()['status']);
+
+        $start = hrtime(true);
+        $schemaManager->waitForSearchIndexes([CmsArticle::class]);
+        $timeMs = (hrtime(true) - $start) / 1_000_000;
+
+        $this->assertSame($nbDocuments, $collection->aggregate([
+            [
+                '$searchMeta' => [
+                    'index' => 'search_articles',
+                    'exists' => ['path' => '_id'],
+                    'count' => ['type' => 'total'],
+                ],
+            ],
+        ])->toArray()[0]['count']['total'], 'All documents are indexed');
+
+        $this->assertSame('READY', $collection->listSearchIndexes(['name' => 'search_articles'])->current()['status'], 'Ready after ' . $timeMs . ' ms');
+    }
+
+    public function testErrors(): void
+    {
+        $schemaManager = $this->dm->getSchemaManager();
+
+        // Search index missing
+        try {
+            $schemaManager->waitForSearchIndexes([CmsArticle::class]);
+            $this->fail('Expected SchemaException not thrown');
+        } catch (SchemaException $exception) {
+            $this->assertSame('The document class "Documents\CmsArticle" is missing the following search index(es): "search_articles"', $exception->getMessage());
+        }
+
+        $schemaManager->createDocumentCollection(CmsArticle::class);
+        $schemaManager->createDocumentSearchIndexes(CmsArticle::class);
+
+        // Timeout too short
+        try {
+            $schemaManager->waitForSearchIndexes([CmsArticle::class], 1);
+            $this->fail('Expected SchemaException not thrown');
+        } catch (MongoDBException $exception) {
+            $this->assertSame('Timed out waiting for search indexes to become queryable after 1 ms. Search indexes are not ready for the following class(es): Documents\CmsArticle', $exception->getMessage());
+        }
+
+        // Not specifying classes waits for all
+        try {
+            $schemaManager->waitForSearchIndexes();
+            $this->fail('Expected SchemaException not thrown');
+        } catch (SchemaException $exception) {
+            // The missing class varies depending on the test execution order,
+            // classes are added to the ClassMetadataFactory in the order they are used
+            $this->assertMatchesRegularExpression('#The document class "Documents\\\\(CmsAddress|VectorEmbedding)" is missing the following search index\(es\): "default"#', $exception->getMessage());
+        }
+
+        // Remove the collection
+        $schemaManager->dropDocumentCollection(CmsArticle::class);
+
+        try {
+            $schemaManager->waitForSearchIndexes([CmsArticle::class]);
+            $this->fail('Expected SchemaException not thrown');
+        } catch (SchemaException $exception) {
+            $this->assertSame('The document class "Documents\CmsArticle" is missing the following search index(es): "search_articles"', $exception->getMessage());
+        }
+    }
+}

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/VectorSearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/VectorSearchTest.php
@@ -6,9 +6,8 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\VectorEmbedding;
+use MongoDB\Driver\WriteConcern;
 use PHPUnit\Framework\Attributes\Group;
-
-use function sleep;
 
 #[Group('atlas')]
 class VectorSearchTest extends BaseTestCase
@@ -20,7 +19,6 @@ class VectorSearchTest extends BaseTestCase
 
         // Create the collection and vector search indexes
         $schemaManager->createDocumentCollection(VectorEmbedding::class);
-        $schemaManager->createDocumentSearchIndexes(VectorEmbedding::class);
 
         // Insert some test documents with vector embeddings
         $doc1              = new VectorEmbedding();
@@ -41,10 +39,14 @@ class VectorSearchTest extends BaseTestCase
         $this->dm->persist($doc1);
         $this->dm->persist($doc2);
         $this->dm->persist($doc3);
-        $this->dm->flush();
+        // Write with majority concern to ensure data is visible for search
+        $this->dm->flush(['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)]);
+
+        // Index must be created after data insertion, so the index status is not immediately "READY"
+        $schemaManager->createDocumentSearchIndexes(VectorEmbedding::class);
 
         // Wait for search index to be ready (Atlas Local needs time to build the index)
-        sleep(2);
+        $schemaManager->waitForSearchIndexes([VectorEmbedding::class]);
 
         $results = $this->dm->createAggregationBuilder(VectorEmbedding::class)
             ->vectorSearch()

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -9,6 +9,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\TimeSeries\Granularity;
+use Doctrine\ODM\MongoDB\SchemaException;
 use Doctrine\ODM\MongoDB\SchemaManager;
 use Documents\BaseDocument;
 use Documents\CmsAddress;
@@ -418,8 +419,8 @@ class SchemaManagerTest extends BaseTestCase
             ->with($this->anything())
             ->willReturn(['foo']);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The following search indexes for Documents\CmsArticle were not created: search_articles');
+        $this->expectException(SchemaException::class);
+        $this->expectExceptionMessage('The document class "Documents\CmsArticle" is missing the following search index(es): "search_articles"');
 
         $this->schemaManager->createDocumentSearchIndexes(CmsArticle::class);
     }
@@ -486,9 +487,9 @@ class SchemaManagerTest extends BaseTestCase
                                 'name' => 'vector_int',
                                 'definition' => [
                                     'fields' => [
-                                        ['type' => 'vector', 'path' => 'vectorInt', 'numDimensions' => 3, 'similarity' => 'cosine'],
                                         ['type' => 'filter', 'path' => 'filterField'],
                                         ['type' => 'filter', 'path' => 'not_mapped_filter'],
+                                        ['type' => 'vector', 'path' => 'vectorInt', 'numDimensions' => 3, 'similarity' => 'cosine'],
                                     ],
                                 ],
                             ],

--- a/tests/Documents/VectorEmbedding.php
+++ b/tests/Documents/VectorEmbedding.php
@@ -20,9 +20,9 @@ use Doctrine\ODM\MongoDB\Types\Type;
 #[VectorSearchIndex(
     name: 'vector_int',
     fields: [
-        ['type' => 'vector', 'path' => 'vectorInt', 'numDimensions' => 3, 'similarity' => ClassMetadata::VECTOR_SIMILARITY_COSINE],
         ['type' => 'filter', 'path' => 'filterField'],
         ['type' => 'filter', 'path' => 'not_mapped_filter'],
+        ['type' => 'vector', 'path' => 'vectorInt', 'numDimensions' => 3, 'similarity' => ClassMetadata::VECTOR_SIMILARITY_COSINE],
     ],
 )]
 class VectorEmbedding


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | [PHPORM-399](https://jira.mongodb.org/browse/PHPORM-399)


#### Summary

This method waits until all search indexes for specified (or all) document classes are both queryable and have indexed all documents in their corresponding collections.

- It takes up to three arguments: a list of document class names (`$classNames`, optional), a maximum wait time in milliseconds (`$maxTimeMs`, default 10,000 ms), and a delay between checks in milliseconds (`$waitTimeMs`, default 100 ms).
- The method validates input arguments, then iterates over the document classes to identify the search indexes that need to be checked.
- In a loop, it checks whether all required search indexes exist and are marked as queryable.
- ~For queryable indexes, it further verifies if all documents have been indexed by comparing the count of indexed documents with the total collection count, using aggregation pipelines appropriate for either `'search'` or `'vectorSearch'` index types.~ (removed because unreliable)
- If not all indexes are ready, it waits for `$waitTimeMs` before checking again, until either all indexes are ready or the maximum wait time (`$maxTimeMs`) is exceeded (in which case an exception is thrown).

This addition provides a mechanism for applications to block until search indexes are fully prepared for querying, ensuring consistency and readiness before proceeding with operations that depend on those indexes.

Similar implementation: https://github.com/mongodb-labs/pymongo-search-utils/blob/dddd51f6e1784caa43e0dc66ec8d9487e0762d58/pymongo_search_utils/index.py#L259-L298
