### PR TITLE
Support update pipelines in query builder

### DIFF
--- a/docs/en/reference/query-builder-api.rst
+++ b/docs/en/reference/query-builder-api.rst
@@ -641,8 +641,7 @@ change document field values atomically. Additionally if you are modifying a fie
 that is a reference you can pass managed document to the Builder and let ODM build
 ``DBRef`` object for you.
 
-You have several modifier operations
-available to you that make it easy to update documents in Mongo:
+The following atomic update operators are available through the builder API:
 
 * ``set($name, $value, $atomic = true)``
 * ``setNewObj($newObj)``
@@ -654,6 +653,49 @@ available to you that make it easy to update documents in Mongo:
 * ``popLast($field)``
 * ``pull($field, $value)``
 * ``pullAll($field, array $valueArray)``
+
+You can also run `updates with Aggregation Pipeline <https://www.mongodb.com/docs/manual/tutorial/update-documents-with-aggregation-pipeline/>`_
+by using the ``pipeline()`` method. You can pass an aggregation builder instance, a ``Pipeline`` instance from the
+MongoDB PHP library, or an array of pipeline stages:
+
+.. code-block:: php
+
+    <?php
+
+    // The three following are equivalent ways to define the same update pipeline stage
+
+    $pipeline = $dm->createAggregationBuilder(User::class)
+        ->set()
+            ->field('totalScore')
+            ->add('$score1', '$score2'),
+        );
+
+    $pipeline = new Pipeline(
+        Stage::set(
+            totalScore: Expression::add(
+                Expression::fieldPath('score1'),
+                Expression::fieldPath('score2'),
+            ),
+        )
+    );
+
+    $pipeline = [
+        ['$set' => [
+            'totalScore' => ['$add' => ['$score1', '$score2']],
+        ]],
+    ]
+
+    $dm->createQueryBuilder(User::class)
+        ->updateOne()
+        ->field('username')->equals('jwage')
+        ->pipeline($pipeline)
+        ->getQuery()
+        ->execute();
+
+.. note::
+
+    Pipeline updates are only available for ``updateOne``, ``updateMany``, and ``findAndUpdate`` operations.
+
 
 Updating multiple documents
 ---------------------------

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -787,7 +787,7 @@ parameters:
 			path: src/Query/Query.php
 
 		-
-			message: '#^Strict comparison using \!\=\= between array\<string, mixed\>\|bool\|int\|MongoDB\\Driver\\ReadPreference\|string and null will always evaluate to true\.$#'
+			message: '#^Strict comparison using \!\=\= between array\<int\<0, max\>\|string, mixed\>\|bool\|int\|MongoDB\\Builder\\Pipeline\|MongoDB\\Driver\\ReadPreference\|string and null will always evaluate to true\.$#'
 			identifier: notIdentical.alwaysTrue
 			count: 1
 			path: src/Query/Query.php
@@ -1099,13 +1099,19 @@ parameters:
 			path: tests/Tests/Query/BuilderTest.php
 
 		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: tests/Tests/Query/PipelineUpdateTest.php
+
+		-
 			message: '#^Method Doctrine\\ODM\\MongoDB\\Tests\\QueryTest\:\:createCursorMock\(\) return type has no value type specified in iterable type Traversable\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/Tests/QueryTest.php
 
 		-
