### PR TITLE
[BC break] Move `doctrine/cache` to optional dependencies

### DIFF
--- a/UPGRADE-2.16.md
+++ b/UPGRADE-2.16.md
@@ -1,5 +1,11 @@
 # UPGRADE FROM 2.15 to 2.16
 
+## Package `doctrine/cache` no longer required
+
+If you use `Doctrine\ODM\MongoDB\Configuration::getMetadataCacheImpl()`,
+then you need to require `doctrine/cache` explicitly in `composer.json`;
+or use `Doctrine\ODM\MongoDB\Configuration::getMetadataCache()` instead.
+
 ## Lazy Proxy Directory
 
 Using proxy classes with PHP 8.4+ is deprecated, only native lazy objects will

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     "require": {
         "php": "^8.1",
         "ext-mongodb": "^1.21 || ^2.0",
-        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.5 || ^2.0",
         "doctrine/event-manager": "^1.0 || ^2.0",
         "doctrine/instantiator": "^1.1 || ^2",
@@ -45,6 +44,7 @@
     "require-dev": {
         "ext-bcmath": "*",
         "doctrine/annotations": "^1.12 || ^2.0",
+        "doctrine/cache": "^2.0",
         "doctrine/coding-standard": "^14.0",
         "doctrine/orm": "^3.2",
         "jmikola/geojson": "^1.0",
@@ -58,7 +58,9 @@
         "symfony/uid": "^5.4 || ^6.0 || ^7.0 || ^8.0"
     },
     "conflict": {
-        "doctrine/annotations": "<1.12 || >=3.0"
+        "doctrine/annotations": "<1.12 || >=3.0",
+        "doctrine/cache": "<1.11",
+        "doctrine/mongodb-odm-bundle": "<5"
     },
     "suggest": {
         "doctrine/annotations": "For annotation mapping support",

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -276,8 +276,13 @@ class Configuration
         return $this->attributes['metadataDriverImpl'] ?? null;
     }
 
+    /** @deprecated Since 2.2, use {@see getMetadataCache()} instead. */
     public function getMetadataCacheImpl(): ?Cache
     {
+        if (! class_exists(DoctrineProvider::class)) {
+            throw new LogicException('The "doctrine/cache" package is deprecated and no longer required by "doctrine/mongodb-odm". Use "getMetadataCache" instead.');
+        }
+
         trigger_deprecation(
             'doctrine/mongodb-odm',
             '2.2',
@@ -289,6 +294,7 @@ class Configuration
         return $this->attributes['metadataCacheImpl'] ?? null;
     }
 
+    /** @deprecated Since 2.2, use {@see setMetadataCache()} instead. */
     public function setMetadataCacheImpl(Cache $cacheImpl): void
     {
         trigger_deprecation(
@@ -310,7 +316,12 @@ class Configuration
 
     public function setMetadataCache(CacheItemPoolInterface $cache): void
     {
-        $this->metadataCache                   = $cache;
+        $this->metadataCache = $cache;
+
+        if (! class_exists(DoctrineProvider::class)) {
+            return;
+        }
+
         $this->attributes['metadataCacheImpl'] = DoctrineProvider::wrap($cache);
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | https://github.com/doctrine/mongodb-odm/issues/2762#issuecomment-3385826776

#### Summary

`doctrine/cache` is deprecated and archived.

Motivation for introducing a breaking change:
- When installing `doctrine/mongodb-odm` with composer, you get a message even if `doctrine/cache` is not actively used.
> Package doctrine/cache is abandoned, you should avoid using it. No replacement was suggested.
- The next major version will require PHP 8.4.

This is a breaking change only when calling `Configuration::getMetadataCacheImpl()`. The workaround is easy: add `doctrine/cache` as project dependency.

I consider projects that use `doctrine/cache` directly without explicitly requiring the package to be in error.

That's why I'm adding a conflict with `doctrine/mongodb-odm-bundle < 5`, which did not have an explicit dependency but used the `Doctrine\Common\Cache` classes:
https://github.com/doctrine/DoctrineMongoDBBundle/blob/48c29009c24ff74c47782c0c9c2736f1f5fd9b0e/DependencyInjection/DoctrineMongoDBExtension.php#L14-L15