### PR TITLE
[3.x] Use PHPUnit 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
-        "phpunit/phpunit": "^10.5.58|^11.5.43",
+        "phpunit/phpunit": "^12.5.1",
         "squizlabs/php_codesniffer": "^4",
         "symfony/cache": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/uid": "^5.4 || ^6.0 || ^7.0 || ^8.0",

--- a/tests/Tests/Aggregation/AggregationTestTrait.php
+++ b/tests/Tests/Aggregation/AggregationTestTrait.php
@@ -17,14 +17,12 @@ trait AggregationTestTrait
         return new Builder($this->dm, $documentName);
     }
 
-    /** @return MockObject|AggregationExpr */
-    protected function getMockAggregationExpr()
+    protected function getMockAggregationExpr(): AggregationExpr&MockObject
     {
         return $this->createMock(AggregationExpr::class);
     }
 
-    /** @return MockObject|QueryExpr */
-    protected function getMockQueryExpr()
+    protected function getMockQueryExpr(): QueryExpr&MockObject
     {
         return $this->createMock(QueryExpr::class);
     }

--- a/tests/Tests/Events/OnClassMetadataNotFoundEventArgsTest.php
+++ b/tests/Tests/Events/OnClassMetadataNotFoundEventArgsTest.php
@@ -14,7 +14,7 @@ class OnClassMetadataNotFoundEventArgsTest extends TestCase
 {
     public function testEventArgsMutability(): void
     {
-        $documentManager = $this->createMock(DocumentManager::class);
+        $documentManager = $this->createStub(DocumentManager::class);
 
         $args = new OnClassMetadataNotFoundEventArgs(stdClass::class, $documentManager);
 

--- a/tests/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Tests/Functional/DocumentPersisterTest.php
@@ -635,7 +635,7 @@ class DocumentPersisterTest extends BaseTestCase
         $collection = $this->createMock(Collection::class);
         $collection->expects($this->once())
             ->method('insertMany')
-            ->with($this->isType('array'), $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern($writeConcern))));
+            ->with($this->isArray(), $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern($writeConcern))));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -656,7 +656,7 @@ class DocumentPersisterTest extends BaseTestCase
         $collection = $this->createMock(Collection::class);
         $collection->expects($this->once())
             ->method('insertMany')
-            ->with($this->isType('array'), $this->logicalNot($this->arrayHasKey('writeConcern')));
+            ->with($this->isArray(), $this->logicalNot($this->arrayHasKey('writeConcern')));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -677,7 +677,7 @@ class DocumentPersisterTest extends BaseTestCase
         $collection = $this->createMock(Collection::class);
         $collection->expects($this->once())
             ->method('updateOne')
-            ->with($this->isType('array'), $this->isType('array'), $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern($writeConcern))));
+            ->with($this->isArray(), $this->isArray(), $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern($writeConcern))));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -699,7 +699,7 @@ class DocumentPersisterTest extends BaseTestCase
         $collection = $this->createMock(Collection::class);
         $collection->expects($this->once())
             ->method('updateOne')
-            ->with($this->isType('array'), $this->logicalNot($this->arrayHasKey('writeConcern')));
+            ->with($this->isArray(), $this->logicalNot($this->arrayHasKey('writeConcern')));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -721,7 +721,7 @@ class DocumentPersisterTest extends BaseTestCase
         $collection = $this->createMock(Collection::class);
         $collection->expects($this->once())
             ->method('deleteOne')
-            ->with($this->isType('array'), $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern($writeConcern))));
+            ->with($this->isArray(), $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern($writeConcern))));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -745,7 +745,7 @@ class DocumentPersisterTest extends BaseTestCase
         $collection = $this->createMock(Collection::class);
         $collection->expects($this->once())
             ->method('deleteOne')
-            ->with($this->isType('array'), $this->logicalNot($this->arrayHasKey('writeConcern')));
+            ->with($this->isArray(), $this->logicalNot($this->arrayHasKey('writeConcern')));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -768,7 +768,7 @@ class DocumentPersisterTest extends BaseTestCase
         $collection = $this->createMock(Collection::class);
         $collection->expects($this->once())
             ->method('insertMany')
-            ->with($this->isType('array'), $this->equalTo(['writeConcern' => new WriteConcern(0)]));
+            ->with($this->isArray(), $this->equalTo(['writeConcern' => new WriteConcern(0)]));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -790,7 +790,7 @@ class DocumentPersisterTest extends BaseTestCase
         $collection = $this->createMock(Collection::class);
         $collection->expects($this->once())
             ->method('insertMany')
