### PR TITLE
Fix return type of compound search operators

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/CompoundSearchOperatorInterface.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/CompoundSearchOperatorInterface.php
@@ -30,7 +30,7 @@ interface CompoundSearchOperatorInterface extends SupportsCompoundableSearchOper
 
     public function exists(string $path): Exists&CompoundSearchOperatorInterface;
 
-    /** @param LineString|Point|Polygon|MultiPolygon|array|null $geometry */
+    /** @param LineString|Point|Polygon|MultiPolygon|array<string, mixed>|null $geometry */
     public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape&CompoundSearchOperatorInterface;
 
     public function geoWithin(string ...$path): GeoWithin&CompoundSearchOperatorInterface;
@@ -39,8 +39,8 @@ interface CompoundSearchOperatorInterface extends SupportsCompoundableSearchOper
     public function moreLikeThis(...$documents): MoreLikeThis&CompoundSearchOperatorInterface;
 
     /**
-     * @param int|float|UTCDateTime|array|Point|null $origin
-     * @param int|float|null                         $pivot
+     * @param int|float|UTCDateTime|array<string, mixed>|Point|null $origin
+     * @param int|float|null                                        $pivot
      */
     public function near($origin = null, $pivot = null, string ...$path): Near&CompoundSearchOperatorInterface;
 

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/CompoundSearchOperatorInterface.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/CompoundSearchOperatorInterface.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
+use GeoJson\Geometry\LineString;
+use GeoJson\Geometry\MultiPolygon;
+use GeoJson\Geometry\Point;
+use GeoJson\Geometry\Polygon;
+use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\UTCDateTime;
+
 interface CompoundSearchOperatorInterface extends SupportsCompoundableSearchOperators
 {
     public function must(): Compound;
@@ -13,4 +20,39 @@ interface CompoundSearchOperatorInterface extends SupportsCompoundableSearchOper
     public function should(?int $minimumShouldMatch = null): Compound;
 
     public function filter(): Compound;
+
+    public function autocomplete(string $path = '', string ...$query): Autocomplete&CompoundSearchOperatorInterface;
+
+    public function embeddedDocument(string $path = ''): EmbeddedDocument&CompoundSearchOperatorInterface;
+
+    /** @param string|int|float|ObjectId|UTCDateTime|null $value */
+    public function equals(string $path = '', $value = null): Equals&CompoundSearchOperatorInterface;
+
+    public function exists(string $path): Exists&CompoundSearchOperatorInterface;
+
+    /** @param LineString|Point|Polygon|MultiPolygon|array|null $geometry */
+    public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape&CompoundSearchOperatorInterface;
+
+    public function geoWithin(string ...$path): GeoWithin&CompoundSearchOperatorInterface;
+
+    /** @param array<string, mixed>|object $documents */
+    public function moreLikeThis(...$documents): MoreLikeThis&CompoundSearchOperatorInterface;
+
+    /**
+     * @param int|float|UTCDateTime|array|Point|null $origin
+     * @param int|float|null                         $pivot
+     */
+    public function near($origin = null, $pivot = null, string ...$path): Near&CompoundSearchOperatorInterface;
+
+    public function phrase(): Phrase&CompoundSearchOperatorInterface;
+
+    public function queryString(string $query = '', string $defaultPath = ''): QueryString&CompoundSearchOperatorInterface;
+
+    public function range(): Range&CompoundSearchOperatorInterface;
+
+    public function regex(): Regex&CompoundSearchOperatorInterface;
+
+    public function text(): Text&CompoundSearchOperatorInterface;
+
+    public function wildcard(): Wildcard&CompoundSearchOperatorInterface;
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsAllSearchOperatorsTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsAllSearchOperatorsTrait.php
@@ -52,7 +52,7 @@ trait SupportsAllSearchOperatorsTrait
         return $this->addOperator(new Exists($this->getSearchStage(), $path));
     }
 
-    /** @param LineString|Point|Polygon|MultiPolygon|array|null $geometry */
+    /** @param LineString|Point|Polygon|MultiPolygon|array<string, mixed>|null $geometry */
     public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape
     {
         return $this->addOperator(new GeoShape($this->getSearchStage(), $geometry, $relation, ...$path));
@@ -70,8 +70,8 @@ trait SupportsAllSearchOperatorsTrait
     }
 
     /**
-     * @param int|float|UTCDateTime|array|Point|null $origin
-     * @param int|float|null                         $pivot
+     * @param int|float|UTCDateTime|array<string, mixed>|Point|null $origin
+     * @param int|float|null                                        $pivot
      */
     public function near($origin = null, $pivot = null, string ...$path): Near
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsCompoundableOperatorsTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsCompoundableOperatorsTrait.php
@@ -66,7 +66,7 @@ trait SupportsCompoundableOperatorsTrait
         return $this->addOperator(new CompoundedExists($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path));
     }
 
