### PR TITLE
Add field type for Binary vectors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
-        "phpunit/phpunit": "^10.4",
+        "phpunit/phpunit": "^10.5.58",
         "squizlabs/php_codesniffer": "^4",
         "symfony/cache": "^5.4 || ^6.0 || ^7.0",
         "symfony/uid": "^5.4 || ^6.0 || ^7.0"

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -152,6 +152,9 @@ Here is a quick overview of the built-in mapping types:
 -  ``string``
 -  ``timestamp``
 -  ``uuid``
+-  ``vector_float32``
+-  ``vector_int8``
+-  ``vector_packed_bit``
 
 You can read more about the available MongoDB types on `php.net <https://www.php.net/mongodb.bson>`_.
 
@@ -165,21 +168,24 @@ You can read more about the available MongoDB types on `php.net <https://www.php
 Generally, the name of each built-in mapping type hints as to how the value will be converted.
 This list explains some of the less obvious mapping types:
 
--  ``bin``: string to MongoDB\BSON\Binary instance with a "generic" type (default)
--  ``bin_bytearray``: string to MongoDB\BSON\Binary instance with a "byte array" type
--  ``bin_custom``: string to MongoDB\BSON\Binary instance with a "custom" type
--  ``bin_func``: string to MongoDB\BSON\Binary instance with a "function" type
--  ``bin_md5``: string to MongoDB\BSON\Binary instance with a "md5" type
--  ``bin_uuid``: string to MongoDB\BSON\Binary instance with a "uuid" type
+-  ``bin``: ``string`` to ``MongoDB\BSON\Binary`` instance with a "generic" type (default)
+-  ``bin_bytearray``: ``string`` to ``MongoDB\BSON\Binary`` instance with a "byte array" type
+-  ``bin_custom``: ``string`` to ``MongoDB\BSON\Binary`` instance with a "custom" type
+-  ``bin_func``: ``string`` to ``MongoDB\BSON\Binary`` instance with a "function" type
+-  ``bin_md5``: ``string`` to ``MongoDB\BSON\Binary`` instance with a "md5" type
+-  ``bin_uuid``: ``string`` to ``MongoDB\BSON\Binary`` instance with a "uuid" type
 -  ``collection``: numerically indexed array to MongoDB array
 -  ``date``: DateTime to ``MongoDB\BSON\UTCDateTime``
 -  ``date_immutable``: DateTimeImmutable to ``MongoDB\BSON\UTCDateTime``
--  ``decimal128``: string to ``MongoDB\BSON\Decimal128``, requires ``ext-bcmath``
+-  ``decimal128``: ``string`` to ``MongoDB\BSON\Decimal128``, requires ``ext-bcmath``
 -  ``hash``: associative array to MongoDB object
--  ``id``: string to ObjectId by default, but other formats are possible
--  ``timestamp``: string to ``MongoDB\BSON\Timestamp``
+-  ``id``: ``string`` to ObjectId by default, but other formats are possible
+-  ``timestamp``: ``string`` to ``MongoDB\BSON\Timestamp``
 -  ``raw``: any type
 -  ``uuid``: `Symfony UID <https://symfony.com/doc/current/components/uid.html>`_ to ``MongoDB\BSON\Binary`` instance with a "uuid" type
+-  ``vector_float32``: list of floats to ``MongoDB\BSON\Binary`` instance with vector type "Float32"
+-  ``vector_int8``: list of integers to ``MongoDB\BSON\Binary`` instance with vector type "Int8"
+-  ``vector_packed_bit``: list of booleans to ``MongoDB\BSON\Binary`` instance with vector type "PackedBit"
 
 .. note::
 
@@ -188,6 +194,10 @@ This list explains some of the less obvious mapping types:
     the Mongo driver should be used. If your hash contains values which are not
     suitable you should either use an embedded document or use formats provided
     by the MongoDB driver (e.g. ``\MongoDB\BSON\UTCDateTime`` instead of ``\DateTime``).
+
+.. note::
+
+    The vector types require the MongoDB PHP extension version 2.2.0 or higher.
 
 .. _reference-php-mapping-types:
 

