### PR TITLE
Don't include static properties in skipped properties

### DIFF
--- a/src/Proxy/Factory/NativeLazyObjectFactory.php
+++ b/src/Proxy/Factory/NativeLazyObjectFactory.php
@@ -101,6 +101,10 @@ class NativeLazyObjectFactory implements ProxyFactory
                 continue;
             }
 
+            if ($property->isStatic()) {
+                continue;
+            }
+
             $skippedProperties[] = $property;
         }
 

--- a/tests/Documents/DocumentWithStaticProperty.php
+++ b/tests/Documents/DocumentWithStaticProperty.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ODM\Document]
+class DocumentWithStaticProperty
+{
+    #[ODM\Id]
+    public string $id;
+
+    public static string $foo = 'bar';
+
+    // We need at least one mapped field to avoid the native lazy object to be
+    // switched to "initialized" state immediately after setting all its properties.
+    #[ODM\Field]
+    public string $mappedField;
+}

--- a/tests/Tests/Functional/ReferencesTest.php
+++ b/tests/Tests/Functional/ReferencesTest.php
@@ -15,6 +15,7 @@ use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Account;
 use Documents\Address;
+use Documents\DocumentWithStaticProperty;
 use Documents\DocumentWithUnmappedProperties;
 use Documents\Group;
 use Documents\Phonenumber;
@@ -35,6 +36,15 @@ class ReferencesTest extends BaseTestCase
         $this->assertInstanceOf(DocumentWithUnmappedProperties::class, $loadedDocument);
 
         self::assertSame('bar', $loadedDocument->foo);
+        self::assertTrue($this->dm->isUninitializedObject($loadedDocument));
+    }
+
+    public function testSkipInitializationForStaticProperties(): void
+    {
+        $loadedDocument = $this->dm->getReference(DocumentWithStaticProperty::class, '123');
+        $this->assertInstanceOf(DocumentWithStaticProperty::class, $loadedDocument);
+
+        self::assertSame('bar', $loadedDocument::$foo);
         self::assertTrue($this->dm->isUninitializedObject($loadedDocument));
     }
 

--- a/tests/Tests/Proxy/Factory/ProxyFactoryTest.php
+++ b/tests/Tests/Proxy/Factory/ProxyFactoryTest.php
@@ -12,6 +12,7 @@ use Doctrine\ODM\MongoDB\LockException;
 use Doctrine\ODM\MongoDB\Proxy\InternalProxy;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Cart;
+use Documents\DocumentWithStaticProperty;
 use Documents\DocumentWithUnmappedProperties;
 use MongoDB\Client;
 use MongoDB\Collection;
@@ -94,6 +95,23 @@ class ProxyFactoryTest extends BaseTestCase
         }
 
         self::assertSame('bar', $proxy->foo);
+    }
+
+    public function testCreateProxyForDocumentWithStaticProperties(): void
+    {
+        $proxy = $this->dm->getReference(DocumentWithStaticProperty::class, '123');
+        self::assertTrue(self::isLazyObject($proxy));
+
+        // Disable initializer so we can access properties without initialising the object
+        if ($proxy instanceof InternalProxy) {
+            $proxy->__setInitialized(true);
+        } elseif ($proxy instanceof GhostObjectInterface) {
+            $proxy->setProxyInitializer(null);
+        } elseif ($this->dm->getConfiguration()->isNativeLazyObjectEnabled()) {
+            $this->dm->getClassMetadata($proxy::class)->getReflectionClass()->markLazyObjectAsInitialized($proxy);
+        }
+
+        self::assertSame('bar', $proxy::$foo);
     }
 }
 


### PR DESCRIPTION
Otherwise, `skipLazyInitialization()` is called on the reflection of static properties, resulting in an error.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

`NativeLazyObjectFactory#getSkippedProperties()` previously returned static properties, resulting in a `ReflectionException: Can not use skipLazyInitialization on static property (...)` when `skipLazyInitialization()` was then called on it.