### PR TITLE
Enable `symfony/var-exporter: 8.0`, without lazy ghost object support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/console": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0",
         "symfony/var-dumper": "^5.4 || ^6.4 || ^7.0 || ^8.0",
-        "symfony/var-exporter": "^6.4 || ^7.0"
+        "symfony/var-exporter": "^6.4 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "ext-bcmath": "*",

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -36,6 +36,7 @@ use ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy;
 use Psr\Cache\CacheItemPoolInterface;
 use ReflectionClass;
 use stdClass;
+use Symfony\Component\VarExporter\LazyGhostTrait;
 use Throwable;
 
 use function array_diff_key;
@@ -44,6 +45,7 @@ use function array_key_exists;
 use function class_exists;
 use function interface_exists;
 use function is_string;
+use function trait_exists;
 use function trigger_deprecation;
 use function trim;
 
@@ -695,12 +697,18 @@ class Configuration
             throw new LogicException('Cannot enable or disable LazyGhostObject when native lazy objects are enabled.');
         }
 
-        if ($flag === false) {
+        if ($flag && ! trait_exists(LazyGhostTrait::class)) {
+            throw new LogicException('Package "symfony/var-exporter" >= 8.0 does not provide lazy ghost objects, use native lazy objects instead.');
+        }
+
+        if (! $flag) {
             if (! class_exists(ProxyManagerConfiguration::class)) {
                 throw new LogicException('Package "friendsofphp/proxy-manager-lts" is required to disable LazyGhostObject.');
             }
 
-            trigger_deprecation('doctrine/mongodb-odm', '2.10', 'Using "friendsofphp/proxy-manager-lts" is deprecated. Use "symfony/var-exporter" LazyGhostObjects instead.');
+            if (PHP_VERSION_ID < 80400) {
+                trigger_deprecation('doctrine/mongodb-odm', '2.10', 'Using "friendsofphp/proxy-manager-lts" is deprecated. Use "symfony/var-exporter" LazyGhostObjects instead.');
+            }
         }
 
         $this->lazyGhostObject = $flag;

--- a/tests/Tests/ConfigurationTest.php
+++ b/tests/Tests/ConfigurationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests;
 
+use Composer\InstalledVersions;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\ConfigurationException;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionFactory;
@@ -17,6 +18,7 @@ use stdClass;
 
 use function base64_encode;
 use function str_repeat;
+use function version_compare;
 
 class ConfigurationTest extends TestCase
 {
@@ -33,6 +35,10 @@ class ConfigurationTest extends TestCase
 
     public function testUseLazyGhostObject(): void
     {
+        if (! version_compare(InstalledVersions::getVersion('symfony/var-exporter'), '8', '<')) {
+            $this->markTestSkipped('Symfony VarExporter 8 or higher is not installed.');
+        }
+
         $c = new Configuration();
 
         self::assertFalse($c->isLazyGhostObjectEnabled());
@@ -40,6 +46,21 @@ class ConfigurationTest extends TestCase
         self::assertTrue($c->isLazyGhostObjectEnabled());
         $c->setUseLazyGhostObject(false);
         self::assertFalse($c->isLazyGhostObjectEnabled());
+    }
+
+    #[RequiresPhp('>= 8.4')]
+    public function testUseLazyGhostObjectWithSymfony8(): void
+    {
+        if (version_compare(InstalledVersions::getVersion('symfony/var-exporter'), '8', '<')) {
+            $this->markTestSkipped('Symfony VarExporter 8 or higher is not installed.');
+        }
+
+        $c = new Configuration();
+
+        self::expectException(LogicException::class);
+        self::expectExceptionMessage('Package "symfony/var-exporter" >= 8.0 does not provide lazy ghost objects, use native lazy objects instead.');
+
+        $c->setUseLazyGhostObject(true);
     }
 
     public function testNativeLazyObjectDeprecatedByDefault(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | -

#### Summary

I was wrong in https://github.com/doctrine/mongodb-odm/pull/2791#discussion_r2466249454. The `symfony/var-exporter` package still exists in version 8.0, but does not provide the lazy objects trait.

I'm allowing its installation, but throw an exception when `Configuration::setUseLazyGhostObject()` is called.

With Symfony 8.0, only the proxy manager and native lazy objects can be used. The bundle will default to native lazy objects.

It's a breaking change for people that uses `doctrine/mongodb-odm` standalone and call `Configuration::setUseLazyGhostObject(true)`. They will update to `symfony/var-exporter: 8.0.0` and get an exception.
