### PR TITLE
PHPORM-395: Fix autocompletion for compound search operators

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsCompoundableOperatorsTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsCompoundableOperatorsTrait.php
@@ -45,56 +45,40 @@ trait SupportsCompoundableOperatorsTrait
      */
     abstract protected function addOperator(SearchOperator $operator): SearchOperator;
 
-    /** return Autocomplete&CompoundSearchOperatorInterface */
-    public function autocomplete(string $path = '', string ...$query): Autocomplete
+    public function autocomplete(string $path = '', string ...$query): CompoundedAutocomplete
     {
         return $this->addOperator(new CompoundedAutocomplete($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path, ...$query));
     }
 
-    /** @return EmbeddedDocument&CompoundSearchOperatorInterface */
-    public function embeddedDocument(string $path = ''): EmbeddedDocument
+    public function embeddedDocument(string $path = ''): CompoundedEmbeddedDocument
     {
         return $this->addOperator(new CompoundedEmbeddedDocument($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path));
     }
 
-    /**
-     * @param string|int|float|ObjectId|UTCDateTime|null $value
-     *
-     * @return Equals&CompoundSearchOperatorInterface
-     */
-    public function equals(string $path = '', $value = null): Equals
+    /** @param string|int|float|ObjectId|UTCDateTime|null $value */
+    public function equals(string $path = '', $value = null): CompoundedEquals
     {
         return $this->addOperator(new CompoundedEquals($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path, $value));
     }
 
-    /** @return Exists&CompoundSearchOperatorInterface */
-    public function exists(string $path): Exists
+    public function exists(string $path): CompoundedExists
     {
         return $this->addOperator(new CompoundedExists($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path));
     }
 
-    /**
-     * @param LineString|Point|Polygon|MultiPolygon|array|null $geometry
-     *
-     * @return GeoShape&CompoundSearchOperatorInterface
-     */
-    public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape
+    /** @param LineString|Point|Polygon|MultiPolygon|array|null $geometry */
+    public function geoShape($geometry = null, string $relation = '', string ...$path): CompoundedGeoShape
     {
         return $this->addOperator(new CompoundedGeoShape($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $geometry, $relation, ...$path));
     }
 
-    /** @return GeoWithin&CompoundSearchOperatorInterface */
-    public function geoWithin(string ...$path): GeoWithin
+    public function geoWithin(string ...$path): CompoundedGeoWithin
     {
         return $this->addOperator(new CompoundedGeoWithin($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), ...$path));
     }
 
-    /**
-     * @param array<string, mixed>|object $documents
-     *
-     * @return MoreLikeThis&CompoundSearchOperatorInterface
-     */
-    public function moreLikeThis(...$documents): MoreLikeThis
+    /** @param array<string, mixed>|object $documents */
+    public function moreLikeThis(...$documents): CompoundedMoreLikeThis
     {
         return $this->addOperator(new CompoundedMoreLikeThis($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), ...$documents));
     }
@@ -102,46 +86,38 @@ trait SupportsCompoundableOperatorsTrait
     /**
      * @param int|float|UTCDateTime|array|Point|null $origin
      * @param int|float|null                         $pivot
-     *
-     * @return Near&CompoundSearchOperatorInterface
      */
-    public function near($origin = null, $pivot = null, string ...$path): Near
+    public function near($origin = null, $pivot = null, string ...$path): CompoundedNear
     {
         return $this->addOperator(new CompoundedNear($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $origin, $pivot, ...$path));
     }
 
-    /** @return Phrase&CompoundSearchOperatorInterface */
-    public function phrase(): Phrase
+    public function phrase(): CompoundedPhrase
     {
         return $this->addOperator(new CompoundedPhrase($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
     }
 
-    /** @return QueryString&CompoundSearchOperatorInterface */
-    public function queryString(string $query = '', string $defaultPath = ''): QueryString
+    public function queryString(string $query = '', string $defaultPath = ''): CompoundedQueryString
     {
         return $this->addOperator(new CompoundedQueryString($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $query, $defaultPath));
     }
 
-    /** @return Range&CompoundSearchOperatorInterface */
-    public function range(): Range
+    public function range(): CompoundedRange
     {
         return $this->addOperator(new CompoundedRange($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
     }
 
-    /** @return Regex&CompoundSearchOperatorInterface */
-    public function regex(): Regex
+    public function regex(): CompoundedRegex
     {
         return $this->addOperator(new CompoundedRegex($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
     }
 
-    /** @return Text&CompoundSearchOperatorInterface */
-    public function text(): Text
+    public function text(): CompoundedText
     {
         return $this->addOperator(new CompoundedText($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
     }
 
-    /** @return Wildcard&CompoundSearchOperatorInterface */
-    public function wildcard(): Wildcard
+    public function wildcard(): CompoundedWildcard
     {
         return $this->addOperator(new CompoundedWildcard($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

For some reason, PhpStorm didn't like the `@return` annotation on the method, which should've told it that the result of a `text()` operator is a special `Text` instance that allows calling other operators. To work around this, using the compounded classes is necessary, which is what's actually being returned. Since this effectively narrows the return type (as that class extends the original operator class but implements an extra interface) we can do this in the trait without running into issues.