-			message: '#^Parameter \#4 \$query of class Doctrine\\ODM\\MongoDB\\Query\\Query constructor expects array\{distinct\?\: string, hint\?\: array\<string, \-1\|1\>\|string, limit\?\: int, maxTimeMS\?\: int, multiple\?\: bool, new\?\: bool, newObj\?\: array\<string, mixed\>, query\?\: array\<string, mixed\>, \.\.\.\}, array\{type\: \-1\} given\.$#'
+			message: '#^Parameter \#4 \$query of class Doctrine\\ODM\\MongoDB\\Query\\Query constructor expects array\{distinct\?\: string, hint\?\: array\<string, \-1\|1\>\|string, limit\?\: int, maxTimeMS\?\: int, multiple\?\: bool, new\?\: bool, newObj\?\: array\<string, mixed\>, pipeline\?\: list\<array\<string, mixed\>\>\|MongoDB\\Builder\\Pipeline, \.\.\.\}, array\{type\: \-1\} given\.$#'
 			identifier: argument.type
 			count: 1
 			path: tests/Tests/QueryTest.php

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1069,6 +1069,8 @@ class Builder
     /**
      * Specifies a pipeline to be used for updates. The pipeline can be an aggregation builder, MongoDB pipeline
      * instance, or an array of pipeline stages.
+     *
+     * @param AggregationBuilder|Pipeline|list<array<string, mixed>> $pipeline
      */
     public function pipeline(AggregationBuilder|array|Pipeline $pipeline): self
     {

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Query;
 
 use BadMethodCallException;
+use Doctrine\ODM\MongoDB\Aggregation\Builder as AggregationBuilder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Iterator\IterableResult;
@@ -14,6 +15,7 @@ use GeoJson\Geometry\Point;
 use InvalidArgumentException;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Javascript;
+use MongoDB\Builder\Pipeline;
 use MongoDB\Collection;
 use MongoDB\Driver\ReadPreference;
 
@@ -1060,6 +1062,23 @@ class Builder
     public function notIn(array $values): self
     {
         $this->expr->notIn($values);
+
+        return $this;
+    }
+
+    /**
+     * Specifies a pipeline to be used for updates. The pipeline can be an aggregation builder, MongoDB pipeline
+     * instance, or an array of pipeline stages.
+     */
+    public function pipeline(AggregationBuilder|array|Pipeline $pipeline): self
+    {
+        if ($this->query['type'] !== Query::TYPE_UPDATE && $this->query['type'] !== Query::TYPE_FIND_AND_UPDATE) {
+            throw new BadMethodCallException('The pipeline() method can only be used with update or findAndUpdate queries.');
+        }
+
+        $this->query['pipeline'] = $pipeline instanceof AggregationBuilder
+            ? $pipeline->getPipeline()
+            : $pipeline;
 
         return $this;
     }

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -496,7 +496,7 @@ final class Query implements IterableResult
                     $update = $this->query['pipeline'];
                 } elseif (! $this->isFirstKeyUpdateOperator()) {
                     if ($multiple) {
-                        throw new InvalidArgumentException('Replacing multiple documents is not supported.');
+                        throw new InvalidArgumentException('Combining the "multiple" option without using an update operator as first operation in a query is not supported.');
                     }
 
                     $operation = 'replaceOne';

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -17,6 +17,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use InvalidArgumentException;
+use MongoDB\Builder\Pipeline;
 use MongoDB\Collection;
 use MongoDB\DeleteResult;
 use MongoDB\Driver\ReadPreference;
@@ -51,6 +52,7 @@ use function is_string;
  *     multiple?: bool,
  *     new?: bool,
  *     newObj?: array<string, mixed>,
+ *     pipeline?: Pipeline|list<array<string, mixed>>,
  *     query?: array<string, mixed>,
  *     readPreference?: ReadPreference,
  *     select?: array<string, 0|1|array<string, mixed>>,
@@ -459,11 +461,17 @@ final class Query implements IterableResult
                 $queryOptions                   = $this->renameQueryOptions($queryOptions, ['select' => 'projection']);
                 $queryOptions['returnDocument'] = $this->query['new'] ?? false ? FindOneAndUpdate::RETURN_DOCUMENT_AFTER : FindOneAndUpdate::RETURN_DOCUMENT_BEFORE;
 
-                $operation = $this->isFirstKeyUpdateOperator() ? 'findOneAndUpdate' : 'findOneAndReplace';
+                if (isset($this->query['pipeline'])) {
+                    $operation = 'findOneAndUpdate';
+                    $update    = $this->query['pipeline'];
+                } else {
+                    $operation = $this->isFirstKeyUpdateOperator() ? 'findOneAndUpdate' : 'findOneAndReplace';
+                    $update    = $this->query['newObj'];
+                }
 
                 return $this->collection->{$operation}(
                     $this->query['query'],
-                    $this->query['newObj'],
+                    $update,
                     array_merge($options, $queryOptions)
                 );
 
@@ -480,29 +488,23 @@ final class Query implements IterableResult
                 return $this->collection->insertOne($this->query['newObj'], $options);
 
             case self::TYPE_UPDATE:
-                $multiple = $this->query['multiple'] ?? false;
+                $multiple  = $this->query['multiple'] ?? false;
+                $operation = $multiple ? 'updateMany' : 'updateOne';
+                $update    = $this->query['newObj'];
 
-                if ($this->isFirstKeyUpdateOperator()) {
-                    $operation = 'updateOne';
-                } else {
+                if (isset($this->query['pipeline'])) {
+                    $update = $this->query['pipeline'];
+                } elseif (! $this->isFirstKeyUpdateOperator()) {
                     if ($multiple) {
-                        throw new InvalidArgumentException('Combining the "multiple" option without using an update operator as first operation in a query is not supported.');
+                        throw new InvalidArgumentException('Replacing multiple documents is not supported.');
                     }
 
                     $operation = 'replaceOne';
                 }
 
-                if ($multiple) {
-                    return $this->collection->updateMany(
-                        $this->query['query'],
-                        $this->query['newObj'],
-                        array_merge($options, $this->getQueryOptions('upsert')),
-                    );
-                }
-
                 return $this->collection->{$operation}(
                     $this->query['query'],
-                    $this->query['newObj'],
+                    $update,
                     array_merge($options, $this->getQueryOptions('upsert'))
                 );
 

--- a/tests/Tests/Query/PipelineUpdateTest.php
+++ b/tests/Tests/Query/PipelineUpdateTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Query;
+
+use BadMethodCallException;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\User;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+
+class PipelineUpdateTest extends BaseTestCase
+{
+    private User $user1;
+    private User $user2;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user1 = new User();
+        $this->user1->setUsername('foo');
+        $this->user1->setHits(1);
+
+        $this->user2 = new User();
+        $this->user2->setUsername('bar');
+        $this->user2->setHits(2);
+
+        $this->dm->persist($this->user1);
+        $this->dm->persist($this->user2);
+
+        $this->dm->flush();
+    }
+
+    public function testUpdateManyWithWrongType(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('The pipeline() method can only be used with update or findAndUpdate queries.');
+
+        $this->dm->createQueryBuilder(User::class)
+            ->pipeline([]);
+    }
+
+    public function testUpdateOneWithAggregationBuilder(): void
+    {
+        $builder = $this->dm->createAggregationBuilder(User::class);
+        $builder
+            ->set()
+                ->field('hits')
+                ->add('$hits', 1);
+
+        $this->dm->createQueryBuilder(User::class)
+            ->updateOne()
+            ->field('username')->equals('foo')
+            ->pipeline($builder)
+            ->getQuery()
+            ->execute();
+
+        $this->dm->clear();
+
+        $user1 = $this->dm->getRepository(User::class)->find($this->user1->getId());
+        self::assertSame(2, $user1->getHits());
+
+        $user2 = $this->dm->getRepository(User::class)->find($this->user2->getId());
+        self::assertSame(2, $user2->getHits());
+    }
+
+    public function testUpdateOneWithDriverPipeline(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::set(
+                hits: Expression::add(Expression::fieldPath('hits'), 1),
+            ),
+        );
+
+        $this->dm->createQueryBuilder(User::class)
+            ->updateOne()
+            ->field('username')->equals('foo')
+            ->pipeline($pipeline)
+            ->getQuery()
+            ->execute();
+
+        $this->dm->clear();
+
+        $user1 = $this->dm->getRepository(User::class)->find($this->user1->getId());
+        self::assertSame(2, $user1->getHits());
+
+        $user2 = $this->dm->getRepository(User::class)->find($this->user2->getId());
+        self::assertSame(2, $user2->getHits());
+    }
+
+    public function testUpdateOneWithPipelineArray(): void
+    {
+        $this->dm->createQueryBuilder(User::class)
+            ->updateOne()
+            ->field('username')->equals('foo')
+            ->pipeline([['$set' => ['hits' => ['$sum' => ['$hits', 1]]]]])
+            ->getQuery()
+            ->execute();
+
+        $this->dm->clear();
+
+        $user1 = $this->dm->getRepository(User::class)->find($this->user1->getId());
+        self::assertSame(2, $user1->getHits());
+
+        $user2 = $this->dm->getRepository(User::class)->find($this->user2->getId());
+        self::assertSame(2, $user2->getHits());
+    }
+
+    public function testUpdateManyWithAggregationBuilder(): void
+    {
+        $builder = $this->dm->createAggregationBuilder(User::class);
+        $builder
+            ->set()
+                ->field('hits')
+                ->multiply('$hits', 2);
+
+        $this->dm->createQueryBuilder(User::class)
+            ->updateMany()
+            ->pipeline($builder)
+            ->getQuery()
+            ->execute();
+
+        $this->dm->clear();
+
+        $user1 = $this->dm->getRepository(User::class)->find($this->user1->getId());
+        self::assertSame(2, $user1->getHits());
+
+        $user2 = $this->dm->getRepository(User::class)->find($this->user2->getId());
+        self::assertSame(4, $user2->getHits());
+    }
+
+    public function testUpdateManyWithDriverPipeline(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::set(
+                hits: Expression::multiply(Expression::fieldPath('hits'), 2),
+            ),
+        );
+
+        $this->dm->createQueryBuilder(User::class)
+            ->updateMany()
+            ->pipeline($pipeline)
+            ->getQuery()
+            ->execute();
+
+        $this->dm->clear();
+
+        $user1 = $this->dm->getRepository(User::class)->find($this->user1->getId());
+        self::assertSame(2, $user1->getHits());
+
+        $user2 = $this->dm->getRepository(User::class)->find($this->user2->getId());
+        self::assertSame(4, $user2->getHits());
+    }
+
+    public function testUpdateManyWithPipelineArray(): void
+    {
+        $this->dm->createQueryBuilder(User::class)
+            ->updateMany()
+            ->pipeline([['$set' => ['hits' => ['$multiply' => ['$hits', 2]]]]])
+            ->getQuery()
+            ->execute();
+
+        $this->dm->clear();
+
+        $user1 = $this->dm->getRepository(User::class)->find($this->user1->getId());
+        self::assertSame(2, $user1->getHits());
+
+        $user2 = $this->dm->getRepository(User::class)->find($this->user2->getId());
+        self::assertSame(4, $user2->getHits());
+    }
+
+    public function testFindOneAndUpdateWithAggregationBuilder(): void
+    {
+        $builder = $this->dm->createAggregationBuilder(User::class);
+        $builder
+            ->set()
+                ->field('hits')
+                ->add('$hits', 1);
+
+        $user = $this->dm->createQueryBuilder(User::class)
+            ->findAndUpdate()
+            ->returnNew()
+            ->field('username')->equals('foo')
+            ->pipeline($builder)
+            ->getQuery()
+            ->execute();
+
+        self::assertSame(2, $user->getHits());
+    }
+
+    public function testFindOneAndUpdateWithDriverPipeline(): void
+    {
+        $this->markTestIncomplete('Collection::findAndUpdate does not support pipeline updates (PHPLIB-1699)');
+
+        $pipeline = new Pipeline(
+            Stage::set(
+                hits: Expression::add(Expression::fieldPath('hits'), 1),
+            ),
+        );
+
+        $user = $this->dm->createQueryBuilder(User::class)
+            ->findAndUpdate()
+            ->returnNew()
+            ->field('username')->equals('foo')
+            ->pipeline($pipeline)
+            ->getQuery()
+            ->execute();
+
+        self::assertSame(2, $user->getHits());
+    }
+
+    public function testFindOneAndUpdateWithPipelineArray(): void
+    {
+        $user = $this->dm->createQueryBuilder(User::class)
+            ->findAndUpdate()
+            ->returnNew()
+            ->field('username')->equals('foo')
+            ->pipeline([['$set' => ['hits' => ['$sum' => ['$hits', 1]]]]])
+            ->getQuery()
+            ->execute();
+
+        self::assertSame(2, $user->getHits());
+    }
+}

