### PR TITLE
Run tests with Symfony 7.4 by default

### DIFF
--- a/.github/workflows/atlas-ci.yml
+++ b/.github/workflows/atlas-ci.yml
@@ -16,13 +16,13 @@ jobs:
         php-version:
           - "8.4"
         symfony-version:
-          - false
+          - ""
         proxy:
           - "native"
         include:
           # Test with LazyGhostObject
           - php-version: "8.2"
-            symfony-version: false
+            symfony-version: ""
             proxy: "lazy-ghost"
             os: "ubuntu-latest"
           # Test with ProxyManager

--- a/.github/workflows/atlas-ci.yml
+++ b/.github/workflows/atlas-ci.yml
@@ -15,19 +15,19 @@ jobs:
       matrix:
         php-version:
           - "8.4"
-        symfony:
+        symfony-version:
           - false
         proxy:
           - "native"
         include:
           # Test with LazyGhostObject
           - php-version: "8.2"
-            symfony: false
+            symfony-version: false
             proxy: "lazy-ghost"
             os: "ubuntu-latest"
           # Test with ProxyManager
           - php-version: "8.1"
-            symfony: "6.4"
+            symfony-version: "6.4"
             proxy: "proxy-manager"
             os: "ubuntu-latest"
 
@@ -70,7 +70,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: "pecl"
+          tools: "flex"
           extensions: "mongodb, bcmath"
           coverage: "none"
           ini-values: "zend.assertions=1"
@@ -82,20 +82,13 @@ jobs:
       - name: "Remove phpbench/phpbench"
         run: composer remove --no-update --dev phpbench/phpbench
 
-      - name: "Configure Symfony ${{ matrix.symfony }}"
-        if: "${{ matrix.symfony != 'stable' }}"
-        run: |
-          composer config minimum-stability dev
-          # update symfony deps
-          composer require --no-update symfony/console:^${{ matrix.symfony }}
-          composer require --no-update symfony/var-dumper:^${{ matrix.symfony }}
-          composer require --no-update --dev symfony/cache:^${{ matrix.symfony }}
-
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "highest"
           composer-options: "--prefer-dist"
+        env:
+          SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
 
       - name: "Run PHPUnit with Atlas Local"
         run: "vendor/bin/phpunit --group atlas"

--- a/.github/workflows/atlas-ci.yml
+++ b/.github/workflows/atlas-ci.yml
@@ -16,13 +16,13 @@ jobs:
         php-version:
           - "8.4"
         symfony:
-          - "stable"
+          - false
         proxy:
           - "native"
         include:
           # Test with LazyGhostObject
           - php-version: "8.2"
-            symfony: "7.4"
+            symfony: false
             proxy: "lazy-ghost"
             os: "ubuntu-latest"
           # Test with ProxyManager

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -116,7 +116,7 @@ jobs:
 #            mongodb-version: "6.0"
 #            driver-version: "stable"
 #            dependencies: "highest"
-#            symfony-version: "
+#            symfony-version: ""
 #            proxy: "lazy-ghost"
 
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -147,6 +147,7 @@ jobs:
           extensions: "mongodb-${{ matrix.driver-version }}, bcmath"
           coverage: "none"
           ini-values: "zend.assertions=1"
+          tools: "flex"
 
       - name: "Show driver information"
         run: "php --ri mongodb"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,7 +44,7 @@ jobs:
             mongodb-version: "6.0"
             driver-version: "1.21.0"
             topology: "server"
-            symfony-version: false
+            symfony-version: ""
             proxy: "lazy-ghost"
           # Test with Symfony 6.4
           - topology: "server"
@@ -60,7 +60,7 @@ jobs:
             mongodb-version: "6.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: false
+            symfony-version: ""
             proxy: "lazy-ghost"
           # Test with a 8.0 replica set
           - topology: "replica_set"
@@ -68,21 +68,21 @@ jobs:
             mongodb-version: "8.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: false
+            symfony-version: ""
             proxy: "lazy-ghost"
           # Test with ProxyManager
           - php-version: "8.2"
             mongodb-version: "6.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: false
+            symfony-version: ""
             proxy: "proxy-manager"
           # Test with Native Lazy Objects
           - php-version: "8.4"
             mongodb-version: "8.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: false
+            symfony-version: ""
             proxy: "native"
           # Test with extension 1.21
           - topology: "server"
@@ -90,7 +90,7 @@ jobs:
             mongodb-version: "8.0"
             driver-version: "1.21.0"
             dependencies: "highest"
-            symfony-version: false
+            symfony-version: ""
             proxy: "lazy-ghost"
           # Test with Symfony 8
           - topology: "server"
@@ -98,7 +98,7 @@ jobs:
             mongodb-version: "8.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: false
+            symfony-version: ""
             proxy: "native"
           # Test removing optional dependencies
           - topology: "server"
@@ -106,7 +106,7 @@ jobs:
             mongodb-version: "8.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: false
+            symfony-version: ""
             proxy: "native"
             remove-optional-dependencies: true
           # Test with a sharded cluster
@@ -116,7 +116,7 @@ jobs:
 #            mongodb-version: "6.0"
 #            driver-version: "stable"
 #            dependencies: "highest"
-#            symfony-version: false
+#            symfony-version: "
 #            proxy: "lazy-ghost"
 
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "8.1"
           - "8.2"
           - "8.3"
           - "8.4"
@@ -35,7 +34,7 @@ jobs:
         dependencies:
           - "highest"
         symfony-version:
-          - "locked"
+          - "7.4"
         proxy:
           - "lazy-ghost"
         include:
