### PR TITLE
Deprecate not overriding `Type::closureToPHP()`

### DIFF
--- a/UPGRADE-2.16.md
+++ b/UPGRADE-2.16.md
@@ -14,3 +14,16 @@ be supported in MongoDB ODM 3.0.
 Calling `Doctrine\ODM\MongoDB\Configuration::setProxyDir()` or
 `Doctrine\ODM\MongoDB\Configuration::getProxyDir()` is deprecated and triggers
 a deprecation notice when using native lazy objects.
+
+## Override `Type::closureToPHP()` for custom type classes
+
+The default implementation of `Doctrine\ODM\MongoDB\Types\Type::closureToPHP()`
+will change in MongoDB ODM 3.0 to call `convertToPHPValue()`. If you have custom
+type classes, use the `Doctrine\ODM\MongoDB\Types\ClosureToPHP` trait or
+implement `closureToPHP()`.
+
+## Deprecate `Type::closureToMongo()`
+
+The method `Doctrine\ODM\MongoDB\Types\Type::closureToMongo()` is not used,
+and will be removed in MongoDB ODM 3.0. Don't call this method, but use
+`convertToDatabaseValue()` instead.

--- a/src/Types/ClosureToPHP.php
+++ b/src/Types/ClosureToPHP.php
@@ -6,6 +6,7 @@ namespace Doctrine\ODM\MongoDB\Types;
 
 use function sprintf;
 
+/** This trait will be deprecated in 3.0 as this behavior will be used by default */
 trait ClosureToPHP
 {
     /** @return string Redirects to the method convertToPHPValue from child class */

--- a/src/Types/CollectionType.php
+++ b/src/Types/CollectionType.php
@@ -29,4 +29,9 @@ class CollectionType extends Type
     {
         return $value !== null ? array_values($value) : null;
     }
+
+    public function closureToPHP(): string
+    {
+        return '$return = array_values($value);';
+    }
 }

--- a/src/Types/HashType.php
+++ b/src/Types/HashType.php
@@ -28,4 +28,9 @@ class HashType extends Type
     {
         return $value !== null ? (array) $value : null;
     }
+
+    public function closureToPHP(): string
+    {
+        return '$return = (array) $value;';
+    }
 }