--- a/lib/Doctrine/ODM/MongoDB/Types/AbstractVectorType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/AbstractVectorType.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Types;
+
+use InvalidArgumentException;
+use MongoDB\BSON\Binary;
+use MongoDB\BSON\VectorType;
+
+use function enum_exists;
+use function get_debug_type;
+use function is_array;
+use function sprintf;
+use function str_replace;
+
+/** @internal */
+abstract class AbstractVectorType extends Type
+{
+    public function convertToDatabaseValue(mixed $value): ?Binary
+    {
+        if (! enum_exists(VectorType::class)) {
+            throw new InvalidArgumentException('MongoDB\BSON\VectorType enum does not exist. Install the MongoDB Extension version 2.2.0 or higher in order to use a vector field type.');
+        }
+
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_array($value)) {
+            return Binary::fromVector($value, $this->getVectorType());
+        }
+
+        if (! $value instanceof Binary) {
+            throw new InvalidArgumentException(sprintf('Invalid data type %s received for vector field, expected null, array or MongoDB\BSON\Binary', get_debug_type($value)));
+        }
+
+        if ($value->getType() !== Binary::TYPE_VECTOR) {
+            throw new InvalidArgumentException(sprintf('Invalid binary data of type %d received for vector field, expected binary type %d', $value->getType(), Binary::TYPE_VECTOR));
+        }
+
+        if ($value->getVectorType() !== $this->getVectorType()) {
+            throw new InvalidArgumentException(sprintf('Invalid binary vector data of vector type %s received for vector field, expected vector type %s', $value->getVectorType()->name, $this->getVectorType()->name));
+        }
+
+        return $value;
+    }
+
+    /** @return list<float>|list<int>|list<bool>|null */
+    public function convertToPHPValue(mixed $value): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (! $value instanceof Binary) {
+            throw new InvalidArgumentException(sprintf('Invalid data of type "%s" received for vector field', get_debug_type($value)));
+        }
+
+        if ($value->getType() !== Binary::TYPE_VECTOR) {
+            throw new InvalidArgumentException(sprintf('Invalid binary data of type %d received for vector field', $value->getType()));
+        }
+
+        if ($value->getVectorType() !== $this->getVectorType()) {
+            throw new InvalidArgumentException(sprintf('Invalid binary vector data of vector type %s received for vector field, expected vector type %s', $value->getVectorType()->name, $this->getVectorType()->name));
+        }
+
+        return $value->toArray();
+    }
+
+    public function closureToMongo(): string
+    {
+        return str_replace('%%vectorType%%', $this->getVectorType()->name, <<<'PHP'
+            if ($value === null) {
+                $return = null;
+                return;
+            }
+
+            if (\is_array($value)) {
+                $return = \MongoDB\BSON\Binary::fromVector($value, \MongoDB\BSON\VectorType::%%vectorType%%);
+                return;
+            }
+
+            if (! $value instanceof \MongoDB\BSON\Binary) {
+                throw new InvalidArgumentException(sprintf('Invalid data type %s received for vector field, expected null, array or MongoDB\BSON\Binary', get_debug_type($value)));
+            }
+
+            if ($value->getType() !== \MongoDB\BSON\Binary::TYPE_VECTOR) {
+                throw new InvalidArgumentException(sprintf('Invalid binary data of type %d received for vector field, expected binary type %d', $value->getType(), \MongoDB\BSON\Binary::TYPE_VECTOR));
+            }
+
+            if ($value->getVectorType() !== \MongoDB\BSON\VectorType::%%vectorType%%) {
+                throw new \InvalidArgumentException(sprintf('Invalid binary vector data of vector type %s received for vector field, expected vector type %%vectorType%%', $value->getVectorType()->name));
+            }
+
+            $return = $value;
+PHP);
+    }
+
+    public function closureToPHP(): string
+    {
+        return str_replace('%%vectorType%%', $this->getVectorType()->name, <<<'PHP'
+            if ($value === null) {
+                $return = null;
+                return;
+            }
+
+            if (\is_array($value)) {
+                $return = $value;
+                return;
+            }
+
+            if (! $value instanceof \MongoDB\BSON\Binary) {
+                throw new \InvalidArgumentException(sprintf('Invalid data of type "%s" received for vector field', get_debug_type($value)));
+            }
+
+            if ($value->getType() !== \MongoDB\BSON\Binary::TYPE_VECTOR) {
+                throw new \InvalidArgumentException(sprintf('Invalid binary data of type %d received for vector field', $value->getType()));
+            }
+
+            if ($value->getVectorType() !== \MongoDB\BSON\VectorType::%%vectorType%%) {
+                throw new \InvalidArgumentException(sprintf('Invalid binary vector data of vector type %s received for vector field, expected vector type %%vectorType%%', $value->getVectorType()->name));
+            }
+
+            $return = $value->toArray();
+PHP);
+    }
+
+    abstract protected function getVectorType(): VectorType;
+}

--- a/lib/Doctrine/ODM/MongoDB/Types/Type.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/Type.php
@@ -47,6 +47,9 @@ abstract class Type
     public const RAW                = 'raw';
     public const DECIMAL128         = 'decimal128';
     public const UUID               = 'uuid';