-    /** @param LineString|Point|Polygon|MultiPolygon|array|null $geometry */
+    /** @param LineString|Point|Polygon|MultiPolygon|array<string, mixed>|null $geometry */
     public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedGeoShape($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $geometry, $relation, ...$path));
@@ -84,8 +84,8 @@ trait SupportsCompoundableOperatorsTrait
     }
 
     /**
-     * @param int|float|UTCDateTime|array|Point|null $origin
-     * @param int|float|null                         $pivot
+     * @param int|float|UTCDateTime|array<string, mixed>|Point|null $origin
+     * @param int|float|null                                        $pivot
      */
     public function near($origin = null, $pivot = null, string ...$path): Near&CompoundSearchOperatorInterface
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsCompoundableOperatorsTrait.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsCompoundableOperatorsTrait.php
@@ -45,56 +45,40 @@ trait SupportsCompoundableOperatorsTrait
      */
     abstract protected function addOperator(SearchOperator $operator): SearchOperator;
 
-    /** return Autocomplete&CompoundSearchOperatorInterface */
-    public function autocomplete(string $path = '', string ...$query): Autocomplete
+    public function autocomplete(string $path = '', string ...$query): Autocomplete&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedAutocomplete($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path, ...$query));
     }
 
-    /** @return EmbeddedDocument&CompoundSearchOperatorInterface */
-    public function embeddedDocument(string $path = ''): EmbeddedDocument
+    public function embeddedDocument(string $path = ''): EmbeddedDocument&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedEmbeddedDocument($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path));
     }
 
-    /**
-     * @param string|int|float|ObjectId|UTCDateTime|null $value
-     *
-     * @return Equals&CompoundSearchOperatorInterface
-     */
-    public function equals(string $path = '', $value = null): Equals
+    /** @param string|int|float|ObjectId|UTCDateTime|null $value */
+    public function equals(string $path = '', $value = null): Equals&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedEquals($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path, $value));
     }
 
-    /** @return Exists&CompoundSearchOperatorInterface */
-    public function exists(string $path): Exists
+    public function exists(string $path): Exists&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedExists($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $path));
     }
 
-    /**
-     * @param LineString|Point|Polygon|MultiPolygon|array|null $geometry
-     *
-     * @return GeoShape&CompoundSearchOperatorInterface
-     */
-    public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape
+    /** @param LineString|Point|Polygon|MultiPolygon|array|null $geometry */
+    public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedGeoShape($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $geometry, $relation, ...$path));
     }
 
-    /** @return GeoWithin&CompoundSearchOperatorInterface */
-    public function geoWithin(string ...$path): GeoWithin
+    public function geoWithin(string ...$path): GeoWithin&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedGeoWithin($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), ...$path));
     }
 
-    /**
-     * @param array<string, mixed>|object $documents
-     *
-     * @return MoreLikeThis&CompoundSearchOperatorInterface
-     */
-    public function moreLikeThis(...$documents): MoreLikeThis
+    /** @param array<string, mixed>|object $documents */
+    public function moreLikeThis(...$documents): MoreLikeThis&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedMoreLikeThis($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), ...$documents));
     }
@@ -102,46 +86,38 @@ trait SupportsCompoundableOperatorsTrait
     /**
      * @param int|float|UTCDateTime|array|Point|null $origin
      * @param int|float|null                         $pivot
-     *
-     * @return Near&CompoundSearchOperatorInterface
      */
-    public function near($origin = null, $pivot = null, string ...$path): Near
+    public function near($origin = null, $pivot = null, string ...$path): Near&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedNear($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $origin, $pivot, ...$path));
     }
 
-    /** @return Phrase&CompoundSearchOperatorInterface */
-    public function phrase(): Phrase
+    public function phrase(): Phrase&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedPhrase($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
     }
 
-    /** @return QueryString&CompoundSearchOperatorInterface */
-    public function queryString(string $query = '', string $defaultPath = ''): QueryString
+    public function queryString(string $query = '', string $defaultPath = ''): QueryString&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedQueryString($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $query, $defaultPath));
     }
 
-    /** @return Range&CompoundSearchOperatorInterface */
-    public function range(): Range
+    public function range(): Range&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedRange($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
     }
 
-    /** @return Regex&CompoundSearchOperatorInterface */
-    public function regex(): Regex
+    public function regex(): Regex&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedRegex($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
     }
 
-    /** @return Text&CompoundSearchOperatorInterface */
-    public function text(): Text
+    public function text(): Text&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedText($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
     }
 
