### PR TITLE
Deprecate remaining namespace alias methods

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -198,6 +198,8 @@ class Configuration
 
     /**
      * Adds a namespace under a certain alias.
+     *
+     * @deprecated Document short aliases are deprecated - use ::class constant instead.
      */
     public function addDocumentNamespace(string $alias, string $namespace): void
     {
@@ -227,6 +229,8 @@ class Configuration
 
     /**
      * Retrieves the list of registered document namespace aliases.
+     *
+     * @deprecated Document short aliases are deprecated - use ::class constant instead.
      *
      * @return array<string, string>
      */

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -203,11 +203,20 @@ class Configuration
      */
     public function addDocumentNamespace(string $alias, string $namespace): void
     {
+        trigger_deprecation(
+            'doctrine/mongodb-odm',
+            '2.3',
+            'Document short namespace aliases such as "%s" are deprecated, use ::class constant instead.',
+            $alias,
+        );
+
         $this->attributes['documentNamespaces'][$alias] = $namespace;
     }
 
     /**
      * Resolves a registered namespace alias to the full namespace.
+     *
+     * @deprecated Document short aliases are deprecated - use ::class constant instead.
      *
      * @throws MongoDBException
      */
@@ -236,16 +245,30 @@ class Configuration
      */
     public function getDocumentNamespaces(): array
     {
+        trigger_deprecation(
+            'doctrine/mongodb-odm',
+            '2.3',
+            'Document short namespace aliases are deprecated, use ::class constant instead.',
+        );
+
         return $this->attributes['documentNamespaces'];
     }
 
     /**
      * Set the document alias map
      *
+     * @deprecated Document short aliases are deprecated - use ::class constant instead.
+     *
      * @param array<string, string> $documentNamespaces
      */
     public function setDocumentNamespaces(array $documentNamespaces): void
     {
+        trigger_deprecation(
+            'doctrine/mongodb-odm',
+            '2.3',
+            'Document short namespace aliases are deprecated, use ::class constant instead.',
+        );
+
         $this->attributes['documentNamespaces'] = $documentNamespaces;
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary


Adds deprecation notices for `addDocumentNamespace()` and `getDocumentNamespaces()` as this functionality is deprecated since 2.3. See https://github.com/doctrine/mongodb-odm/pull/2956#discussion_r2592707528