+    public const VECTOR_FLOAT32     = 'vector_float32';
+    public const VECTOR_INT8        = 'vector_int8';
+    public const VECTOR_PACKED_BIT  = 'vector_packed_bit';
 
     /** @deprecated const was deprecated in doctrine/mongodb-odm 2.1 and will be removed in 3.0. Use Type::INT instead */
     public const INTID = 'int_id';
@@ -89,6 +92,9 @@ abstract class Type
         self::RAW => Types\RawType::class,
         self::DECIMAL128 => Types\Decimal128Type::class,
         self::UUID => Types\BinaryUuidType::class,
+        self::VECTOR_FLOAT32 => Types\VectorFloat32Type::class,
+        self::VECTOR_INT8 => Types\VectorInt8Type::class,
+        self::VECTOR_PACKED_BIT => Types\VectorPackedBitType::class,
     ];
 
     /** Prevent instantiation and force use of the factory method. */

--- a/lib/Doctrine/ODM/MongoDB/Types/VectorFloat32Type.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/VectorFloat32Type.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Types;
+
+use MongoDB\BSON\VectorType;
+
+final class VectorFloat32Type extends AbstractVectorType
+{
+    protected function getVectorType(): VectorType
+    {
+        return VectorType::Float32;
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Types/VectorInt8Type.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/VectorInt8Type.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Types;
+
+use MongoDB\BSON\VectorType;
+
+final class VectorInt8Type extends AbstractVectorType
+{
+    protected function getVectorType(): VectorType
+    {
+        return VectorType::Int8;
+    }
+}

--- a/lib/Doctrine/ODM/MongoDB/Types/VectorPackedBitType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/VectorPackedBitType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Types;
+
+use MongoDB\BSON\VectorType;
+
+final class VectorPackedBitType extends AbstractVectorType
+{
+    protected function getVectorType(): VectorType
+    {
+        return VectorType::PackedBit;
+    }
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -50,6 +50,10 @@ parameters:
         identifier: property.unusedType
         path: tests/
 
+      # Requires ext-mongodb 2.2+
+      - message: '#MongoDB\\BSON\\VectorType#'
+      - message: '#MongoDB\\BSON\\Binary\:\:(TYPE_VECTOR|getVectorType|toArray|fromVector)#'
+
   # To be removed when reaching phpstan level 6
   checkMissingVarTagTypehint: true
   checkMissingTypehints: true

--- a/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/VectorSearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Aggregation/Stage/VectorSearchTest.php
@@ -93,9 +93,7 @@ class VectorSearchTest extends BaseTestCase
     public function testQueryVectorAcceptsBinary(): void
     {
         [$stage] = $this->createVectorSearchStage();
-        // @phpstan-ignore class.notFound (requires ext-mongodb 2.2+)
         if (enum_exists(VectorType::class)) {
-            // @phpstan-ignore staticMethod.notFound (requires ext-mongodb 2.2+)
             $binaryVector = Binary::fromVector([1, 2, 3], VectorType::Int8);
             self::assertInstanceOf(Binary::class, $binaryVector);
         } else {

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/VectorTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/VectorTypeTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Types;
+
+use Doctrine\ODM\MongoDB\Types\Type;
+use InvalidArgumentException;
+use MongoDB\BSON\Binary;
+use MongoDB\BSON\VectorType;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+
+#[RequiresPhpExtension('mongodb', '>= 2.2')]
+class VectorTypeTest extends TestCase
+{
+    #[DataProvider('providePhpVectors')]
+    public function testConvertToDatabaseValue(string $name, mixed $value, mixed $expectedValue): void
+    {
+        $this->assertEquals($expectedValue, Type::getType($name)->convertToDatabaseValue($value));
+    }
+
+    #[DataProvider('providePhpVectors')]
+    public function testClosureToDatabase(string $name, mixed $value, mixed $expectedValue): void
+    {
+        $return = $this;
+        eval(Type::getType($name)->closureToMongo());
+
+        $this->assertEquals($expectedValue, $return);
+    }
+
+    /** @return iterable<array{0: Type::VECTOR_*, 1: mixed, 2: mixed}> */
+    public static function providePhpVectors(): iterable
+    {
+        $array  = [1.0, 2.0, 3.0, 4.0];
+        $binary = Binary::fromVector($array, VectorType::Float32);
+
+        yield [Type::VECTOR_FLOAT32, null, null];
+        yield [Type::VECTOR_FLOAT32, $array, $binary];
+        yield [Type::VECTOR_FLOAT32, $binary, $binary];
+
+        $array  = [1, 2, 3, 4];
+        $binary = Binary::fromVector($array, VectorType::Int8);
+
+        yield [Type::VECTOR_INT8, null, null];
+        yield [Type::VECTOR_INT8, $array, $binary];
+        yield [Type::VECTOR_INT8, $binary, $binary];
+
+        $array  = [true, false, 0, 1];
+        $binary = Binary::fromVector($array, VectorType::PackedBit);
+
+        yield [Type::VECTOR_PACKED_BIT, null, null];
+        yield [Type::VECTOR_PACKED_BIT, $array, $binary];
+        yield [Type::VECTOR_PACKED_BIT, $binary, $binary];
+    }
+
+    #[DataProvider('provideDatabaseVectors')]
+    public function testConvertToPHPValue(string $name, mixed $value, mixed $expectedValue): void
+    {
+        $this->assertEquals($expectedValue, Type::getType($name)->convertToPHPValue($value));
+    }
+
+    #[DataProvider('provideDatabaseVectors')]
+    public function testClosureToPHP(string $name, mixed $value, mixed $expectedValue): void
+    {
+        $return = $this;
+        eval(Type::getType($name)->closureToPHP());
+
+        $this->assertEquals($expectedValue, $return);
+    }
+
+    /** @return iterable<array{0: Type::VECTOR_*, 1: mixed, 2: mixed}> */
+    public static function provideDatabaseVectors(): iterable
+    {
+        $array  = [1.0, 2.0, 3.0, 4.0];
+        $binary = Binary::fromVector($array, VectorType::Float32);
+
+        yield [Type::VECTOR_FLOAT32, null, null];
+        yield [Type::VECTOR_FLOAT32, $array, $array];
+        yield [Type::VECTOR_FLOAT32, $binary, $array];
+
+        $array  = [1, 2, 3, 4];
+        $binary = Binary::fromVector($array, VectorType::Int8);
+
+        yield [Type::VECTOR_INT8, null, null];
+        yield [Type::VECTOR_INT8, $array, $array];
+        yield [Type::VECTOR_INT8, $binary, $array];
+
+        $array  = [true, false, 0, 1];
+        $binary = Binary::fromVector($array, VectorType::PackedBit);
+
+        yield [Type::VECTOR_PACKED_BIT, null, null];
+        yield [Type::VECTOR_PACKED_BIT, $array, $array];
+        yield [Type::VECTOR_PACKED_BIT, $binary, $array];
+    }
+
+    #[DataProvider('provideDatabaseValueException')]
+    public function testConvertToPHPValueException(mixed $value, string $message): void
+    {
+        $type = Type::getType(Type::VECTOR_FLOAT32);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+        $type->convertToDatabaseValue($value);
+    }
+
+    #[DataProvider('provideDatabaseValueException')]
+    public function testClosureToPHPValueException(mixed $value, string $message): void
+    {
+        $type = Type::getType(Type::VECTOR_FLOAT32);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+        eval($type->closureToMongo());
+    }
+
+    /** @return iterable<array{0: mixed, 1: string}> */
+    public static function provideDatabaseValueException(): iterable
+    {
+        yield ['invalid', 'Invalid data type string received for vector field, expected null, array or MongoDB\BSON\Binary'];
+        yield [new Binary("\x03\x00\x01\x02\x03", Binary::TYPE_GENERIC), 'Invalid binary data of type 0 received for vector field'];
+        yield [Binary::fromVector([1, 2, 3], VectorType::Int8), 'Invalid binary vector data of vector type Int8 received for vector field, expected vector type Float32'];
+    }
+
+    #[DataProvider('providePHPValueException')]
+    public function testConvertToDatabaseValueException(mixed $value, string $message): void
+    {
+        $type = Type::getType(Type::VECTOR_FLOAT32);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+        $type->convertToPHPValue($value);
+    }
+
+    #[DataProvider('providePHPValueException')]
+    public function testClosureToDatabaseException(mixed $value, string $message): void
+    {
+        $type = Type::getType(Type::VECTOR_FLOAT32);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+        eval($type->closureToPHP());
+    }
+
+    public static function providePHPValueException(): iterable
+    {
+        yield ['invalid', 'Invalid data of type "string" received for vector field'];
+        yield [new Binary("\x03\x00\x01\x02\x03", Binary::TYPE_GENERIC), 'Invalid binary data of type 0 received for vector field'];
+        yield [Binary::fromVector([1, 2, 3], VectorType::Int8), 'Invalid binary vector data of vector type Int8 received for vector field, expected vector type Float32'];
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | [PHPORM-384](https://jira.mongodb.org/browse/PHPORM-384)

#### Summary

Vector can be compressed into a binary field thanks to the new `MongoDB\BSON\Binary::TYPE_VECTOR` introduced in MongoDB PHP Extension v2.2.0