### PR TITLE
Prepare field names for search indexes and vector search indexes

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Builder.php
@@ -570,7 +570,7 @@ class Builder
      */
     public function search(): Stage\Search
     {
-        $stage = new Stage\Search($this);
+        $stage = new Stage\Search($this, $this->getDocumentPersister());
 
         return $this->addStage($stage);
     }
@@ -660,7 +660,7 @@ class Builder
      */
     public function vectorSearch(): Stage\VectorSearch
     {
-        $stage = new Stage\VectorSearch($this);
+        $stage = new Stage\VectorSearch($this, $this->getDocumentPersister());
 
         return $this->addStage($stage);
     }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
@@ -9,6 +9,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SearchOperator;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsAllSearchOperators;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsAllSearchOperatorsTrait;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 
 use function in_array;
 use function is_array;
@@ -70,7 +71,7 @@ class Search extends Stage implements SupportsAllSearchOperators
     /** @var array<string, -1|1|SortMeta> */
     private array $sort = [];
 
-    public function __construct(Builder $builder)
+    public function __construct(Builder $builder, private DocumentPersister $persister)
     {
         parent::__construct($builder);
     }
@@ -105,7 +106,7 @@ class Search extends Stage implements SupportsAllSearchOperators
         }
 
         if ($this->sort) {
-            $params->sort = (object) $this->sort;
+            $params->sort = (object) $this->persister->prepareSort($this->sort);
         }
 
         if ($this->operator !== null) {
@@ -213,5 +214,10 @@ class Search extends Stage implements SupportsAllSearchOperators
     protected function getSearchStage(): static
     {
         return $this;
+    }
+
+    protected function getDocumentPersister(): DocumentPersister
+    {
+        return $this->persister;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/AbstractSearchOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/AbstractSearchOperator.php
@@ -85,6 +85,16 @@ abstract class AbstractSearchOperator extends Stage implements SearchOperator
         return $this->persister->prepareFieldName($field);
     }
 
+    /**
+     * @param list<array<string, mixed>|object> $documents
+     *
+     * @return list<array<string, mixed>|object>
+     */
+    protected function prepareDocuments(array $documents): array
+    {
+        return array_map($this->persister->prepareQueryOrNewObj(...), $documents);
+    }
+
     protected function getDocumentPersister(): DocumentPersister
     {
         return $this->persister;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/AbstractSearchOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/AbstractSearchOperator.php
@@ -7,6 +7,10 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
+
+use function array_map;
+use function is_array;
 
 /**
  * @internal
@@ -18,7 +22,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
  */
 abstract class AbstractSearchOperator extends Stage implements SearchOperator
 {
-    public function __construct(private Search $search)
+    public function __construct(private Search $search, private DocumentPersister $persister)
     {
         parent::__construct($search->builder);
     }
@@ -63,5 +67,26 @@ abstract class AbstractSearchOperator extends Stage implements SearchOperator
     protected function getSearchStage(): Search
     {
         return $this->search;
+    }
+
+    /**
+     * @param T $field
+     *
+     * @return T
+     *
+     * @template T of string|string[]
+     */
+    protected function prepareFieldPath(string|array $field): string|array
+    {
+        if (is_array($field)) {
+            return array_map($this->persister->prepareFieldName(...), $field);
+        }
+
+        return $this->persister->prepareFieldName($field);
+    }
+
+    protected function getDocumentPersister(): DocumentPersister
+    {
+        return $this->persister;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Autocomplete.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Autocomplete.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 
 use function array_values;
 
@@ -23,9 +24,9 @@ class Autocomplete extends AbstractSearchOperator implements ScoredSearchOperato
     private string $tokenOrder = '';
     private ?object $fuzzy     = null;
 
-    public function __construct(Search $search, string $path, string ...$query)
+    public function __construct(Search $search, DocumentPersister $persister, string $path, string ...$query)
     {
-        parent::__construct($search);
+        parent::__construct($search, $persister);
 
         $this->query(...$query);
         $this->path($path);
@@ -79,7 +80,7 @@ class Autocomplete extends AbstractSearchOperator implements ScoredSearchOperato
     {
         $params = (object) [
             'query' => $this->query,
-            'path' => $this->path,
+            'path' => $this->prepareFieldPath($this->path),
         ];
 
         if ($this->tokenOrder) {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Closure;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 
 use function array_map;
 
@@ -28,6 +30,11 @@ class Compound extends AbstractSearchOperator implements CompoundSearchOperatorI
 
     private string $currentClause    = 'must';
     private ?int $minimumShouldMatch = null;
+
+    public function __construct(Search $search, private DocumentPersister $persister)
+    {
+        parent::__construct($search, $this->persister);
+    }
 
     /**
      * @param T $operator
@@ -121,5 +128,10 @@ class Compound extends AbstractSearchOperator implements CompoundSearchOperatorI
     protected function getCompoundStage(): Compound
     {
         return $this;
+    }
+
+    protected function getDocumentPersister(): DocumentPersister
+    {
+        return $this->persister;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound.php
@@ -31,11 +31,6 @@ class Compound extends AbstractSearchOperator implements CompoundSearchOperatorI
     private string $currentClause    = 'must';
     private ?int $minimumShouldMatch = null;
 
-    public function __construct(Search $search, private DocumentPersister $persister)
-    {
-        parent::__construct($search, $this->persister);
-    }
-
     /**
      * @param T $operator
      *
@@ -128,10 +123,5 @@ class Compound extends AbstractSearchOperator implements CompoundSearchOperatorI
     protected function getCompoundStage(): Compound
     {
         return $this;
-    }
-
-    protected function getDocumentPersister(): DocumentPersister
-    {
-        return $this->persister;
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Closure;
-use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
-use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 
 use function array_map;
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/EmbeddedDocument.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/EmbeddedDocument.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 
 /**
  * @internal
@@ -19,9 +20,9 @@ class EmbeddedDocument extends AbstractSearchOperator implements SupportsEmbedda
     private string $path;
     private ?SearchOperator $operator = null;
 
-    public function __construct(Search $search, string $path)
+    public function __construct(Search $search, DocumentPersister $persister, string $path)
     {
-        parent::__construct($search);
+        parent::__construct($search, $persister);
 
         $this->path($path);
     }
@@ -52,7 +53,7 @@ class EmbeddedDocument extends AbstractSearchOperator implements SupportsEmbedda
 
     public function getOperatorParams(): object
     {
-        $params = (object) ['path' => $this->path];
+        $params = (object) ['path' => $this->prepareFieldPath($this->path)];
 
         if ($this->operator) {
             $params->operator = (object) $this->operator->getExpression();

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Equals.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Equals.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
 
@@ -22,9 +23,9 @@ class Equals extends AbstractSearchOperator implements ScoredSearchOperator
     private mixed $value;
 
     /** @param string|int|float|ObjectId|UTCDateTime|null $value */
-    public function __construct(Search $search, string $path = '', $value = null)
+    public function __construct(Search $search, DocumentPersister $persister, string $path = '', $value = null)
     {
-        parent::__construct($search);
+        parent::__construct($search, $persister);
 
         $this
             ->path($path)
@@ -54,7 +55,7 @@ class Equals extends AbstractSearchOperator implements ScoredSearchOperator
     public function getOperatorParams(): object
     {
         $params = (object) [
-            'path' => $this->path,
+            'path' => $this->prepareFieldPath($this->path),
             'value' => $this->value,
         ];
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Exists.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Exists.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 
 /**
  * @internal
@@ -13,9 +14,9 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
  */
 class Exists extends AbstractSearchOperator
 {
-    public function __construct(Search $search, private string $path = '')
+    public function __construct(Search $search, DocumentPersister $persister, private string $path = '')
     {
-        parent::__construct($search);
+        parent::__construct($search, $persister);
     }
 
     public function getOperatorName(): string
@@ -25,6 +26,6 @@ class Exists extends AbstractSearchOperator
 
     public function getOperatorParams(): object
     {
-        return (object) ['path' => $this->path];
+        return (object) ['path' => $this->prepareFieldPath($this->path)];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoShape.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoShape.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use GeoJson\Geometry\Geometry;
 use GeoJson\Geometry\LineString;
 use GeoJson\Geometry\MultiPolygon;
@@ -27,9 +28,9 @@ class GeoShape extends AbstractSearchOperator implements ScoredSearchOperator
     private LineString|Point|Polygon|MultiPolygon|array|null $geometry = null;
 
     /** @param LineString|Point|Polygon|MultiPolygon|array|null $geometry */
-    public function __construct(Search $search, $geometry = null, string $relation = '', string ...$path)
+    public function __construct(Search $search, DocumentPersister $persister, $geometry = null, string $relation = '', string ...$path)
     {
-        parent::__construct($search);
+        parent::__construct($search, $persister);
 
         $this
             ->geometry($geometry)
@@ -67,7 +68,7 @@ class GeoShape extends AbstractSearchOperator implements ScoredSearchOperator
     public function getOperatorParams(): object
     {
         $params = (object) [
-            'path' => $this->path,
+            'path' => $this->prepareFieldPath($this->path),
             'relation' => $this->relation,
             'geometry' => $this->geometry instanceof Geometry
                 ? $this->geometry->jsonSerialize()

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoWithin.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/GeoWithin.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use GeoJson\Geometry\Geometry;
 use GeoJson\Geometry\MultiPolygon;
 use GeoJson\Geometry\Point;
@@ -27,9 +28,9 @@ class GeoWithin extends AbstractSearchOperator implements ScoredSearchOperator
 
     private array|MultiPolygon|Polygon|null $geometry = null;
 
-    public function __construct(Search $search, string ...$path)
+    public function __construct(Search $search, DocumentPersister $persister, string ...$path)
     {
-        parent::__construct($search);
+        parent::__construct($search, $persister);
 
         $this->path(...$path);
     }
@@ -84,7 +85,7 @@ class GeoWithin extends AbstractSearchOperator implements ScoredSearchOperator
 
     public function getOperatorParams(): object
     {
-        $params = (object) ['path' => $this->path];
+        $params = (object) ['path' => $this->prepareFieldPath($this->path)];
 
         if ($this->box) {
             $params->box = $this->box;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/MoreLikeThis.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/MoreLikeThis.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 
+use function array_map;
 use function array_values;
 
 /**
@@ -34,7 +35,8 @@ class MoreLikeThis extends AbstractSearchOperator
 
     public function getOperatorParams(): object
     {
-        // @todo map full object
-        return (object) ['like' => $this->like];
+        return (object) [
+            'like' => array_map($this->getDocumentPersister()->prepareQueryOrNewObj(...), $this->like),
+        ];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/MoreLikeThis.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/MoreLikeThis.php
@@ -7,7 +7,6 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 
-use function array_map;
 use function array_values;
 
 /**
@@ -36,7 +35,7 @@ class MoreLikeThis extends AbstractSearchOperator
     public function getOperatorParams(): object
     {
         return (object) [
-            'like' => array_map($this->getDocumentPersister()->prepareQueryOrNewObj(...), $this->like),
+            'like' => $this->prepareDocuments($this->like),
         ];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/MoreLikeThis.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/MoreLikeThis.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 
 use function array_values;
 
@@ -19,9 +20,9 @@ class MoreLikeThis extends AbstractSearchOperator
     private array $like = [];
 
     /** @param array<string, mixed>|object $documents */
-    public function __construct(Search $search, ...$documents)
+    public function __construct(Search $search, DocumentPersister $persister, ...$documents)
     {
-        parent::__construct($search);
+        parent::__construct($search, $persister);
 
         $this->like = array_values($documents);
     }
@@ -33,6 +34,7 @@ class MoreLikeThis extends AbstractSearchOperator
 
     public function getOperatorParams(): object
     {
+        // @todo map full object
         return (object) ['like' => $this->like];
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Near.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Near.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use GeoJson\Geometry\Geometry;
 use GeoJson\Geometry\Point;
 use MongoDB\BSON\UTCDateTime;
@@ -29,9 +30,9 @@ class Near extends AbstractSearchOperator implements ScoredSearchOperator
      * @param int|float|UTCDateTime|array|Point|null $origin
      * @param int|float|null                         $pivot
      */
-    public function __construct(Search $search, $origin = null, $pivot = null, string ...$path)
+    public function __construct(Search $search, DocumentPersister $persister, $origin = null, $pivot = null, string ...$path)
     {
-        parent::__construct($search);
+        parent::__construct($search, $persister);
 
         $this
             ->origin($origin)
@@ -74,7 +75,7 @@ class Near extends AbstractSearchOperator implements ScoredSearchOperator
                 ? $this->origin->jsonSerialize()
                 : $this->origin,
             'pivot' => $this->pivot,
-            'path' => $this->path,
+            'path' => $this->prepareFieldPath($this->path),
         ];
 
         return $this->appendScore($params);

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Phrase.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Phrase.php
@@ -52,7 +52,7 @@ class Phrase extends AbstractSearchOperator implements ScoredSearchOperator
     {
         $params = (object) [
             'query' => $this->query,
-            'path' => $this->path,
+            'path' => $this->prepareFieldPath($this->path),
         ];
 
         if ($this->slop !== null) {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/QueryString.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/QueryString.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 
 /**
  * @internal
@@ -18,9 +19,9 @@ class QueryString extends AbstractSearchOperator implements ScoredSearchOperator
     private string $query;
     private string $defaultPath;
 
-    public function __construct(Search $search, string $query = '', string $defaultPath = '')
+    public function __construct(Search $search, DocumentPersister $persister, string $query = '', string $defaultPath = '')
     {
-        parent::__construct($search);
+        parent::__construct($search, $persister);
 
         $this
             ->query($query)
@@ -50,7 +51,7 @@ class QueryString extends AbstractSearchOperator implements ScoredSearchOperator
     {
         $params = (object) [
             'query' => $this->query,
-            'defaultPath' => $this->defaultPath,
+            'defaultPath' => $this->prepareFieldPath($this->defaultPath),
         ];
 
         return $this->appendScore($params);

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Range.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Range.php
@@ -73,7 +73,7 @@ class Range extends AbstractSearchOperator implements ScoredSearchOperator
 
     public function getOperatorParams(): object
     {
-        $params = (object) ['path' => $this->path];
+        $params = (object) ['path' => $this->prepareFieldPath($this->path)];
 
         if ($this->gt !== null) {
             $name          = $this->includeLowerBound ? 'gte' : 'gt';

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Regex.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Regex.php
@@ -50,7 +50,7 @@ class Regex extends AbstractSearchOperator implements ScoredSearchOperator
     {
         $params = (object) [
             'query' => $this->query,
-            'path' => $this->path,
+            'path' => $this->prepareFieldPath($this->path),
         ];
 
         if ($this->allowAnalyzedField !== null) {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsAllSearchOperatorsTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsAllSearchOperatorsTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use GeoJson\Geometry\LineString;
 use GeoJson\Geometry\MultiPolygon;
 use GeoJson\Geometry\Point;
@@ -15,6 +16,8 @@ use MongoDB\BSON\UTCDateTime;
 /** @internal */
 trait SupportsAllSearchOperatorsTrait
 {
+    abstract protected function getDocumentPersister(): DocumentPersister;
+
     abstract protected function getSearchStage(): Search;
 
     /**
@@ -28,45 +31,45 @@ trait SupportsAllSearchOperatorsTrait
 
     public function autocomplete(string $path = '', string ...$query): Autocomplete
     {
-        return $this->addOperator(new Autocomplete($this->getSearchStage(), $path, ...$query));
+        return $this->addOperator(new Autocomplete($this->getSearchStage(), $this->getDocumentPersister(), $path, ...$query));
     }
 
     public function compound(): Compound
     {
-        return $this->addOperator(new Compound($this->getSearchStage()));
+        return $this->addOperator(new Compound($this->getSearchStage(), $this->getDocumentPersister()));
     }
 
     public function embeddedDocument(string $path = ''): EmbeddedDocument
     {
-        return $this->addOperator(new EmbeddedDocument($this->getSearchStage(), $path));
+        return $this->addOperator(new EmbeddedDocument($this->getSearchStage(), $this->getDocumentPersister(), $path));
     }
 
     /** @param string|int|float|ObjectId|UTCDateTime|null $value */
     public function equals(string $path = '', $value = null): Equals
     {
-        return $this->addOperator(new Equals($this->getSearchStage(), $path, $value));
+        return $this->addOperator(new Equals($this->getSearchStage(), $this->getDocumentPersister(), $path, $value));
     }
 
     public function exists(string $path): Exists
     {
-        return $this->addOperator(new Exists($this->getSearchStage(), $path));
+        return $this->addOperator(new Exists($this->getSearchStage(), $this->getDocumentPersister(), $path));
     }
 
     /** @param LineString|Point|Polygon|MultiPolygon|array<string, mixed>|null $geometry */
     public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape
     {
-        return $this->addOperator(new GeoShape($this->getSearchStage(), $geometry, $relation, ...$path));
+        return $this->addOperator(new GeoShape($this->getSearchStage(), $this->getDocumentPersister(), $geometry, $relation, ...$path));
     }
 
     public function geoWithin(string ...$path): GeoWithin
     {
-        return $this->addOperator(new GeoWithin($this->getSearchStage(), ...$path));
+        return $this->addOperator(new GeoWithin($this->getSearchStage(), $this->getDocumentPersister(), ...$path));
     }
 
     /** @param array<string, mixed>|object $documents */
     public function moreLikeThis(...$documents): MoreLikeThis
     {
-        return $this->addOperator(new MoreLikeThis($this->getSearchStage(), ...$documents));
+        return $this->addOperator(new MoreLikeThis($this->getSearchStage(), $this->getDocumentPersister(), ...$documents));
     }
 
     /**
@@ -75,36 +78,36 @@ trait SupportsAllSearchOperatorsTrait
      */
     public function near($origin = null, $pivot = null, string ...$path): Near
     {
-        return $this->addOperator(new Near($this->getSearchStage(), $origin, $pivot, ...$path));
+        return $this->addOperator(new Near($this->getSearchStage(), $this->getDocumentPersister(), $origin, $pivot, ...$path));
     }
 
     public function phrase(): Phrase
     {
-        return $this->addOperator(new Phrase($this->getSearchStage()));
+        return $this->addOperator(new Phrase($this->getSearchStage(), $this->getDocumentPersister()));
     }
 
     public function queryString(string $query = '', string $defaultPath = ''): QueryString
     {
-        return $this->addOperator(new QueryString($this->getSearchStage(), $query, $defaultPath));
+        return $this->addOperator(new QueryString($this->getSearchStage(), $this->getDocumentPersister(), $query, $defaultPath));
     }
 
     public function range(): Range
     {
-        return $this->addOperator(new Range($this->getSearchStage()));
+        return $this->addOperator(new Range($this->getSearchStage(), $this->getDocumentPersister()));
     }
 
     public function regex(): Regex
     {
-        return $this->addOperator(new Regex($this->getSearchStage()));
+        return $this->addOperator(new Regex($this->getSearchStage(), $this->getDocumentPersister()));
     }
 
     public function text(): Text
     {
-        return $this->addOperator(new Text($this->getSearchStage()));
+        return $this->addOperator(new Text($this->getSearchStage(), $this->getDocumentPersister()));
     }
 
     public function wildcard(): Wildcard
     {
-        return $this->addOperator(new Wildcard($this->getSearchStage()));
+        return $this->addOperator(new Wildcard($this->getSearchStage(), $this->getDocumentPersister()));
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsCompoundableOperatorsTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsCompoundableOperatorsTrait.php
@@ -20,6 +20,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedRange;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedRegex;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedText;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\Compound\CompoundedWildcard;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use GeoJson\Geometry\LineString;
 use GeoJson\Geometry\MultiPolygon;
 use GeoJson\Geometry\Point;
@@ -30,6 +31,8 @@ use MongoDB\BSON\UTCDateTime;
 /** @internal */
 trait SupportsCompoundableOperatorsTrait
 {
+    abstract protected function getDocumentPersister(): DocumentPersister;
+
     abstract protected function getSearchStage(): Search;
 
     abstract protected function getCompoundStage(): Compound;
@@ -47,40 +50,40 @@ trait SupportsCompoundableOperatorsTrait
 
     public function autocomplete(string $path = '', string ...$query): Autocomplete&CompoundSearchOperatorInterface
     {
-        return $this->addOperator(new CompoundedAutocomplete($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path, ...$query));
+        return $this->addOperator(new CompoundedAutocomplete($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister(), $path, ...$query));
     }
 
     public function embeddedDocument(string $path = ''): EmbeddedDocument&CompoundSearchOperatorInterface
     {
-        return $this->addOperator(new CompoundedEmbeddedDocument($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path));
+        return $this->addOperator(new CompoundedEmbeddedDocument($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister(), $path));
     }
 
     /** @param string|int|float|ObjectId|UTCDateTime|null $value */
     public function equals(string $path = '', $value = null): Equals&CompoundSearchOperatorInterface
     {
-        return $this->addOperator(new CompoundedEquals($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path, $value));
+        return $this->addOperator(new CompoundedEquals($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister(), $path, $value));
     }
 
     public function exists(string $path): Exists&CompoundSearchOperatorInterface
     {
-        return $this->addOperator(new CompoundedExists($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path));
+        return $this->addOperator(new CompoundedExists($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister(), $path));
     }
 
     /** @param LineString|Point|Polygon|MultiPolygon|array<string, mixed>|null $geometry */
     public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape&CompoundSearchOperatorInterface
     {
-        return $this->addOperator(new CompoundedGeoShape($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $geometry, $relation, ...$path));
+        return $this->addOperator(new CompoundedGeoShape($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister(), $geometry, $relation, ...$path));
     }
 
     public function geoWithin(string ...$path): GeoWithin&CompoundSearchOperatorInterface
     {
-        return $this->addOperator(new CompoundedGeoWithin($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), ...$path));
+        return $this->addOperator(new CompoundedGeoWithin($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister(), ...$path));
     }
 
     /** @param array<string, mixed>|object $documents */
     public function moreLikeThis(...$documents): MoreLikeThis&CompoundSearchOperatorInterface
     {
-        return $this->addOperator(new CompoundedMoreLikeThis($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), ...$documents));
+        return $this->addOperator(new CompoundedMoreLikeThis($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister(), ...$documents));
     }
 
     /**
@@ -89,36 +92,36 @@ trait SupportsCompoundableOperatorsTrait
      */
     public function near($origin = null, $pivot = null, string ...$path): Near&CompoundSearchOperatorInterface
     {
-        return $this->addOperator(new CompoundedNear($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $origin, $pivot, ...$path));
+        return $this->addOperator(new CompoundedNear($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister(), $origin, $pivot, ...$path));
     }
 
     public function phrase(): Phrase&CompoundSearchOperatorInterface
     {
-        return $this->addOperator(new CompoundedPhrase($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
+        return $this->addOperator(new CompoundedPhrase($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister()));
     }
 
     public function queryString(string $query = '', string $defaultPath = ''): QueryString&CompoundSearchOperatorInterface
     {
-        return $this->addOperator(new CompoundedQueryString($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $query, $defaultPath));
+        return $this->addOperator(new CompoundedQueryString($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister(), $query, $defaultPath));
     }
 
     public function range(): Range&CompoundSearchOperatorInterface
     {
-        return $this->addOperator(new CompoundedRange($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
+        return $this->addOperator(new CompoundedRange($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister()));
     }
 
     public function regex(): Regex&CompoundSearchOperatorInterface
     {
-        return $this->addOperator(new CompoundedRegex($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
+        return $this->addOperator(new CompoundedRegex($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister()));
     }
 
     public function text(): Text&CompoundSearchOperatorInterface
     {
-        return $this->addOperator(new CompoundedText($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
+        return $this->addOperator(new CompoundedText($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister()));
     }
 
     public function wildcard(): Wildcard&CompoundSearchOperatorInterface
     {
-        return $this->addOperator(new CompoundedWildcard($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
+        return $this->addOperator(new CompoundedWildcard($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister()));
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Text.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Text.php
@@ -71,7 +71,7 @@ class Text extends AbstractSearchOperator implements ScoredSearchOperator
     {
         $params = (object) [
             'query' => $this->query,
-            'path' => $this->path,
+            'path' => $this->prepareFieldPath($this->path),
         ];
 
         if ($this->fuzzy) {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Wildcard.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Wildcard.php
@@ -50,7 +50,7 @@ class Wildcard extends AbstractSearchOperator implements ScoredSearchOperator
     {
         $params = (object) [
             'query' => $this->query,
-            'path' => $this->path,
+            'path' => $this->prepareFieldPath($this->path),
         ];
 
         if ($this->allowAnalyzedField !== null) {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/VectorSearch.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/VectorSearch.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
+use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use Doctrine\ODM\MongoDB\Query\Expr;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
@@ -36,7 +37,7 @@ class VectorSearch extends Stage
     /** @phpstan-var Vector|null */
     private array|Binary|null $queryVector = null;
 
-    public function __construct(Builder $builder)
+    public function __construct(Builder $builder, private DocumentPersister $persister)
     {
         parent::__construct($builder);
     }
@@ -66,7 +67,7 @@ class VectorSearch extends Stage
         }
 
         if ($this->path !== null) {
-            $params['path'] = $this->path;
+            $params['path'] = $this->persister->prepareFieldName($this->path);
         }
 
         if ($this->queryVector !== null) {

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -263,6 +263,7 @@ use function trigger_deprecation;
  *      synonyms?: list<SearchIndexSynonym>,
  * }
  * @phpstan-type SearchIndexMapping array{
+ *      type: 'search'|'vectorSearch',
  *      name: string,
  *      definition: SearchIndexDefinition
  * }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -254,11 +254,11 @@ use function trigger_deprecation;
  * @phpstan-type SearchIndexDefinition array{
  *      mappings: array{
  *          dynamic?: bool,
- *          fields?: array,
+ *          fields?: array<string, array<string, mixed>>,
  *      },
  *      analyzer?: string,
  *      searchAnalyzer?: string,
- *      analyzers?: array,
+ *      analyzers?: list<array<string, mixed>>,
  *      storedSource?: SearchIndexStoredSource,
  *      synonyms?: list<SearchIndexSynonym>,
  * }

--- a/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/DocumentPersister.php
@@ -71,7 +71,7 @@ use function trigger_deprecation;
  *
  * @internal
  *
- * @template T of object
+ * @template T of object = object
  *
  * @phpstan-type CommitOptions array{
  *      fsync?: bool,

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -368,7 +368,7 @@ final class SchemaManager
 
         /* createSearchIndexes builds indexes asynchronously but still reports
          * the names of created indexes. Report an error if any defined names
-         * were not actually created. */
+         * were not created. */
         $unprocessedNames = array_diff($definedNames, $createdNames);
 
         if (! empty($unprocessedNames)) {

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -39,6 +39,7 @@ use function str_contains;
 /**
  * @phpstan-import-type IndexMapping from ClassMetadata
  * @phpstan-import-type IndexOptions from ClassMetadata
+ * @phpstan-import-type SearchIndexMapping from ClassMetadata
  */
 final class SchemaManager
 {
@@ -355,7 +356,7 @@ final class SchemaManager
             throw new InvalidArgumentException('Cannot create search indexes for mapped super classes, embedded documents, query result documents, or views.');
         }
 
-        $searchIndexes = $class->getSearchIndexes();
+        $searchIndexes = $this->prepareSearchIndexes($class);
 
         if (empty($searchIndexes)) {
             return;
@@ -410,7 +411,7 @@ final class SchemaManager
             throw new InvalidArgumentException('Cannot update search indexes for mapped super classes, embedded documents, query result documents, or views.');
         }
 
-        $searchIndexes = $class->getSearchIndexes();
+        $searchIndexes = $this->prepareSearchIndexes($class);
         $collection    = $this->dm->getDocumentCollection($class->name);
 
         $definedNames = array_column($searchIndexes, 'name');
@@ -484,6 +485,59 @@ final class SchemaManager
         foreach ($searchIndexes as $searchIndex) {
             $collection->dropSearchIndex($searchIndex['name']);
         }
+    }
+
+    /**
+     * @param ClassMetadata<object> $class
+     *
+     * @phpstan-return list<SearchIndexMapping>
+     */
+    private function prepareSearchIndexes(ClassMetadata $class): array
+    {
+        $persister  = $this->dm->getUnitOfWork()->getDocumentPersister($class->name);
+        $indexes    = $class->getSearchIndexes();
+        $newIndexes = [];
+
+        foreach ($indexes as $index) {
+            $definition = $index['definition'];
+            if (is_array($definition['fields'] ?? null)) {
+                // Vector Search Index
+                $fields = [];
+                foreach ($definition['fields'] as $field) {
+                    $key = $persister->prepareFieldName($field['path']);
+                    if ($class->hasField($key)) {
+                        $field['path'] = $class->getFieldMapping($key)['name'];
+                    } else {
+                        $field['path'] = $key;
+                    }
+
+                    $fields[] = $field;
+                }
+
+                $definition['fields'] = $fields;
+            } elseif (is_array($definition['mappings']['fields'] ?? null)) {
+                // Search Index with fields mappings
+                $fields = [];
+                foreach ($definition['mappings']['fields'] as $name => $field) {
+                    $key = $persister->prepareFieldName($name);
+                    if ($class->hasField($key)) {
+                        $fields[$class->getFieldMapping($key)['name']] = $field;
+                    } else {
+                        $fields[$key] = $field;
+                    }
+                }
+
+                $definition['mappings']['fields'] = $fields;
+            }
+
+            $newIndexes[] = [
+                'type' => $index['type'],
+                'name' => $index['name'],
+                'definition' => $definition,
+            ];
+        }
+
+        return $newIndexes;
     }
 
     /**

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactoryInterface;
+use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Repository\ViewRepository;
 use Doctrine\ODM\MongoDB\Utility\EncryptedFieldsMapGenerator;
 use InvalidArgumentException;
@@ -490,7 +491,10 @@ final class SchemaManager
     /**
      * @param ClassMetadata<object> $class
      *
+     * @return list<array<string, mixed>>
      * @phpstan-return list<SearchIndexMapping>
+     *
+     * @throws MappingException
      */
     private function prepareSearchIndexes(ClassMetadata $class): array
     {

--- a/lib/Doctrine/ODM/MongoDB/SchemaManager.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaManager.php
@@ -6,7 +6,6 @@ namespace Doctrine\ODM\MongoDB;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactoryInterface;
-use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Repository\ViewRepository;
 use Doctrine\ODM\MongoDB\Utility\EncryptedFieldsMapGenerator;
 use InvalidArgumentException;
@@ -491,10 +490,7 @@ final class SchemaManager
     /**
      * @param ClassMetadata<object> $class
      *
-     * @return list<array<string, mixed>>
      * @phpstan-return list<SearchIndexMapping>
-     *
-     * @throws MappingException
      */
     private function prepareSearchIndexes(ClassMetadata $class): array
     {
@@ -505,7 +501,7 @@ final class SchemaManager
         foreach ($indexes as $index) {
             $definition = $index['definition'];
             if (is_array($definition['fields'] ?? null)) {
-                // Vector Search Index
+                // Vector Search Index, field names in 'path' parameter
                 $fields = [];
                 foreach ($definition['fields'] as $field) {
                     $key = $persister->prepareFieldName($field['path']);
@@ -520,7 +516,7 @@ final class SchemaManager
 
                 $definition['fields'] = $fields;
             } elseif (is_array($definition['mappings']['fields'] ?? null)) {
-                // Search Index with fields mappings
+                // Search Index with fields mappings, field names as keys
                 $fields = [];
                 foreach ($definition['mappings']['fields'] as $name => $field) {
                     $key = $persister->prepareFieldName($name);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
@@ -8,8 +8,10 @@ use Closure;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\AbstractSearchOperator;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsEmbeddableSearchOperators;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\User;
 use Generator;
 use GeoJson\Geometry\Point;
 use GeoJson\Geometry\Polygon;
@@ -34,8 +36,7 @@ class SearchTest extends BaseTestCase
                     'path' => 'content',
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->autocomplete('content', 'MongoDB', 'Aggregation', 'Pipeline')
                     ->path('content');
             },
@@ -49,8 +50,7 @@ class SearchTest extends BaseTestCase
                     'tokenOrder' => 'any',
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->autocomplete()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('content')
@@ -68,8 +68,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->autocomplete()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('content')
@@ -87,8 +86,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->autocomplete()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('content')
@@ -108,8 +106,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->autocomplete()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('content')
@@ -134,8 +131,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->compound()
                     ->must()
                         ->text()
@@ -166,8 +162,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->compound()
                     ->must()
                         ->text()
@@ -197,8 +192,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->compound()
                     ->must()
                         ->text()
@@ -226,8 +220,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->embeddedDocument('items')
                     ->text()
                         ->path('items.content')
@@ -270,8 +263,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search $stage) {
                 return $stage->embeddedDocument('items')
                     ->compound()
                         ->must()
@@ -295,8 +287,7 @@ class SearchTest extends BaseTestCase
                     'value' => 'MongoDB Aggregation Pipeline',
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->equals('content', 'MongoDB Aggregation Pipeline');
             },
         ];
@@ -311,8 +302,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->equals()
                     ->path('content')
                     ->value('MongoDB Aggregation Pipeline')
@@ -330,8 +320,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->equals()
                     ->path('content')
                     ->value('MongoDB Aggregation Pipeline')
@@ -346,8 +335,7 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'exists' => (object) ['path' => 'content'],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->exists('content');
             },
         ];
@@ -363,8 +351,7 @@ class SearchTest extends BaseTestCase
                     'geometry' => ['coordinates' => [12.345, 23.456], 'type' => 'Point'],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->geoShape(
                     new Point([12.345, 23.456]),
                     'contains',
@@ -385,8 +372,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->geoShape()
                     ->path('location')
                     ->relation('contains')
@@ -406,8 +392,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->geoShape()
                     ->path('location')
                     ->relation('contains')
@@ -429,8 +414,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->geoWithin('location1', 'location2')
                     ->box(new Point([-12.345, -23.456]), new Point([12.345, 23.456]));
             },
@@ -446,8 +430,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->geoWithin()
                     ->path('location')
                     ->circle(new Point([12.345, 23.456]), 3.14);
@@ -467,8 +450,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->geoWithin()
                     ->path('location')
                     ->geometry(new Polygon([
@@ -491,8 +473,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->geoWithin()
                     ->path('location')
                     ->circle(new Point([12.345, 23.456]), 3.14)
@@ -513,8 +494,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->geoWithin()
                     ->path('location')
                     ->circle(new Point([12.345, 23.456]), 3.14)
@@ -529,8 +509,7 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'moreLikeThis' => (object) ['like' => [['title' => 'The Godfather']]],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->moreLikeThis(['title' => 'The Godfather']);
             },
         ];
@@ -544,8 +523,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->moreLikeThis(['title' => 'The Godfather'], ['title' => 'The Green Mile']);
             },
         ];
@@ -561,8 +539,7 @@ class SearchTest extends BaseTestCase
                     'path' => ['value1', 'value2'],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->near(5, 3, 'value1', 'value2');
             },
         ];
@@ -577,8 +554,7 @@ class SearchTest extends BaseTestCase
                     'path' => ['createdAt'],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) use ($date) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) use ($date) {
                 return $stage->near()
                     ->path('createdAt')
                     ->origin($date)
@@ -594,8 +570,7 @@ class SearchTest extends BaseTestCase
                     'path' => ['createdAt'],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->near()
                     ->path('createdAt')
                     ->origin(new Point([12.345, 23.456]))
@@ -613,8 +588,7 @@ class SearchTest extends BaseTestCase
                     'path' => ['title', 'content'],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->phrase()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('title', 'content');
@@ -629,8 +603,7 @@ class SearchTest extends BaseTestCase
                     'slop' => 3,
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->phrase()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('content')
@@ -648,8 +621,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->phrase()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('content')
@@ -667,8 +639,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->phrase()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('content')
@@ -686,8 +657,7 @@ class SearchTest extends BaseTestCase
                     'defaultPath' => 'content',
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->queryString('MongoDB Aggregation Pipeline', 'content');
             },
         ];
@@ -702,8 +672,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->queryString()
                     ->query('content:pipeline OR title:pipeline')
                     ->defaultPath('content')
@@ -721,8 +690,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->queryString()
                     ->query('content:pipeline OR title:pipeline')
                     ->defaultPath('content')
@@ -740,8 +708,7 @@ class SearchTest extends BaseTestCase
                     'gt' => 5,
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->range()
                     ->path('field1', 'field2')
                     ->gt(5);
@@ -755,8 +722,7 @@ class SearchTest extends BaseTestCase
                     'gte' => 5,
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->range()
                     ->path('field1', 'field2')
                     ->gte(5);
@@ -770,8 +736,7 @@ class SearchTest extends BaseTestCase
                     'lt' => 5,
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->range()
                     ->path('field1', 'field2')
                     ->lt(5);
@@ -785,8 +750,7 @@ class SearchTest extends BaseTestCase
                     'lte' => 5,
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->range()
                     ->path('field1', 'field2')
                     ->lte(5);
@@ -801,8 +765,7 @@ class SearchTest extends BaseTestCase
                     'gte' => 5,
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->range()
                     ->path('field1', 'field2')
                     ->lte(10)
@@ -821,8 +784,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->range()
                     ->path('field1', 'field2')
                     ->lte(10)
@@ -842,8 +804,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->range()
                     ->path('field1', 'field2')
                     ->lte(10)
@@ -862,8 +823,7 @@ class SearchTest extends BaseTestCase
                     'path' => ['title', 'content'],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->regex()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('title', 'content');
@@ -878,8 +838,7 @@ class SearchTest extends BaseTestCase
                     'allowAnalyzedField' => true,
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->regex()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('title', 'content')
@@ -895,8 +854,7 @@ class SearchTest extends BaseTestCase
                     'allowAnalyzedField' => false,
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->regex()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('title', 'content')
@@ -914,8 +872,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->regex()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('title', 'content')
@@ -933,8 +890,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->regex()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('title', 'content')
@@ -952,8 +908,7 @@ class SearchTest extends BaseTestCase
                     'path' => ['title', 'content'],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->text()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('title', 'content');
@@ -968,8 +923,7 @@ class SearchTest extends BaseTestCase
                     'synonyms' => 'mySynonyms',
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->text()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('content')
@@ -987,8 +941,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->text()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('content')
@@ -1006,8 +959,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->text()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('content')
@@ -1027,8 +979,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->text()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('content')
@@ -1046,8 +997,7 @@ class SearchTest extends BaseTestCase
                     'path' => ['title', 'content'],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->wildcard()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('title', 'content');
@@ -1062,8 +1012,7 @@ class SearchTest extends BaseTestCase
                     'allowAnalyzedField' => true,
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->wildcard()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('title', 'content')
@@ -1079,8 +1028,7 @@ class SearchTest extends BaseTestCase
                     'allowAnalyzedField' => false,
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->wildcard()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('title', 'content')
@@ -1098,8 +1046,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->wildcard()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('title', 'content')
@@ -1117,8 +1064,7 @@ class SearchTest extends BaseTestCase
                     ],
                 ],
             ],
-            /** @param Search|CompoundSearchOperatorInterface $stage */
-            'createOperator' => static function ($stage) {
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->wildcard()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
                     ->path('title', 'content')
@@ -1159,7 +1105,7 @@ class SearchTest extends BaseTestCase
             'returnStoredSource' => true,
         ];
 
-        $searchStage = new Search($this->getTestAggregationBuilder());
+        $searchStage = $this->createSearchStage();
         $searchStage
             ->index('my_search_index');
 
@@ -1207,7 +1153,7 @@ class SearchTest extends BaseTestCase
             ],
         ];
 
-        $searchStage = new Search($this->getTestAggregationBuilder());
+        $searchStage = $this->createSearchStage();
         $searchStage
             ->index('my_search_index');
 
@@ -1244,7 +1190,7 @@ class SearchTest extends BaseTestCase
     #[DataProvider('provideWildcardBuilders')]
     public function testSearchCompoundOperators(array $expectedOperator, Closure $createOperator): void
     {
-        $searchStage = new Search($this->getTestAggregationBuilder());
+        $searchStage = $this->createSearchStage();
         $compound    = $searchStage
             ->index('my_search_index')
             ->compound();
@@ -1293,7 +1239,7 @@ class SearchTest extends BaseTestCase
     #[DataProvider('provideWildcardBuilders')]
     public function testSearchEmbeddedDocumentOperators(array $expectedOperator, Closure $createOperator): void
     {
-        $searchStage = new Search($this->getTestAggregationBuilder());
+        $searchStage = $this->createSearchStage();
         $embedded    = $searchStage
             ->index('my_search_index')
             ->embeddedDocument('foo');
@@ -1332,7 +1278,7 @@ class SearchTest extends BaseTestCase
             'searchBefore' => 'marker',
         ];
 
-        $searchStage = new Search($this->getTestAggregationBuilder());
+        $searchStage = $this->createSearchStage();
         $searchStage
             ->index('my_search_index')
             ->searchBefore('marker');
@@ -1373,7 +1319,7 @@ class SearchTest extends BaseTestCase
             'searchAfter' => 'marker',
         ];
 
-        $searchStage = new Search($this->getTestAggregationBuilder());
+        $searchStage = $this->createSearchStage();
         $searchStage
             ->index('my_search_index')
             ->searchAfter('marker');
@@ -1394,5 +1340,10 @@ class SearchTest extends BaseTestCase
             ['$search' => (object) array_merge($baseExpected, $expectedOperator)],
             $searchStage->getExpression(),
         );
+    }
+
+    private function createSearchStage(string $className = User::class): Search
+    {
+        return new Search($this->getTestAggregationBuilder($className), $this->dm->getUnitOfWork()->getDocumentPersister($className));
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
@@ -1342,6 +1342,7 @@ class SearchTest extends BaseTestCase
         );
     }
 
+    /** @param class-string $className */
     private function createSearchStage(string $className = User::class): Search
     {
         return new Search($this->getTestAggregationBuilder($className), $this->dm->getUnitOfWork()->getDocumentPersister($className));

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
 use Closure;
+use DateTime;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\AbstractSearchOperator;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterface;
@@ -525,6 +526,19 @@ class SearchTest extends BaseTestCase
             ],
             'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->moreLikeThis(['title' => 'The Godfather'], ['title' => 'The Green Mile']);
+            },
+        ];
+
+        yield 'MoreLikeThis with field names mapping' => [
+            'expectedOperator' => [
+                'moreLikeThis' => (object) [
+                    'like' => [
+                        ['disable-at' => new UTCDateTime(new DateTime('2020-01-01T00:00:00Z'))],
+                    ],
+                ],
+            ],
+            'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
+                return $stage->moreLikeThis(['disabledAt' => new DateTime('2020-01-01T00:00:00Z')]);
             },
         ];
     }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/SearchTest.php
@@ -12,6 +12,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\CompoundSearchOperatorInterfac
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search\SupportsEmbeddableSearchOperators;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\CmsArticle;
 use Documents\User;
 use Generator;
 use GeoJson\Geometry\Point;
@@ -34,12 +35,12 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'autocomplete' => (object) [
                     'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
-                    'path' => 'content',
+                    'path' => 'article_title',
                 ],
             ],
             'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->autocomplete('content', 'MongoDB', 'Aggregation', 'Pipeline')
-                    ->path('content');
+                    ->path('title');
             },
         ];
 
@@ -63,7 +64,7 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'autocomplete' => (object) [
                     'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
-                    'path' => 'content',
+                    'path' => 'article_title',
                     'score' => (object) [
                         'boost' => (object) ['value' => 1.5],
                     ],
@@ -72,7 +73,7 @@ class SearchTest extends BaseTestCase
             'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->autocomplete()
                     ->query('MongoDB', 'Aggregation', 'Pipeline')
-                    ->path('content')
+                    ->path('title')
                     ->boostScore(1.5);
             },
         ];
@@ -334,10 +335,10 @@ class SearchTest extends BaseTestCase
     {
         yield 'Exists required only' => [
             'expectedOperator' => [
-                'exists' => (object) ['path' => 'content'],
+                'exists' => (object) ['path' => 'article_title'],
             ],
             'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
-                return $stage->exists('content');
+                return $stage->exists('title');
             },
         ];
     }
@@ -347,7 +348,7 @@ class SearchTest extends BaseTestCase
         yield 'CompoundedGeoShape required only' => [
             'expectedOperator' => [
                 'geoShape' => (object) [
-                    'path' => ['location1', 'location2'],
+                    'path' => ['article_title', 'location2'],
                     'relation' => 'contains',
                     'geometry' => ['coordinates' => [12.345, 23.456], 'type' => 'Point'],
                 ],
@@ -356,7 +357,7 @@ class SearchTest extends BaseTestCase
                 return $stage->geoShape(
                     new Point([12.345, 23.456]),
                     'contains',
-                    'location1',
+                    'title',
                     'location2',
                 );
             },
@@ -408,7 +409,7 @@ class SearchTest extends BaseTestCase
         yield 'GeoWithin box' => [
             'expectedOperator' => [
                 'geoWithin' => (object) [
-                    'path' => ['location1', 'location2'],
+                    'path' => ['article_title', 'location2'],
                     'box' => (object) [
                         'bottomLeft' => ['coordinates' => [-12.345, -23.456], 'type' => 'Point'],
                         'topRight' => ['coordinates' => [12.345, 23.456], 'type' => 'Point'],
@@ -416,7 +417,7 @@ class SearchTest extends BaseTestCase
                 ],
             ],
             'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
-                return $stage->geoWithin('location1', 'location2')
+                return $stage->geoWithin('title', 'location2')
                     ->box(new Point([-12.345, -23.456]), new Point([12.345, 23.456]));
             },
         ];
@@ -508,7 +509,7 @@ class SearchTest extends BaseTestCase
     {
         yield 'MoreLikeThis with single like' => [
             'expectedOperator' => [
-                'moreLikeThis' => (object) ['like' => [['title' => 'The Godfather']]],
+                'moreLikeThis' => (object) ['like' => [['article_title' => 'The Godfather']]],
             ],
             'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->moreLikeThis(['title' => 'The Godfather']);
@@ -519,13 +520,13 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'moreLikeThis' => (object) [
                     'like' => [
-                        ['title' => 'The Godfather'],
-                        ['title' => 'The Green Mile'],
+                        ['article_title' => 'The Godfather', 'not_mapped_field' => 'Some value'],
+                        ['article_title' => 'The Green Mile'],
                     ],
                 ],
             ],
             'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
-                return $stage->moreLikeThis(['title' => 'The Godfather'], ['title' => 'The Green Mile']);
+                return $stage->moreLikeThis(['title' => 'The Godfather', 'not_mapped_field' => 'Some value'], ['title' => 'The Green Mile']);
             },
         ];
 
@@ -540,6 +541,7 @@ class SearchTest extends BaseTestCase
             'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->moreLikeThis(['disabledAt' => new DateTime('2020-01-01T00:00:00Z')]);
             },
+            'className' => User::class,
         ];
     }
 
@@ -550,11 +552,11 @@ class SearchTest extends BaseTestCase
                 'near' => (object) [
                     'origin' => 5,
                     'pivot' => 3,
-                    'path' => ['value1', 'value2'],
+                    'path' => ['article_title', 'value2'],
                 ],
             ],
             'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
-                return $stage->near(5, 3, 'value1', 'value2');
+                return $stage->near(5, 3, 'title', 'value2');
             },
         ];
 
@@ -599,7 +601,7 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'phrase' => (object) [
                     'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
-                    'path' => ['title', 'content'],
+                    'path' => ['article_title', 'content'],
                 ],
             ],
             'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
@@ -668,11 +670,11 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'queryString' => (object) [
                     'query' => 'MongoDB Aggregation Pipeline',
-                    'defaultPath' => 'content',
+                    'defaultPath' => 'article_title',
                 ],
             ],
             'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
-                return $stage->queryString('MongoDB Aggregation Pipeline', 'content');
+                return $stage->queryString('MongoDB Aggregation Pipeline', 'title');
             },
         ];
 
@@ -718,13 +720,13 @@ class SearchTest extends BaseTestCase
         yield 'Range gt only' => [
             'expectedOperator' => [
                 'range' => (object) [
-                    'path' => ['field1', 'field2'],
+                    'path' => ['article_title', 'field2'],
                     'gt' => 5,
                 ],
             ],
             'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
                 return $stage->range()
-                    ->path('field1', 'field2')
+                    ->path('title', 'field2')
                     ->gt(5);
             },
         ];
@@ -834,7 +836,7 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'regex' => (object) [
                     'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
-                    'path' => ['title', 'content'],
+                    'path' => ['article_title', 'content'],
                 ],
             ],
             'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
@@ -848,7 +850,7 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'regex' => (object) [
                     'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
-                    'path' => ['title', 'content'],
+                    'path' => ['article_title', 'content'],
                     'allowAnalyzedField' => true,
                 ],
             ],
