### PR TITLE
Always prepare full references when querying

### DIFF
--- a/src/Persisters/DocumentPersister.php
+++ b/src/Persisters/DocumentPersister.php
@@ -41,7 +41,6 @@ use stdClass;
 
 use function array_combine;
 use function array_fill;
-use function array_intersect_key;
 use function array_key_exists;
 use function array_keys;
 use function array_map;
@@ -1610,36 +1609,11 @@ final class DocumentPersister
             return [[$fieldName, $reference]];
         }
 
-        switch ($mapping['storeAs']) {
-            case ClassMetadata::REFERENCE_STORE_AS_REF:
-                $keys = ['id' => true];
-                break;
-
-            case ClassMetadata::REFERENCE_STORE_AS_DB_REF:
-            case ClassMetadata::REFERENCE_STORE_AS_DB_REF_WITH_DB:
-                $keys = ['$ref' => true, '$id' => true, '$db' => true];
-
-                if ($mapping['storeAs'] === ClassMetadata::REFERENCE_STORE_AS_DB_REF) {
-                    unset($keys['$db']);
-                }
-
-                if (isset($mapping['targetDocument'])) {
-                    unset($keys['$ref'], $keys['$db']);
-                }
-
-                break;
-
-            default:
-                throw new InvalidArgumentException(sprintf('Reference type %s is invalid.', $mapping['storeAs']));
-        }
-
-        if ($mapping['type'] === ClassMetadata::MANY) {
-            return [[$fieldName, ['$elemMatch' => array_intersect_key($reference, $keys)]]];
-        }
-
-        return array_map(
-            static fn ($key) => [$fieldName . '.' . $key, $reference[$key]],
-            array_keys($keys),
-        );
+        return $mapping['type'] === ClassMetadata::MANY
+            ? [[$fieldName, ['$elemMatch' => $reference]]]
+            : array_map(
+                static fn ($key) => [$fieldName . '.' . $key, $reference[$key]],
+                array_keys($reference),
+            );
     }
 }

--- a/src/Persisters/DocumentPersister.php
+++ b/src/Persisters/DocumentPersister.php
@@ -1605,15 +1605,25 @@ final class DocumentPersister
     private function prepareReference(string $fieldName, object $value, array $mapping, bool $inNewObj): array
     {
         $reference = $this->dm->createReference($value, $mapping);
+
+        // If a reference is stored as an identifier, we can always match it
+        // directly. For ReferenceMany, multi-key indexes are used to match
+        // array elements
         if ($inNewObj || $mapping['storeAs'] === ClassMetadata::REFERENCE_STORE_AS_ID) {
             return [[$fieldName, $reference]];
         }
 
-        return $mapping['type'] === ClassMetadata::MANY
-            ? [[$fieldName, ['$elemMatch' => $reference]]]
-            : array_map(
-                static fn ($key) => [$fieldName . '.' . $key, $reference[$key]],
-                array_keys($reference),
-            );
+        // For other ReferenceMany fields, we need to use $elemMatch to find a
+        // single array element that matches all fields
+        if ($mapping['type'] === ClassMetadata::MANY) {
+            return [[$fieldName, ['$elemMatch' => $reference]]];
+        }
+
+        // For ReferenceOne fields, we can use multiple conditions on individual
+        // fields, prefixed with the field name of the reference
+        return array_map(
+            static fn ($key) => [$fieldName . '.' . $key, $reference[$key]],
+            array_keys($reference),
+        );
     }
 }

--- a/tests/Tests/DocumentRepositoryTest.php
+++ b/tests/Tests/DocumentRepositoryTest.php
@@ -42,7 +42,10 @@ class DocumentRepositoryTest extends BaseTestCase
             ->getUnitOfWork()
             ->getDocumentPersister(User::class)
             ->prepareQueryOrNewObj(['account' => $account]);
-        $expectedQuery = ['account.$id' => new ObjectId($account->getId())];
+        $expectedQuery = [
+            'account.$ref' => $this->dm->getDocumentCollection(Account::class)->getCollectionName(),
+            'account.$id' => new ObjectId($account->getId()),
+        ];
         self::assertEquals($expectedQuery, $query);
 
         self::assertSame($user, $this->dm->getRepository(User::class)->findOneBy(['account' => $account]));
