### PR TITLE
[3.x] Move symfony/var-dumper to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0",
-        "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0",
         "symfony/var-exporter": "^6.2 || ^7.0"
     },
     "require-dev": {
@@ -53,14 +52,16 @@
         "phpunit/phpunit": "^10.5.58",
         "squizlabs/php_codesniffer": "^4",
         "symfony/cache": "^5.4 || ^6.0 || ^7.0",
-        "symfony/uid": "^5.4 || ^6.0 || ^7.0"
+        "symfony/uid": "^5.4 || ^6.0 || ^7.0",
+        "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0"
     },
     "conflict": {
         "doctrine/annotations": "<1.12 || >=3.0"
     },
     "suggest": {
         "doctrine/annotations": "For annotation mapping support",
-        "ext-bcmath": "Decimal128 type support"
+        "ext-bcmath": "Decimal128 type support",
+        "symfony/var-dumper": "To enable the odm:query command"
     },
     "autoload": {
         "psr-4": { "Doctrine\\ODM\\MongoDB\\": "src" }

--- a/src/Tools/Console/Command/QueryCommand.php
+++ b/src/Tools/Console/Command/QueryCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 
 use function assert;
+use function class_exists;
 use function is_numeric;
 use function is_string;
 use function json_decode;
@@ -107,5 +108,10 @@ EOT
         }
 
         return 0;
+    }
+
+    public function isEnabled(): bool
+    {
+        return class_exists(VarCloner::class);
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | Fix https://github.com/doctrine/mongodb-odm/issues/2448

#### Summary

Enable the `odm:query` command only when the VarDumper component is installed.
Removed it from required dependencies.

Use `Command::isEnabled()` to conditionally enable the `odm:query` command when the dependency is available.