### PR TITLE
Deprecate `ClassMetadata::isIdGeneratorUuid()`

### DIFF
--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -2170,9 +2170,13 @@ use const PHP_VERSION_ID;
 
     /**
      * Checks whether the class will generate a uuid id.
+     *
+     * @deprecated Since 2.15, the UUID id generator is deprecated. Use GENERATOR_TYPE_AUTO with the UUID type instead.
      */
     public function isIdGeneratorUuid(): bool
     {
+        trigger_deprecation('doctrine/mongodb-odm', '2.15', 'The method %s() is deprecated. Use GENERATOR_TYPE_AUTO with the UUID type instead.', __FUNCTION__);
+
         return $this->generatorType === self::GENERATOR_TYPE_UUID;
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

Since https://github.com/doctrine/mongodb-odm/pull/2826, the string UUID generator is deprecated, and the constant `ClassMetadata::GENERATOR_TYPE_UUID` is also deprecated.
The method that uses this method need to be deprecated too.