### PR TITLE
Cleanup group annotations in tests and useless test

### DIFF
--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1229Test.php
@@ -8,7 +8,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
-use PHPUnit\Framework\Attributes\Group;
 
 use function assert;
 use function count;
@@ -42,7 +41,6 @@ class GH1229Test extends BaseTestCase
         $this->secondParentId = $secondParent->id;
     }
 
-    #[Group('m')]
     public function testMethodAWithoutClone(): void
     {
         $firstParent = $this->dm->find(GH1229Parent::CLASSNAME, $this->firstParentId);
@@ -88,7 +86,6 @@ class GH1229Test extends BaseTestCase
         self::assertInstanceOf(GH1229ChildTypeB::CLASSNAME, $children[1]);
     }
 
-    #[Group('m')]
     public function testMethodAWithClone(): void
     {
         $firstParent = $this->dm->find(GH1229Parent::CLASSNAME, $this->firstParentId);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1346Test.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/Ticket/GH1346Test.php
@@ -8,11 +8,9 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
-use PHPUnit\Framework\Attributes\Group;
 
 class GH1346Test extends BaseTestCase
 {
-    #[Group('GH1346Test')]
     public function testPublicProperty(): void
     {
         $referenced1    = new GH1346ReferencedDocument();

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractAnnotationDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractAnnotationDriverTestCase.php
@@ -71,7 +71,6 @@ abstract class AbstractAnnotationDriverTestCase extends AbstractMappingDriverTes
         self::assertEquals(AnnotationDriverTestParent::class, $child->fieldMappings['foo']['declared'], 'Inherited public field from Document parent is declared in Document parent');
     }
 
-    /** @group DDC-268 */
     public function testLoadMetadataForNonDocumentThrowsException(): void
     {
         $cm               = new ClassMetadata('stdClass');
@@ -81,7 +80,6 @@ abstract class AbstractAnnotationDriverTestCase extends AbstractMappingDriverTes
         $annotationDriver->loadMetadataForClass('stdClass', $cm);
     }
 
-    /** @group DDC-268 */
     public function testColumnWithMissingTypeDefaultsToString(): void
     {
         $cm               = new ClassMetadata(ColumnWithoutType::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractAnnotationDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/AbstractAnnotationDriverTestCase.php
@@ -91,31 +91,6 @@ abstract class AbstractAnnotationDriverTestCase extends AbstractMappingDriverTes
         self::assertEquals('id', $cm->fieldMappings['id']['type']);
     }
 
-    /** @group DDC-318 */
-    public function testGetAllClassNamesIsIdempotent(): void
-    {
-        $annotationDriver = $this->loadDriverForCMSDocuments();
-        $original         = $annotationDriver->getAllClassNames();
-
-        $annotationDriver = $this->loadDriverForCMSDocuments();
-        $afterTestReset   = $annotationDriver->getAllClassNames();
-
-        self::assertEquals($original, $afterTestReset);
-    }
-
-    /** @group DDC-318 */
-    public function testGetAllClassNamesIsIdempotentEvenWithDifferentDriverInstances(): void
-    {
-        $annotationDriver = $this->loadDriverForCMSDocuments();
-        $original         = $annotationDriver->getAllClassNames();
-
-        $annotationDriver = $this->loadDriverForCMSDocuments();
-        $afterTestReset   = $annotationDriver->getAllClassNames();
-
-        self::assertEquals($original, $afterTestReset);
-    }
-
-    /** @group DDC-318 */
     public function testGetAllClassNamesReturnsAlreadyLoadedClassesIfAppropriate(): void
     {
         $annotationDriver = $this->loadDriverForCMSDocuments();
@@ -124,7 +99,6 @@ abstract class AbstractAnnotationDriverTestCase extends AbstractMappingDriverTes
         self::assertContains(CmsUser::class, $classes);
     }
 
-    /** @group DDC-318 */
     public function testGetClassNamesReturnsOnlyTheAppropriateClasses(): void
     {
         $extraneousClassName = ColumnWithoutType::class;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/BasicInheritanceMappingTest.php
@@ -60,7 +60,6 @@ class BasicInheritanceMappingTest extends BaseTestCase
         self::assertTrue(isset($class->fieldMappings['mappedRelated1']));
     }
 
-    /** @group DDC-388 */
     public function testSerializationWithPrivateFieldsFromMappedSuperclass(): void
     {
         $class = $this->factory->getMetadataFor(DocumentSubClass2::class);

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/ClassMetadataTest.php
@@ -267,7 +267,6 @@ class ClassMetadataTest extends BaseTestCase
         ]);
     }
 
-    /** @group DDC-115 */
     public function testMapAssocationInGlobalNamespace(): void
     {
         require_once __DIR__ . '/Documents/GlobalNamespaceDocument.php';
@@ -308,7 +307,6 @@ class ClassMetadataTest extends BaseTestCase
         self::assertNull($cm->getAssociationTargetClass('groups'));
     }
 
-    /** @group DDC-115 */
     public function testSetDiscriminatorMapInGlobalNamespace(): void
     {
         require_once __DIR__ . '/Documents/GlobalNamespaceDocument.php';
@@ -320,7 +318,6 @@ class ClassMetadataTest extends BaseTestCase
         self::assertEquals(DoctrineGlobal_User::class, $cm->discriminatorMap['foo']);
     }
 
-    /** @group DDC-115 */
     public function testSetSubClassesInGlobalNamespace(): void
     {
         require_once __DIR__ . '/Documents/GlobalNamespaceDocument.php';

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/AbstractDriverTestCase.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/AbstractDriverTestCase.php
@@ -6,7 +6,6 @@ namespace Doctrine\ODM\MongoDB\Tests\Mapping\Symfony;
 
 use Doctrine\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\Persistence\Mapping\MappingException;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -17,7 +16,6 @@ use function sys_get_temp_dir;
 use function touch;
 use function unlink;
 
-#[Group('DDC-1418')]
 abstract class AbstractDriverTestCase extends TestCase
 {
     protected string $dir;

--- a/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/XmlDriverTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Mapping/Symfony/XmlDriverTest.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Mapping\Symfony;
 
 use Doctrine\ODM\MongoDB\Mapping\Driver\SimplifiedXmlDriver;
-use PHPUnit\Framework\Attributes\Group;
 
 use function array_flip;
 
-#[Group('DDC-1418')]
 class XmlDriverTest extends AbstractDriverTestCase
 {
     protected function getFileExtension(): string


### PR DESCRIPTION
All the removed groups are not used. The referenced tickets can't be found on GitHub issues.