### PR TITLE
Use double-quotes for array-shape annotations, as PHPStorm does not understand single-quotes

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AddFields.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/AddFields.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Expr;
  * Fluent interface for adding a $addFields stage to an aggregation pipeline.
  *
  * @phpstan-import-type OperatorExpression from Expr
- * @phpstan-type AddFieldsStageExpression array{'$addFields': array<string, OperatorExpression|mixed>}
+ * @phpstan-type AddFieldsStageExpression array{"$addFields": array<string, OperatorExpression|mixed>}
  * @final
  */
 class AddFields extends Operator

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/CollStats.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/CollStats.php
@@ -11,7 +11,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
  * Fluent interface for adding a $collStats stage to an aggregation pipeline.
  *
  * @phpstan-type CollStatsStageExpression array{
- *     '$collStats': array{
+ *     "$collStats": array{
  *         latencyStats?: array{histograms?: bool},
  *         storageStats?: array{},
  *     }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Count.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Count.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 /**
  * Fluent interface for adding a $count stage to an aggregation pipeline.
  *
- * @phpstan-type CountStageExpression array{'$count': string}
+ * @phpstan-type CountStageExpression array{"$count": string}
  */
 class Count extends Stage
 {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Densify.php
@@ -13,10 +13,10 @@ use function array_values;
 /**
  * Fluent interface for adding a $densify stage to an aggregation pipeline.
  *
- * @phpstan-type BoundsType 'full'|'partition'|array{0: int|float|UTCDateTime, 1: int|float|UTCDateTime}
- * @phpstan-type UnitType 'year'|'month'|'week'|'day'|'hour'|'minute'|'second'|'millisecond'
+ * @phpstan-type BoundsType "full"|"partition"|array{0: int|float|UTCDateTime, 1: int|float|UTCDateTime}
+ * @phpstan-type UnitType "year"|"month"|"week"|"day"|"hour"|"minute"|"second"|"millisecond"
  * @phpstan-type DensifyStageExpression array{
- *     '$densify': object{
+ *     "$densify": object{
  *         field: string,
  *         partitionByFields?: list<string>,
  *         range: object{
@@ -55,7 +55,7 @@ class Densify extends Stage
      * @param array|string $bounds
      * @param int|float    $step
      * @phpstan-param BoundsType  $bounds
-     * @phpstan-param ''|UnitType $unit
+     * @phpstan-param ""|UnitType $unit
      */
     public function range($bounds, $step, string $unit = ''): static
     {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Facet.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Facet.php
@@ -15,7 +15,7 @@ use function array_map;
  * Fluent interface for adding a $facet stage to an aggregation pipeline.
  *
  * @phpstan-import-type PipelineExpression from Builder
- * @phpstan-type FacetStageExpression array{'$facet': array<string, PipelineExpression>}
+ * @phpstan-type FacetStageExpression array{"$facet": array<string, PipelineExpression>}
  */
 class Facet extends Stage
 {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Fill.php
@@ -22,7 +22,7 @@ use function strtolower;
  * @phpstan-type SortDirection int|SortDirectionKeywords
  * @phpstan-type SortShape array<string, SortDirection>
  * @phpstan-type FillStageExpression array{
- *     '$fill': array{
+ *     "$fill": array{
  *         partitionBy?: string|OperatorExpression,
  *         partitionByFields?: list<string>,
  *         sortBy?: SortShape,

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Group.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Group.php
@@ -12,7 +12,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Operator\ProvidesGroupAccumulatorOperators;
 /**
  * Fluent interface for adding a $group stage to an aggregation pipeline.
  *
- * @phpstan-type GroupStageExpression array{'$group': array<string, mixed>}
+ * @phpstan-type GroupStageExpression array{"$group": array<string, mixed>}
  */
 class Group extends Operator implements GroupAccumulatorOperators
 {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/IndexStats.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/IndexStats.php
@@ -10,7 +10,7 @@ use stdClass;
 /**
  * Fluent interface for adding a $indexStats stage to an aggregation pipeline.
  *
- * @phpstan-type IndexStatsStageExpression array{'$indexStats': object}
+ * @phpstan-type IndexStatsStageExpression array{"$indexStats": object}
  */
 class IndexStats extends Stage
 {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Limit.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Limit.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 /**
  * Fluent interface for adding a $limit stage to an aggregation pipeline.
  *
- * @phpstan-type LimitStageExpression array{'$limit': int}
+ * @phpstan-type LimitStageExpression array{"$limit": int}
  */
 class Limit extends Stage
 {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Lookup.php
@@ -19,9 +19,9 @@ use InvalidArgumentException;
  * @phpstan-import-type PipelineExpression from Builder
  * @phpstan-type PipelineParamType Builder|Stage|PipelineExpression
  * @phpstan-type LookupStageExpression array{
- *     '$lookup': array{
+ *     "$lookup": array{
  *         from: string,
- *         'as'?: string,
+ *         "as"?: string,
  *         localField?: string,
  *         foreignField?: string,
  *         pipeline?: PipelineExpression,

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Merge.php
@@ -18,11 +18,11 @@ use function is_array;
 /**
  * @phpstan-import-type PipelineExpression from Builder
  * @phpstan-type OutputCollection string|array{db: string, coll: string}
- * @phpstan-type WhenMatchedType 'replace'|'keepExisting'|'merge'|'fail'|PipelineExpression
+ * @phpstan-type WhenMatchedType "replace"|"keepExisting"|"merge"|"fail"|PipelineExpression
  * @phpstan-type WhenMatchedParamType Builder|Stage|WhenMatchedType
- * @phpstan-type WhenNotMatchedType 'insert'|'discard'|'fail'
+ * @phpstan-type WhenNotMatchedType "insert"|"discard"|"fail"
  * @phpstan-type MergeStageExpression array{
- *     '$merge': object{
+ *     "$merge": object{
  *         into: OutputCollection,
  *         on?: string|list<string>,
  *         let?: array<string, mixed|Expr>,

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Out.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Out.php
@@ -15,7 +15,7 @@ use function is_array;
 
 /**
  * @phpstan-import-type OutputCollection from Merge
- * @phpstan-type OutStageExpression array{'$out': OutputCollection}
+ * @phpstan-type OutStageExpression array{"$out": OutputCollection}
  */
 class Out extends Stage
 {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Project.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Project.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Expr;
  * Fluent interface for adding a $project stage to an aggregation pipeline.
  *
  * @phpstan-import-type OperatorExpression from Expr
- * @phpstan-type ProjectStageExpression array{'$project': array<string, OperatorExpression|mixed>}
+ * @phpstan-type ProjectStageExpression array{"$project": array<string, OperatorExpression|mixed>}
  */
 class Project extends Operator
 {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Redact.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Redact.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Expr;
  * Fluent interface for adding a $redact stage to an aggregation pipeline.
  *
  * @phpstan-import-type OperatorExpression from Expr
- * @phpstan-type SetStageExpression array{'$redact': array<string, OperatorExpression|mixed>}
+ * @phpstan-type SetStageExpression array{"$redact": array<string, OperatorExpression|mixed>}
  */
 class Redact extends Operator
 {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceRoot.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceRoot.php
@@ -9,7 +9,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Expr;
 /**
  * @phpstan-import-type OperatorExpression from Expr
  * @phpstan-type ReplaceRootStageExpression array{
- *     '$replaceRoot': array{
+ *     "$replaceRoot": array{
  *         newRoot: OperatorExpression|string,
  *     }
  * }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceWith.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/ReplaceWith.php
@@ -8,7 +8,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Expr;
 
 /**
  * @phpstan-import-type OperatorExpression from Expr
- * @phpstan-type ReplaceWithStageExpression array{'$replaceWith': OperatorExpression|string}
+ * @phpstan-type ReplaceWithStageExpression array{"$replaceWith": OperatorExpression|string}
  */
 class ReplaceWith extends AbstractReplace
 {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Sample.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Sample.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 /**
  * Fluent interface for adding a $sample stage to an aggregation pipeline.
  *
- * @phpstan-type SampleStageExpression array{'$sample': array{size: int}}
+ * @phpstan-type SampleStageExpression array{"$sample": array{size: int}}
  */
 class Sample extends Stage
 {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Search.php
@@ -18,12 +18,12 @@ use function strtolower;
 
 /**
  * @phpstan-import-type SortDirectionKeywords from Sort
- * @phpstan-type CountType 'lowerBound'|'total'
- * @phpstan-type SortMetaKeywords 'searchScore'
- * @phpstan-type SortMeta array{'$meta': SortMetaKeywords}
+ * @phpstan-type CountType "lowerBound"|"total"
+ * @phpstan-type SortMetaKeywords "searchScore"
+ * @phpstan-type SortMeta array{"$meta": SortMetaKeywords}
  * @phpstan-type SortShape array<string, int|SortMeta|SortDirectionKeywords>
  * @phpstan-type SearchStageExpression array{
- *     '$search': object{
+ *     "$search": object{
  *         index?: string,
  *         count?: object{
  *            type: CountType,

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Set.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Set.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Expr;
  * Fluent interface for adding a $set stage to an aggregation pipeline.
  *
  * @phpstan-import-type OperatorExpression from Expr
- * @phpstan-type SetStageExpression array{'$set': array<string, OperatorExpression|mixed>}
+ * @phpstan-type SetStageExpression array{"$set": array<string, OperatorExpression|mixed>}
  * @final
  */
 class Set extends Operator

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SetWindowFields.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SetWindowFields.php
@@ -19,7 +19,7 @@ use function strtolower;
  * @phpstan-type SortDirection int|SortDirectionKeywords
  * @phpstan-type SortShape array<string, SortDirection>
  * @phpstan-type SetWindowFieldsStageExpression array{
- *     '$setWindowFields': object{
+ *     "$setWindowFields": object{
  *         partitionBy?: string|OperatorExpression,
  *         sortBy?: SortShape,
  *         output: object,

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SetWindowFields/Output.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SetWindowFields/Output.php
@@ -22,9 +22,9 @@ use function sprintf;
  * Fluent builder for output param of $setWindowFields stage
  *
  * @phpstan-import-type SortShape from SetWindowFields
- * @phpstan-type WindowBound 'current'|'unbounded'|int
+ * @phpstan-type WindowBound "current"|"unbounded"|int
  * @phpstan-type WindowBounds array{0: WindowBound, 1: WindowBound}
- * @phpstan-type WindowUnit 'year'|'quarter'|'month'|'week'|'day'|'hour'|'minute'|'second'|'millisecond'
+ * @phpstan-type WindowUnit "year"|"quarter"|"month"|"week"|"day"|"hour"|"minute"|"second"|"millisecond"
  * @phpstan-type Window object{
  *     document?: WindowBounds,
  *     range?: WindowBounds,

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Skip.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Skip.php
@@ -10,7 +10,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
 /**
  * Fluent interface for adding a $skip stage to an aggregation pipeline.
  *
- * @phpstan-type SkipStageExpression array{'$skip': int}
+ * @phpstan-type SkipStageExpression array{"$skip": int}
  */
 class Skip extends Stage
 {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Sort.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Sort.php
@@ -15,12 +15,12 @@ use function strtolower;
 /**
  * Fluent interface for adding a $sort stage to an aggregation pipeline.
  *
- * @phpstan-type SortMetaKeywords 'textScore'|'indexKey'
- * @phpstan-type SortDirectionKeywords 'asc'|'desc'
- * @phpstan-type SortMeta array{'$meta': SortMetaKeywords}
+ * @phpstan-type SortMetaKeywords "textScore"|"indexKey"
+ * @phpstan-type SortDirectionKeywords "asc"|"desc"
+ * @phpstan-type SortMeta array{"$meta": SortMetaKeywords}
  * @phpstan-type SortShape array<string, int|SortMeta|SortDirectionKeywords>
  * @phpstan-type SortStageExpression array{
- *     '$sort': array<string, int|SortMeta>
+ *     "$sort": array<string, int|SortMeta>
  * }
  */
 class Sort extends Stage

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SortByCount.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/SortByCount.php
@@ -11,7 +11,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 
 use function substr;
 
-/** @phpstan-type SortByCountStageExpression array{'$sortByCount': string} */
+/** @phpstan-type SortByCountStageExpression array{"$sortByCount": string} */
 class SortByCount extends Stage
 {
     private string $fieldName;

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnionWith.php
@@ -16,7 +16,7 @@ use InvalidArgumentException;
  * @phpstan-import-type PipelineExpression from Builder
  * @phpstan-type PipelineParamType array|Builder|Stage|PipelineExpression
  * @phpstan-type UnionWithStageExpression array{
- *     '$unionWith': object{
+ *     "$unionWith": object{
  *         coll: string,
  *         pipeline?: PipelineExpression,
  *     }

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnsetStage.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/UnsetStage.php
@@ -14,7 +14,7 @@ use function array_values;
 /**
  * Fluent interface for adding an $unset stage to an aggregation pipeline.
  *
- * @phpstan-type UnsetStageExpression array{'$unset': list<string>}
+ * @phpstan-type UnsetStageExpression array{"$unset": list<string>}
  */
 class UnsetStage extends Stage
 {

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Unwind.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/Unwind.php
@@ -11,7 +11,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Stage;
  * Fluent interface for adding a $unwind stage to an aggregation pipeline.
  *
  * @phpstan-type UnwindStageExpression array{
- *     '$unwind': string|array{
+ *     "$unwind": string|array{
  *         path: string,
  *         includeArrayIndex?: string,
  *         preserveNullAndEmptyArrays?: bool,

--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/VectorSearch.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/VectorSearch.php
@@ -15,7 +15,7 @@ use MongoDB\BSON\Int64;
 /**
  * @phpstan-type Vector list<int|Int64>|list<float|Decimal128>|list<bool|0|1>|Binary
  * @phpstan-type VectorSearchStageExpression array{
- *     '$vectorSearch': object{
+ *     "$vectorSearch": object{
  *         exact?: bool,
  *         filter?: object,
  *         index?: string,

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -263,12 +263,12 @@ use function trigger_deprecation;
  *      synonyms?: list<SearchIndexSynonym>,
  * }
  * @phpstan-type SearchIndexMapping array{
- *      type: 'search'|'vectorSearch',
+ *      type: "search"|"vectorSearch",
  *      name: string,
  *      definition: SearchIndexDefinition
  * }
  * @phpstan-type VectorSearchIndexField array{
- *     type: 'vector'|'filter',
+ *     type: "vector"|"filter",
  *     path: string,
  *     numDimensions?: int,
  *     similarity?: self::VECTOR_SIMILARITY_*,
@@ -1279,7 +1279,7 @@ use function trigger_deprecation;
      * Add a search index for this Document.
      *
      * @phpstan-param SearchIndexDefinition|VectorSearchIndexDefinition $definition
-     * @phpstan-param 'search'|'vectorSearch' $type
+     * @phpstan-param "search"|"vectorSearch" $type
      */
     public function addSearchIndex(array $definition, ?string $name = null, string $type = 'search'): void
     {

--- a/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ODM/MongoDB/Persisters/CollectionPersister.php
@@ -329,7 +329,7 @@ final class CollectionPersister
     }
 
     /**
-     * Perform collections update for 'pushAll' strategy.
+     * Perform collection update for 'pushAll' strategy.
      *
      * @param object                                                          $parent       Parent object to which passed collections is belong.
      * @param string[]                                                        $collsPaths   Paths of collections that is passed.

--- a/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/MongoDB/UnitOfWork.php
@@ -583,7 +583,7 @@ final class UnitOfWork implements PropertyChangedListener
     /**
      * Gets the changeset for a document.
      *
-     * @return array array('property' => array(0 => mixed, 1 => mixed))
+     * @return array{property: array{0: mixed, 1: mixed}}
      * @phpstan-return array<string, ChangeSet>
      */
     public function getDocumentChangeSet(object $document): array


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes/no
| Fixed issues | 

Before:
<img width="579" height="365" alt="image" src="https://github.com/user-attachments/assets/2a7bbee1-5925-49de-af43-50ee33dc50e3" />

After:
<img width="584" height="376" alt="image" src="https://github.com/user-attachments/assets/ab17b966-3723-43d5-a36f-3f9d1d25ca6f" />
