### PR TITLE
Fix binary vector types and conversion in `$vectorSearch` stage

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/VectorSearch.php
+++ b/lib/Doctrine/ODM/MongoDB/Aggregation/Stage/VectorSearch.php
@@ -8,6 +8,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use Doctrine\ODM\MongoDB\Query\Expr;
+use Doctrine\ODM\MongoDB\Types\Type;
 use InvalidArgumentException;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
@@ -81,7 +82,7 @@ class VectorSearch extends Stage
         }
 
         if ($this->queryVector !== null) {
-            $params['queryVector'] = $this->queryVector;
+            $params['queryVector'] = Type::getType($this->persister->getClassMetadata()->fieldMappings[$this->path]['type'] ?? Type::RAW)->convertToDatabaseValue($this->queryVector);
         }
 
         return [$this->getStageName() => $params];

--- a/lib/Doctrine/ODM/MongoDB/Types/AbstractVectorType.php
+++ b/lib/Doctrine/ODM/MongoDB/Types/AbstractVectorType.php
@@ -77,27 +77,17 @@ abstract class AbstractVectorType extends Type
         return str_replace('%%vectorType%%', $this->getVectorType()->name, <<<'PHP'
             if ($value === null) {
                 $return = null;
-                return;
-            }
-
-            if (\is_array($value)) {
+            } elseif (\is_array($value)) {
                 $return = \MongoDB\BSON\Binary::fromVector($value, \MongoDB\BSON\VectorType::%%vectorType%%);
-                return;
-            }
-
-            if (! $value instanceof \MongoDB\BSON\Binary) {
+            } elseif (! $value instanceof \MongoDB\BSON\Binary) {
                 throw new InvalidArgumentException(sprintf('Invalid data type %s received for vector field, expected null, array or MongoDB\BSON\Binary', get_debug_type($value)));
-            }
-
-            if ($value->getType() !== \MongoDB\BSON\Binary::TYPE_VECTOR) {
+            } elseif ($value->getType() !== \MongoDB\BSON\Binary::TYPE_VECTOR) {
                 throw new InvalidArgumentException(sprintf('Invalid binary data of type %d received for vector field, expected binary type %d', $value->getType(), \MongoDB\BSON\Binary::TYPE_VECTOR));
-            }
-
-            if ($value->getVectorType() !== \MongoDB\BSON\VectorType::%%vectorType%%) {
+            } elseif ($value->getVectorType() !== \MongoDB\BSON\VectorType::%%vectorType%%) {
                 throw new \InvalidArgumentException(sprintf('Invalid binary vector data of vector type %s received for vector field, expected vector type %%vectorType%%', $value->getVectorType()->name));
+            } else {
+                $return = $value;
             }
-
-            $return = $value;
 PHP);
     }
 
@@ -106,27 +96,17 @@ PHP);
         return str_replace('%%vectorType%%', $this->getVectorType()->name, <<<'PHP'
             if ($value === null) {
                 $return = null;
-                return;
-            }
-
-            if (\is_array($value)) {
+            } elseif (\is_array($value)) {
                 $return = $value;
-                return;
-            }
-
-            if (! $value instanceof \MongoDB\BSON\Binary) {
+            } elseif (! $value instanceof \MongoDB\BSON\Binary) {
                 throw new \InvalidArgumentException(sprintf('Invalid data of type "%s" received for vector field', get_debug_type($value)));
-            }
-
-            if ($value->getType() !== \MongoDB\BSON\Binary::TYPE_VECTOR) {
+            } elseif ($value->getType() !== \MongoDB\BSON\Binary::TYPE_VECTOR) {
                 throw new \InvalidArgumentException(sprintf('Invalid binary data of type %d received for vector field', $value->getType()));
-            }
-
-            if ($value->getVectorType() !== \MongoDB\BSON\VectorType::%%vectorType%%) {
+            } elseif ($value->getVectorType() !== \MongoDB\BSON\VectorType::%%vectorType%%) {
                 throw new \InvalidArgumentException(sprintf('Invalid binary vector data of vector type %s received for vector field, expected vector type %%vectorType%%', $value->getVectorType()->name));
+            } else {
+                $return = $value->toArray();
             }
-
-            $return = $value->toArray();
 PHP);
     }
 

--- a/tests/Doctrine/ODM/MongoDB/Tests/Functional/VectorSearchTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Functional/VectorSearchTest.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Doctrine\ODM\MongoDB\Types\Type;
 use Documents\VectorEmbedding;
+use MongoDB\BSON\Binary;
 use MongoDB\Driver\WriteConcern;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 #[Group('atlas')]
 class VectorSearchTest extends BaseTestCase
@@ -45,8 +48,20 @@ class VectorSearchTest extends BaseTestCase
         // Index must be created after data insertion, so the index status is not immediately "READY"
         $schemaManager->createDocumentSearchIndexes(VectorEmbedding::class);
 
