### PR TITLE
Upgrade to PHPUnit 11 for PHP >= 8.2 and check deprecation messages

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -190,7 +190,10 @@ jobs:
           topology: ${{ matrix.topology }}
 
       - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit --exclude-group=atlas ${{ matrix.dependencies == 'lowest' && '--do-not-fail-on-deprecation --do-not-fail-on-warning --do-not-fail-on-notice' || '' }}"
+        run: |
+          vendor/bin/phpunit --exclude-group=atlas \
+          ${{ matrix.dependencies == 'lowest' && '--do-not-fail-on-deprecation --do-not-fail-on-warning --do-not-fail-on-notice' || '' }} \
+          ${{ matrix.proxy == 'native' && matrix.dependencies != 'lowest' && '--do-not-fail-on-deprecation' || '' }}
         env:
           DOCTRINE_MONGODB_SERVER: ${{ steps.setup-mongodb.outputs.cluster-uri }}
           USE_LAZY_GHOST_OBJECT: ${{ matrix.proxy == 'lazy-ghost' && '1' || '0' }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -190,10 +190,7 @@ jobs:
           topology: ${{ matrix.topology }}
 
       - name: "Run PHPUnit"
-        run: |
-          vendor/bin/phpunit --exclude-group=atlas \
-          ${{ matrix.dependencies == 'lowest' && '--do-not-fail-on-deprecation --do-not-fail-on-warning --do-not-fail-on-notice' || '' }} \
-          ${{ matrix.proxy == 'native' && matrix.dependencies != 'lowest' && '--do-not-fail-on-deprecation' || '' }}
+        run: vendor/bin/phpunit --exclude-group=atlas ${{ matrix.dependencies == 'lowest' && '--do-not-fail-on-deprecation --do-not-fail-on-warning --do-not-fail-on-notice' || '' }}
         env:
           DOCTRINE_MONGODB_SERVER: ${{ steps.setup-mongodb.outputs.cluster-uri }}
           USE_LAZY_GHOST_OBJECT: ${{ matrix.proxy == 'lazy-ghost' && '1' || '0' }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -190,7 +190,7 @@ jobs:
           topology: ${{ matrix.topology }}
 
       - name: "Run PHPUnit"
-        run: vendor/bin/phpunit --exclude-group=atlas ${{ matrix.dependencies == 'lowest' && '--do-not-fail-on-deprecation --do-not-fail-on-warning --do-not-fail-on-notice' || '' }}
+        run: "vendor/bin/phpunit --exclude-group=atlas ${{ matrix.dependencies == 'lowest' && '--do-not-fail-on-deprecation --do-not-fail-on-warning --do-not-fail-on-notice' || '' }}"
         env:
           DOCTRINE_MONGODB_SERVER: ${{ steps.setup-mongodb.outputs.cluster-uri }}
           USE_LAZY_GHOST_OBJECT: ${{ matrix.proxy == 'lazy-ghost' && '1' || '0' }}

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
-        "phpunit/phpunit": "^10.5.58",
+        "phpunit/phpunit": "^10.5.58|^11.5.43",
         "squizlabs/php_codesniffer": "^4",
         "symfony/cache": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/uid": "^5.4 || ^6.0 || ^7.0 || ^8.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
         bootstrap="tests/bootstrap.php"
         cacheDirectory=".phpunit.cache"
         displayDetailsOnAllIssues="true"

--- a/src/Proxy/Factory/LazyGhostProxyFactory.php
+++ b/src/Proxy/Factory/LazyGhostProxyFactory.php
@@ -28,10 +28,8 @@ use function dirname;
 use function file_exists;
 use function file_put_contents;
 use function filemtime;
-use function get_debug_type;
 use function is_dir;
 use function is_int;
-use function is_scalar;
 use function is_writable;
 use function ltrim;
 use function mkdir;
@@ -115,7 +113,7 @@ EOPHP;
         }
 
         if (is_int($autoGenerate) && ($autoGenerate < 0 || $autoGenerate > 4)) {
-            throw new InvalidArgumentException(sprintf('Invalid auto generate mode "%s" given.', is_scalar($autoGenerate) ? (string) $autoGenerate : get_debug_type($autoGenerate)));
+            throw new InvalidArgumentException(sprintf('Invalid auto generate mode "%d" given.', $autoGenerate));
         }
 
         $this->uow                   = $dm->getUnitOfWork();

--- a/tests/Tests/BaseTestCase.php
+++ b/tests/Tests/BaseTestCase.php
@@ -105,12 +105,11 @@ abstract class BaseTestCase extends TestCase
         $config->setPersistentCollectionNamespace('PersistentCollections');
         $config->setDefaultDB(DOCTRINE_MONGODB_DATABASE);
         $config->setMetadataDriverImpl(static::createMetadataDriverImpl());
-        if ($_ENV['USE_LAZY_GHOST_OBJECT']) {
-            $config->setUseLazyGhostObject(true);
-        }
 
         if ($_ENV['USE_NATIVE_LAZY_OBJECT']) {
             $config->setUseNativeLazyObject(true);
+        } elseif ($_ENV['USE_LAZY_GHOST_OBJECT']) {
+            $config->setUseLazyGhostObject(true);
         }
 
         if ($config->isNativeLazyObjectEnabled()) {

--- a/tests/Tests/ConfigurationTest.php
+++ b/tests/Tests/ConfigurationTest.php
@@ -11,6 +11,7 @@ use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionFactory;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionGenerator;
 use LogicException;
 use MongoDB\Driver\Manager;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
@@ -37,6 +38,7 @@ class ConfigurationTest extends TestCase
         $c->setUseNativeLazyObject(true);
     }
 
+    #[IgnoreDeprecations]
     public function testUseLazyGhostObject(): void
     {
         $c = new Configuration();
@@ -74,6 +76,7 @@ class ConfigurationTest extends TestCase
         $c->setUseLazyGhostObject(true);
     }
 
+    #[IgnoreDeprecations]
     public function testNativeLazyObjectDeprecatedByDefault(): void
     {
         $c = new Configuration();

--- a/tests/Tests/Functional/CustomTypeTest.php
+++ b/tests/Tests/Functional/CustomTypeTest.php
@@ -47,7 +47,7 @@ class CustomTypeTest extends BaseTestCase
 
         $country = $this->dm->find(Country::class, $country->id);
 
-        self::assertContainsOnly('DateTime', $country->nationalHolidays);
+        self::assertContainsOnlyInstancesOf(DateTime::class, $country->nationalHolidays);
     }
 
     public function testConvertToDatabaseValueExpectsArray(): void

--- a/tests/Tests/Functional/ShardKeyTest.php
+++ b/tests/Tests/Functional/ShardKeyTest.php
@@ -35,7 +35,9 @@ class ShardKeyTest extends BaseTestCase
 
     public function tearDown(): void
     {
-        $this->logger->unregister();
+        if (isset($this->logger)) {
+            $this->logger->unregister();
+        }
 
         parent::tearDown();
     }

--- a/tests/Tests/Functional/TargetDocumentTest.php
+++ b/tests/Tests/Functional/TargetDocumentTest.php
@@ -7,11 +7,12 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use stdClass;
 
 class TargetDocumentTest extends BaseTestCase
 {
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testMappedSuperClassAsTargetDocument(): void
     {
         $test            = new TargetDocumentTestDocument();

--- a/tests/Tests/Query/FilterCollectionTest.php
+++ b/tests/Tests/Query/FilterCollectionTest.php
@@ -22,7 +22,7 @@ class FilterCollectionTest extends BaseTestCase
 
         $enabledFilters = $filterCollection->getEnabledFilters();
         self::assertCount(1, $enabledFilters);
-        self::assertContainsOnly(BsonFilter::class, $enabledFilters);
+        self::assertContainsOnlyInstancesOf(BsonFilter::class, $enabledFilters);
 
         $filterCollection->disable('testFilter');
         self::assertEmpty($filterCollection->getEnabledFilters());

--- a/tests/Tests/QueryTest.php
+++ b/tests/Tests/QueryTest.php
@@ -508,7 +508,7 @@ class QueryTest extends BaseTestCase
         $collection->expects($this->once())
             ->method('find')
             ->with(['foo' => 'bar'], ['hint' => 'foo'])
-            ->will($this->returnValue($cursor));
+            ->willReturn($cursor);
 
         // Using QueryBuilder->find adds hint to the query array
         $queryArray = [


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

In order to test deprecation messages, we must use PHPUnit 9 with Symfony bridge or PHPUnit 11+.

This PR enable PHPUnit 11 with PHP 8.2+ (and [keep 10 for PHP 8.1](https://phpunit.de/supported-versions.html)).

We have to ignore deprecation when Symfony lazy ghost are enabled, because the trait is deprecated.
