### PR TITLE
Add types for benchmarks

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         php-version:
           - "8.1"
+          - "8.4"
 
     services:
       mongodb:

--- a/benchmark/BaseBench.php
+++ b/benchmark/BaseBench.php
@@ -9,7 +9,6 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use MongoDB\Client;
 use MongoDB\Model\DatabaseInfo;
-use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 use function array_map;
@@ -19,14 +18,12 @@ use function iterator_to_array;
 
 use const PHP_VERSION_ID;
 
-/** @BeforeMethods({"initDocumentManager", "clearDatabase"}) */
 abstract class BaseBench
 {
     public const DATABASE_NAME           = 'doctrine_odm_performance';
     private const DEFAULT_MONGODB_SERVER = 'mongodb://localhost:27017';
 
-    /** @var DocumentManager */
-    protected static $documentManager;
+    protected static DocumentManager $documentManager;
 
     protected function getDocumentManager(): DocumentManager
     {

--- a/benchmark/Document/HydrateDocumentBench.php
+++ b/benchmark/Document/HydrateDocumentBench.php
@@ -12,26 +12,25 @@ use MongoDB\BSON\UTCDateTime;
 use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Warmup;
 
-#[BeforeMethods(['init'])]
+#[BeforeMethods(['initDocumentManager', 'clearDatabase', 'init'])]
 final class HydrateDocumentBench extends BaseBench
 {
     /** @var array<string, mixed> */
-    private static $data;
+    private static array $data;
 
     /** @var array<string, mixed> */
-    private static $embedOneData;
+    private static array $embedOneData;
 
     /** @var array<string, mixed[]> */
-    private static $embedManyData;
+    private static array $embedManyData;
 
     /** @var array<string, mixed[]> */
-    private static $referenceOneData;
+    private static array $referenceOneData;
 
     /** @var array<string, mixed[]> */
-    private static $referenceManyData;
+    private static array $referenceManyData;
 
-    /** @var HydratorInterface */
-    private static $hydrator;
+    private static HydratorInterface $hydrator;
 
     public function init(): void
     {

--- a/benchmark/Document/LoadDocumentBench.php
+++ b/benchmark/Document/LoadDocumentBench.php
@@ -17,11 +17,10 @@ use PhpBench\Attributes\Warmup;
 
 use function assert;
 
-#[BeforeMethods(['init'])]
+#[BeforeMethods(['initDocumentManager', 'clearDatabase', 'init'])]
 final class LoadDocumentBench extends BaseBench
 {
-    /** @var ObjectId */
-    private static $userId;
+    private static ObjectId $userId;
 
     public function init(): void
     {
@@ -87,8 +86,7 @@ final class LoadDocumentBench extends BaseBench
         });
     }
 
-    /** @return User */
-    private function loadDocument()
+    private function loadDocument(): User
     {
         $document = $this->getDocumentManager()->find(User::class, self::$userId);
         assert($document instanceof User);

--- a/benchmark/Document/StoreDocumentBench.php
+++ b/benchmark/Document/StoreDocumentBench.php
@@ -11,8 +11,10 @@ use Documents\Address;
 use Documents\Group;
 use Documents\Phonenumber;
 use Documents\User;
+use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Warmup;
 
+#[BeforeMethods(['initDocumentManager', 'clearDatabase'])]
 final class StoreDocumentBench extends BaseBench
 {
     #[Warmup(2)]


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no (internal classes only)
| Fixed issues | https://github.com/doctrine/mongodb-odm/pull/2945#discussion_r2575994038

#### Summary


Add missing types in Benchmarks and use `#[BeforeMethod]` attribute consistently.

>Important note here: I had to move #[BeforeMethods] only to the child classes as it appears that using PHP Attributes changes the order of execution of these methods when tagging both base and child classes - it previously executed parent first, now executes child first which breaks these benchmarks.