@@ -864,7 +866,7 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'regex' => (object) [
                     'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
-                    'path' => ['title', 'content'],
+                    'path' => ['article_title', 'content'],
                     'allowAnalyzedField' => false,
                 ],
             ],
@@ -880,7 +882,7 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'regex' => (object) [
                     'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
-                    'path' => ['title', 'content'],
+                    'path' => ['article_title', 'content'],
                     'score' => (object) [
                         'boost' => (object) ['value' => 1.5],
                     ],
@@ -898,7 +900,7 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'regex' => (object) [
                     'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
-                    'path' => ['title', 'content'],
+                    'path' => ['article_title', 'content'],
                     'score' => (object) [
                         'constant' => (object) ['value' => 1.5],
                     ],
@@ -919,7 +921,7 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'text' => (object) [
                     'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
-                    'path' => ['title', 'content'],
+                    'path' => ['article_title', 'content'],
                 ],
             ],
             'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
@@ -1008,7 +1010,7 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'wildcard' => (object) [
                     'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
-                    'path' => ['title', 'content'],
+                    'path' => ['article_title', 'content'],
                 ],
             ],
             'createOperator' => static function (Search|CompoundSearchOperatorInterface|SupportsEmbeddableSearchOperators $stage) {
@@ -1022,7 +1024,7 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'wildcard' => (object) [
                     'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
-                    'path' => ['title', 'content'],
+                    'path' => ['article_title', 'content'],
                     'allowAnalyzedField' => true,
                 ],
             ],
