### PR TITLE
Add `onReference` event when a new lazy object reference is created

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -159,6 +159,13 @@ the life-time of their registered documents.
    document has been loaded into the current DocumentManager from the
    database or after the refresh operation has been applied to it.
 -
+   ``onReference`` - The onReference event occurs when a lazy document reference
+   is created. The data of the document are not loaded yet at this point; if
+   you access any mapped field of the document, a database query will be
+   triggered to load the document data. Which defeats the purpose of using
+   lazy references in the first place.
+   This can be used to inject dependencies into unmapped properties.
+-
    ``loadClassMetadata`` - The loadClassMetadata event occurs after the
    mapping metadata for a class has been loaded from a mapping source
    (attributes/xml).

--- a/src/Events.php
+++ b/src/Events.php
@@ -87,6 +87,18 @@ final class Events
     public const postLoad = 'postLoad';
 
     /**
+     * The onReference event occurs when a lazy document reference is created.
+     *
+     * Note that the data of the document are not loaded yet at this point; if
+     * you access any mapped field of the document, a database query will be
+     * triggered to load the document data. Which defeats the purpose of using
+     * lazy references in the first place.
+     *
+     * This is a document lifecycle event.
+     */
+    public const onReference = 'onReference';
+
+    /**
      * The loadClassMetadata event occurs after the mapping metadata for a class
      * has been loaded from a mapping source (annotations/xml).
      */

--- a/src/Proxy/Factory/LazyGhostProxyFactory.php
+++ b/src/Proxy/Factory/LazyGhostProxyFactory.php
@@ -230,18 +230,20 @@ EOPHP;
             $reflector = $reflector->getParentClass();
         }
 
-        $className       = $class->getName(); // aliases and case sensitivity
-        $entityPersister = $this->uow->getDocumentPersister($className);
-        $initializer     = $this->createLazyInitializer($class, $entityPersister);
-        $proxyClassName  = $this->loadProxyClass($class);
+        $className             = $class->getName(); // aliases and case sensitivity
+        $entityPersister       = $this->uow->getDocumentPersister($className);
+        $initializer           = $this->createLazyInitializer($class, $entityPersister);
+        $proxyClassName        = $this->loadProxyClass($class);
+        $lifecycleEventManager = $this->lifecycleEventManager;
 
-        $proxyFactory = Closure::bind(static function (mixed $identifier) use ($initializer, $skippedProperties, $class): InternalProxy {
+        $proxyFactory = Closure::bind(static function (mixed $identifier) use ($initializer, $skippedProperties, $class, $lifecycleEventManager): InternalProxy {
             /** @see LazyGhostTrait::createLazyGhost() */
             $proxy = static::createLazyGhost(static function (InternalProxy $object) use ($initializer, $identifier): void {
                 $initializer($object, $identifier);
             }, $skippedProperties);
 
             $class->setIdentifierValue($proxy, $identifier);
+            $lifecycleEventManager->onReference($proxy);
 
             return $proxy;
         }, null, $proxyClassName);

--- a/src/Proxy/Factory/NativeLazyObjectFactory.php
+++ b/src/Proxy/Factory/NativeLazyObjectFactory.php
@@ -72,6 +72,8 @@ class NativeLazyObjectFactory implements ProxyFactory
             self::$lazyObjects[$proxy] = true;
         }
 
+        $this->lifecycleEventManager->onReference($proxy);
+
         return $proxy;
     }
 

--- a/src/Proxy/Factory/StaticProxyFactory.php
+++ b/src/Proxy/Factory/StaticProxyFactory.php
@@ -61,6 +61,7 @@ final class StaticProxyFactory implements ProxyFactory
             );
 
         $metadata->setIdentifierValue($ghostObject, $identifier);
+        $this->lifecycleEventManager->onReference($ghostObject);
 
         return $ghostObject;
     }

--- a/src/Utility/LifecycleEventManager.php
+++ b/src/Utility/LifecycleEventManager.php
@@ -134,6 +134,11 @@ final class LifecycleEventManager
         $this->cascadePostUpdate($class, $document, $session);
     }
 
+    public function onReference(object $document): void
+    {
+        $this->evm->dispatchEvent(Events::onReference, new LifecycleEventArgs($document, $this->dm));
+    }
+
     /**
      * Invokes prePersist callbacks and events for given document.
      *

--- a/tests/Tests/Events/OnReferenceEvent.php
+++ b/tests/Tests/Events/OnReferenceEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Events;
+
+use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
+use Doctrine\ODM\MongoDB\Events;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\User;
+
+class OnReferenceEvent extends BaseTestCase
+{
+    public function testOnReferenceEventIsDispatchedByGetReference(): void
+    {
+        $this->dm->getEventManager()->addEventListener(Events::onReference, $listener = new class {
+            public object $eventArgs;
+
+            public function onReference($eventArgs): void
+            {
+                $this->eventArgs = $eventArgs;
+            }
+        });
+
+        $this->dm->getReference(User::class, '123456789012345678901234');
+
+        self::assertTrue(isset($listener->eventArgs), 'onReference event was not dispatched');
+        self::assertInstanceOf(LifecycleEventArgs::class, $listener->eventArgs);
+        self::assertInstanceOf(User::class, $listener->eventArgs->getObject());
+        self::assertTrue($this->dm->isUninitializedObject($listener->eventArgs->getObject()));
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | Fix https://github.com/doctrine/mongodb-odm/issues/2916

#### Summary

This feature enable the injection of dependencies into lazy documents, even if they are not loaded.

I am willing to discuss whether this feature is a good idea.