### PR TITLE
Fix `useLazyGhostObject` option is `false` when `useNativeLazyObject` is `true`

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -337,6 +337,10 @@ class Configuration
      */
     public function getAutoGenerateProxyClasses(): int
     {
+        if ($this->nativeLazyObject) {
+            return self::AUTOGENERATE_NEVER;
+        }
+
         return $this->attributes['autoGenerateProxyClasses'] ?? self::AUTOGENERATE_FILE_NOT_EXISTS;
     }
 
@@ -708,7 +712,7 @@ class Configuration
 
     public function isLazyGhostObjectEnabled(): bool
     {
-        return $this->lazyGhostObject;
+        return $this->lazyGhostObject && ! $this->nativeLazyObject;
     }
 
     public function setUseNativeLazyObject(bool $nativeLazyObject): void
@@ -718,7 +722,6 @@ class Configuration
         }
 
         $this->nativeLazyObject = $nativeLazyObject;
-        $this->lazyGhostObject  = ! $nativeLazyObject || $this->lazyGhostObject;
     }
 
     public function isNativeLazyObjectEnabled(): bool

--- a/tests/Tests/ConfigurationTest.php
+++ b/tests/Tests/ConfigurationTest.php
@@ -31,6 +31,20 @@ class ConfigurationTest extends TestCase
         $c->setUseNativeLazyObject(true);
     }
 
+    #[RequiresPhp('>= 8.4')]
+    public function testUseNativeLazyObjectPriorityOverLazyGhost(): void
+    {
+        $c = new Configuration();
+
+        $c->setUseLazyGhostObject(true);
+        $c->setUseNativeLazyObject(true);
+
+        self::assertTrue($c->isNativeLazyObjectEnabled());
+        self::assertFalse($c->isLazyGhostObjectEnabled());
+
+        self::assertSame(Configuration::AUTOGENERATE_NEVER, $c->getAutoGenerateProxyClasses());
+    }
+
     public function testUseLazyGhostObject(): void
     {
         $c = new Configuration();
@@ -42,7 +56,7 @@ class ConfigurationTest extends TestCase
         self::assertFalse($c->isLazyGhostObjectEnabled());
     }
 
-    public function testNativeLazyObjectDeprecatedByDefault(): void
+    public function testNativeLazyObjectDisabledByDefault(): void
     {
         $c = new Configuration();
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

We can't have both symfony lazy-ghost and native lazy objects enabled at the same time.
Also disable auto generate proxy classes.

