### PR TITLE
Deprecate `ClassMetadataFactoryInterface::setProxyClassNameResolver()`

### DIFF
--- a/src/DocumentManager.php
+++ b/src/DocumentManager.php
@@ -176,7 +176,9 @@ class DocumentManager implements ObjectManager
         $this->metadataFactory    = new $metadataFactoryClassName();
         $this->metadataFactory->setDocumentManager($this);
         $this->metadataFactory->setConfiguration($this->config);
-        $this->metadataFactory->setProxyClassNameResolver($this->classNameResolver);
+        if (! $this->config->isNativeLazyObjectEnabled()) {
+            $this->metadataFactory->setProxyClassNameResolver($this->classNameResolver);
+        }
 
         $cacheDriver = $this->config->getMetadataCache();
         if ($cacheDriver) {
@@ -310,10 +312,14 @@ class DocumentManager implements ObjectManager
     /**
      * Returns the class name resolver which is used to resolve real class names for proxy objects.
      *
-     * @deprecated Fetch metadata for any class string (e.g. proxy object class) and read the class name from the metadata object
+     * @deprecated Since 2.15, the use of proxy classes is deprecated and will be removed in Doctrine ODM 3.0.
      */
     public function getClassNameResolver(): ClassNameResolver
     {
+        if ($this->getConfiguration()->isNativeLazyObjectEnabled()) {
+            trigger_deprecation('doctrine/mongodb-odm', '2.15', 'The %s() method is deprecated and will be removed in Doctrine ODM 3.0. There are no proxy classes when using native lazy objects', __METHOD__);
+        }
+
         return $this->classNameResolver;
     }
 

--- a/src/DocumentNotFoundException.php
+++ b/src/DocumentNotFoundException.php
@@ -12,7 +12,7 @@ use function sprintf;
 use const JSON_THROW_ON_ERROR;
 
 /**
- * Class for exception when encountering proxy object that has
+ * Class for exception when encountering a lazy object that has
  * an identifier that does not exist in the database.
  */
 final class DocumentNotFoundException extends MongoDBException

--- a/src/Events.php
+++ b/src/Events.php
@@ -130,7 +130,7 @@ final class Events
     public const onClear = 'onClear';
 
     /**
-     * The documentNotFound event occurs if a proxy object could not be found in
+     * The documentNotFound event occurs if a lazy object could not be found in
      * the database.
      */
     public const documentNotFound = 'documentNotFound';

--- a/src/Mapping/ClassMetadataFactoryInterface.php
+++ b/src/Mapping/ClassMetadataFactoryInterface.php
@@ -35,6 +35,8 @@ interface ClassMetadataFactoryInterface extends ClassMetadataFactory
 
     /**
      * Sets a resolver for real class names of a proxy.
+     *
+     * @deprecated This method is deprecated and will be removed in Doctrine ODM 3.0.
      */
     public function setProxyClassNameResolver(ProxyClassNameResolver $resolver): void;
 }

--- a/tests/Tests/DocumentManagerTest.php
+++ b/tests/Tests/DocumentManagerTest.php
@@ -14,6 +14,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\Proxy\Factory\ProxyFactory;
+use Doctrine\ODM\MongoDB\Proxy\Resolver\ClassNameResolver;
 use Doctrine\ODM\MongoDB\Query\Builder as QueryBuilder;
 use Doctrine\ODM\MongoDB\Query\FilterCollection;
 use Doctrine\ODM\MongoDB\SchemaManager;
@@ -34,6 +35,7 @@ use InvalidArgumentException;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Client;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use RuntimeException;
 use stdClass;
 
@@ -260,6 +262,13 @@ class DocumentManagerTest extends BaseTestCase
     {
         $mapping = ClassMetadataTestUtil::getFieldMapping(['targetDocument' => User::class]);
         self::assertEquals(User::class, $this->dm->getClassNameForAssociation($mapping, null));
+    }
+
+    #[IgnoreDeprecations]
+    public function testGetClassNameResolver(): void
+    {
+        $resolver = $this->dm->getClassNameResolver();
+        self::assertInstanceOf(ClassNameResolver::class, $resolver);
     }
 }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

Native lazy objects remove the need for a `ClassNameResolver`.
Also deprecating in https://github.com/doctrine/persistence/pull/460