-    /** @return Wildcard&CompoundSearchOperatorInterface */
-    public function wildcard(): Wildcard
+    public function wildcard(): Wildcard&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedWildcard($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage()));
     }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsGeoShapeOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsGeoShapeOperator.php
@@ -11,6 +11,6 @@ use GeoJson\Geometry\Polygon;
 
 interface SupportsGeoShapeOperator
 {
-    /** @param LineString|Point|Polygon|MultiPolygon|array|null $geometry */
+    /** @param LineString|Point|Polygon|MultiPolygon|array<string, mixed>|null $geometry */
     public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape;
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsNearOperator.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsNearOperator.php
@@ -10,8 +10,8 @@ use MongoDB\BSON\UTCDateTime;
 interface SupportsNearOperator
 {
     /**
-     * @param int|float|UTCDateTime|array|Point|null $origin
-     * @param int|float|null                         $pivot
+     * @param int|float|UTCDateTime|array<string, mixed>|Point|null $origin
+     * @param int|float|null                                        $pivot
      */
     public function near($origin = null, $pivot = null, string ...$path): Near;
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -223,44 +223,8 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Out.php
 
 		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound.php
-
-		-
 			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedAutocomplete\:\:__construct\(\) has parameter \$args with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedAutocomplete.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedAutocomplete\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedAutocomplete.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedAutocomplete\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedAutocomplete.php
 
@@ -271,32 +235,8 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedEmbeddedDocument.php
 
 		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedEmbeddedDocument\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedEmbeddedDocument.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedEmbeddedDocument\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedEmbeddedDocument.php
-
-		-
 			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedEquals\:\:__construct\(\) has parameter \$args with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedEquals.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedEquals\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedEquals.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedEquals\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedEquals.php
 
@@ -307,32 +247,8 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedExists.php
 
 		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedExists\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedExists.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedExists\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedExists.php
-
-		-
 			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedGeoShape\:\:__construct\(\) has parameter \$args with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedGeoShape.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedGeoShape\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedGeoShape.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedGeoShape\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedGeoShape.php
 
@@ -343,32 +259,8 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedGeoWithin.php
 
 		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedGeoWithin\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedGeoWithin.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedGeoWithin\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedGeoWithin.php
-
-		-
 			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedMoreLikeThis\:\:__construct\(\) has parameter \$args with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedMoreLikeThis.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedMoreLikeThis\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedMoreLikeThis.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedMoreLikeThis\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedMoreLikeThis.php
 
@@ -379,32 +271,8 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedNear.php
 
 		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedNear\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedNear.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedNear\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedNear.php
-
-		-
 			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedPhrase\:\:__construct\(\) has parameter \$args with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedPhrase.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedPhrase\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedPhrase.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedPhrase\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedPhrase.php
 
@@ -415,32 +283,8 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedQueryString.php
 
 		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedQueryString\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedQueryString.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedQueryString\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedQueryString.php
-
-		-
 			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedRange\:\:__construct\(\) has parameter \$args with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedRange.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedRange\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedRange.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedRange\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedRange.php
 
@@ -451,32 +295,8 @@ parameters:
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedRegex.php
 
 		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedRegex\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedRegex.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedRegex\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedRegex.php
-
-		-
 			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedText\:\:__construct\(\) has parameter \$args with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedText.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedText\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedText.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedText\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedText.php
 
@@ -485,30 +305,6 @@ parameters:
 			identifier: missingType.parameter
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedWildcard.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedWildcard\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedWildcard.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\Compound\\CompoundedWildcard\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Compound/CompoundedWildcard.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\EmbeddedDocument\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/EmbeddedDocument.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\EmbeddedDocument\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/EmbeddedDocument.php
 
 		-
 			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\GeoShape\:\:__construct\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
@@ -599,18 +395,6 @@ parameters:
 			identifier: property.onlyWritten
 			count: 1
 			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/Range.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\SupportsGeoShapeOperator\:\:geoShape\(\) has parameter \$geometry with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsGeoShapeOperator.php
-
-		-
-			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Search\\SupportsNearOperator\:\:near\(\) has parameter \$origin with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search/SupportsNearOperator.php
 
 		-
 			message: '#^Method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\SortByCount\:\:__construct\(\) has parameter \$class with generic class Doctrine\\ODM\\MongoDB\\Mapping\\ClassMetadata but does not specify its types\: T$#'


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | [PHPORM-395](https://jira.mongodb.org/browse/PHPORM-395)

#### Summary

When `Compound::autocomplete()` returns `Autocomplete&CompoundSearchOperatorInterface` it inherits from the methods of `CompoundSearchOperatorInterface`. So the methods for search operator must specify that a the returned operator is also an instance of `CompoundSearchOperatorInterface`.