-            ->with($this->isType('array'), $this->logicalNot($this->arrayHasKey('writeConcern')));
+            ->with($this->isArray(), $this->logicalNot($this->arrayHasKey('writeConcern')));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -812,7 +812,7 @@ class DocumentPersisterTest extends BaseTestCase
         $collection = $this->createMock(Collection::class);
         $collection->expects($this->once())
             ->method('insertMany')
-            ->with($this->isType('array'), $this->equalTo(['writeConcern' => new WriteConcern(0)]));
+            ->with($this->isArray(), $this->equalTo(['writeConcern' => new WriteConcern(0)]));
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);

--- a/tests/Tests/Functional/SplObjectHashCollisionsTest.php
+++ b/tests/Tests/Functional/SplObjectHashCollisionsTest.php
@@ -15,7 +15,7 @@ class SplObjectHashCollisionsTest extends BaseTestCase
 {
     /** @param callable(DocumentManager, object=): void $f */
     #[DataProvider('provideParentAssociationsIsCleared')]
-    public function testParentAssociationsIsCleared(callable $f): void
+    public function testParentAssociationsIsCleared(callable $f, int $leftover): void
     {
         $d         = new SplColDoc();
         $d->one    = new SplColEmbed('d.one.v1');

--- a/tests/Tests/Proxy/Factory/ProxyFactoryTest.php
+++ b/tests/Tests/Proxy/Factory/ProxyFactoryTest.php
@@ -19,8 +19,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class ProxyFactoryTest extends BaseTestCase
 {
-    /** @var Client|MockObject */
-    private Client $client;
+    private Client&MockObject $client;
 
     public function testProxyInitializeWithException(): void
     {

--- a/tests/Tests/Query/BuilderTest.php
+++ b/tests/Tests/Query/BuilderTest.php
@@ -497,8 +497,8 @@ class BuilderTest extends BaseTestCase
             'type()' => ['type', [7]],
             'all()' => ['all', [['value1', 'value2']]],
             'mod()' => ['mod', [2, 0]],
-            'near()' => ['near', [1, 2], null, 5, 10],
-            'nearSphere()' => ['nearSphere', [1, 2], null, 5, 10],
+            'near()' => ['near', [[1, 2], null, 5, 10]],
+            'nearSphere()' => ['nearSphere', [[1, 2], null, 5, 10]],
             'geoIntersects()' => ['geoIntersects', [self::createGeometry()]],
             'geoWithin()' => ['geoWithin', [self::createGeometry()]],
             'geoWithinBox()' => ['geoWithinBox', [1, 2, 3, 4]],
@@ -864,8 +864,7 @@ class BuilderTest extends BaseTestCase
         return new Builder($this->dm, User::class);
     }
 
-    /** @return MockObject&Expr */
-    private function getMockExpr()
+    private function getMockExpr(): Expr&MockObject
     {
         return $this->createMock(Expr::class);
     }

--- a/tests/Tests/QueryTest.php
+++ b/tests/Tests/QueryTest.php
@@ -22,16 +22,15 @@ use LogicException;
 use MongoDB\BSON\Int64;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
-use MongoDB\Driver\CursorId;
 use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\Server;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use Traversable;
 
 use function array_keys;
-use function class_exists;
 use function iterator_to_array;
 
 use const DOCTRINE_MONGODB_DATABASE;
@@ -426,7 +425,7 @@ class QueryTest extends BaseTestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new Query($this->dm, new ClassMetadata(User::class), $this->getMockCollection(), ['type' => -1], []);
+        new Query($this->dm, new ClassMetadata(User::class), $this->createStub(Collection::class), ['type' => -1], []);
     }
 
     /** @param Query::TYPE_* $type */
@@ -502,7 +501,7 @@ class QueryTest extends BaseTestCase
 
     public function testFindWithHint(): void
     {
-        $cursor = $this->createCursorMock();
+        $cursor = $this->createCursorStub();
 
         $collection = $this->getMockCollection();
         $collection->expects($this->once())
@@ -529,7 +528,7 @@ class QueryTest extends BaseTestCase
         $nearest            = new ReadPreference('nearest');
         $secondaryPreferred = new ReadPreference('secondaryPreferred');
 
-        $cursor = $this->createCursorMock();
+        $cursor = $this->createCursorStub();
 
         $collection = $this->getMockCollection();
         $collection->expects($this->once())
@@ -620,20 +619,14 @@ class QueryTest extends BaseTestCase
         iterator_to_array($iterator);
     }
 
-    /** @return MockObject&Collection */
-    private function getMockCollection()
+    private function getMockCollection(): Collection&MockObject
     {
         return $this->createMock(Collection::class);
     }
 
-    private function createCursorMock(): CursorInterface|Traversable
+    private function createCursorStub(): CursorInterface&Stub
     {
-        return $this->createMock(
-            // Use the cursorID class to differentiate between 1.x and 2.x
-            class_exists(CursorId::class)
-                ? Traversable::class
-                : CursorInterface::class,
-        );
+        return $this->createStub(CursorInterface::class);
     }
 }
 

--- a/tests/Tests/SchemaManagerTest.php
+++ b/tests/Tests/SchemaManagerTest.php
@@ -45,6 +45,7 @@ use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use ReflectionProperty;
 
 use function array_count_values;
@@ -100,8 +101,8 @@ class SchemaManagerTest extends BaseTestCase
     {
         parent::setUp();
 
-        $client   = $this->createMock(Client::class);
-        $this->dm = DocumentManager::create($client, $this->dm->getConfiguration(), $this->createMock(EventManager::class));
+        $client   = $this->createStub(Client::class);
+        $this->dm = DocumentManager::create($client, $this->dm->getConfiguration(), $this->createStub(EventManager::class));
 
         foreach ($this->dm->getMetadataFactory()->getAllMetadata() as $cm) {
             if ($cm->isMappedSuperclass || $cm->isEmbeddedDocument || $cm->isQueryResultDocument) {
@@ -109,7 +110,7 @@ class SchemaManagerTest extends BaseTestCase
             }
 
             if ($cm->isFile) {
-                $this->documentBuckets[$cm->getBucketName()] = $this->getMockBucket();
+                $this->documentBuckets[$cm->getBucketName()] = $this->getBucketStub();
             } else {
                 $this->documentCollections[$cm->getCollection()] = $this->getMockCollection($cm->getCollection());
             }
@@ -1407,30 +1408,27 @@ EOT;
         return ($cm->getDatabase() ?: $this->dm->getConfiguration()->getDefaultDB()) ?: 'doctrine';
     }
 
-    /** @return Bucket&MockObject */
-    private function getMockBucket()
+    private function getBucketStub(): Bucket&Stub
     {
-        $mock = $this->createMock(Bucket::class);
+        $mock = $this->createStub(Bucket::class);
         $mock->method('getFilesCollection')->willReturn($this->getMockCollection());
         $mock->method('getChunksCollection')->willReturn($this->getMockCollection());
 
         return $mock;
     }
 
-    /** @return Collection&MockObject */
-    private function getMockCollection(?string $name = null)
+    private function getMockCollection(?string $name = null): Collection&MockObject
     {
         $collection = $this->createMock(Collection::class);
-        $collection->method('getCollectionName')->willReturnCallback(static fn () => $name);
+        $collection->expects($this->atLeast(0))->method('getCollectionName')->willReturnCallback(static fn () => $name);
 
         return $collection;
     }
 
-    /** @return Database&MockObject */
-    private function getMockDatabase()
+    private function getMockDatabase(): Database&MockObject
     {
         $db = $this->createMock(Database::class);
-        $db->method('getCollection')->willReturnCallback(fn (string $collection) => $this->documentCollections[$collection]);
+        $db->expects($this->atLeast(0))->method('getCollection')->willReturnCallback(fn (string $collection) => $this->documentCollections[$collection]);
         $db->method('selectGridFSBucket')->willReturnCallback(fn (array $options) => $this->documentBuckets[$options['bucketName']]);
         $db->method('listCollections')->willReturnCallback(function () {
             $collections = [];

--- a/tests/Tests/SchemaManagerTest.php
+++ b/tests/Tests/SchemaManagerTest.php
@@ -89,7 +89,7 @@ class SchemaManagerTest extends BaseTestCase
     /** @var array<Collection&MockObject> */
     private array $documentCollections = [];
 
-    /** @var array<Bucket&MockObject> */
+    /** @var array<Bucket&Stub> */
     private array $documentBuckets = [];
 
     /** @var array<Database&MockObject> */

--- a/tests/Tests/UnitOfWorkTest.php
+++ b/tests/Tests/UnitOfWorkTest.php
@@ -559,7 +559,7 @@ class UnitOfWorkTest extends BaseTestCase
         $collection = $this->createMock(MongoDBCollection::class);
         $collection->expects($this->once())
             ->method('insertMany')
-            ->with($this->isType('array'), $this->logicalNot($this->arrayHasKey('writeConcern')));
+            ->with($this->isArray(), $this->logicalNot($this->arrayHasKey('writeConcern')));
 
         $documentPersister = $this->uow->getDocumentPersister(ForumUser::class);
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

Updates tests to use PHPUnit 12 features and avoids deprecations:
- Creating a Mock with no expectations (Stub should be used)
- `isType('array')` -> `isArray()`
- Providing extra arguments to a test via data provider