@@ -65,6 +68,7 @@ class DocumentRepositoryTest extends BaseTestCase
             'user.$ref' => 'users',
             'user.$id' => new ObjectId($user->getId()),
             'user.$db' => DOCTRINE_MONGODB_DATABASE,
+            'user._doctrine_class_name' => User::class,
         ];
         self::assertEquals($expectedQuery, $query);
 
@@ -87,6 +91,7 @@ class DocumentRepositoryTest extends BaseTestCase
         $expectedQuery = [
             'userDbRef.$ref' => 'users',
             'userDbRef.$id' => new ObjectId($user->getId()),
+            'userDbRef._doctrine_class_name' => User::class,
         ];
         self::assertEquals($expectedQuery, $query);
 
@@ -105,7 +110,15 @@ class DocumentRepositoryTest extends BaseTestCase
             ->getUnitOfWork()
             ->getDocumentPersister(Developer::class)
             ->prepareQueryOrNewObj(['projects' => $project]);
-        $expectedQuery = ['projects' => ['$elemMatch' => ['$id' => new ObjectId($project->getId())]]];
+        $expectedQuery = [
+            'projects' => [
+                '$elemMatch' => [
+                    '$ref' => $this->dm->getDocumentCollection(SubProject::class)->getCollectionName(),
+                    '$id' => new ObjectId($project->getId()),
+                    'type' => 'sub-project',
+                ],
+            ],
+        ];
         self::assertEquals($expectedQuery, $query);
 
         self::assertSame($developer, $this->dm->getRepository(Developer::class)->findOneBy(['projects' => $project]));
@@ -150,6 +163,7 @@ class DocumentRepositoryTest extends BaseTestCase
         $expectedQuery = [
             'groups' => [
                 '$elemMatch' => [
+                    '$ref' => $this->dm->getDocumentCollection(Group::class)->getCollectionName(),
                     '$id' => new ObjectId($group->getId()),
                 ],
             ],

--- a/tests/Tests/Functional/Ticket/GH2825Test.php
+++ b/tests/Tests/Functional/Ticket/GH2825Test.php
@@ -201,6 +201,120 @@ class GH2825Test extends BaseTestCase
         self::assertEquals(['id' => $referenceId], $result['referencedDocumentsStoreAsRef'][0]);
         self::assertEquals(['$ref' => 'GH2825Document', '$id' => $referenceId], $result['referencedDocumentsStoreAsDbRef'][0]);
     }
