### PR TITLE
Deprecate array syntax for discriminator field

### DIFF
--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -1140,9 +1140,14 @@ use const PHP_VERSION_ID;
             return;
         }
 
-        // @todo: deprecate, document and remove this:
         // Handle array argument with name/fieldName keys for BC
         if (is_array($discriminatorField)) {
+            trigger_deprecation(
+                'doctrine/mongodb-odm',
+                '2.16',
+                'Passing array to %s() is deprecated, pass string instead.',
+                __FUNCTION__,
+            );
             if (isset($discriminatorField['name'])) {
                 $discriminatorField = $discriminatorField['name'];
             } elseif (isset($discriminatorField['fieldName'])) {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Passing an array like `['fieldName' => 'discr']` allowed in the past to define the value in `name` or `fieldName` array index. However, since 2.3 `#[DiscriminatorField]` constructor is typed as `string`:
https://github.com/doctrine/mongodb-odm/blob/ffad107b16fd9bf64d06140a789bb6bdf3722ad2/src/Mapping/Annotations/DiscriminatorField.php#L22
and `XmlDriver` casts the value passed as `string` since 2.2:
https://github.com/doctrine/mongodb-odm/blob/ffad107b16fd9bf64d06140a789bb6bdf3722ad2/src/Mapping/Driver/XmlDriver.php#L185
so the only option to set it is by directly calling the `setDiscriminatorField()` method on the `ClassMetadata`.
