### PR TITLE
Skip native lazy object initialization for unmapped properties

### DIFF
--- a/docs/en/cookbook/lookup-reference.rst
+++ b/docs/en/cookbook/lookup-reference.rst
@@ -14,6 +14,12 @@ need the referenced documents, you can use the ``$lookup`` stage in MongoDB's
 aggregation pipeline. It's similar to a SQL join, without duplication of data in
 the result set when there is many references to load.
 
+.. note::
+
+    Lazy loading of references only occurs when accessing an uninitialized mapped property.
+    If you access a property that is not mapped in Doctrine, that will not trigger
+    loading of the referenced document.
+
 Example setup
 -------------
 

--- a/src/Proxy/Factory/NativeLazyObjectFactory.php
+++ b/src/Proxy/Factory/NativeLazyObjectFactory.php
@@ -12,8 +12,10 @@ use Doctrine\ODM\MongoDB\Utility\LifecycleEventManager;
 use Doctrine\Persistence\NotifyPropertyChanged;
 use LogicException;
 use ReflectionClass;
+use ReflectionProperty;
 use WeakMap;
 
+use function array_key_exists;
 use function count;
 
 use const PHP_VERSION_ID;
@@ -26,6 +28,9 @@ class NativeLazyObjectFactory implements ProxyFactory
 
     private readonly UnitOfWork $unitOfWork;
     private readonly LifecycleEventManager $lifecycleEventManager;
+
+    /** @var array<class-string, ReflectionProperty[]> */
+    private array $skippedProperties = [];
 
     public function __construct(
         DocumentManager $documentManager,
@@ -68,11 +73,38 @@ class NativeLazyObjectFactory implements ProxyFactory
 
         $metadata->propertyAccessors[$metadata->identifier]->setValue($proxy, $identifier);
 
+        foreach ($this->getSkippedProperties($metadata) as $property) {
+            $property->skipLazyInitialization($proxy);
+        }
+
         if (isset(self::$lazyObjects)) {
             self::$lazyObjects[$proxy] = true;
         }
 
         return $proxy;
+    }
+
+    /** @return ReflectionProperty[] */
+    private function getSkippedProperties(ClassMetadata $metadata): array
+    {
+        if (isset($this->skippedProperties[$metadata->name])) {
+            return $this->skippedProperties[$metadata->name];
+        }
+
+        $skippedProperties = [];
+        foreach ($metadata->reflClass->getProperties() as $property) {
+            if (array_key_exists($property->name, $metadata->propertyAccessors)) {
+                continue;
+            }
+
+            if ($property->isVirtual()) {
+                continue;
+            }
+
+            $skippedProperties[] = $property;
+        }
+
+        return $this->skippedProperties[$metadata->name] = $skippedProperties;
     }
 
     /** @internal Only for tests */

--- a/tests/Documents/DocumentWithUnmappedProperties.php
+++ b/tests/Documents/DocumentWithUnmappedProperties.php
@@ -4,14 +4,18 @@ declare(strict_types=1);
 
 namespace Documents;
 
-use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
-use Doctrine\ODM\MongoDB\Mapping\Annotations\Id;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
-#[Document]
+#[ODM\Document]
 class DocumentWithUnmappedProperties
 {
-    #[Id]
+    #[ODM\Id]
     public string $id;
 
     public string $foo = 'bar';
+
+    // We need at least one mapped field to avoid the native lazy object to be
+    // switched to "initialized" state immediately after setting all its properties.
+    #[ODM\Field]
+    public string $mappedField;
 }

--- a/tests/Tests/Functional/ReferencesTest.php
+++ b/tests/Tests/Functional/ReferencesTest.php
@@ -15,6 +15,7 @@ use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Account;
 use Documents\Address;
+use Documents\DocumentWithUnmappedProperties;
 use Documents\Group;
 use Documents\Phonenumber;
 use Documents\Profile;
@@ -28,6 +29,15 @@ use function assert;
 
 class ReferencesTest extends BaseTestCase
 {
+    public function testSkipInitializationForUnmappedProperties(): void
+    {
+        $loadedDocument = $this->dm->getReference(DocumentWithUnmappedProperties::class, '123');
+        $this->assertInstanceOf(DocumentWithUnmappedProperties::class, $loadedDocument);
+
+        // Accessing unmapped property should not initialize the document
+        self::assertSame('bar', $loadedDocument->foo);
+    }
+
     public function testManyDeleteReference(): void
     {
         $user = new User();

--- a/tests/Tests/Functional/ReferencesTest.php
+++ b/tests/Tests/Functional/ReferencesTest.php
@@ -34,8 +34,8 @@ class ReferencesTest extends BaseTestCase
         $loadedDocument = $this->dm->getReference(DocumentWithUnmappedProperties::class, '123');
         $this->assertInstanceOf(DocumentWithUnmappedProperties::class, $loadedDocument);
 
-        // Accessing unmapped property should not initialize the document
         self::assertSame('bar', $loadedDocument->foo);
+        self::assertTrue($this->dm->isUninitializedObject($loadedDocument));
     }
 
     public function testManyDeleteReference(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes-ish (see https://github.com/doctrine/mongodb-odm/issues/2916)
| Fixed issues | -

#### Summary

Re-implement https://github.com/doctrine/mongodb-odm/pull/2698 for native lazy objects.

Using the method [`ReflectionProperty::skipLazyInitialization`](https://www.php.net/manual/en/reflectionproperty.skiplazyinitialization.php), accessing properties that are not mapped in Doctrine will not initialize the document object.
