### PR TITLE
Update benchmark configuration

### DIFF
--- a/benchmark/BaseBench.php
+++ b/benchmark/BaseBench.php
@@ -17,6 +17,8 @@ use function getenv;
 use function in_array;
 use function iterator_to_array;
 
+use const PHP_VERSION_ID;
+
 /** @BeforeMethods({"initDocumentManager", "clearDatabase"}) */
 abstract class BaseBench
 {
@@ -44,6 +46,12 @@ abstract class BaseBench
         $config->setDefaultDB(self::DATABASE_NAME);
         $config->setMetadataDriverImpl(self::createMetadataDriverImpl());
         $config->setMetadataCache(new ArrayAdapter());
+
+        if (PHP_VERSION_ID >= 80400) {
+            $config->setUseNativeLazyObject(true);
+        } else {
+            $config->setUseLazyGhostObject(true);
+        }
 
         $client = new Client(
             getenv('DOCTRINE_MONGODB_SERVER') ?: self::DEFAULT_MONGODB_SERVER,

--- a/benchmark/Document/HydrateDocumentBench.php
+++ b/benchmark/Document/HydrateDocumentBench.php
@@ -9,10 +9,10 @@ use Doctrine\ODM\MongoDB\Hydrator\HydratorInterface;
 use Documents\User;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
-use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
-use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Warmup;
 
-/** @BeforeMethods({"init"}, extend=true) */
+#[BeforeMethods(['init'])]
 final class HydrateDocumentBench extends BaseBench
 {
     /** @var array<string, mixed> */
@@ -78,31 +78,31 @@ final class HydrateDocumentBench extends BaseBench
             ->getHydratorFor(User::class);
     }
 
-    /** @Warmup(2) */
+    #[Warmup(2)]
     public function benchHydrateDocument(): void
     {
         self::$hydrator->hydrate(new User(), self::$data);
     }
 
-    /** @Warmup(2) */
+    #[Warmup(2)]
     public function benchHydrateDocumentWithEmbedOne(): void
     {
         self::$hydrator->hydrate(new User(), self::$data + self::$embedOneData);
     }
 
-    /** @Warmup(2) */
+    #[Warmup(2)]
     public function benchHydrateDocumentWithEmbedMany(): void
     {
         self::$hydrator->hydrate(new User(), self::$data + self::$embedManyData);
     }
 
-    /** @Warmup(2) */
+    #[Warmup(2)]
     public function benchHydrateDocumentWithReferenceOne(): void
     {
         self::$hydrator->hydrate(new User(), self::$data + self::$referenceOneData);
     }
 
-    /** @Warmup(2) */
+    #[Warmup(2)]
     public function benchHydrateDocumentWithReferenceMany(): void
     {
         self::$hydrator->hydrate(new User(), self::$data + self::$referenceManyData);

--- a/benchmark/Document/LoadDocumentBench.php
+++ b/benchmark/Document/LoadDocumentBench.php
@@ -12,12 +12,12 @@ use Documents\Group;
 use Documents\Phonenumber;
 use Documents\User;
 use MongoDB\BSON\ObjectId;
-use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
-use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Warmup;
 
 use function assert;
 
-/** @BeforeMethods({"init"}, extend=true) */
+#[BeforeMethods(['init'])]
 final class LoadDocumentBench extends BaseBench
 {
     /** @var ObjectId */
@@ -53,19 +53,19 @@ final class LoadDocumentBench extends BaseBench
         $this->getDocumentManager()->clear();
     }
 
-    /** @Warmup(2) */
+    #[Warmup(2)]
     public function benchLoadDocument(): void
     {
         $this->loadDocument();
     }
 
-    /** @Warmup(2) */
+    #[Warmup(2)]
     public function benchLoadEmbedOne(): void
     {
         $this->loadDocument()->getAddress()->getCity();
     }
 
-    /** @Warmup(2) */
+    #[Warmup(2)]
     public function benchLoadEmbedMany(): void
     {
         $this->loadDocument()->getPhonenumbers()->forAll(static function (int $key, Phonenumber $element) {
@@ -73,13 +73,13 @@ final class LoadDocumentBench extends BaseBench
         });
     }
 
-    /** @Warmup(2) */
+    #[Warmup(2)]
     public function benchLoadReferenceOne(): void
     {
         $this->loadDocument()->getAccount()->getName();
     }
 
-    /** @Warmup(2) */
+    #[Warmup(2)]
     public function benchLoadReferenceMany(): void
     {
         $this->loadDocument()->getGroups()->forAll(static function (int $key, Group $group) {

--- a/benchmark/Document/StoreDocumentBench.php
+++ b/benchmark/Document/StoreDocumentBench.php
@@ -11,11 +11,11 @@ use Documents\Address;
 use Documents\Group;
 use Documents\Phonenumber;
 use Documents\User;
-use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+use PhpBench\Attributes\Warmup;
 
 final class StoreDocumentBench extends BaseBench
 {
-    /** @Warmup(2) */
+    #[Warmup(2)]
     public function benchStoreDocument(): void
     {
         $user = new User();
@@ -27,7 +27,7 @@ final class StoreDocumentBench extends BaseBench
         $this->getDocumentManager()->clear();
     }
 
-    /** @Warmup(2) */
+    #[Warmup(2)]
     public function benchStoreDocumentWithEmbedOne(): void
     {
         $address = new Address();
@@ -44,7 +44,7 @@ final class StoreDocumentBench extends BaseBench
         $this->getDocumentManager()->clear();
     }
 
-    /** @Warmup(2) */
+    #[Warmup(2)]
     public function benchStoreDocumentWithEmbedMany(): void
     {
         $user = new User();
@@ -58,7 +58,7 @@ final class StoreDocumentBench extends BaseBench
         $this->getDocumentManager()->clear();
     }
 
-    /** @Warmup(2) */
+    #[Warmup(2)]
     public function benchStoreDocumentWithReferenceOne(): void
     {
         $account = new Account();
@@ -74,7 +74,7 @@ final class StoreDocumentBench extends BaseBench
         $this->getDocumentManager()->clear();
     }
 
-    /** @Warmup(2) */
+    #[Warmup(2)]
     public function benchStoreDocumentWithReferenceMany(): void
     {
         $group1 = new Group('One');

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "doctrine/coding-standard": "^14.0",
         "doctrine/orm": "^3.2",
         "jmikola/geojson": "^1.0",
-        "phpbench/phpbench": "^1.0.0",
+        "phpbench/phpbench": "^1.4.0",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | task
| BC Break     | no
| Fixed issues | -

#### Summary

- Fix proxy configuration to use native lazy objects on PHP 8.4, to avoid deprecation message.
- Replace phpbench annotations with [attributes](https://phpbench.readthedocs.io/en/latest/annotributes.html).

