### PR TITLE
Disable `use-next-minor-as-default-branch` in release job

### DIFF
--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -9,8 +9,6 @@ jobs:
   release:
     name: "Git tag, release & create merge-up PR"
     uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@12.0.0"
-    with:
-      use-next-minor-as-default-branch: true
     secrets:
       GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
       GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Fix https://github.com/doctrine/.github/issues/71

#### Summary

As detailed in https://github.com/laminas/automatic-releases/issues/241, this doesn't work.