### PR TITLE
Ensure proxy-manager is not used when native lazy objects are enabled

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -92,6 +92,15 @@ jobs:
             dependencies: "highest"
             symfony-version: "stable"
             proxy: "lazy-ghost"
+          # Test removing optional dependencies
+          - topology: "server"
+            php-version: "8.4"
+            mongodb-version: "8.0"
+            driver-version: "stable"
+            dependencies: "highest"
+            symfony-version: "stable"
+            proxy: "native"
+            remove-optional-dependencies: true
           # Test with a sharded cluster
           # Currently disabled due to a bug where MongoDB reports "sharding status unknown"
 #          - topology: "sharded_cluster"
@@ -147,6 +156,13 @@ jobs:
           composer require --no-update symfony/console:^${{ matrix.symfony-version }}
           composer require --no-update symfony/var-dumper:^${{ matrix.symfony-version }}
           composer require --no-update --dev symfony/cache:^${{ matrix.symfony-version }}
+
+      - name: "Remove optional dependencies"
+        if: "${{ matrix.remove-optional-dependencies }}"
+        run: |
+          composer remove --no-update friendsofphp/proxy-manager-lts symfony/var-exporter
+          composer remove --no-update --dev symfony/cache doctrine/orm doctrine/annotations
+          composer remove --no-update --dev doctrine/coding-standard phpstan/phpstan phpstan/phpstan-deprecation-rule phpstan/phpstan-phpunit
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -708,7 +708,8 @@ class Configuration
 
     public function isLazyGhostObjectEnabled(): bool
     {
-        return $this->lazyGhostObject;
+        // Always false if native lazy objects are enabled
+        return $this->lazyGhostObject && ! $this->nativeLazyObject;
     }
 
     public function setUseNativeLazyObject(bool $nativeLazyObject): void
@@ -718,7 +719,6 @@ class Configuration
         }
 
         $this->nativeLazyObject = $nativeLazyObject;
-        $this->lazyGhostObject  = ! $nativeLazyObject || $this->lazyGhostObject;
     }
 
     public function isNativeLazyObjectEnabled(): bool

--- a/src/DocumentManager.php
+++ b/src/DocumentManager.php
@@ -154,9 +154,23 @@ class DocumentManager implements ObjectManager
             $this->config->getDriverOptions(),
         );
 
-        $this->classNameResolver = $this->config->isLazyGhostObjectEnabled()
-            ? new CachingClassNameResolver(new LazyGhostProxyClassNameResolver())
-            : new CachingClassNameResolver(new ProxyManagerClassNameResolver($this->config));
+        if ($this->config->isNativeLazyObjectEnabled()) {
+            $this->classNameResolver = new class implements ClassNameResolver, ProxyClassNameResolver {
+                public function getRealClass(string $class): string
+                {
+                    return $class;
+                }
+
+                public function resolveClassName(string $className): string
+                {
+                    return $className;
+                }
+            };
+        } elseif ($this->config->isLazyGhostObjectEnabled()) {
+            $this->classNameResolver = new CachingClassNameResolver(new LazyGhostProxyClassNameResolver());
+        } else {
+            $this->classNameResolver = new CachingClassNameResolver(new ProxyManagerClassNameResolver($this->config));
+        }
 
         $metadataFactoryClassName = $this->config->getClassMetadataFactoryName();
         $this->metadataFactory    = new $metadataFactoryClassName();

--- a/src/Hydrator/HydratorFactory.php
+++ b/src/Hydrator/HydratorFactory.php
@@ -451,29 +451,18 @@ EOF
             }
         }
 
+        // Skip initialization to not load any object data
         if (PHP_VERSION_ID >= 80400) {
             $metadata->reflClass->markLazyObjectAsInitialized($document);
         }
 
         if ($document instanceof InternalProxy) {
-            // Skip initialization to not load any object data
             $document->__setInitialized(true);
         }
 
         // Support for legacy proxy-manager-lts
