### PR TITLE
Deprecate `Configuration::getProxyDir` and `setProxyDir`

### DIFF
--- a/UPGRADE-2.16.md
+++ b/UPGRADE-2.16.md
@@ -1,0 +1,10 @@
+# UPGRADE FROM 2.15 to 2.16
+
+## Lazy Proxy Directory
+
+Using proxy classes with PHP 8.4+ is deprecated, only native lazy objects will
+be supported in MongoDB ODM 3.0.
+
+Calling `Doctrine\ODM\MongoDB\Configuration::setProxyDir()` or
+`Doctrine\ODM\MongoDB\Configuration::getProxyDir()` is deprecated and triggers
+a deprecation notice when using native lazy objects.

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -316,6 +316,8 @@ class Configuration
 
     /**
      * Sets the directory where Doctrine generates any necessary proxy class files.
+     *
+     * @deprecated Since 2.16, proxy directory is no longer used when native lazy objects are enabled.
      */
     public function setProxyDir(string $dir): void
     {
@@ -325,9 +327,15 @@ class Configuration
 
     /**
      * Gets the directory where Doctrine generates any necessary proxy class files.
+     *
+     * @deprecated Since 2.16, proxy directory is no longer used when native lazy objects are enabled.
      */
     public function getProxyDir(): ?string
     {
+        if ($this->isNativeLazyObjectEnabled()) {
+            trigger_deprecation('doctrine/mongodb-odm', '2.16', 'Using "%s" is deprecated when native lazy objects are enabled.', __METHOD__);
+        }
+
         return $this->attributes['proxyDir'] ?? null;
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

The proxy dir is not used when native lazy objects are used. Trigger the deprecation only when it's enabled.
