### PR TITLE
Fix paths of generated files in benchmarks

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -63,4 +63,4 @@ jobs:
           path: composer.lock
 
       - name: "Run PHPBench"
-        run: "vendor/bin/phpbench run --report=default --revs=100 --iterations=5 --report=aggregate"
+        run: "vendor/bin/phpbench run --report=default --report=aggregate"

--- a/benchmark/BaseBench.php
+++ b/benchmark/BaseBench.php
@@ -34,11 +34,12 @@ abstract class BaseBench
     {
         $config = new Configuration();
 
-        $config->setProxyDir(__DIR__ . '/../../tests/Proxies');
+        $config->setProxyDir(__DIR__ . '/../tests/Proxies');
         $config->setProxyNamespace('Proxies');
-        $config->setHydratorDir(__DIR__ . '/../../tests/Hydrators');
+        $config->setHydratorDir(__DIR__ . '/../tests/Hydrators');
+        $config->setAutoGenerateHydratorClasses(Configuration::AUTOGENERATE_ALWAYS);
         $config->setHydratorNamespace('Hydrators');
-        $config->setPersistentCollectionDir(__DIR__ . '/../../tests/PersistentCollections');
+        $config->setPersistentCollectionDir(__DIR__ . '/../tests/PersistentCollections');
         $config->setPersistentCollectionNamespace('PersistentCollections');
         $config->setDefaultDB(self::DATABASE_NAME);
         $config->setMetadataDriverImpl(self::createMetadataDriverImpl());

--- a/benchmark/Document/HydrateDocumentBench.php
+++ b/benchmark/Document/HydrateDocumentBench.php
@@ -10,13 +10,21 @@ use Documents\User;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
 use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
 use PhpBench\Attributes\Warmup;
 
 #[BeforeMethods(['initDocumentManager', 'clearDatabase', 'init'])]
+#[Warmup(2)]
+#[Revs(100)]
+#[Iterations(5)]
 final class HydrateDocumentBench extends BaseBench
 {
     /** @var array<string, mixed> */
     private static array $data;
+
+    /** @var array<string, mixed> */
+    private static array $extraData;
 
     /** @var array<string, mixed> */
     private static array $embedOneData;
@@ -38,6 +46,17 @@ final class HydrateDocumentBench extends BaseBench
             '_id' => new ObjectId(),
             'username' => 'alcaeus',
             'createdAt' => new UTCDateTime(),
+        ];
+
+        self::$extraData = [
+            'hits' => 100,
+            'age' => 30,
+            'nullTest' => null,
+            'logs' => [
+                'User logged in',
+                'User updated profile',
+                'User logged out',
+            ],
         ];
 
         self::$embedOneData = [
@@ -77,31 +96,26 @@ final class HydrateDocumentBench extends BaseBench
             ->getHydratorFor(User::class);
     }
 
-    #[Warmup(2)]
     public function benchHydrateDocument(): void
     {
-        self::$hydrator->hydrate(new User(), self::$data);
+        self::$hydrator->hydrate(new User(), self::$data + self::$extraData);
     }
 
-    #[Warmup(2)]
     public function benchHydrateDocumentWithEmbedOne(): void
     {
         self::$hydrator->hydrate(new User(), self::$data + self::$embedOneData);
     }
 
-    #[Warmup(2)]
     public function benchHydrateDocumentWithEmbedMany(): void
     {
         self::$hydrator->hydrate(new User(), self::$data + self::$embedManyData);
     }
 
-    #[Warmup(2)]
     public function benchHydrateDocumentWithReferenceOne(): void
     {
         self::$hydrator->hydrate(new User(), self::$data + self::$referenceOneData);
     }
 
-    #[Warmup(2)]
     public function benchHydrateDocumentWithReferenceMany(): void
     {
         self::$hydrator->hydrate(new User(), self::$data + self::$referenceManyData);

--- a/benchmark/Document/LoadDocumentBench.php
+++ b/benchmark/Document/LoadDocumentBench.php
@@ -13,11 +13,16 @@ use Documents\Phonenumber;
 use Documents\User;
 use MongoDB\BSON\ObjectId;
 use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
 use PhpBench\Attributes\Warmup;
 
 use function assert;
 
 #[BeforeMethods(['initDocumentManager', 'clearDatabase', 'init'])]
+#[Warmup(2)]
+#[Revs(100)]
+#[Iterations(5)]
 final class LoadDocumentBench extends BaseBench
 {
     private static ObjectId $userId;
@@ -52,19 +57,16 @@ final class LoadDocumentBench extends BaseBench
         $this->getDocumentManager()->clear();
     }
 
-    #[Warmup(2)]
     public function benchLoadDocument(): void
     {
         $this->loadDocument();
     }
 
-    #[Warmup(2)]
     public function benchLoadEmbedOne(): void
     {
         $this->loadDocument()->getAddress()->getCity();
     }
 
-    #[Warmup(2)]
     public function benchLoadEmbedMany(): void
     {
         $this->loadDocument()->getPhonenumbers()->forAll(static function (int $key, Phonenumber $element) {
@@ -72,13 +74,11 @@ final class LoadDocumentBench extends BaseBench
         });
     }
 
-    #[Warmup(2)]
     public function benchLoadReferenceOne(): void
     {
         $this->loadDocument()->getAccount()->getName();
     }
 
-    #[Warmup(2)]
     public function benchLoadReferenceMany(): void
     {
         $this->loadDocument()->getGroups()->forAll(static function (int $key, Group $group) {

--- a/benchmark/Document/StoreDocumentBench.php
+++ b/benchmark/Document/StoreDocumentBench.php
@@ -12,12 +12,16 @@ use Documents\Group;
 use Documents\Phonenumber;
 use Documents\User;
 use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
 use PhpBench\Attributes\Warmup;
 
 #[BeforeMethods(['initDocumentManager', 'clearDatabase'])]
+#[Warmup(2)]
+#[Revs(100)]
+#[Iterations(5)]
 final class StoreDocumentBench extends BaseBench
 {
-    #[Warmup(2)]
     public function benchStoreDocument(): void
     {
         $user = new User();
@@ -29,7 +33,6 @@ final class StoreDocumentBench extends BaseBench
         $this->getDocumentManager()->clear();
     }
 
-    #[Warmup(2)]
     public function benchStoreDocumentWithEmbedOne(): void
     {
         $address = new Address();
@@ -46,7 +49,6 @@ final class StoreDocumentBench extends BaseBench
         $this->getDocumentManager()->clear();
     }
 
-    #[Warmup(2)]
     public function benchStoreDocumentWithEmbedMany(): void
     {
         $user = new User();
@@ -60,7 +62,6 @@ final class StoreDocumentBench extends BaseBench
         $this->getDocumentManager()->clear();
     }
 
-    #[Warmup(2)]
     public function benchStoreDocumentWithReferenceOne(): void
     {
         $account = new Account();
@@ -76,7 +77,6 @@ final class StoreDocumentBench extends BaseBench
         $this->getDocumentManager()->clear();
     }
 
-    #[Warmup(2)]
     public function benchStoreDocumentWithReferenceMany(): void
     {
         $group1 = new Group('One');


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

#### Summary

The proxy/hydrator/collection classes are generated in the parent of the project dir. The PR fix the config to use the same path in `tests` dir.

