### PR TITLE
[3.x] Remove chained method `Stage::search()` as the `$search` stage must be the first of the pipeline

### DIFF
--- a/src/Aggregation/Stage.php
+++ b/src/Aggregation/Stage.php
@@ -6,8 +6,6 @@ namespace Doctrine\ODM\MongoDB\Aggregation;
 
 use GeoJson\Geometry\Point;
 
-use function trigger_deprecation;
-
 /**
  * Fluent interface for building aggregation pipelines.
  *
@@ -341,21 +339,6 @@ abstract class Stage
     public function sample(int $size): Stage\Sample
     {
         return $this->builder->sample($size);
-    }
-
-    /**
-     * The $search stage performs a full-text search on the specified field or
-     * fields which must be covered by an Atlas Search index.
-     *
-     * @deprecated Since doctrine/mongodb-odm 2.13. This $search stage must be the first of the pipeline, use Builder::search() instead.
-     *
-     * @see https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#mongodb-pipeline-pipe.-search
-     */
-    public function search(): Stage\Search
-    {
-        trigger_deprecation('doctrine/mongodb-odm', '2.13', 'Using "%s" is deprecated because the $search stage must be the first of the pipeline, use "%s::search()" instead.', __METHOD__, Builder::class);
-
-        return $this->builder->search();
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | https://github.com/doctrine/mongodb-odm/pull/2823



