### PR TITLE
Add an example for using the `compound` search operator

### DIFF
--- a/docs/en/reference/aggregation-stage-reference.rst
+++ b/docs/en/reference/aggregation-stage-reference.rst
@@ -701,6 +701,27 @@ for a reference of all available operators.
                 ->fields('title', 'content')
     ;
 
+To combine multiple search operators, use the `compound operator <https://www.mongodb.com/docs/atlas/atlas-search/compound/>`_:
+
+.. code-block:: php
+
+    <?php
+
+    $builder = $dm->createAggregationBuilder(\Documents\Fruits::class);
+    $builder
+        ->compound()
+            ->must()
+                ->text()->query('varieties')->path('description')
+            ->should(minimumShouldMatch: 1)
+                ->text()->query('Fuji')->path('description')
+                ->text()->query('Golden Delicious')->path('description')
+    ;
+
+This aggregation will return `Fruits` documents from whose `description` field
+contains the word "varieties" (must), and should also contain either "Fuji" or
+"Golden Delicious" in the `description` field (at least one due to
+`minimumShouldMatch: 1`).
+
 $set
 ----
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | doc
| BC Break     | no
| Fixed issues | -

#### Summary

The [`compound` search operator](https://www.mongodb.com/docs/atlas/atlas-search/compound/) is very common for combining multiple search operators, its usage is more complex, that's why it needs a dedicated example.