--- a/src/Types/KeyType.php
+++ b/src/Types/KeyType.php
@@ -12,6 +12,8 @@ use MongoDB\BSON\MinKey;
  */
 class KeyType extends Type
 {
+    use ClosureToPHP;
+
     /** @return MinKey|MaxKey|null */
     public function convertToDatabaseValue($value)
     {

--- a/src/Types/TimestampType.php
+++ b/src/Types/TimestampType.php
@@ -14,6 +14,8 @@ use function substr;
  */
 class TimestampType extends Type
 {
+    use ClosureToPHP;
+
     /** @return Timestamp|null */
     public function convertToDatabaseValue($value)
     {

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -15,6 +15,7 @@ use function explode;
 use function gettype;
 use function is_object;
 use function str_replace;
+use function trigger_deprecation;
 
 /**
  * The Type interface.
@@ -129,18 +130,26 @@ abstract class Type
     /**
      * Get the PHP code equivalent to {@see convertToDatabaseValue()}, used in code generator.
      * Use variables $value for input and $return for output.
+     *
+     * @deprecated Since 2.16, will be removed in 3.0.
      */
     public function closureToMongo(): string
     {
+        trigger_deprecation('doctrine/mongodb-odm', '2.16', 'Type::closureToMongo() is deprecated and will be removed in 3.0.');
+
         return '$return = $value;';
     }
 
     /**
      * Get the PHP code equivalent to {@see convertToPHPValue()}, used in code generator.
      * Use variables $value for input and $return for output.
+     *
+     * @abstract The default implementation will change in 3.0.
      */
     public function closureToPHP(): string
     {
+        trigger_deprecation('doctrine/mongodb-odm', '2.16', 'The method Type::closureToPHP() will change its default implementation in 3.0 to use convertToPHPValue(). Override this method if you need custom behavior before upgrading to 3.0 or use the trait ClosureToPHP to get the upcoming behavior now.');
+
         return '$return = $value;';
     }
 

--- a/tests/Tests/CaptureDeprecationMessages.php
+++ b/tests/Tests/CaptureDeprecationMessages.php
@@ -16,9 +16,13 @@ trait CaptureDeprecationMessages
      * This method can be replaced with expectUserDeprecationMessage() in PHPUnit 11+.
      * https://docs.phpunit.de/en/11.1/error-handling.html#expecting-deprecations-e-user-deprecated
      *
-     * @param list<string> $errors
+     * @param callable(): T $callable
+     * @param list<string>  $errors
+     *
+     * @return T
      *
      * @param-out list<string> $errors
+     * @template T
      */
     private function captureDeprecationMessages(callable $callable, ?array &$errors): mixed
     {

--- a/tests/Tests/Functional/CustomTypeTest.php
+++ b/tests/Tests/Functional/CustomTypeTest.php
@@ -7,11 +7,11 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 use DateTime;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Doctrine\ODM\MongoDB\Tests\CaptureDeprecationMessages;
 use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Exception;
 use PHPUnit\Framework\Attributes\After;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use ReflectionProperty;
 
 use function array_map;
@@ -21,6 +21,8 @@ use function is_array;
 
 class CustomTypeTest extends BaseTestCase
 {
+    use CaptureDeprecationMessages;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -92,12 +94,14 @@ class CustomTypeTest extends BaseTestCase
         self::assertSame(['name' => 'French', 'code' => 'fr'], $databaseValue);
     }
 
-    #[IgnoreDeprecations]
     public function testNotOverridingClosureToPHPIsDeprecated(): void
     {
         $type = Type::getType('custom_type_without_closure_to_php');
 
-        self::assertSame('$return = $value;', $type->closureToPHP());
+        $code = $this->captureDeprecationMessages(static fn () => $type->closureToPHP(), $deprecations);
+
+        self::assertSame('$return = $value;', $code);
+        self::assertSame(['Since doctrine/mongodb-odm 2.16: The method Type::closureToPHP() will change its default implementation in 3.0 to use convertToPHPValue(). Override this method if you need custom behavior before upgrading to 3.0 or use the trait ClosureToPHP to get the upcoming behavior now.'], $deprecations);
     }
 }
 

--- a/tests/Tests/Functional/CustomTypeTest.php
+++ b/tests/Tests/Functional/CustomTypeTest.php
@@ -11,6 +11,7 @@ use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Exception;
 use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use ReflectionProperty;
 
 use function array_map;
@@ -26,6 +27,7 @@ class CustomTypeTest extends BaseTestCase
 
         Type::addType('date_collection', DateCollectionType::class);
         Type::addType(Language::class, LanguageType::class);
+        Type::addType('custom_type_without_closure_to_php', CustomTypeWithoutClosureToPHP::class);
     }
 
     #[After]
@@ -88,6 +90,14 @@ class CustomTypeTest extends BaseTestCase
 
         $databaseValue = Type::convertPHPToDatabaseValue($lang);
         self::assertSame(['name' => 'French', 'code' => 'fr'], $databaseValue);
+    }
+
+    #[IgnoreDeprecations]
+    public function testNotOverridingClosureToPHPIsDeprecated(): void
+    {
+        $type = Type::getType('custom_type_without_closure_to_php');
+
+        self::assertSame('$return = $value;', $type->closureToPHP());
     }
 }
 
@@ -197,4 +207,8 @@ class LanguageType extends Type
 
         return new Language($value['name'], $value['code']);
     }
+}
+
+class CustomTypeWithoutClosureToPHP extends Type
+{
 }

--- a/tests/Tests/Types/TypeTest.php
+++ b/tests/Tests/Types/TypeTest.php
@@ -42,6 +42,16 @@ class TypeTest extends BaseTestCase
         self::assertSameTypeAndValue($bsonValue, $type->convertToDatabaseValue($phpValue));
     }
 
+    #[DataProvider('provideTypes')]
+    public function testConversionWithClosureToPHP(string $typeIdentifier, mixed $expectedValue, mixed $value = null): void
+    {
+        $value ??= $expectedValue;
+        $return = $this;
+        eval(Type::getType($typeIdentifier)->closureToPHP());
+
+        self::assertSameTypeAndValue($expectedValue, $return);
+    }
+
     public static function provideTypes(): array
     {
         return [


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | Fix #2870

#### Summary

The default implementation of `Type::closureToPhp()` is incorrect as it forwards the unmodified value.
https://github.com/doctrine/mongodb-odm/blob/bf2e243204634fe0892794347554fc4b240c9148/src/Types/Type.php#L142-L145

In 3.0, I want to change the default implementation to use the one from the `ClosureToPHP` trait that calls the type class.
https://github.com/doctrine/mongodb-odm/blob/bf2e243204634fe0892794347554fc4b240c9148/src/Types/ClosureToPHP.php#L14-L16

Also adding the missing implementation for `collection` and `hash`.

Any type that does not override the `closureToPhp` will get a deprecation notice.