### PR TITLE
Update .doctrine-project.json for 2.15

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -6,16 +6,21 @@
     "docsSlug": "doctrine-mongodb-odm",
     "versions": [
         {
-            "name": "2.15",
-            "branchName": "2.15.x",
+            "name": "2.16",
+            "branchName": "2.16.x",
             "slug": "latest",
             "upcoming": true
         },
         {
-            "name": "2.14",
-            "branchName": "2.14.x",
-            "slug": "2.14",
+            "name": "2.15",
+            "branchName": "2.15.x",
+            "slug": "2.15",
             "current": true
+        },
+        {
+            "name": "2.14",
+            "slug": "2.14",
+            "maintained": false
         },
         {
             "name": "2.13",

--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -67,12 +67,6 @@
             "name": "2.6",
             "slug": "2.6",
             "maintained": false
-        },
-        {
-            "name": "1.3",
-            "branchName": "1.3.x",
-            "slug": "1.3",
-            "maintained": false
         }
     ]
 }

--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -6,6 +6,12 @@
     "docsSlug": "doctrine-mongodb-odm",
     "versions": [
         {
+            "name": "3.0",
+            "branchName": "3.0.x",
+            "slug": "3.0",
+            "upcoming": true
+        },
+        {
             "name": "2.16",
             "branchName": "2.16.x",
             "slug": "latest",
@@ -63,54 +69,9 @@
             "maintained": false
         },
         {
-            "name": "2.5",
-            "slug": "2.5",
-            "maintained": false
-        },
-        {
-            "name": "2.4",
-            "slug": "2.4",
-            "maintained": false
-        },
-        {
-            "name": "2.3",
-            "slug": "2.3",
-            "maintained": false
-        },
-        {
-            "name": "2.2",
-            "slug": "2.2",
-            "maintained": false
-        },
-        {
-            "name": "2.1",
-            "slug": "2.1",
-            "maintained": false
-        },
-        {
-            "name": "2.0",
-            "slug": "2.0",
-            "maintained": false
-        },
-        {
             "name": "1.3",
             "branchName": "1.3.x",
             "slug": "1.3",
-            "maintained": false
-        },
-        {
-            "name": "1.2",
-            "slug": "1.2",
-            "maintained": false
-        },
-        {
-            "name": "1.1",
-            "slug": "1.1",
-            "maintained": false
-        },
-        {
-            "name": "1.0",
-            "slug": "1.0",
             "maintained": false
         }
     ]


### PR DESCRIPTION
- Update the current branch to `2.15`
- Add version `3.0` as work as started.
- Remove all versions older than 2 years

Reason:
> - Algolia has no unlimitied space for indices and creating indices
> - Some newer versions got rst fixes that are missing in older versions (because unmaintained and upmerge PITA) that cause at least warnings/notices during the build
> - We can remove quick-fixes or centralized solutions in the website code at some point that were done because of older project version docs