@@ -45,7 +44,7 @@ jobs:
             mongodb-version: "6.0"
             driver-version: "1.21.0"
             topology: "server"
-            symfony-version: "locked"
+            symfony-version: false
             proxy: "lazy-ghost"
           # Test with Symfony 6.4
           - topology: "server"
@@ -61,7 +60,7 @@ jobs:
             mongodb-version: "6.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: "locked"
+            symfony-version: false
             proxy: "lazy-ghost"
           # Test with a 8.0 replica set
           - topology: "replica_set"
@@ -69,21 +68,21 @@ jobs:
             mongodb-version: "8.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: "locked"
+            symfony-version: false
             proxy: "lazy-ghost"
           # Test with ProxyManager
           - php-version: "8.2"
             mongodb-version: "6.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: "locked"
+            symfony-version: false
             proxy: "proxy-manager"
           # Test with Native Lazy Objects
           - php-version: "8.4"
             mongodb-version: "8.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: "locked"
+            symfony-version: false
             proxy: "native"
           # Test with extension 1.21
           - topology: "server"
@@ -91,15 +90,7 @@ jobs:
             mongodb-version: "8.0"
             driver-version: "1.21.0"
             dependencies: "highest"
-            symfony-version: "locked"
-            proxy: "lazy-ghost"
-          # Test with Symfony 7.4 LTS
-          - topology: "server"
-            php-version: "8.2"
-            mongodb-version: "8.0"
-            driver-version: "stable"
-            dependencies: "highest"
-            symfony-version: "7.4"
+            symfony-version: false
             proxy: "lazy-ghost"
           # Test with Symfony 8
           - topology: "server"
@@ -115,7 +106,7 @@ jobs:
             mongodb-version: "8.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: "locked"
+            symfony-version: false
             proxy: "native"
             remove-optional-dependencies: true
           # Test with a sharded cluster
@@ -125,7 +116,7 @@ jobs:
 #            mongodb-version: "6.0"
 #            driver-version: "stable"
 #            dependencies: "highest"
-#            symfony-version: "locked"
+#            symfony-version: false
 #            proxy: "lazy-ghost"
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/console": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0",
         "symfony/var-dumper": "^5.4 || ^6.4 || ^7.0 || ^8.0",
-        "symfony/var-exporter": "^6.4 || ^7.0 || ^8.0"
+        "symfony/var-exporter": "^6.4.1 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "ext-bcmath": "*",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -355,12 +355,6 @@ parameters:
 			path: src/Event/OnClearEventArgs.php
 
 		-
-			message: '#^Parameter \#1 \$initializer of method ProxyManager\\Proxy\\GhostObjectInterface\<object\>\:\:setProxyInitializer\(\) expects \(Closure\(ProxyManager\\Proxy\\GhostObjectInterface\<object\>\=, string\=, array\<string, mixed\>\=, Closure\|null\=, array\<string, mixed\>\=\)\: bool\)\|null, Closure\(ProxyManager\\Proxy\\GhostObjectInterface, string, array, mixed, array\)\: true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Hydrator/HydratorFactory.php
-
-		-
 			message: '#^Property Doctrine\\ODM\\MongoDB\\Hydrator\\HydratorFactory\:\:\$hydratorNamespace \(string\|null\) is never assigned null so it can be removed from the property type\.$#'
 			identifier: property.unusedType
 			count: 1
@@ -733,8 +727,8 @@ parameters:
 			path: src/Proxy/Factory/LazyGhostProxyFactory.php
 
 		-
-			message: '#^Call to function is_scalar\(\) with int\<min, \-1\>\|int\<5, max\> will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
+			message: '#^Call to an undefined static method Symfony\\Component\\VarExporter\\ProxyHelper\:\:generateLazyGhost\(\)\.$#'
+			identifier: staticMethod.notFound
 			count: 1
 			path: src/Proxy/Factory/LazyGhostProxyFactory.php
 
@@ -899,6 +893,12 @@ parameters:
 			identifier: argument.templateType
 			count: 3
 			path: src/Utility/LifecycleEventManager.php
+
+		-
+			message: '#^Method Documents\\Encryption\\Client\:\:__construct\(\) has parameter \$clientCards with generic interface Doctrine\\Common\\Collections\\Collection but does not specify its types\: TKey, T$#'
+			identifier: missingType.generics
+			count: 1
+			path: tests/Documents/Encryption/Client.php
 
 		-
 			message: '#^Parameter \#1 \$builder of method Doctrine\\ODM\\MongoDB\\Aggregation\\Stage\\Facet\:\:pipeline\(\) expects Doctrine\\ODM\\MongoDB\\Aggregation\\Builder\|Doctrine\\ODM\\MongoDB\\Aggregation\\Stage, stdClass given\.$#'
@@ -1241,9 +1241,3 @@ parameters:
 			identifier: staticMethod.impossibleType
 			count: 1
 			path: tests/Tests/Types/BinaryUuidTypeTest.php
-
-		-
-			message: '#^Method Documents\\Encryption\\Client\:\:__construct\(\) has parameter \$clientCards with generic interface Doctrine\\Common\\Collections\\Collection but does not specify its types\: TKey, T$#'
-			identifier: missingType.generics
-			count: 1
-			path: tests/Documents/Encryption/Client.php


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | ci
| BC Break     | no
| Fixed issues | -

#### Summary

Fix failing jobs with Symfony 8 and lazy-ghost objects, not supported in this version.
Updating to run tests on Symfony 7.4 by default, relying on additional jobs to run on Symfony 8 and native lazy objects.
