### PR TITLE
Fix test on using a Binary vector in the `$vectorSearch` aggregation

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/VectorSearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/VectorSearchTest.php
@@ -11,6 +11,9 @@ use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\User;
 use Documents\VectorEmbedding;
 use MongoDB\BSON\Binary;
+use MongoDB\BSON\VectorType;
+
+use function enum_exists;
 
 class VectorSearchTest extends BaseTestCase
 {
@@ -80,8 +83,16 @@ class VectorSearchTest extends BaseTestCase
 
     public function testQueryVectorAcceptsBinary(): void
     {
-        [$stage]      = $this->createVectorSearchStage();
-        $binaryVector = new Binary("\x01\x02\x03", 9);
+        [$stage] = $this->createVectorSearchStage();
+        // @phpstan-ignore class.notFound (requires ext-mongodb 2.2+)
+        if (enum_exists(VectorType::class)) {
+            // @phpstan-ignore staticMethod.notFound (requires ext-mongodb 2.2+)
+            $binaryVector = Binary::fromVector([1, 2, 3], VectorType::Int8);
+            self::assertInstanceOf(Binary::class, $binaryVector);
+        } else {
+            $binaryVector = new Binary("\x03\x00\x01\x02\x03", 9);
+        }
+
         $stage->queryVector($binaryVector);
         self::assertSame(['$vectorSearch' => ['queryVector' => $binaryVector]], $stage->getExpression());
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | [PHPORM-387](https://jira.mongodb.org/browse/PHPORM-387)

#### Summary

The binary vector are added by https://github.com/mongodb/mongo-php-driver/pull/1853, available in ext-mongodb 2.2+