--- a/tests/Tests/Query/PipelineUpdateTest.php
+++ b/tests/Tests/Query/PipelineUpdateTest.php
@@ -188,6 +188,7 @@ class PipelineUpdateTest extends BaseTestCase
             ->getQuery()
             ->execute();
 
+        self::assertInstanceOf(User::class, $user);
         self::assertSame(2, $user->getHits());
     }
 
@@ -209,6 +210,7 @@ class PipelineUpdateTest extends BaseTestCase
             ->getQuery()
             ->execute();
 
+        self::assertInstanceOf(User::class, $user);
         self::assertSame(2, $user->getHits());
     }
 
@@ -222,6 +224,7 @@ class PipelineUpdateTest extends BaseTestCase
             ->getQuery()
             ->execute();
 
+        self::assertInstanceOf(User::class, $user);
         self::assertSame(2, $user->getHits());
     }
 }

--- a/tests/Tests/Query/PipelineUpdateTest.php
+++ b/tests/Tests/Query/PipelineUpdateTest.php
@@ -194,7 +194,7 @@ class PipelineUpdateTest extends BaseTestCase
 
     public function testFindOneAndUpdateWithDriverPipeline(): void
     {
-        $this->markTestIncomplete('Collection::findAndUpdate does not support pipeline updates (PHPLIB-1699)');
+        $this->markTestSkipped('Collection::findAndUpdate does not support pipeline updates (PHPLIB-1699)');
 
         $pipeline = new Pipeline(
             Stage::set(


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

This PR adds a new `pipeline()` method to the query builder which can be used to run aggregation pipelines for `updateOne`, `updateMany`, and `findAndUpdate` operations. The method accepts either an aggregation builder instance, a `Pipeline` instance from the MongoDB library, or an array of pipeline stages.