### PR TITLE
Remove support for partial `DocumentManager::clear()`

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -616,14 +616,9 @@ Define the ``EventTest`` class with a ``onClear()`` method:
     {
         public function onClear(\Doctrine\ODM\MongoDB\Event\OnClearEventArgs $eventArgs): void
         {
-            $class = $eventArgs->getDocumentClass();
             $dm = $eventArgs->getDocumentManager();
             $uow = $dm->getUnitOfWork();
 
-            // Check if event clears all documents.
-            if ($eventArgs->clearsAllDocuments()) {
-                // do something
-            }
             // do something
         }
     }

--- a/src/DocumentManager.php
+++ b/src/DocumentManager.php
@@ -41,7 +41,6 @@ use function gettype;
 use function is_object;
 use function ltrim;
 use function sprintf;
-use function trigger_deprecation;
 
 /**
  * The DocumentManager class is the central access point for managing the
@@ -696,21 +695,10 @@ class DocumentManager implements ObjectManager
      *
      * All documents that are currently managed by this DocumentManager become
      * detached.
-     *
-     * @param string|null $objectName if given, only documents of this type will get detached
      */
-    public function clear($objectName = null): void
+    public function clear(): void
     {
-        if ($objectName !== null) {
-            trigger_deprecation(
-                'doctrine/mongodb-odm',
-                '2.4',
-                'Calling %s() with any arguments to clear specific documents is deprecated and will not be supported in Doctrine ODM 3.0.',
-                __METHOD__,
-            );
-        }
-
-        $this->unitOfWork->clear($objectName);
+        $this->unitOfWork->clear();
     }
 
     /**

--- a/src/Event/OnClearEventArgs.php
+++ b/src/Event/OnClearEventArgs.php
@@ -7,10 +7,6 @@ namespace Doctrine\ODM\MongoDB\Event;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\Persistence\Event\OnClearEventArgs as BaseOnClearEventArgs;
 
-use function func_num_args;
-use function method_exists;
-use function trigger_deprecation;
-
 /**
  * Provides event arguments for the onClear event.
  *
@@ -18,109 +14,8 @@ use function trigger_deprecation;
  */
 final class OnClearEventArgs extends BaseOnClearEventArgs
 {
-    /**
-     * @deprecated
-     *
-     * @var class-string|null
-     */
-    private ?string $entityClass;
-
-    /** @param class-string|null $entityClass */
-    public function __construct($objectManager, $entityClass = null)
-    {
-        if (method_exists(parent::class, 'getEntityClass') && $entityClass !== null) {
-            parent::__construct($objectManager, $entityClass);
-        } else {
-            if (func_num_args() > 1) {
-                trigger_deprecation(
-                    'doctrine/mongodb-odm',
-                    '2.4',
-                    'Passing $entityClass argument to %s::%s() is deprecated and will not be supported in Doctrine ODM 3.0.',
-                    self::class,
-                    __METHOD__,
-                );
-            }
-
-            parent::__construct($objectManager);
-        }
-
-        $this->entityClass = $entityClass;
-    }
-
     public function getDocumentManager(): DocumentManager
     {
         return $this->getObjectManager();
-    }
-
-    /**
-     * @deprecated no replacement planned
-     *
-     * @return class-string|null
-     */
-    public function getDocumentClass(): ?string
-    {
-        trigger_deprecation(
-            'doctrine/mongodb-odm',
-            '2.4',
-            'Calling %s() is deprecated and will not be supported in Doctrine ODM 3.0.',
-            __METHOD__,
-        );
-
-        return $this->entityClass;
-    }
-
-    /**
-     * Returns whether this event clears all documents.
-     *
-     * @deprecated no replacement planned
-     */
-    public function clearsAllDocuments(): bool
-    {
-        trigger_deprecation(
-            'doctrine/mongodb-odm',
-            '2.4',
-            'Calling %s() is deprecated and will not be supported in Doctrine ODM 3.0.',
-            __METHOD__,
-        );
-
-        return $this->entityClass !== null;
-    }
-
-    /** @deprecated no replacement planned */
-    public function clearsAllEntities(): bool
-    {
-        if (method_exists(parent::class, 'clearsAllEntities')) {
-            return parent::clearsAllEntities();
-        }
-
-        trigger_deprecation(
-            'doctrine/mongodb-odm',
-            '2.4',
-            'Calling %s() is deprecated and will not be supported in Doctrine ODM 3.0.',
-            __METHOD__,
-        );
-
-        return $this->entityClass !== null;
-    }
-
-    /**
-     * @deprecated no replacement planned
-     *
-     * @return class-string|null
-     */
-    public function getEntityClass(): ?string
-    {
-        if (method_exists(parent::class, 'getEntityClass')) {
-            return parent::getEntityClass();
-        }
-
-        trigger_deprecation(
-            'doctrine/mongodb-odm',
-            '2.4',
-            'Calling %s() is deprecated and will not be supported in Doctrine ODM 3.0.',
-            __METHOD__,
-        );
-
-        return $this->entityClass;
     }
 }

