### PR TITLE
Add an assertion on missing search index when a `$search` or `$vectorSearch` pipeline returns an empty result

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
@@ -11,9 +11,11 @@ use Doctrine\ODM\MongoDB\Iterator\IterableResult;
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
 use Doctrine\ODM\MongoDB\Iterator\UnrewindableIterator;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\SchemaException;
 use MongoDB\Collection;
 use MongoDB\Driver\CursorInterface;
 
+use function array_key_first;
 use function array_merge;
 
 /** @phpstan-import-type PipelineExpression from Builder */
@@ -64,6 +66,48 @@ final class Aggregation implements IterableResult
             $cursor = new HydratingIterator($cursor, $this->dm->getUnitOfWork(), $this->classMetadata);
         }
 
-        return $this->rewindable ? new CachingIterator($cursor) : new UnrewindableIterator($cursor);
+        $iterator = $this->rewindable ? new CachingIterator($cursor) : new UnrewindableIterator($cursor);
+
+        $this->assertSearchIndexExistsWhenAggregationResultsIsEmpty($iterator);
+
+        return $iterator;
+    }
+
+    /**
+     * If the server implements a server-side error for missing search indexes,
+     * this assertion can be removed.
+     *
+     * @see https://jira.mongodb.org/browse/SERVER-110974
+     *
+     * @param Iterator<object> $iterator
+     */
+    private function assertSearchIndexExistsWhenAggregationResultsIsEmpty(Iterator $iterator): void
+    {
+        if ($iterator->current() !== false) {
+            return; // Results not empty
+        }
+
+        if (! $this->dm->getConfiguration()->assertSearchIndexExistsWhenAggregationResultsIsEmpty()) {
+            return; // Feature disabled
+        }
+
+        // Search stages must be the first stage in the pipeline
+        $indexName = match (array_key_first($this->pipeline[0])) {
+            '$search' => $this->pipeline[0]['$search']->index ?? null,
+            '$searchMeta' => $this->pipeline[0]['$searchMeta']->index ?? null,
+            '$vectorSearch' => $this->pipeline[0]['$vectorSearch']->index ?? null,
+            default => null,
+        };
+
+        if ($indexName === null) {
+            return; // Not a search aggregation or index not specified
+        }
+
+        $index = $this->collection->listSearchIndexes(['filter' => ['name' => $indexName]])->current();
+        if ($index) {
+            return; // Index exists
+        }
+
+        throw SchemaException::searchIndexNotFound($this->collection->getNamespace(), $indexName);
     }
 }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation;
 
+use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Iterator\CachingIterator;
 use Doctrine\ODM\MongoDB\Iterator\HydratingIterator;
@@ -15,8 +16,10 @@ use Doctrine\ODM\MongoDB\SchemaException;
 use MongoDB\Collection;
 use MongoDB\Driver\CursorInterface;
 
-use function array_key_first;
 use function array_merge;
+use function current;
+use function in_array;
+use function key;
 
 /** @phpstan-import-type PipelineExpression from Builder */
 final class Aggregation implements IterableResult
@@ -68,7 +71,7 @@ final class Aggregation implements IterableResult
 
         $iterator = $this->rewindable ? new CachingIterator($cursor) : new UnrewindableIterator($cursor);
 
-        $this->assertSearchIndexExistsWhenAggregationResultsIsEmpty($iterator);
+        $this->assertSearchIndexExistsForEmptyResult($iterator);
 
         return $iterator;
     }
@@ -78,32 +81,30 @@ final class Aggregation implements IterableResult
      * this assertion can be removed.
      *
      * @see https://jira.mongodb.org/browse/SERVER-110974
+     * @see Configuration::setAssertSearchIndexExistsForEmptyResult()
      *
-     * @param Iterator<object> $iterator
+     * @param CachingIterator<mixed>|UnrewindableIterator<mixed> $iterator
      */