-        if ($document instanceof GhostObjectInterface && $document->getProxyInitializer() !== null) {
-            // Inject an empty initialiser to not load any object data
-            $document->setProxyInitializer(static function (
-                GhostObjectInterface $ghostObject,
-                string $method, // we don't care
-                array $parameters, // we don't care
-                &$initializer,
-                array $properties, // we currently do not use this
-            ): bool {
-                $initializer = null;
-
-                return true;
-            });
+        if ($document instanceof GhostObjectInterface) {
+            $document->setProxyInitializer(null);
         }
 
         $data = $this->getHydratorFor($metadata->name)->hydrate($document, $data, $hints);

--- a/src/Mapping/PropertyAccessors/ObjectCastPropertyAccessor.php
+++ b/src/Mapping/PropertyAccessors/ObjectCastPropertyAccessor.php
@@ -52,7 +52,7 @@ class ObjectCastPropertyAccessor implements PropertyAccessor
             $object->__setInitialized(false);
         } elseif ($object instanceof GhostObjectInterface && ! $object->isProxyInitialized()) {
             $initializer = $object->getProxyInitializer();
-            $object->setProxyInitializer();
+            $object->setProxyInitializer(null);
             $this->reflectionProperty->setValue($object, $value);
             $object->setProxyInitializer($initializer);
         } else {

--- a/src/Proxy/Factory/StaticProxyFactory.php
+++ b/src/Proxy/Factory/StaticProxyFactory.php
@@ -146,7 +146,7 @@ final class StaticProxyFactory implements ProxyFactory
         $skippedFieldsFqns = [];
 
         foreach ($metadata->getIdentifierFieldNames() as $idField) {
-            $skippedFieldsFqns[] = $this->propertyFqcn($metadata->getReflectionProperty($idField));
+            $skippedFieldsFqns[] = $this->propertyFqcn($metadata->getPropertyAccessor($idField)->getUnderlyingReflector());
         }
 
         foreach ($metadata->getReflectionClass()->getProperties() as $property) {

--- a/tests/Documents/Tag.php
+++ b/tests/Documents/Tag.php
@@ -14,7 +14,7 @@ class Tag
     public ?string $id;
 
     #[ODM\Field]
-    public readonly string $name;
+    public string $name;
 
     /** @var Collection<int, BlogPost> */
     #[ODM\ReferenceMany(targetDocument: BlogPost::class, mappedBy: 'tags')]

--- a/tests/Tests/BaseTestCase.php
+++ b/tests/Tests/BaseTestCase.php
@@ -105,8 +105,13 @@ abstract class BaseTestCase extends TestCase
         $config->setPersistentCollectionNamespace('PersistentCollections');
         $config->setDefaultDB(DOCTRINE_MONGODB_DATABASE);
         $config->setMetadataDriverImpl(static::createMetadataDriverImpl());
-        $config->setUseLazyGhostObject((bool) $_ENV['USE_LAZY_GHOST_OBJECT']);
-        $config->setUseNativeLazyObject((bool) $_ENV['USE_NATIVE_LAZY_OBJECT']);
+        if ($_ENV['USE_LAZY_GHOST_OBJECT']) {
+            $config->setUseLazyGhostObject(true);
+        }
+
+        if ($_ENV['USE_NATIVE_LAZY_OBJECT']) {
+            $config->setUseNativeLazyObject(true);
+        }
 
         if ($config->isNativeLazyObjectEnabled()) {
             NativeLazyObjectFactory::enableTracking();

--- a/tests/Tests/ConfigurationTest.php
+++ b/tests/Tests/ConfigurationTest.php
@@ -13,9 +13,11 @@ use MongoDB\Driver\Manager;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use ProxyManager\Configuration as ProxyManagerConfiguration;
 use stdClass;
 
 use function base64_encode;
+use function class_exists;
 use function str_repeat;
 
 class ConfigurationTest extends TestCase
@@ -38,6 +40,12 @@ class ConfigurationTest extends TestCase
         self::assertFalse($c->isLazyGhostObjectEnabled());
         $c->setUseLazyGhostObject(true);
         self::assertTrue($c->isLazyGhostObjectEnabled());
+
+        if (! class_exists(ProxyManagerConfiguration::class)) {
+            $this->expectException(LogicException::class);
+            $this->expectExceptionMessage('Package "friendsofphp/proxy-manager-lts" is required to disable LazyGhostObject.');
+        }
+
         $c->setUseLazyGhostObject(false);
         self::assertFalse($c->isLazyGhostObjectEnabled());
     }

--- a/tests/Tests/Functional/ReadOnlyPropertiesTest.php
+++ b/tests/Tests/Functional/ReadOnlyPropertiesTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Functional;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Field;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Id;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\ReferenceOne;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+
+class ReadOnlyPropertiesTest extends BaseTestCase
+{
+    public function testReadOnlyDocument(): void
+    {
+        $configuration = $this->dm->getConfiguration();
+        if (! $configuration->isNativeLazyObjectEnabled() && ! $configuration->isLazyGhostObjectEnabled()) {
+            $this->markTestSkipped('Read-only properties are not supported by the legacy Proxy Manager. https://github.com/FriendsOfPHP/proxy-manager-lts/issues/26');
+        }
+
+        $document           = new ReadOnlyProperties('Test Name');
+        $document->onlyRead = new ReadOnlyProperties('Nested Name');
+        $this->dm->persist($document);
+        $this->dm->persist($document->onlyRead);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $document = $this->dm->getRepository(ReadOnlyProperties::class)->find($document->id);
+        $this->assertEquals('Test Name', $document->name);
+        $this->assertEquals('Nested Name', $document->onlyRead->name);
+    }
+}
+
+#[Document]
+class ReadOnlyProperties
+{
+    #[Id]
+    public readonly string $id; // @phpstan-ignore property.uninitializedReadonly (initialized by reflection)
+
+    #[Field]
+    public readonly string $name;
+
+    #[ReferenceOne(targetDocument: self::class)]
+    public ?self $onlyRead;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Tests/Mapping/AnnotationDriverTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\Persistence\Mapping\Driver\FileClassLocator;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 
 use function call_user_func;
 use function class_exists;
@@ -19,6 +21,7 @@ use function sprintf;
 
 use const E_USER_DEPRECATED;
 
+#[RequiresMethod(AnnotationReader::class, '__construct')]
 class AnnotationDriverTest extends AbstractAnnotationDriverTestCase
 {
     protected static function loadDriver(array $paths = []): MappingDriver

--- a/tests/Tests/Mapping/LegacyReflectionFieldsTest.php
+++ b/tests/Tests/Mapping/LegacyReflectionFieldsTest.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Mapping;
 
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Field;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Id;
 use Doctrine\ODM\MongoDB\Mapping\LegacyReflectionFields;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Address;
-use Documents\Tag;
 use Documents\User;
 use LogicException;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+
+use function sprintf;
 
 #[IgnoreDeprecations]
 class LegacyReflectionFieldsTest extends BaseTestCase
@@ -56,20 +60,33 @@ class LegacyReflectionFieldsTest extends BaseTestCase
 
     public function testGetSetReadonly(): void
     {
-        $class = $this->dm->getClassMetadata(Tag::class);
+        $class = $this->dm->getClassMetadata(ReadOnlyProperty::class);
         self::assertInstanceOf(LegacyReflectionFields::class, $class->reflFields);
 
-        $tag = new Tag('Important');
+        $tag = new ReadOnlyProperty('Important');
         $this->dm->persist($tag);
         $this->dm->flush();
 
-        $tag = $this->dm->find(Tag::class, $tag->id);
+        $tag = $this->dm->find(ReadOnlyProperty::class, $tag->id);
 
         // Accessing the readonly property through reflection
         self::assertEquals('Important', $class->getReflectionProperty('name')->getValue($tag));
 
         self::expectException(LogicException::class);
-        self::expectExceptionMessage('Attempting to change readonly property Documents\Tag::$name');
+        self::expectExceptionMessage(sprintf('Attempting to change readonly property %s::$name', ReadOnlyProperty::class));
         $class->getReflectionProperty('name')->setValue($tag, 'Very Important');
+    }
+}
+
+#[Document]
+class ReadOnlyProperty
+{
+    #[Id]
+    public string $id;
+
+    public function __construct(
+        #[Field]
+        public readonly string $name,
+    ) {
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

#### Summary

- Fix initialization of proxies when hydrating collection with ProxyManager (bug fix).
- Fix unsetting native lazy object config to not enable symfony lazy ghost objects (bug fix)
- Add a CI job without optional dependencies to ensure they are not required.
- Create test with read-only properties with lazy-objects. Not supported by ProxyManager https://github.com/FriendsOfPHP/proxy-manager-lts/issues/26