--- a/src/Repository/DocumentRepository.php
+++ b/src/Repository/DocumentRepository.php
@@ -23,7 +23,6 @@ use Doctrine\Persistence\ObjectRepository;
 use function assert;
 use function count;
 use function is_array;
-use function trigger_deprecation;
 
 /**
  * A DocumentRepository serves as a repository for documents with generic as well as
@@ -80,23 +79,6 @@ class DocumentRepository implements ObjectRepository, Selectable
     public function createAggregationBuilder(): AggregationBuilder
     {
         return $this->dm->createAggregationBuilder($this->documentName);
-    }
-
-    /**
-     * Clears the repository, causing all managed documents to become detached.
-     *
-     * @deprecated Deprecated in 2.6, will be removed in 3.0
-     */
-    public function clear(): void
-    {
-        trigger_deprecation(
-            'doctrine/mongodb-odm',
-            '2.6',
-            'The %s() method is deprecated and will be removed in Doctrine ODM 3.0.',
-            __METHOD__,
-        );
-
-        $this->dm->clear($this->class->rootDocumentName);
     }
 
     /**

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -2399,41 +2399,26 @@ final class UnitOfWork implements PropertyChangedListener
      *
      * @internal
      */
-    public function clear(?string $documentName = null): void
+    public function clear(): void
     {
-        if ($documentName === null) {
-            $this->identityMap                  =
-            $this->documentIdentifiers          =
-            $this->originalDocumentData         =
-            $this->documentChangeSets           =
-            $this->documentStates               =
-            $this->scheduledForSynchronization  =
-            $this->scheduledDocumentInsertions  =
-            $this->scheduledDocumentUpserts     =
-            $this->scheduledDocumentUpdates     =
-            $this->scheduledDocumentDeletions   =
-            $this->scheduledCollectionUpdates   =
-            $this->scheduledCollectionDeletions =
-            $this->parentAssociations           =
-            $this->embeddedDocumentsRegistry    =
-            $this->orphanRemovals               =
-            $this->hasScheduledCollections      = [];
+        $this->identityMap                  =
+        $this->documentIdentifiers          =
+        $this->originalDocumentData         =
+        $this->documentChangeSets           =
+        $this->documentStates               =
+        $this->scheduledForSynchronization  =
+        $this->scheduledDocumentInsertions  =
+        $this->scheduledDocumentUpserts     =
+        $this->scheduledDocumentUpdates     =
+        $this->scheduledDocumentDeletions   =
+        $this->scheduledCollectionUpdates   =
+        $this->scheduledCollectionDeletions =
+        $this->parentAssociations           =
+        $this->embeddedDocumentsRegistry    =
+        $this->orphanRemovals               =
+        $this->hasScheduledCollections      = [];
 
-            $event = new Event\OnClearEventArgs($this->dm);
-        } else {
-            $visited = [];
-            foreach ($this->identityMap as $className => $documents) {
-                if ($className !== $documentName) {
-                    continue;
-                }
-
-                foreach ($documents as $document) {
-                    $this->doDetach($document, $visited);
-                }
-            }
-
-            $event = new Event\OnClearEventArgs($this->dm, $documentName);
-        }
+        $event = new Event\OnClearEventArgs($this->dm);
 
         $this->evm->dispatchEvent(Events::onClear, $event);
     }

--- a/tests/Tests/Functional/SplObjectHashCollisionsTest.php
+++ b/tests/Tests/Functional/SplObjectHashCollisionsTest.php
@@ -9,7 +9,6 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use ReflectionObject;
 
 class SplObjectHashCollisionsTest extends BaseTestCase
@@ -66,17 +65,6 @@ class SplObjectHashCollisionsTest extends BaseTestCase
                 1,
             ],
         ];
-    }
-
-    #[IgnoreDeprecations]
-    public function testParentAssociationsLeftoverPartialClear(): void
-    {
-        $this->testParentAssociationsLeftover(
-            static function (DocumentManager $dm): void {
-                $dm->clear(SplColDoc::class);
-            },
-            1,
-        );
     }
 
     private function expectCount(string $prop, int $expected): void

--- a/tests/Tests/UnitOfWorkTest.php
+++ b/tests/Tests/UnitOfWorkTest.php
@@ -29,7 +29,6 @@ use MongoDB\Collection as MongoDBCollection;
 use MongoDB\Driver\WriteConcern;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use ReflectionProperty;
 use Throwable;
 
@@ -39,20 +38,6 @@ use function sprintf;
 
 class UnitOfWorkTest extends BaseTestCase
 {
-    /** Clear by class name is deprecated */
-    #[IgnoreDeprecations]
-    public function testPartialClear(): void
-    {
-        $user   = new ForumUser();
-        $avatar = new ForumAvatar();
-        $this->uow->persist($avatar);
-        $this->uow->persist($user);
-
-        $this->uow->clear(ForumUser::class);
-        self::assertFalse($this->uow->isScheduledForInsert($user));
-        self::assertTrue($this->uow->isScheduledForInsert($avatar));
-    }
-
     public function testIsDocumentScheduled(): void
     {
         $class = $this->dm->getClassMetadata(ForumUser::class);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | yes
| Fixed issues | 

#### Summary

Use `DocumentManager::detach($document)` instead.