+
+    public function testQueryBuilderQueriesEmbeddedReferenceOneCorrectlyUsingEquals(): void
+    {
+        $document           = new GH2825Document('document');
+        $document->embedded = new GH2825Embedded('embedded');
+
+        $reference                                 = new GH2825Document('original');
+        $document->embedded->referenceStoreAsId    = $reference;
+        $document->embedded->referenceStoreAsRef   = $reference;
+        $document->embedded->referenceStoreAsDbRef = $reference;
+
+        $this->dm->persist($reference);
+        $this->dm->persist($document);
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $reference = $this->dm->find(GH2825Document::class, $reference->id);
+
+        $query = $this->dm->createQueryBuilder(GH2825Document::class)
+            ->field('embedded.referenceStoreAsId')->equals($reference)
+            ->getQuery();
+
+        self::assertEquals(
+            ['embedded.referenceStoreAsId' => new ObjectId($reference->id)],
+            $query->debug('query'),
+        );
+
+        self::assertNotNull($query->getSingleResult());
+
+        $query = $this->dm->createQueryBuilder(GH2825Document::class)
+            ->field('embedded.referenceStoreAsRef')->equals($reference)
+            ->getQuery();
+
+        self::assertEquals(
+            ['embedded.referenceStoreAsRef.id' => new ObjectId($reference->id)],
+            $query->debug('query'),
+        );
+
+        self::assertNotNull($query->getSingleResult());
+
+        $query = $this->dm->createQueryBuilder(GH2825Document::class)
+            ->field('embedded.referenceStoreAsDbRef')->equals($reference)
+            ->getQuery();
+
+        self::assertEquals(
+            [
+                'embedded.referenceStoreAsDbRef.$ref' => $this->dm->getDocumentCollection(GH2825Document::class)->getCollectionName(),
+                'embedded.referenceStoreAsDbRef.$id' => new ObjectId($reference->id),
+            ],
+            $query->debug('query'),
+        );
+
+        self::assertNotNull($query->getSingleResult());
+    }
+
+    public function testQueryBuilderQueriesEmbeddedReferenceManyCorrectlyUsingEquals(): void
+    {
+        $document           = new GH2825Document('document');
+        $document->embedded = new GH2825Embedded('embedded');
+
+        $reference                                             = new GH2825Document('original');
+        $document->embedded->referencedDocumentsStoreAsId[]    = $reference;
+        $document->embedded->referencedDocumentsStoreAsRef[]   = $reference;
+        $document->embedded->referencedDocumentsStoreAsDbRef[] = $reference;
+
+        $this->dm->persist($reference);
+        $this->dm->persist($document);
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $reference = $this->dm->find(GH2825Document::class, $reference->id);
+
+        $query = $this->dm->createQueryBuilder(GH2825Document::class)
+            ->field('embedded.referencedDocumentsStoreAsId')->equals($reference)
+            ->getQuery();
+
+        self::assertEquals(
+            ['embedded.referencedDocumentsStoreAsId' => new ObjectId($reference->id)],
+            $query->debug('query'),
+        );
+
+        self::assertNotNull($query->getSingleResult());
+
+        $query = $this->dm->createQueryBuilder(GH2825Document::class)
+            ->field('embedded.referencedDocumentsStoreAsRef')->equals($reference)
+            ->getQuery();
+
+        self::assertEquals(
+            ['embedded.referencedDocumentsStoreAsRef' => ['$elemMatch' => ['id' => new ObjectId($reference->id)]]],
+            $query->debug('query'),
+        );
+
+        self::assertNotNull($query->getSingleResult());
+
+        $query = $this->dm->createQueryBuilder(GH2825Document::class)
+            ->field('embedded.referencedDocumentsStoreAsDbRef')->equals($reference)
+            ->getQuery();
+
+        self::assertEquals(
+            [
+                'embedded.referencedDocumentsStoreAsDbRef' => [
+                    '$elemMatch' => [
+                        '$ref' => $this->dm->getDocumentCollection(GH2825Document::class)->getCollectionName(),
+                        '$id' => new ObjectId($reference->id),
+                    ],
+                ],
+            ],
+            $query->debug('query'),
+        );
+
+        self::assertNotNull($query->getSingleResult());
+    }
 }
 
 #[ODM\Document]

--- a/tests/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
+++ b/tests/Tests/Persisters/DocumentPersisterGetShardKeyQueryTest.php
@@ -88,7 +88,10 @@ class DocumentPersisterGetShardKeyQueryTest extends BaseTestCase
         $method        = new ReflectionMethod($persister, 'getShardKeyQuery');
         $shardKeyQuery = $method->invoke($persister, $o);
 
-        self::assertSame(['reference.$id' => $userId], $shardKeyQuery);
+        self::assertSame([
+            'reference.$ref' => $this->dm->getDocumentCollection(User::class)->getCollectionName(),
+            'reference.$id' => $userId,
+        ], $shardKeyQuery);
     }
 }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Related to #1837 

#### Summary

I noticed that the changes made in #2827 always created partial queries for references. This can lead to wrong results when using discriminated references where identifiers are reused across collections (e.g. when using ascending numeric identifiers). This PR fixes this, bringing the behaviour of `Expr::equals` in line with `Expr::references` and `Expr::includesReferenceTo`, essentially making those methods unnecessary.

This fix required some changes in tests where we made assertions on query shapes. I made sure that the changes don't introduce a regression with shard keys, and I'm sure that it doesn't. While looking at this, I noticed that the support for references as shard keys may actually not work as expected due to how indexes work when the index value is a document. In order to match a document, both key order and values need to be identical, so if a document contains a value of `{ foo: 'bar', bar: 'baz' }`, using `{ bar: 'baz', foo: 'bar' }` will not match despite the documents having the same PHP representation (and being equal for all intents and purposes). This may also mean that the typical reference queries of `{ "bar.$id": "..." }` may not necessarily be able to use the underlying index of the shard key. I'm not particularly worried about this, but wanted to mention it in case someone trips over this.

I'll be following up this PR with another one to deprecate `references` and `includesReferenceTo` in 2.16.x for subsequent removal in 3.0.