### PR TITLE
[3.x] Remove `doctrine/cache` support

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -68,3 +68,15 @@ to retain the functionality.
 
 `Doctrine\ODM\MongoDB\Event\OnClearEventArgs`' methods `getDocumentClass` and 
 `clearsAllDocuments` have been removed.
+
+## Remove `doctrine/cache` dependency
+
+The `doctrine/cache` library is deprecated and archived, superseded by [PSR-6](https://www.php-fig.org/psr/psr-6/).
+The methods `Configuration::getMetadataCacheImpl()` and `Configuration::setMetadataCacheImpl()`
+have been removed in favor of `Configuration::getMetadataCache()` and
+`Configuration::setMetadataCache()`, respectively.
+
+```diff
+- $dm->getConfiguration()->getMetadataCacheImpl();
++ $dm->getConfiguration()->getMetadataCache();
+```

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "php": "^8.4",
         "ext-mongodb": "^2.1",
         "composer-runtime-api": "^2.0",
-        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/collections": "^1.5 || ^2.0",
         "doctrine/event-manager": "^1.0 || ^2.0",
         "doctrine/instantiator": "^1.1 || ^2",

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB;
 
 use Composer\InstalledVersions;
-use Doctrine\Common\Cache\Cache;
-use Doctrine\Common\Cache\Psr6\CacheAdapter;
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactoryInterface;
 use Doctrine\ODM\MongoDB\PersistentCollection\DefaultPersistentCollectionFactory;
@@ -122,7 +119,6 @@ class Configuration
      *      }>,
      *      hydratorDir?: string,
      *      hydratorNamespace?: string,
-     *      metadataCacheImpl?: Cache,
      *      metadataDriverImpl?: MappingDriver,
      *      persistentCollectionFactory?: PersistentCollectionFactory,
      *      persistentCollectionGenerator?: PersistentCollectionGenerator,
@@ -260,33 +256,6 @@ class Configuration
         return $this->attributes['metadataDriverImpl'] ?? null;
     }
 
-    public function getMetadataCacheImpl(): ?Cache
-    {
-        trigger_deprecation(
-            'doctrine/mongodb-odm',
-            '2.2',
-            'Using "%s" is deprecated. Please use "%s::getMetadataCache" instead.',
-            __METHOD__,
-            self::class,
-        );
-
-        return $this->attributes['metadataCacheImpl'] ?? null;
-    }
-
-    public function setMetadataCacheImpl(Cache $cacheImpl): void
-    {
-        trigger_deprecation(
-            'doctrine/mongodb-odm',
-            '2.2',
-            'Using "%s" is deprecated. Please use "%s::setMetadataCache" instead.',
-            __METHOD__,
-            self::class,
-        );
-
-        $this->attributes['metadataCacheImpl'] = $cacheImpl;
-        $this->metadataCache                   = CacheAdapter::wrap($cacheImpl);
-    }
-
     public function getMetadataCache(): ?CacheItemPoolInterface
     {
         return $this->metadataCache;
@@ -294,8 +263,7 @@ class Configuration
 
     public function setMetadataCache(CacheItemPoolInterface $cache): void
     {
-        $this->metadataCache                   = $cache;
-        $this->attributes['metadataCacheImpl'] = DoctrineProvider::wrap($cache);
+        $this->metadataCache = $cache;
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | https://github.com/doctrine/mongodb-odm/issues/2762

#### Summary

The archived package is not required since #2912