-        // Wait for search index to be ready (Atlas Local needs time to build the index)
+        // Wait for the search index to be ready (Atlas Local needs time to build the index)
         $schemaManager->waitForSearchIndexes([VectorEmbedding::class]);
+
+        $results = $this->dm->createQueryBuilder(VectorEmbedding::class)->getQuery()->toArray();
+        $this->assertCount(3, $results, 'All documents should be present in the collection');
+
+        foreach ($results as $result) {
+            $this->assertInstanceOf(VectorEmbedding::class, $result);
+
+            $this->assertIsArray($result->vectorFloat);
+            $this->assertCount(3, $result->vectorFloat);
+            $this->assertIsArray($result->vectorInt);
+            $this->assertCount(3, $result->vectorInt);
+        }
 
         $results = $this->dm->createAggregationBuilder(VectorEmbedding::class)
             ->vectorSearch()
@@ -68,6 +83,7 @@ class VectorSearchTest extends BaseTestCase
 
         // Test with filter
         $results = ($builder = $this->dm->createAggregationBuilder(VectorEmbedding::class))
+            ->hydrate(VectorEmbedding::class)
             ->vectorSearch()
                 ->index('vector_int')
                 ->queryVector([1, 1, 3])
@@ -79,8 +95,28 @@ class VectorSearchTest extends BaseTestCase
 
         $this->assertCount(2, $results);
         foreach ($results as $result) {
-            $this->assertIsArray($result);
-            $this->assertEquals('active', $result['filterField'], 'Filtered results should only contain active documents');
+            $this->assertInstanceOf(VectorEmbedding::class, $result);
+            $this->assertEquals('active', $result->filterField, 'Filtered results should only contain active documents');
         }
+    }
+
+    #[RequiresPhpExtension('mongodb', '>= 2.2')]
+    public function testAtlasVectorSearchWithBinaryType(): void
+    {
+        $cm = $this->dm->getClassMetadata(VectorEmbedding::class);
+
+        $cm->fieldMappings['vectorFloat']['type'] = Type::VECTOR_FLOAT32;
+        $cm->fieldMappings['vectorInt']['type']   = Type::VECTOR_INT8;
+
+        // Change the collection name to avoid conflicts with asynchronous index building
+        $cm->collection .= '_binary_type';
+
+        $this->testAtlasVectorSearch();
+
+        // Ensure that the vectors are stored in as binary vectors
+        $doc = $this->dm->getDocumentCollection(VectorEmbedding::class)->findOne(['filterField' => 'active']);
+        $this->assertIsArray($doc);
+        $this->assertInstanceOf(Binary::class, $doc['vectorInt']);
+        $this->assertInstanceOf(Binary::class, $doc['db_vector_float']);
     }
 }

--- a/tests/Doctrine/ODM/MongoDB/Tests/Types/VectorTypeTest.php
+++ b/tests/Doctrine/ODM/MongoDB/Tests/Types/VectorTypeTest.php
@@ -12,13 +12,15 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 
+use function get_debug_type;
+
 #[RequiresPhpExtension('mongodb', '>= 2.2')]
 class VectorTypeTest extends TestCase
 {
     #[DataProvider('providePhpVectors')]
     public function testConvertToDatabaseValue(string $name, mixed $value, mixed $expectedValue): void
     {
-        $this->assertEquals($expectedValue, Type::getType($name)->convertToDatabaseValue($value));
+        $this->assertSameTypeAndValue($expectedValue, Type::getType($name)->convertToDatabaseValue($value));
     }
 
     #[DataProvider('providePhpVectors')]
@@ -27,7 +29,7 @@ class VectorTypeTest extends TestCase
         $return = $this;
         eval(Type::getType($name)->closureToMongo());
 
-        $this->assertEquals($expectedValue, $return);
+        $this->assertSameTypeAndValue($expectedValue, $return);
     }
 
     /** @return iterable<array{0: Type::VECTOR_*, 1: mixed, 2: mixed}> */
@@ -148,5 +150,11 @@ class VectorTypeTest extends TestCase
         yield ['invalid', 'Invalid data of type "string" received for vector field'];
         yield [new Binary("\x03\x00\x01\x02\x03", Binary::TYPE_GENERIC), 'Invalid binary data of type 0 received for vector field'];
         yield [Binary::fromVector([1, 2, 3], VectorType::Int8), 'Invalid binary vector data of vector type Int8 received for vector field, expected vector type Float32'];
+    }
+
+    private function assertSameTypeAndValue(mixed $expected, mixed $actual): void
+    {
+        $this->assertSame(get_debug_type($expected), get_debug_type($actual));
+        $this->assertEquals($expected, $actual);
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

#### Summary

- Fix the vector types for generated code. Calling `return` is not permitted.
- In the `$vectorSearch` stage, convert the vector to Binary using the field type.