@@ -1038,7 +1040,7 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'wildcard' => (object) [
                     'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
-                    'path' => ['title', 'content'],
+                    'path' => ['article_title', 'content'],
                     'allowAnalyzedField' => false,
                 ],
             ],
@@ -1054,7 +1056,7 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'wildcard' => (object) [
                     'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
-                    'path' => ['title', 'content'],
+                    'path' => ['article_title', 'content'],
                     'score' => (object) [
                         'boost' => (object) ['value' => 1.5],
                     ],
@@ -1072,7 +1074,7 @@ class SearchTest extends BaseTestCase
             'expectedOperator' => [
                 'wildcard' => (object) [
                     'query' => ['MongoDB', 'Aggregation', 'Pipeline'],
-                    'path' => ['title', 'content'],
+                    'path' => ['article_title', 'content'],
                     'score' => (object) [
                         'constant' => (object) ['value' => 1.5],
                     ],
@@ -1103,7 +1105,7 @@ class SearchTest extends BaseTestCase
     #[DataProvider('provideRegexBuilders')]
     #[DataProvider('provideTextBuilders')]
     #[DataProvider('provideWildcardBuilders')]
-    public function testSearchOperators(array $expectedOperator, Closure $createOperator): void
+    public function testSearchOperators(array $expectedOperator, Closure $createOperator, ?string $className = null): void
     {
         $baseExpected = [
             'index' => 'my_search_index',
@@ -1119,7 +1121,7 @@ class SearchTest extends BaseTestCase
             'returnStoredSource' => true,
         ];
 
-        $searchStage = $this->createSearchStage();
+        $searchStage = $this->createSearchStage($className);
         $searchStage
             ->index('my_search_index');
 
@@ -1156,7 +1158,7 @@ class SearchTest extends BaseTestCase
     #[DataProvider('provideRegexBuilders')]
     #[DataProvider('provideTextBuilders')]
     #[DataProvider('provideWildcardBuilders')]
-    public function testSearchOperatorsWithSort(array $expectedOperator, Closure $createOperator): void
+    public function testSearchOperatorsWithSort(array $expectedOperator, Closure $createOperator, ?string $className = null): void
     {
         $baseExpected = [
             'index' => 'my_search_index',
@@ -1167,7 +1169,7 @@ class SearchTest extends BaseTestCase
             ],
         ];
 
-        $searchStage = $this->createSearchStage();
+        $searchStage = $this->createSearchStage($className);
         $searchStage
             ->index('my_search_index');
 
@@ -1202,9 +1204,9 @@ class SearchTest extends BaseTestCase
     #[DataProvider('provideRegexBuilders')]
     #[DataProvider('provideTextBuilders')]
     #[DataProvider('provideWildcardBuilders')]
-    public function testSearchCompoundOperators(array $expectedOperator, Closure $createOperator): void
+    public function testSearchCompoundOperators(array $expectedOperator, Closure $createOperator, ?string $className = null): void
     {
-        $searchStage = $this->createSearchStage();
+        $searchStage = $this->createSearchStage($className);
         $compound    = $searchStage
             ->index('my_search_index')
             ->compound();
@@ -1251,9 +1253,9 @@ class SearchTest extends BaseTestCase
     #[DataProvider('provideRegexBuilders')]
     #[DataProvider('provideTextBuilders')]
     #[DataProvider('provideWildcardBuilders')]
-    public function testSearchEmbeddedDocumentOperators(array $expectedOperator, Closure $createOperator): void
+    public function testSearchEmbeddedDocumentOperators(array $expectedOperator, Closure $createOperator, ?string $className = null): void
     {
-        $searchStage = $this->createSearchStage();
+        $searchStage = $this->createSearchStage($className);
         $embedded    = $searchStage
             ->index('my_search_index')
             ->embeddedDocument('foo');
@@ -1275,7 +1277,7 @@ class SearchTest extends BaseTestCase
     }
 
     #[DataProvider('provideAutocompleteBuilders')]
-    public function testSearchOperatorsWithSearchBefore(array $expectedOperator, Closure $createOperator): void
+    public function testSearchOperatorsWithSearchBefore(array $expectedOperator, Closure $createOperator, ?string $className = null): void
     {
         $baseExpected = [
             'index' => 'my_search_index',
@@ -1292,7 +1294,7 @@ class SearchTest extends BaseTestCase
             'searchBefore' => 'marker',
         ];
 
-        $searchStage = $this->createSearchStage();
+        $searchStage = $this->createSearchStage($className);
         $searchStage
             ->index('my_search_index')
             ->searchBefore('marker');
@@ -1316,7 +1318,7 @@ class SearchTest extends BaseTestCase
     }
 
     #[DataProvider('provideAutocompleteBuilders')]
-    public function testSearchOperatorsWithSearchAfter(array $expectedOperator, Closure $createOperator): void
+    public function testSearchOperatorsWithSearchAfter(array $expectedOperator, Closure $createOperator, ?string $className = null): void
     {
         $baseExpected = [
             'index' => 'my_search_index',
@@ -1333,7 +1335,7 @@ class SearchTest extends BaseTestCase
             'searchAfter' => 'marker',
         ];
 
-        $searchStage = $this->createSearchStage();
+        $searchStage = $this->createSearchStage($className);
         $searchStage
             ->index('my_search_index')
             ->searchAfter('marker');
@@ -1357,8 +1359,10 @@ class SearchTest extends BaseTestCase
     }
 
     /** @param class-string $className */
-    private function createSearchStage(string $className = User::class): Search
+    private function createSearchStage(?string $className = null): Search
     {
+        $className ??= CmsArticle::class;
+
         return new Search($this->getTestAggregationBuilder($className), $this->dm->getUnitOfWork()->getDocumentPersister($className));
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/VectorSearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/VectorSearchTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\VectorSearch;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\User;
+use Documents\VectorEmbedding;
 use MongoDB\BSON\Binary;
 
 class VectorSearchTest extends BaseTestCase
@@ -15,63 +18,69 @@ class VectorSearchTest extends BaseTestCase
 
     public function testEmptyStage(): void
     {
-        $stage = new VectorSearch($this->getTestAggregationBuilder());
+        [$stage] = $this->createVectorSearchStage();
         self::assertSame(['$vectorSearch' => []], $stage->getExpression());
     }
 
     public function testExact(): void
     {
-        $stage = new VectorSearch($this->getTestAggregationBuilder());
+        [$stage, $builder] = $this->createVectorSearchStage();
         $stage->exact(true);
         self::assertSame(['$vectorSearch' => ['exact' => true]], $stage->getExpression());
     }
 
     public function testFilter(): void
     {
-        $builder = $this->getTestAggregationBuilder();
-        $stage   = new VectorSearch($builder);
+        [$stage, $builder] = $this->createVectorSearchStage();
         $stage->filter($builder->matchExpr()->field('status')->notEqual('inactive'));
         self::assertSame(['$vectorSearch' => ['filter' => ['status' => ['$ne' => 'inactive']]]], $stage->getExpression());
     }
 
     public function testIndex(): void
     {
-        $stage = new VectorSearch($this->getTestAggregationBuilder());
+        [$stage] = $this->createVectorSearchStage();
         $stage->index('myIndex');
         self::assertSame(['$vectorSearch' => ['index' => 'myIndex']], $stage->getExpression());
     }
 
     public function testLimit(): void
     {
-        $stage = new VectorSearch($this->getTestAggregationBuilder());
+        [$stage] = $this->createVectorSearchStage();
         $stage->limit(10);
         self::assertSame(['$vectorSearch' => ['limit' => 10]], $stage->getExpression());
     }
 
     public function testNumCandidates(): void
     {
-        $stage = new VectorSearch($this->getTestAggregationBuilder());
+        [$stage] = $this->createVectorSearchStage();
         $stage->numCandidates(5);
         self::assertSame(['$vectorSearch' => ['numCandidates' => 5]], $stage->getExpression());
     }
 
     public function testPath(): void
     {
-        $stage = new VectorSearch($this->getTestAggregationBuilder());
+        [$stage] = $this->createVectorSearchStage();
         $stage->path('vectorField');
         self::assertSame(['$vectorSearch' => ['path' => 'vectorField']], $stage->getExpression());
     }
 
+    public function testPathIsPrepared(): void
+    {
+        [$stage] = $this->createVectorSearchStage(VectorEmbedding::class);
+        $stage->path('vectorFloat');
+        self::assertSame(['$vectorSearch' => ['path' => 'db_vector_float']], $stage->getExpression());
+    }
+
     public function testQueryVector(): void
     {
-        $stage = new VectorSearch($this->getTestAggregationBuilder());
+        [$stage] = $this->createVectorSearchStage();
         $stage->queryVector([1, 2, 3]);
         self::assertSame(['$vectorSearch' => ['queryVector' => [1, 2, 3]]], $stage->getExpression());
     }
 
     public function testQueryVectorAcceptsBinary(): void
     {
-        $stage        = new VectorSearch($this->getTestAggregationBuilder());
+        [$stage]      = $this->createVectorSearchStage();
         $binaryVector = new Binary("\x01\x02\x03", 9);
         $stage->queryVector($binaryVector);
         self::assertSame(['$vectorSearch' => ['queryVector' => $binaryVector]], $stage->getExpression());
@@ -79,8 +88,8 @@ class VectorSearchTest extends BaseTestCase
 
     public function testChainingAllOptions(): void
     {
-        $builder = $this->getTestAggregationBuilder();
-        $stage   = (new VectorSearch($builder))
+        [$stage, $builder] = $this->createVectorSearchStage();
+        $stage
             ->exact(false)
             ->filter($builder->matchExpr()->field('status')->notEqual('inactive'))
             ->index('idx')
@@ -99,5 +108,18 @@ class VectorSearchTest extends BaseTestCase
                 'queryVector' => [0.1, 0.2],
             ],
         ], $stage->getExpression());
+    }
+
+    /**
+     * @param class-string $className
+     *
+     * @return array{0: VectorSearch, 1: Builder}
+     */
+    private function createVectorSearchStage(string $className = User::class): array
+    {
+        return [
+            new VectorSearch($builder = $this->getTestAggregationBuilder($className), $this->dm->getUnitOfWork()->getDocumentPersister($className)),
+            $builder,
+        ];
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtlasSearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtlasSearchTest.php
@@ -53,7 +53,7 @@ class AtlasSearchTest extends BaseTestCase
         $results = $this->dm->createAggregationBuilder(CmsArticle::class)
             ->search()
                 ->index('search_articles')
-                ->text()
+                ->autocomplete()
                     ->query('Mongo')
                     ->path('title')
                     ->fuzzy(2, 2)

--- a/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/SchemaManagerTest.php
@@ -410,28 +410,98 @@ class SchemaManagerTest extends BaseTestCase
         $this->schemaManager->createSearchIndexes();
     }
 
+    public function testCreateDocumentSearchIndexesNotCreatedError(): void
+    {
+        $this->documentCollections['CmsArticle']
+            ->expects($this->once())
+            ->method('createSearchIndexes')
+            ->with($this->anything())
+            ->willReturn(['foo']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The following search indexes for Documents\CmsArticle were not created: search_articles');
+
+        $this->schemaManager->createDocumentSearchIndexes(CmsArticle::class);
+    }
+
     public function testCreateDocumentSearchIndexes(): void
     {
         $expectedCollectionName = $this->dm->getClassMetadata(CmsArticle::class)->getCollection();
         foreach ($this->documentCollections as $collectionName => $collection) {
             if ($collectionName === $expectedCollectionName) {
-                $collection
+                $this->documentCollections['CmsArticle']
                     ->expects($this->once())
                     ->method('createSearchIndexes')
-                    ->with([
-                        [
-                            'definition' => ['mappings' => ['dynamic' => true]],
-                            'name' => 'search_articles',
-                            'type' => 'search',
-                        ],
-                    ])
-                    ->willReturn(['search_articles']);
+                    ->with($this->anything())
+                    ->willReturnCallback(function (array $indexes) {
+                        $this->assertSame([
+                            [
+                                'type' => 'search',
+                                'name' => 'search_articles',
+                                'definition' => [
+                                    'mappings' => [
+                                        'dynamic' => true,
+                                        'fields' => [
+                                            'article_title' => ['type' => 'autocomplete'],
+                                            'text' => ['type' => 'string'],
+                                            'not_mapped_field' => ['type' => 'token'],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ], $indexes);
+
+                        return ['search_articles'];
+                    });
             } else {
                 $collection->expects($this->never())->method('createSearchIndexes');
             }
         }
 
         $this->schemaManager->createDocumentSearchIndexes(CmsArticle::class);
+    }
+
+    public function testCreateVectorSearchIndex(): void
+    {
+        $expectedCollectionName = $this->dm->getClassMetadata(VectorEmbedding::class)->getCollection();
+        foreach ($this->documentCollections as $collectionName => $collection) {
+            if ($collectionName === $expectedCollectionName) {
+                $this->documentCollections['vector_embeddings']
+                    ->expects($this->once())
+                    ->method('createSearchIndexes')
+                    ->with($this->anything())
+                    ->willReturnCallback(function (array $indexes) {
+                        $this->assertSame([
+                            [
+                                'type' => 'vectorSearch',
+                                'name' => 'default',
+                                'definition' => [
+                                    'fields' => [
+                                        ['type' => 'vector', 'path' => 'db_vector_float', 'numDimensions' => 3, 'similarity' => 'dotProduct'],
+                                    ],
+                                ],
+                            ],
+                            [
+                                'type' => 'vectorSearch',
+                                'name' => 'vector_int',
+                                'definition' => [
+                                    'fields' => [
+                                        ['type' => 'vector', 'path' => 'vectorInt', 'numDimensions' => 3, 'similarity' => 'cosine'],
+                                        ['type' => 'filter', 'path' => 'filterField'],
+                                        ['type' => 'filter', 'path' => 'not_mapped_filter'],
+                                    ],
+                                ],
+                            ],
+                        ], $indexes);
+
+                        return ['default', 'vector_int'];
+                    });
+            } else {
+                $collection->expects($this->never())->method('createSearchIndexes');
+            }
+        }
+
+        $this->schemaManager->createDocumentSearchIndexes(VectorEmbedding::class);
     }
 
     public function testCreateDocumentSearchIndexesNotSupported(): void

--- a/tests/Documents/CmsArticle.php
+++ b/tests/Documents/CmsArticle.php
@@ -8,7 +8,15 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 #[ODM\Index(keys: ['topic' => 'asc'])]
-#[ODM\SearchIndex(name: 'search_articles', dynamic: true)]
+#[ODM\SearchIndex(
+    name: 'search_articles',
+    dynamic: true,
+    fields: [
+        'title' => ['type' => 'autocomplete'],
+        'text' => ['type' => 'string'],
+        'not_mapped_field' => ['type' => 'token'],
+    ],
+)]
 #[ODM\Document]
 class CmsArticle
 {
@@ -19,7 +27,7 @@ class CmsArticle
     #[ODM\Field(type: 'string')]
     public $topic;
     /** @var string|null */
-    #[ODM\Field(type: 'string')]
+    #[ODM\Field(type: 'string', name: 'article_title')]
     public $title;
     /** @var string|null */
     #[ODM\Field(type: 'string')]

--- a/tests/Documents/VectorEmbedding.php
+++ b/tests/Documents/VectorEmbedding.php
@@ -22,6 +22,7 @@ use Doctrine\ODM\MongoDB\Types\Type;
     fields: [
         ['type' => 'vector', 'path' => 'vectorInt', 'numDimensions' => 3, 'similarity' => ClassMetadata::VECTOR_SIMILARITY_COSINE],
         ['type' => 'filter', 'path' => 'filterField'],
+        ['type' => 'filter', 'path' => 'not_mapped_filter'],
     ],
 )]
 class VectorEmbedding
@@ -30,7 +31,7 @@ class VectorEmbedding
     public ?string $id = null;
 
     /** @var list<float> */
-    #[Field(type: Type::COLLECTION)]
+    #[Field(type: Type::COLLECTION, name: 'db_vector_float')]
     public array $vectorFloat = [];
 
     /** @var list<int> */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | maybe
| Fixed issues | [PHPORM-391](https://jira.mongodb.org/browse/PHPORM-391) [PHPORM-392](https://jira.mongodb.org/browse/PHPORM-392)

#### Summary

Map field names in search and vector search index definitions. Since the `$search` and `$vectorSearch` stages must always be first, we know there is no field name mapped from a previous stage.

- [ ] Support field path with dot notation, from https://github.com/doctrine/mongodb-odm/pull/2827
- [x] Add unit tests
- [x] Update functional tests, from https://github.com/doctrine/mongodb-odm/pull/2829