-    private function assertSearchIndexExistsWhenAggregationResultsIsEmpty(Iterator $iterator): void
+    private function assertSearchIndexExistsForEmptyResult(CachingIterator|UnrewindableIterator $iterator): void
     {
-        if ($iterator->current() !== false) {
+        // The iterator is always rewinded
+        if ($iterator->current()) {
             return; // Results not empty
         }
 
-        if (! $this->dm->getConfiguration()->assertSearchIndexExistsWhenAggregationResultsIsEmpty()) {
+        if (! $this->dm->getConfiguration()->assertSearchIndexExistsForEmptyResult()) {
             return; // Feature disabled
         }
 
         // Search stages must be the first stage in the pipeline
-        $indexName = match (array_key_first($this->pipeline[0])) {
-            '$search' => $this->pipeline[0]['$search']->index ?? null,
-            '$searchMeta' => $this->pipeline[0]['$searchMeta']->index ?? null,
-            '$vectorSearch' => $this->pipeline[0]['$vectorSearch']->index ?? null,
-            default => null,
-        };
-
-        if ($indexName === null) {
-            return; // Not a search aggregation or index not specified
+        $stage = $this->pipeline[0] ?? null;
+        if (! $stage || ! in_array(key($stage), ['$search', '$searchMeta', '$vectorSearch'], true)) {
+            return; // Not a search aggregation
         }
 
-        $index = $this->collection->listSearchIndexes(['filter' => ['name' => $indexName]])->current();
+        // @phpcs:ignore SlevomatCodingStandard.PHP.UselessParentheses
+        $indexName = ((object) current($stage))->index ?? 'default';
+        $index     = $this->collection->listSearchIndexes(['filter' => ['name' => $indexName]])->current();
         if ($index) {
             return; // Index exists
         }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Aggregation.php
@@ -88,7 +88,7 @@ final class Aggregation implements IterableResult
     private function assertSearchIndexExistsForEmptyResult(CachingIterator|UnrewindableIterator $iterator): void
     {
         // The iterator is always rewinded
-        if ($iterator->current()) {
+        if ($iterator->key() !== null) {
             return; // Results not empty
         }
 
@@ -104,8 +104,7 @@ final class Aggregation implements IterableResult
 
         // @phpcs:ignore SlevomatCodingStandard.PHP.UselessParentheses
         $indexName = ((object) current($stage))->index ?? 'default';
-        $index     = $this->collection->listSearchIndexes(['filter' => ['name' => $indexName]])->current();
-        if ($index) {
+        if ($this->collection->listSearchIndexes(['filter' => ['name' => $indexName]])->key() !== null) {
             return; // Index exists
         }
 

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -812,18 +812,19 @@ class Configuration
     /**
      * Pipelines using a search index that does not exist or is not queryable
      * will return zero documents. By enabling this feature, an additional query
-     * is made when the pipeline doesn't return any results to check if the
-     * search index exists and is queryable. If the index does not exist or is
-     * not queryable, an exception is thrown. This feature is enabled by default.
+     * is performed when the pipeline doesn't return any results to check if the
+     * search index exists. If the index does not exist, an exception is thrown.
+     * This feature is enabled by default.
+     * This applies to $search, $searchMeta and $vectorSearch pipelines.
      */
-    public function setAssertSearchIndexExistsWhenAggregationResultsIsEmpty(bool $enabled): void
+    public function setAssertSearchIndexExistsForEmptyResult(bool $enabled): void
     {
-        $this->attributes['assertSearchIndexExistsWhenAggregationResultsIsEmpty'] = $enabled;
+        $this->attributes['assertSearchIndexExistsForEmptyResult'] = $enabled;
     }
 
-    public function assertSearchIndexExistsWhenAggregationResultsIsEmpty(): bool
+    public function assertSearchIndexExistsForEmptyResult(): bool
     {
-        return $this->attributes['assertSearchIndexExistsWhenAggregationResultsIsEmpty'] ?? true;
+        return $this->attributes['assertSearchIndexExistsForEmptyResult'] ?? true;
     }
 }
 

--- a/lib/Doctrine/ODM/MongoDB/Configuration.php
+++ b/lib/Doctrine/ODM/MongoDB/Configuration.php
@@ -808,6 +808,23 @@ class Configuration
             ...$this->attributes['autoEncryption'] ?? [],
         ];
     }
+
+    /**
+     * Pipelines using a search index that does not exist or is not queryable
+     * will return zero documents. By enabling this feature, an additional query
+     * is made when the pipeline doesn't return any results to check if the
+     * search index exists and is queryable. If the index does not exist or is
+     * not queryable, an exception is thrown. This feature is enabled by default.
+     */
+    public function setAssertSearchIndexExistsWhenAggregationResultsIsEmpty(bool $enabled): void
+    {
+        $this->attributes['assertSearchIndexExistsWhenAggregationResultsIsEmpty'] = $enabled;
+    }
+
+    public function assertSearchIndexExistsWhenAggregationResultsIsEmpty(): bool
+    {
+        return $this->attributes['assertSearchIndexExistsWhenAggregationResultsIsEmpty'] ?? true;
+    }
 }
 
 interface_exists(MappingDriver::class);

--- a/lib/Doctrine/ODM/MongoDB/SchemaException.php
+++ b/lib/Doctrine/ODM/MongoDB/SchemaException.php
@@ -23,4 +23,10 @@ final class SchemaException extends RuntimeException
     {
         return new self(sprintf('The document class "%s" is missing the following search index(es): "%s"', $documentClass, implode('", "', $missingIndexes)));
     }
+
+    /** @internal */
+    public static function searchIndexNotFound(string $namespace, string $indexName): self
+    {
+        return new self(sprintf('The search index "%s" of the collection "%s" is not found.', $indexName, $namespace));
+    }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtlasSearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtlasSearchTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\ODM\MongoDB\SchemaException;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsArticle;
 use Documents\CmsUser;
@@ -54,6 +55,7 @@ class AtlasSearchTest extends BaseTestCase
         $schemaManager->waitForSearchIndexes([CmsArticle::class, CmsUser::class]);
 
         $results = $this->dm->createAggregationBuilder(CmsArticle::class)
+            ->rewindable(false)
             ->search()
                 ->index('search_articles')
                 ->autocomplete()
@@ -115,5 +117,36 @@ class AtlasSearchTest extends BaseTestCase
             ->getAggregation()->execute()->toArray();
 
         $this->assertNotEmpty($results, 'Count search should return results');
+    }
+
+    public function testIndexNotCreated(): void
+    {
+        $aggregation = $this->dm->createAggregationBuilder(CmsArticle::class)
+            ->search()
+                ->index('search_articles')
+                ->text()
+                ->query('Atlas Search')
+                ->path('text')
+            ->getAggregation();
+
+        $this->expectException(SchemaException::class);
+        $this->expectExceptionMessageMatches('#^The search index "search_articles" of the collection "[^."]+\.CmsArticle" is not found\.$#');
+
+        $aggregation->execute();
+    }
+
+    public function testIndexNotCreatedWithoutException(): void
+    {
+        $this->dm->getConfiguration()->setAssertSearchIndexExistsWhenAggregationResultsIsEmpty(false);
+
+        $results = $this->dm->createAggregationBuilder(CmsArticle::class)
+            ->search()
+                ->index('search_articles')
+                ->text()
+                ->query('Atlas Search')
+                ->path('text')
+            ->getAggregation()->execute();
+
+        $this->assertCount(0, $results->toArray());
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtlasSearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/AtlasSearchTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
+use Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\SchemaException;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsArticle;
@@ -55,7 +56,6 @@ class AtlasSearchTest extends BaseTestCase
         $schemaManager->waitForSearchIndexes([CmsArticle::class, CmsUser::class]);
 
         $results = $this->dm->createAggregationBuilder(CmsArticle::class)
-            ->rewindable(false)
             ->search()
                 ->index('search_articles')
                 ->autocomplete()
@@ -137,7 +137,7 @@ class AtlasSearchTest extends BaseTestCase
 
     public function testIndexNotCreatedWithoutException(): void
     {
-        $this->dm->getConfiguration()->setAssertSearchIndexExistsWhenAggregationResultsIsEmpty(false);
+        $this->dm->getConfiguration()->setAssertSearchIndexExistsForEmptyResult(false);
 
         $results = $this->dm->createAggregationBuilder(CmsArticle::class)
             ->search()
@@ -148,5 +148,21 @@ class AtlasSearchTest extends BaseTestCase
             ->getAggregation()->execute();
 
         $this->assertCount(0, $results->toArray());
+    }
+
+    public function testIndexNotCreatedWithCustomStage(): void
+    {
+        $aggregation = ($builder = $this->dm->createAggregationBuilder(CmsArticle::class))
+            ->addStage(new class ($builder) extends Stage {
+                public function getExpression(): array
+                {
+                    return ['$search' => ['text' => ['query' => 'Atlas Search', 'path' => 'text']]];
+                }
+            })->getAggregation();
+
+        $this->expectException(SchemaException::class);
+        $this->expectExceptionMessageMatches('#^The search index "default" of the collection "[^."]+\.CmsArticle" is not found\.$#');
+
+        $aggregation->execute();
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | maybe
| Fixed issues | [PHPORM-388](https://jira.mongodb.org/browse/PHPORM-388)

#### Summary

When performing a search query on a search index that doesn't exist, the aggregation returns no results. This is frustrating for users that will try to optimize the query while the issue is the missing search index.

This PR adds a configuration setting (enabled by default) to check if the search index exists only when performing a search aggregation with no returned results.
