### PR TITLE
[Deprecation] PHP 8.5 - Avoid null array index

### DIFF
--- a/src/Persisters/DocumentPersister.php
+++ b/src/Persisters/DocumentPersister.php
@@ -994,7 +994,7 @@ final class DocumentPersister
      */
     public function addDiscriminatorToPreparedQuery(array $preparedQuery): array
     {
-        if (isset($preparedQuery[$this->class->discriminatorField]) || $this->class->discriminatorField === null) {
+        if ($this->class->discriminatorField === null || isset($preparedQuery[$this->class->discriminatorField])) {
             return $preparedQuery;
         }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

Avoids accessing an array using null index which triggers deprecation in PHP 8.5
