### PR TITLE
Replace annotations with attributes in the doc

### DIFF
--- a/docs/en/cookbook/lookup-reference.rst
+++ b/docs/en/cookbook/lookup-reference.rst
@@ -2,7 +2,7 @@ Loading references with Lookup
 ==============================
 
 Doctrine ODM provides a way to load reference documents from other collections
-using the ``#[ReferenceOne]`` and ``#[ReferenceMany]`` annotations. This is
+using the ``#[ReferenceOne]`` and ``#[ReferenceMany]`` attributes. This is
 perfect to keep independent document updates and avoid data duplication. But
 sometimes you need to load the referenced documents with the main document in a
 single query. This is where MongoDB's aggregation pipeline and the ``$lookup``

--- a/docs/en/cookbook/vector-search.rst
+++ b/docs/en/cookbook/vector-search.rst
@@ -176,7 +176,7 @@ Notes
 - Vector embeddings should be generated using a reliable embedding system
 - The vector field must be of type ``float[]``, ``int[]`` or ``bool[]``, it
   must match with the embedding vector type and dimensions.
-- The ``#[VectorSearchIndex]`` annotation configures the index for vector search
+- The ``#[VectorSearchIndex]`` attribute configures the index for vector search
 - Use the aggregation builder's ``vectorSearch`` stage to query for similar vectors.
 - Doctrine ODM 2.13+ is required for vector search support.
 

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -21,7 +21,7 @@ Change the metadata driver configuration to use the ``AttributeDriver``:
     - $config->setMetadataDriverImpl(AnnotationsDriver::create(__DIR__ . '/Documents'));
     + $config->setMetadataDriverImpl(AttributeDriver::create(__DIR__ . '/Documents'));
 
-Replace the ``@ORM\Document`` annotations with the ``#[ORM\Document]`` attribute.
+Replace the ``@ODM\Document`` annotations with the ``#[ODM\Document]`` attribute.
 
 .. code-block:: diff
 
@@ -30,19 +30,19 @@ Replace the ``@ORM\Document`` annotations with the ``#[ORM\Document]`` attribute
     - /**
     -  * @ODM\Document
     -  */
-    + #[ORM\Document]
+    + #[ODM\Document]
     class User
     {
     -    /**
-    -     * @ORM\Id
+    -     * @ODM\Id
     -     */
-    +     #[ORM\Id]
+    +     #[ODM\Id]
         public string $id;
 
     -    /**
-    -     * @ORM\Column(type="string")
+    -     * @ODM\Field(type="string")
     -     */
-    +     #[ORM\Column(type: "string")]
+    +     #[ODM\Field(type: "string")]
         public string $name;
     }
 

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -11,7 +11,7 @@ Mapping Drivers
 Doctrine provides several different ways for specifying object
 document mapping metadata:
 
--  `Attributes <annotations-reference>`_
+-  `Attributes <attributes-reference>`_
 -  `XML <xml-mapping>`_
 -  Raw PHP Code
 

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -75,7 +75,7 @@ To make the above classes persistent, we need to provide Doctrine with some
 mapping information so that it knows how to consume the objects and persist
 them to the database.
 
-You can provide your mapping information in Annotations or XML:
+You can provide your mapping information in Attribute or XML:
 
 .. configuration-block::
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | documentation
| BC Break     | no
| Fixed issues | -

#### Summary

- Replace 'annotation' with 'attribute' in the docs
- Fix migration guide to apply to ODM instead of ORM
