### PR TITLE
Fix documentation sidebar

### DIFF
--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -5,7 +5,7 @@
    :depth: 3
    :glob:
 
-   tutorials/*
+   tutorials/getting-started
 
 .. toctree::
    :caption: Reference
@@ -53,4 +53,14 @@
    :depth: 3
    :glob:
 
-   cookbook/*
+   cookbook/blending-orm-and-mongodb-odm
+   cookbook/implementing-array-access-for-domain-objects
+   cookbook/implementing-the-notify-changetracking-policy
+   cookbook/lookup-reference
+   cookbook/mapping-classes-to-orm-and-odm
+   cookbook/queryable-encryption
+   cookbook/resolve-target-document-listener
+   cookbook/simple-search-engine
+   cookbook/time-series-data
+   cookbook/validation-of-documents
+   cookbook/vector-search


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

#### Summary

The links need to be added explicitly, the `/*` notation does not work anymore.
I think the issue was introduced by https://github.com/doctrine/mongodb-odm/pull/2849

https://www.doctrine-project.org/projects/doctrine-mongodb-odm/en/latest/cookbook/queryable-encryption.html
