### PR TITLE
[3.0] Add remaining type hints

### DIFF
--- a/src/Aggregation/Aggregation.php
+++ b/src/Aggregation/Aggregation.php
@@ -29,7 +29,7 @@ final class Aggregation implements IterableResult
      * @param array<string, mixed> $options
      * @phpstan-param PipelineExpression $pipeline
      */
-    public function __construct(private DocumentManager $dm, private ?ClassMetadata $classMetadata, private Collection $collection, private array $pipeline, private array $options = [], private bool $rewindable = true)
+    public function __construct(private readonly DocumentManager $dm, private readonly ?ClassMetadata $classMetadata, private readonly Collection $collection, private array $pipeline, private readonly array $options = [], private readonly bool $rewindable = true)
     {
     }
 

--- a/src/Aggregation/Builder.php
+++ b/src/Aggregation/Builder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation;
 
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Iterator\IterableResult;
@@ -27,7 +28,10 @@ use function sprintf;
 /**
  * Fluent interface for building aggregation pipelines.
  *
- * @phpstan-import-type SortShape from Sort
+ * @phpstan-import-type SortDirectionKeywords from Sort
+ * @phpstan-import-type SortMetaKeywords from Search
+ * @phpstan-import-type SortMeta from Search
+ * @phpstan-import-type SortShape from Search
  * @phpstan-type StageExpression array<string, mixed>
  * @phpstan-type PipelineExpression list<StageExpression>
  */
@@ -598,10 +602,11 @@ class Builder
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sort/
      *
      * @param array<string, int|string|array<string, string>>|string $fieldName Field name or array of field/order pairs
-     * @param int|string|null                                        $order     Field order (if one field is specified)
+     * @param int|string|array|null                                  $order     Field order (if one field is specified)
      * @phpstan-param SortShape|string $fieldName Field name or array of field/order pairs
+     * @phpstan-param int|SortMeta|SortDirectionKeywords|null $order
      */
-    public function sort(array|string $fieldName, int|string|null $order = null): Stage\Sort
+    public function sort(array|string $fieldName, int|string|array|null $order = null): Stage\Sort
     {
         $fields = is_array($fieldName) ? $fieldName : [$fieldName => $order];
         // fixme: move to sort stage

--- a/src/Aggregation/Expr.php
+++ b/src/Aggregation/Expr.php
@@ -28,6 +28,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use Doctrine\ODM\MongoDB\Types\Type;
 use LogicException;
+use MongoDB\BSON\Javascript;
 
 use function array_filter;
 use function array_map;
@@ -83,12 +84,12 @@ class Expr implements
     {
     }
 
-    public function abs($number): static
+    public function abs(mixed $number): static
     {
         return $this->operator('$abs', $number);
     }
 
-    public function accumulator($init, $accumulate, $accumulateArgs, $merge, $initArgs = null, $finalize = null, $lang = 'js'): static
+    public function accumulator(string|Javascript $init, string|Javascript $accumulate, mixed $accumulateArgs, string|Javascript $merge, mixed $initArgs = null, string|Javascript|null $finalize = null, string $lang = 'js'): static
     {
         return $this->operator(
             '$accumulator',
@@ -107,7 +108,7 @@ class Expr implements
         );
     }
 
-    public function add($expression1, $expression2, ...$expressions): static
+    public function add(mixed $expression1, mixed $expression2, mixed ...$expressions): static
     {
         return $this->operator('$add', func_get_args());
     }
@@ -120,7 +121,7 @@ class Expr implements
      * @param array<string, mixed>|Expr $expression
      * @param array<string, mixed>|Expr ...$expressions
      */
-    public function addAnd($expression, ...$expressions): static
+    public function addAnd(mixed $expression, mixed ...$expressions): static
     {
         $this->expr['$and'] = array_merge(
             $this->expr['$and'] ?? [],
@@ -138,7 +139,7 @@ class Expr implements
      * @param array<string, mixed>|Expr $expression
      * @param array<string, mixed>|Expr ...$expressions
      */
-    public function addOr($expression, ...$expressions): static
+    public function addOr(mixed $expression, mixed ...$expressions): static
     {
         $this->expr['$or'] = array_merge(
             $this->expr['$or'] ?? [],
@@ -148,57 +149,57 @@ class Expr implements
         return $this;
     }
 
-    public function addToSet($expression): static
+    public function addToSet(mixed $expression): static
     {
         return $this->operator('$addToSet', $expression);
     }
 
-    public function allElementsTrue($expression): static
+    public function allElementsTrue(mixed $expression): static
     {
         return $this->operator('$allElementsTrue', $expression);
     }
 
-    public function and($expression, ...$expressions): static
+    public function and(mixed $expression, mixed ...$expressions): static
     {
         return $this->operator('$and', func_get_args());
     }
 
-    public function anyElementTrue($expression): static
+    public function anyElementTrue(mixed $expression): static
     {
         return $this->operator('$anyElementTrue', $expression);
     }
 
-    public function arrayElemAt($array, $index): static
+    public function arrayElemAt(mixed $array, mixed $index): static
     {
         return $this->operator('$arrayElemAt', func_get_args());
     }
 
-    public function avg($expression, ...$expressions): static
+    public function avg(mixed $expression, mixed ...$expressions): static
     {
         return $this->accumulatorOperator('$avg', ...func_get_args());
     }
 
-    public function binarySize($expression): static
+    public function binarySize(mixed $expression): static
     {
         return $this->operator('$binarySize', $expression);
     }
 
-    public function bottom($output, $sortBy): static
+    public function bottom(mixed $output, array $sortBy): static
     {
         return $this->operator('$bottom', ['output' => $output, 'sortBy' => $sortBy]);
     }
 
-    public function bottomN($output, $sortBy, $n): static
+    public function bottomN(mixed $output, array $sortBy, mixed $n): static
     {
         return $this->operator('$bottomN', ['output' => $output, 'sortBy' => $sortBy, 'n' => $n]);
     }
 
-    public function bsonSize($expression): static
+    public function bsonSize(mixed $expression): static
     {
         return $this->operator('$bsonSize', $expression);
     }
 
-    public function case($expression): static
+    public function case(mixed $expression): static
     {
         $this->requiresSwitchStatement(static::class . '::case');
 
@@ -207,27 +208,27 @@ class Expr implements
         return $this;
     }
 
-    public function ceil($number): static
+    public function ceil(mixed $number): static
     {
         return $this->operator('$ceil', $number);
     }
 
-    public function cmp($expression1, $expression2): static
+    public function cmp(mixed $expression1, mixed $expression2): static
     {
         return $this->operator('$cmp', func_get_args());
     }
 
-    public function concat($expression1, $expression2, ...$expressions): static
+    public function concat(mixed $expression1, mixed $expression2, mixed ...$expressions): static
     {
         return $this->operator('$concat', func_get_args());
     }
 
-    public function concatArrays($array1, $array2, ...$arrays): static
+    public function concatArrays(mixed $array1, mixed $array2, mixed ...$arrays): static
     {
         return $this->operator('$concatArrays', func_get_args());
     }
 
-    public function cond($if, $then, $else): static
+    public function cond(mixed $if, mixed $then, mixed $else): static
     {
         return $this->operator('$cond', ['if' => $if, 'then' => $then, 'else' => $else]);
     }
@@ -241,11 +242,9 @@ class Expr implements
      *
      * @internal
      *
-     * @param mixed|self $expression
-     *
      * @return string|array<string, mixed>
      */
-    public static function convertExpression($expression)
+    public static function convertExpression(mixed $expression): mixed
     {
         if (is_array($expression)) {
             return array_map(static fn ($expression) => static::convertExpression($expression), $expression);
@@ -263,17 +262,17 @@ class Expr implements
         return $this->operator('$count', []);
     }
 
-    public function covariancePop($expression1, $expression2): static
+    public function covariancePop(mixed $expression1, mixed $expression2): static
     {
         return $this->operator('$covariancePop', func_get_args());
     }
 
-    public function covarianceSamp($expression1, $expression2): static
+    public function covarianceSamp(mixed $expression1, mixed $expression2): static
     {
         return $this->operator('$covarianceSamp', func_get_args());
     }
 
-    public function dateAdd($startDate, $unit, $amount, $timezone = null): static
+    public function dateAdd(mixed $startDate, mixed $unit, mixed $amount, mixed $timezone = null): static
     {
         return $this->operator(
             '$dateAdd',
@@ -289,7 +288,7 @@ class Expr implements
         );
     }
 
-    public function dateDiff($startDate, $endDate, $unit, $timezone = null, $startOfWeek = null): static
+    public function dateDiff(mixed $startDate, mixed $endDate, mixed $unit, mixed $timezone = null, mixed $startOfWeek = null): static
     {
         return $this->operator(
             '$dateDiff',
@@ -306,7 +305,7 @@ class Expr implements
         );
     }
 
-    public function dateFromParts($year = null, $isoWeekYear = null, $month = null, $isoWeek = null, $day = null, $isoDayOfWeek = null, $hour = null, $minute = null, $second = null, $millisecond = null, $timezone = null): static
+    public function dateFromParts(mixed $year = null, mixed $isoWeekYear = null, mixed $month = null, mixed $isoWeek = null, mixed $day = null, mixed $isoDayOfWeek = null, mixed $hour = null, mixed $minute = null, mixed $second = null, mixed $millisecond = null, mixed $timezone = null): static
     {
         return $this->operator(
             '$dateFromParts',
@@ -341,7 +340,7 @@ class Expr implements
         );
     }
 
-    public function dateFromString($dateString, $format = null, $timezone = null, $onError = null, $onNull = null): static
+    public function dateFromString(mixed $dateString, mixed $format = null, mixed $timezone = null, mixed $onError = null, mixed $onNull = null): static
     {
         return $this->operator(
             '$dateFromString',
@@ -358,7 +357,7 @@ class Expr implements
         );
     }
 
-    public function dateSubtract($startDate, $unit, $amount, $timezone = null): static
+    public function dateSubtract(mixed $startDate, mixed $unit, mixed $amount, mixed $timezone = null): static
     {
         return $this->operator(
             '$dateSubtract',
@@ -374,7 +373,7 @@ class Expr implements
         );
     }
 
-    public function dateToParts($date, $timezone = null, $iso8601 = null): static
+    public function dateToParts(mixed $date, mixed $timezone = null, mixed $iso8601 = null): static
     {
         return $this->operator(
             '$dateToParts',
@@ -389,7 +388,7 @@ class Expr implements
         );
     }
 
-    public function dateToString(string $format, $expression, $timezone = null, $onNull = null): static
+    public function dateToString(string $format, mixed $expression, mixed $timezone = null, mixed $onNull = null): static
     {
         return $this->operator(
             '$dateToString',
@@ -405,7 +404,7 @@ class Expr implements
         );
     }
 
-    public function dateTrunc($date, $unit, $binSize = null, $timezone = null, $startOfWeek = null): static
+    public function dateTrunc(mixed $date, mixed $unit, mixed $binSize = null, mixed $timezone = null, mixed $startOfWeek = null): static
     {
         return $this->operator(
             '$dateTrunc',
@@ -422,22 +421,22 @@ class Expr implements
         );
     }
 
-    public function dayOfMonth($expression): static
+    public function dayOfMonth(mixed $expression): static
     {
         return $this->operator('$dayOfMonth', $expression);
     }
 
-    public function dayOfWeek($expression): static
+    public function dayOfWeek(mixed $expression): static
     {
         return $this->operator('$dayOfWeek', $expression);
     }
 
-    public function dayOfYear($expression): static
+    public function dayOfYear(mixed $expression): static
     {
         return $this->operator('$dayOfYear', $expression);
     }
 
-    public function default($expression): static
+    public function default(mixed $expression): static
     {
         $this->requiresSwitchStatement(static::class . '::default');
 
@@ -455,12 +454,12 @@ class Expr implements
         return $this->operator('$denseRank', []);
     }
 
-    public function derivative($input, string $unit): static
+    public function derivative(mixed $input, string $unit): static
     {
         return $this->operator('$derivative', ['input' => $input, 'unit' => $unit]);
     }
 
-    public function divide($expression1, $expression2): static
+    public function divide(mixed $expression1, mixed $expression2): static
     {
         return $this->operator('$divide', func_get_args());
     }
@@ -470,17 +469,17 @@ class Expr implements
         return $this->operator('$documentNumber', []);
     }
 
-    public function eq($expression1, $expression2): static
+    public function eq(mixed $expression1, mixed $expression2): static
     {
         return $this->operator('$eq', func_get_args());
     }
 
-    public function exp($exponent): static
+    public function exp(mixed $exponent): static
     {
         return $this->operator('$exp', $exponent);
     }
 
-    public function expMovingAvg($input, ?int $n = null, ?float $alpha = null): static
+    public function expMovingAvg(mixed $input, ?int $n = null, ?float $alpha = null): static
     {
         return $this->operator(
             '$expMovingAvg',
@@ -503,7 +502,7 @@ class Expr implements
         return new static($this->dm, $this->class);
     }
 
-    public function expression($value): static
+    public function expression(mixed $value): static
     {
         if (! $this->currentField) {
             throw new LogicException(sprintf('%s requires setting a current field using field().', __METHOD__));
@@ -525,17 +524,17 @@ class Expr implements
         return $this;
     }
 
-    public function filter($input, $as, $cond): static
+    public function filter(mixed $input, mixed $as, mixed $cond): static
     {
         return $this->operator('$filter', ['input' => $input, 'as' => $as, 'cond' => $cond]);
     }
 
-    public function first($expression): static
+    public function first(mixed $expression): static
     {
         return $this->operator('$first', $expression);
     }
 
-    public function firstN($expression, $n): static
+    public function firstN(mixed $expression, mixed $n): static
     {
         return $this->operator('$firstN', [
             'input' => $expression,
@@ -543,12 +542,12 @@ class Expr implements
         ]);
     }
 
-    public function function($body, $args, $lang = 'js'): static
+    public function function(string|Javascript $body, mixed $args, string $lang = 'js'): static
     {
         return $this->operator('$function', ['body' => $body, 'args' => $args, 'lang' => $lang]);
     }
 
-    public function floor($number): static
+    public function floor(mixed $number): static
     {
         return $this->operator('$floor', $number);
     }
@@ -559,7 +558,7 @@ class Expr implements
         return $this->expr;
     }
 
-    public function getField($field, $input = null): static
+    public function getField(mixed $field, mixed $input = null): static
     {
         return $this->operator(
             '$getField',
@@ -573,32 +572,32 @@ class Expr implements
         );
     }
 
-    public function gt($expression1, $expression2): static
+    public function gt(mixed $expression1, mixed $expression2): static
     {
         return $this->operator('$gt', func_get_args());
     }
 
-    public function gte($expression1, $expression2): static
+    public function gte(mixed $expression1, mixed $expression2): static
     {
         return $this->operator('$gte', func_get_args());
     }
 
-    public function hour($expression): static
+    public function hour(mixed $expression): static
     {
         return $this->operator('$hour', $expression);
     }
 
-    public function ifNull($expression, $replacementExpression): static
+    public function ifNull(mixed $expression, mixed $replacementExpression): static
     {
         return $this->operator('$ifNull', func_get_args());
     }
 
-    public function in($expression, $arrayExpression): static
+    public function in(mixed $expression, mixed $arrayExpression): static
     {
         return $this->operator('$in', func_get_args());
     }
 
-    public function indexOfArray($arrayExpression, $searchExpression, $start = null, $end = null): static
+    public function indexOfArray(mixed $arrayExpression, mixed $searchExpression, mixed $start = null, mixed $end = null): static
     {
         $args = [$arrayExpression, $searchExpression];
         if ($start !== null) {
@@ -612,7 +611,7 @@ class Expr implements
         return $this->operator('$indexOfArray', $args);
     }
 
-    public function indexOfBytes($stringExpression, $substringExpression, $start = null, $end = null): static
+    public function indexOfBytes(mixed $stringExpression, mixed $substringExpression, string|int|null $start = null, string|int|null $end = null): static
     {
         $args = [$stringExpression, $substringExpression];
         if ($start !== null) {
@@ -626,7 +625,7 @@ class Expr implements
         return $this->operator('$indexOfBytes', $args);
     }
 
-    public function indexOfCP($stringExpression, $substringExpression, $start = null, $end = null): static
+    public function indexOfCP(mixed $stringExpression, mixed $substringExpression, string|int|null $start = null, string|int|null $end = null): static
     {
         $args = [$stringExpression, $substringExpression];
         if ($start !== null) {
@@ -640,37 +639,37 @@ class Expr implements
         return $this->operator('$indexOfCP', $args);
     }
 
-    public function integral($input, string $unit): static
+    public function integral(mixed $input, string $unit): static
     {
         return $this->operator('$integral', ['input' => $input, 'unit' => $unit]);
     }
 
-    public function isArray($expression): static
+    public function isArray(mixed $expression): static
     {
         return $this->operator('$isArray', $expression);
     }
 
-    public function isoDayOfWeek($expression): static
+    public function isoDayOfWeek(mixed $expression): static
     {
         return $this->operator('$isoDayOfWeek', $expression);
     }
 
-    public function isoWeek($expression): static
+    public function isoWeek(mixed $expression): static
     {
         return $this->operator('$isoWeek', $expression);
     }
 
-    public function isoWeekYear($expression): static
+    public function isoWeekYear(mixed $expression): static
     {
         return $this->operator('$isoWeekYear', $expression);
     }
 
-    public function last($expression): static
+    public function last(mixed $expression): static
     {
         return $this->operator('$last', $expression);
     }
 
-    public function lastN($expression, $n): static
+    public function lastN(mixed $expression, mixed $n): static
     {
         return $this->operator('$lastN', [
             'input' => $expression,
@@ -678,62 +677,62 @@ class Expr implements
         ]);
     }
 
-    public function let($vars, $in): static
+    public function let(mixed $vars, mixed $in): static
     {
         return $this->operator('$let', ['vars' => $vars, 'in' => $in]);
     }
 
-    public function linearFill($expression): static
+    public function linearFill(mixed $expression): static
     {
         return $this->operator('$linearFill', $expression);
     }
 
-    public function literal($value): static
+    public function literal(mixed $value): static
     {
         return $this->operator('$literal', $value);
     }
 
-    public function ln($number): static
+    public function ln(mixed $number): static
     {
         return $this->operator('$ln', $number);
     }
 
-    public function locf($expression): static
+    public function locf(mixed $expression): static
     {
         return $this->operator('$locf', $expression);
     }
 
-    public function log($number, $base): static
+    public function log(mixed $number, mixed $base): static
     {
         return $this->operator('$log', func_get_args());
     }
 
-    public function log10($number): static
+    public function log10(mixed $number): static
     {
         return $this->operator('$log10', $number);
     }
 
-    public function lt($expression1, $expression2): static
+    public function lt(mixed $expression1, mixed $expression2): static
     {
         return $this->operator('$lt', func_get_args());
     }
 
-    public function lte($expression1, $expression2): static
+    public function lte(mixed $expression1, mixed $expression2): static
     {
         return $this->operator('$lte', func_get_args());
     }
 
-    public function map($input, $as, $in): static
+    public function map(mixed $input, string $as, mixed $in): static
     {
         return $this->operator('$map', ['input' => $input, 'as' => $as, 'in' => $in]);
     }
 
-    public function max($expression, ...$expressions): static
+    public function max(mixed $expression, mixed ...$expressions): static
     {
         return $this->accumulatorOperator('$max', ...func_get_args());
     }
 
-    public function maxN($expression, $n): static
+    public function maxN(mixed $expression, mixed $n): static
     {
         return $this->operator('$maxN', [
             'input' => $expression,
@@ -741,27 +740,27 @@ class Expr implements
         ]);
     }
 
-    public function mergeObjects($expression, ...$expressions): static
+    public function mergeObjects(mixed $expression, mixed ...$expressions): static
     {
         return $this->accumulatorOperator('$mergeObjects', ...func_get_args());
     }
 
-    public function meta($metaDataKeyword): static
+    public function meta(mixed $metaDataKeyword): static
     {
         return $this->operator('$meta', $metaDataKeyword);
     }
 
-    public function millisecond($expression): static
+    public function millisecond(mixed $expression): static
     {
         return $this->operator('$millisecond', $expression);
     }
 
-    public function min($expression, ...$expressions): static
+    public function min(mixed $expression, mixed ...$expressions): static
     {
         return $this->accumulatorOperator('$min', ...func_get_args());
     }
 
-    public function minN($expression, $n): static
+    public function minN(mixed $expression, mixed $n): static
     {
         return $this->operator('$minN', [
             'input' => $expression,
@@ -769,42 +768,42 @@ class Expr implements
         ]);
     }
 
-    public function minute($expression): static
+    public function minute(mixed $expression): static
     {
         return $this->operator('$minute', $expression);
     }
 
-    public function mod($expression1, $expression2): static
+    public function mod(mixed $expression1, mixed $expression2): static
     {
         return $this->operator('$mod', func_get_args());
     }
 
-    public function month($expression): static
+    public function month(mixed $expression): static
     {
         return $this->operator('$month', $expression);
     }
 
-    public function multiply($expression1, $expression2, ...$expressions): static
+    public function multiply(mixed $expression1, mixed $expression2, mixed ...$expressions): static
     {
         return $this->operator('$multiply', func_get_args());
     }
 
-    public function ne($expression1, $expression2): static
+    public function ne(mixed $expression1, mixed $expression2): static
     {
         return $this->operator('$ne', func_get_args());
     }
 
-    public function not($expression): static
+    public function not(mixed $expression): static
     {
         return $this->operator('$not', $expression);
     }
 
-    public function pow($number, $exponent): static
+    public function pow(mixed $number, mixed $exponent): static
     {
         return $this->operator('$pow', func_get_args());
     }
 
-    public function push($expression): static
+    public function push(mixed $expression): static
     {
         return $this->operator('$push', $expression);
     }
@@ -814,7 +813,7 @@ class Expr implements
         return $this->operator('$rand', []);
     }
 
-    public function range($start, $end, $step = null): static
+    public function range(mixed $start, mixed $end, mixed $step = null): static
     {
         return $this->operator('$range', func_get_args());
     }
@@ -824,12 +823,12 @@ class Expr implements
         return $this->operator('$rank', []);
     }
 
-    public function reduce($input, $initialValue, $in): static
+    public function reduce(mixed $input, mixed $initialValue, mixed $in): static
     {
         return $this->operator('$reduce', ['input' => $input, 'initialValue' => $initialValue, 'in' => $in]);
     }
 
-    public function reverseArray($expression): static
+    public function reverseArray(mixed $expression): static
     {
         return $this->operator('$reverseArray', $expression);
     }
@@ -839,42 +838,42 @@ class Expr implements
         return $this->operator('$sampleRate', $rate);
     }
 
-    public function second($expression): static
+    public function second(mixed $expression): static
     {
         return $this->operator('$second', $expression);
     }
 
-    public function setDifference($expression1, $expression2): static
+    public function setDifference(mixed $expression1, mixed $expression2): static
     {
         return $this->operator('$setDifference', func_get_args());
     }
 
-    public function setEquals($expression1, $expression2, ...$expressions): static
+    public function setEquals(mixed $expression1, mixed $expression2, mixed ...$expressions): static
     {
         return $this->operator('$setEquals', func_get_args());
     }
 
-    public function setField($field, $input, $value): static
+    public function setField(mixed $field, mixed $input, mixed $value): static
     {
         return $this->operator('$setField', ['field' => $field, 'input' => $input, 'value' => $value]);
     }
 
-    public function setIntersection($expression1, $expression2, ...$expressions): static
+    public function setIntersection(mixed $expression1, mixed $expression2, mixed ...$expressions): static
     {
         return $this->operator('$setIntersection', func_get_args());
     }
 
-    public function setIsSubset($expression1, $expression2): static
+    public function setIsSubset(mixed $expression1, mixed $expression2): static
     {
         return $this->operator('$setIsSubset', func_get_args());
     }
 
-    public function setUnion($expression1, $expression2, ...$expressions): static
+    public function setUnion(mixed $expression1, mixed $expression2, mixed ...$expressions): static
     {
         return $this->operator('$setUnion', func_get_args());
     }
 
-    public function shift($output, int $by, $default = null): static
+    public function shift(mixed $output, int $by, mixed $default = null): static
     {
         return $this->operator(
             '$shift',
@@ -889,12 +888,12 @@ class Expr implements
         );
     }
 
-    public function size($expression): static
+    public function size(mixed $expression): static
     {
         return $this->operator('$size', $expression);
     }
 
-    public function slice($array, $n, $position = null): static
+    public function slice(mixed $array, mixed $n, mixed $position = null): static
     {
         // With two args provided, the order of parameters is <array>, <n>.
         // With three args provided, the order of parameters is <array>,
@@ -908,7 +907,7 @@ class Expr implements
         return $this->operator('$slice', $args);
     }
 
-    public function sortArray($input, $sortBy): static
+    public function sortArray(mixed $input, array $sortBy): static
     {
         return $this->operator('$sortArray', [
             'input' => $input,
@@ -916,157 +915,157 @@ class Expr implements
         ]);
     }
 
-    public function split($string, $delimiter): static
+    public function split(mixed $string, mixed $delimiter): static
     {
         return $this->operator('$split', func_get_args());
     }
 
-    public function sqrt($expression): static
+    public function sqrt(mixed $expression): static
     {
         return $this->operator('$sqrt', $expression);
     }
 
-    public function stdDevPop($expression, ...$expressions): static
+    public function stdDevPop(mixed $expression, mixed ...$expressions): static
     {
         return $this->accumulatorOperator('$stdDevPop', ...func_get_args());
     }
 
-    public function stdDevSamp($expression, ...$expressions): static
+    public function stdDevSamp(mixed $expression, mixed ...$expressions): static
     {
         return $this->accumulatorOperator('$stdDevSamp', ...func_get_args());
     }
 
-    public function strcasecmp($expression1, $expression2): static
+    public function strcasecmp(mixed $expression1, mixed $expression2): static
     {
         return $this->operator('$strcasecmp', func_get_args());
     }
 
-    public function strLenBytes($string): static
+    public function strLenBytes(mixed $string): static
     {
         return $this->operator('$strLenBytes', $string);
     }
 
-    public function strLenCP($string): static
+    public function strLenCP(mixed $string): static
     {
         return $this->operator('$strLenCP', $string);
     }
 
-    public function substr($string, $start, $length): static
+    public function substr(mixed $string, mixed $start, mixed $length): static
     {
         return $this->operator('$substr', func_get_args());
     }
 
-    public function substrBytes($string, $start, $count): static
+    public function substrBytes(mixed $string, mixed $start, mixed $count): static
     {
         return $this->operator('$substrBytes', func_get_args());
     }
 
-    public function substrCP($string, $start, $count): static
+    public function substrCP(mixed $string, mixed $start, mixed $count): static
     {
         return $this->operator('$substrCP', func_get_args());
     }
 
-    public function subtract($expression1, $expression2): static
+    public function subtract(mixed $expression1, mixed $expression2): static
     {
         return $this->operator('$subtract', func_get_args());
     }
 
-    public function sum($expression, ...$expressions): static
+    public function sum(mixed $expression, mixed ...$expressions): static
     {
         return $this->accumulatorOperator('$sum', ...func_get_args());
     }
 
-    public function toBool($expression): static
+    public function toBool(mixed $expression): static
     {
         return $this->operator('$toBool', $expression);
     }
 
-    public function toDate($expression): static
+    public function toDate(mixed $expression): static
     {
         return $this->operator('$toDate', $expression);
     }
 
-    public function toDecimal($expression): static
+    public function toDecimal(mixed $expression): static
     {
         return $this->operator('$toDecimal', $expression);
     }
 
-    public function toDouble($expression): static
+    public function toDouble(mixed $expression): static
     {
         return $this->operator('$toDouble', $expression);
     }
 
-    public function toInt($expression): static
+    public function toInt(mixed $expression): static
     {
         return $this->operator('$toInt', $expression);
     }
 
-    public function toLong($expression): static
+    public function toLong(mixed $expression): static
     {
         return $this->operator('$toLong', $expression);
     }
 
-    public function toLower($expression): static
+    public function toLower(mixed $expression): static
     {
         return $this->operator('$toLower', $expression);
     }
 
-    public function toObjectId($expression): static
+    public function toObjectId(mixed $expression): static
     {
         return $this->operator('$toObjectId', $expression);
     }
 
-    public function top($output, $sortBy): static
+    public function top(mixed $output, array $sortBy): static
     {
         return $this->operator('$top', ['output' => $output, 'sortBy' => $sortBy]);
     }
 
-    public function topN($output, $sortBy, $n): static
+    public function topN(mixed $output, array $sortBy, mixed $n): static
     {
         return $this->operator('$topN', ['output' => $output, 'sortBy' => $sortBy, 'n' => $n]);
     }
 
-    public function toString($expression): static
+    public function toString(mixed $expression): static
     {
         return $this->operator('$toString', $expression);
     }
 
-    public function toUpper($expression): static
+    public function toUpper(mixed $expression): static
     {
         return $this->operator('$toUpper', $expression);
     }
 
-    public function trunc($number): static
+    public function trunc(mixed $number): static
     {
         return $this->operator('$trunc', $number);
     }
 
-    public function tsIncrement($expression): static
+    public function tsIncrement(mixed $expression): static
     {
         return $this->operator('$tsIncrement', $expression);
     }
 
-    public function tsSecond($expression): static
+    public function tsSecond(mixed $expression): static
     {
         return $this->operator('$tsSecond', $expression);
     }
 
-    public function type($expression): static
+    public function type(mixed $expression): static
     {
         return $this->operator('$type', $expression);
     }
 
-    public function week($expression): static
+    public function week(mixed $expression): static
     {
         return $this->operator('$week', $expression);
     }
 
-    public function year($expression): static
+    public function year(mixed $expression): static
     {
         return $this->operator('$year', $expression);
     }
 
-    public function zip($inputs, ?bool $useLongestLength = null, $defaults = null): static
+    public function zip(mixed $inputs, ?bool $useLongestLength = null, mixed $defaults = null): static
     {
         $args = ['inputs' => $inputs];
         if ($useLongestLength !== null) {
@@ -1084,10 +1083,8 @@ class Expr implements
      * Wrapper for accumulator operators that exist in forms with one and multiple arguments
      *
      * @see Expr::operator()
-     *
-     * @param mixed|self ...$expressions
      */
-    private function accumulatorOperator(string $operator, ...$expressions): static
+    private function accumulatorOperator(string $operator, mixed ...$expressions): static
     {
         if (count($expressions) === 1) {
             return $this->operator($operator, $expressions[0]);
@@ -1102,12 +1099,8 @@ class Expr implements
      * - If the argument is an array, it is recursively prepared.
      * - If the argument is an Expr instance, its expression is returned.
      * - Otherwise, the argument is converted to a MongoDB type according to the ODM type information.
-     *
-     * @param mixed|self $expression
-     *
-     * @return mixed
      */
-    private function prepareArgument($expression)
+    private function prepareArgument(mixed $expression): mixed
     {
         if (is_string($expression) && substr($expression, 0, 1) === '$') {
             return '$' . $this->getDocumentPersister()->prepareFieldName(substr($expression, 1));
@@ -1135,10 +1128,8 @@ class Expr implements
      *
      * If there is a current field, the operator will be set on it; otherwise,
      * the operator is set at the top level of the query.
-     *
-     * @param mixed|mixed[]|self $expression
      */
-    private function operator(string $operator, $expression): static
+    private function operator(string $operator, mixed $expression): static
     {
         if ($this->currentField) {
             $this->expr[$this->currentField][$operator] = $this->prepareArgument($expression);
@@ -1149,7 +1140,7 @@ class Expr implements
         return $this;
     }
 
-    public function or($expression, ...$expressions): static
+    public function or(mixed $expression, mixed ...$expressions): static
     {
         return $this->operator('$or', func_get_args());
     }
@@ -1175,7 +1166,7 @@ class Expr implements
         return $this;
     }
 
-    public function then($expression): static
+    public function then(mixed $expression): static
     {
         if (! is_array($this->switchBranch)) {
             throw new BadMethodCallException(static::class . '::then requires a valid case statement (call case() first).');
@@ -1194,17 +1185,17 @@ class Expr implements
         return $this;
     }
 
-    public function arrayToObject($array): static
+    public function arrayToObject(mixed $array): static
     {
         return $this->operator('$arrayToObject', $array);
     }
 
-    public function objectToArray($object): static
+    public function objectToArray(mixed $object): static
     {
         return $this->operator('$objectToArray', $object);
     }
 
-    public function regexFind($input, $regex, $options = null): static
+    public function regexFind(mixed $input, mixed $regex, ?string $options = null): static
     {
         return $this->operator(
             '$regexFind',
@@ -1219,7 +1210,7 @@ class Expr implements
         );
     }
 
-    public function regexFindAll($input, $regex, $options = null): static
+    public function regexFindAll(mixed $input, mixed $regex, ?string $options = null): static
     {
         return $this->operator(
             '$regexFindAll',
@@ -1234,7 +1225,7 @@ class Expr implements
         );
     }
 
-    public function regexMatch($input, $regex, $options = null): static
+    public function regexMatch(mixed $input, mixed $regex, ?string $options = null): static
     {
         return $this->operator(
             '$regexMatch',
@@ -1249,7 +1240,7 @@ class Expr implements
         );
     }
 
-    public function replaceAll($input, $find, $replacement): static
+    public function replaceAll(mixed $input, mixed $find, mixed $replacement): static
     {
         return $this->operator('$replaceAll', [
             'input' => $input,
@@ -1258,7 +1249,7 @@ class Expr implements
         ]);
     }
 
-    public function replaceOne($input, $find, $replacement): static
+    public function replaceOne(mixed $input, mixed $find, mixed $replacement): static
     {
         return $this->operator('$replaceOne', [
             'input' => $input,
@@ -1267,102 +1258,102 @@ class Expr implements
         ]);
     }
 
-    public function round($number, $place = null): static
+    public function round(mixed $number, mixed $place = null): static
     {
         return $this->operator('$round', func_get_args());
     }
 
-    public function trim($input, $chars = null): static
+    public function trim(mixed $input, mixed $chars = null): static
     {
         return $this->operator('$trim', func_get_args());
     }
 
-    public function ltrim($input, $chars = null): static
+    public function ltrim(mixed $input, mixed $chars = null): static
     {
         return $this->operator('$ltrim', func_get_args());
     }
 
-    public function rtrim($input, $chars = null): static
+    public function rtrim(mixed $input, mixed $chars = null): static
     {
         return $this->operator('$rtrim', func_get_args());
     }
 
-    public function sin($expression): static
+    public function sin(mixed $expression): static
     {
         return $this->operator('$sin', $expression);
     }
 
-    public function cos($expression): static
+    public function cos(mixed $expression): static
     {
         return $this->operator('$cos', $expression);
     }
 
-    public function tan($expression): static
+    public function tan(mixed $expression): static
     {
         return $this->operator('$tan', $expression);
     }
 
-    public function asin($expression): static
+    public function asin(mixed $expression): static
     {
         return $this->operator('$asin', $expression);
     }
 
-    public function acos($expression): static
+    public function acos(mixed $expression): static
     {
         return $this->operator('$acos', $expression);
     }
 
-    public function atan($expression): static
+    public function atan(mixed $expression): static
     {
         return $this->operator('$atan', $expression);
     }
 
-    public function atan2($expression1, $expression2): static
+    public function atan2(mixed $expression1, mixed $expression2): static
     {
         return $this->operator('$atan2', func_get_args());
     }
 
-    public function asinh($expression): static
+    public function asinh(mixed $expression): static
     {
         return $this->operator('$asinh', $expression);
     }
 
-    public function acosh($expression): static
+    public function acosh(mixed $expression): static
     {
         return $this->operator('$acosh', $expression);
     }
 
-    public function atanh($expression): static
+    public function atanh(mixed $expression): static
     {
         return $this->operator('$atanh', $expression);
     }
 
-    public function sinh($expression): static
+    public function sinh(mixed $expression): static
     {
         return $this->operator('$sinh', $expression);
     }
 
-    public function cosh($expression): static
+    public function cosh(mixed $expression): static
     {
         return $this->operator('$cosh', $expression);
     }
 
-    public function tanh($expression): static
+    public function tanh(mixed $expression): static
     {
         return $this->operator('$tanh', $expression);
     }
 
-    public function degreesToRadians($expression): static
+    public function degreesToRadians(mixed $expression): static
     {
         return $this->operator('$degreesToRadians', $expression);
     }
 
-    public function radiansToDegrees($expression): static
+    public function radiansToDegrees(mixed $expression): static
     {
         return $this->operator('$radiansToDegrees', $expression);
     }
 
-    public function convert($input, $to, $onError = null, $onNull = null): static
+    public function convert(mixed $input, mixed $to, mixed $onError = null, mixed $onNull = null): static
     {
         return $this->operator(
             '$convert',
@@ -1378,7 +1369,7 @@ class Expr implements
         );
     }
 
-    public function isNumber($expression): static
+    public function isNumber(mixed $expression): static
     {
         return $this->operator('$isNumber', $expression);
     }

--- a/src/Aggregation/Expr.php
+++ b/src/Aggregation/Expr.php
@@ -241,8 +241,6 @@ class Expr implements
      * are returned directly.
      *
      * @internal
-     *
-     * @return string|array<string, mixed>
      */
     public static function convertExpression(mixed $expression): mixed
     {

--- a/src/Aggregation/Operator/AccumulatorOperators.php
+++ b/src/Aggregation/Operator/AccumulatorOperators.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Operator;
 
-use Doctrine\ODM\MongoDB\Aggregation\Expr;
-
 /**
  * Interface containing all accumulator aggregation pipeline operators.
  *
@@ -20,11 +18,8 @@ interface AccumulatorOperators
      * Returns the average value of numeric values. Ignores non-numeric values.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/avg/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr ...$expressions
      */
-    public function avg($expression, ...$expressions): static;
+    public function avg(mixed $expression, mixed ...$expressions): static;
 
     /**
      * Returns the maximum value of numeric values.
@@ -33,11 +28,8 @@ interface AccumulatorOperators
      * values of different types.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/max/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr ...$expressions
      */
-    public function max($expression, ...$expressions): static;
+    public function max(mixed $expression, mixed ...$expressions): static;
 
     /**
      * Returns the minimum value of numeric values.
@@ -46,11 +38,8 @@ interface AccumulatorOperators
      * values of different types.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/min/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr ...$expressions
      */
-    public function min($expression, ...$expressions): static;
+    public function min(mixed $expression, mixed ...$expressions): static;
 
     /**
      * Calculates the population standard deviation of the input values. Use if
@@ -59,11 +48,8 @@ interface AccumulatorOperators
      * ignores non-numeric values.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevPop/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr ...$expressions
      */
-    public function stdDevPop($expression, ...$expressions): static;
+    public function stdDevPop(mixed $expression, mixed ...$expressions): static;
 
     /**
      * Calculates the sample standard deviation of the input values. Use if the
@@ -71,19 +57,13 @@ interface AccumulatorOperators
      * generalize about the population. $stdDevSamp ignores non-numeric values.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevSamp/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr ...$expressions
      */
-    public function stdDevSamp($expression, ...$expressions): static;
+    public function stdDevSamp(mixed $expression, mixed ...$expressions): static;
 
     /**
      * Calculates the collective sum of numeric values. Ignores non-numeric values.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sum/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr ...$expressions
      */
-    public function sum($expression, ...$expressions): static;
+    public function sum(mixed $expression, mixed ...$expressions): static;
 }

--- a/src/Aggregation/Operator/ArithmeticOperators.php
+++ b/src/Aggregation/Operator/ArithmeticOperators.php
@@ -23,10 +23,8 @@ interface ArithmeticOperators
      * to a number.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/abs/
-     *
-     * @param mixed|Expr $number
      */
-    public function abs($number): static;
+    public function abs(mixed $number): static;
 
     /**
      * Adds numbers together or adds numbers and a date. If one of the arguments
@@ -38,11 +36,9 @@ interface ArithmeticOperators
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/add/
      *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      * @param mixed|Expr ...$expressions Additional expressions
      */
-    public function add($expression1, $expression2, ...$expressions): static;
+    public function add(mixed $expression1, mixed $expression2, mixed ...$expressions): static;
 
     /**
      * Returns the smallest integer greater than or equal to the specified
@@ -52,10 +48,8 @@ interface ArithmeticOperators
      * resolves to a number.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/ceil/
-     *
-     * @param mixed|Expr $number
      */
-    public function ceil($number): static;
+    public function ceil(mixed $number): static;
 
     /**
      * Divides one number by another and returns the result. The first argument
@@ -64,11 +58,8 @@ interface ArithmeticOperators
      * The arguments can be any valid expression as long as the resolve to numbers.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/divide/
-     *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      */
-    public function divide($expression1, $expression2): static;
+    public function divide(mixed $expression1, mixed $expression2): static;
 
     /**
      * Raises Euler’s number to the specified exponent and returns the result.
@@ -77,10 +68,8 @@ interface ArithmeticOperators
      * resolves to a number.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/exp/
-     *
-     * @param mixed|Expr $exponent
      */
-    public function exp($exponent): static;
+    public function exp(mixed $exponent): static;
 
     /**
      * Returns the largest integer less than or equal to the specified number.
@@ -89,10 +78,8 @@ interface ArithmeticOperators
      * resolves to a number.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/floor/
-     *
-     * @param mixed|Expr $number
      */
-    public function floor($number): static;
+    public function floor(mixed $number): static;
 
     /**
      * Calculates the natural logarithm ln (i.e loge) of a number and returns
@@ -102,10 +89,8 @@ interface ArithmeticOperators
      * resolves to a non-negative number.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/log/
-     *
-     * @param mixed|Expr $number
      */
-    public function ln($number): static;
+    public function ln(mixed $number): static;
 
     /**
      * Calculates the log of a number in the specified base and returns the
@@ -117,11 +102,8 @@ interface ArithmeticOperators
      * to a positive number greater than 1.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/log/
-     *
-     * @param mixed|Expr $number
-     * @param mixed|Expr $base
      */
-    public function log($number, $base): static;
+    public function log(mixed $number, mixed $base): static;
 
     /**
      * Calculates the log base 10 of a number and returns the result as a double.
@@ -130,10 +112,8 @@ interface ArithmeticOperators
      * resolves to a non-negative number.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/log10/
-     *
-     * @param mixed|Expr $number
      */
-    public function log10($number): static;
+    public function log10(mixed $number): static;
 
     /**
      * Divides one number by another and returns the remainder. The first
@@ -143,11 +123,8 @@ interface ArithmeticOperators
      * numbers.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/mod/
-     *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      */
-    public function mod($expression1, $expression2): static;
+    public function mod(mixed $expression1, mixed $expression2): static;
 
     /**
      * Multiplies numbers together and returns the result.
@@ -157,11 +134,9 @@ interface ArithmeticOperators
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/multiply/
      *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      * @param mixed|Expr ...$expressions Additional expressions
      */
-    public function multiply($expression1, $expression2, ...$expressions): static;
+    public function multiply(mixed $expression1, mixed $expression2, mixed ...$expressions): static;
 
     /**
      * Raises a number to the specified exponent and returns the result.
@@ -172,11 +147,8 @@ interface ArithmeticOperators
      * resolves to a number.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/pow/
-     *
-     * @param mixed|Expr $number
-     * @param mixed|Expr $exponent
      */
-    public function pow($number, $exponent): static;
+    public function pow(mixed $number, mixed $exponent): static;
 
     /**
      * Rounds a number to a whole integer or to a specified decimal place.
@@ -185,11 +157,8 @@ interface ArithmeticOperators
      * to a number.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/round/
-     *
-     * @param mixed|Expr      $number
-     * @param mixed|Expr|null $place
      */
-    public function round($number, $place = null): static;
+    public function round(mixed $number, mixed $place = null): static;
 
     /**
      * Calculates the square root of a positive number and returns the result as
@@ -199,10 +168,8 @@ interface ArithmeticOperators
      * non-negative number.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sqrt/
-     *
-     * @param mixed|Expr $expression
      */
-    public function sqrt($expression): static;
+    public function sqrt(mixed $expression): static;
 
     /**
      * Subtracts two numbers to return the difference. The second argument is
@@ -211,11 +178,8 @@ interface ArithmeticOperators
      * The arguments can be any valid expression as long as they resolve to numbers and/or dates.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/subtract/
-     *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      */
-    public function subtract($expression1, $expression2): static;
+    public function subtract(mixed $expression1, mixed $expression2): static;
 
     /**
      * Truncates a number to its integer.
@@ -224,8 +188,6 @@ interface ArithmeticOperators
      * resolves to a number.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/trunc/
-     *
-     * @param mixed|Expr $number
      */
-    public function trunc($number): static;
+    public function trunc(mixed $number): static;
 }

--- a/src/Aggregation/Operator/ArrayOperators.php
+++ b/src/Aggregation/Operator/ArrayOperators.php
@@ -25,20 +25,15 @@ interface ArrayOperators
      * to an integer.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/arrayElemAt/
-     *
-     * @param mixed|Expr $array
-     * @param mixed|Expr $index
      */
-    public function arrayElemAt($array, $index): static;
+    public function arrayElemAt(mixed $array, mixed $index): static;
 
     /**
      * Converts an array into a single document.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/arrayToObject/
-     *
-     * @param mixed|Expr $array
      */
-    public function arrayToObject($array): static;
+    public function arrayToObject(mixed $array): static;
 
     /**
      * Concatenates arrays to return the concatenated array.
@@ -48,11 +43,9 @@ interface ArrayOperators
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/concatArrays/
      *
-     * @param mixed|Expr $array1
-     * @param mixed|Expr $array2
      * @param mixed|Expr ...$arrays Additional expressions
      */
-    public function concatArrays($array1, $array2, ...$arrays): static;
+    public function concatArrays(mixed $array1, mixed $array2, mixed ...$arrays): static;
 
     /**
      * Selects a subset of the array to return based on the specified condition.
@@ -61,33 +54,24 @@ interface ArrayOperators
      * returned elements are in the original order.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/filter/
-     *
-     * @param mixed|Expr $input
-     * @param mixed|Expr $as
-     * @param mixed|Expr $cond
      */
-    public function filter($input, $as, $cond): static;
+    public function filter(mixed $input, mixed $as, mixed $cond): static;
 
     /**
      * Returns the first array element. Distinct from the $first group
      * accumulator.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/first-array-element/
-     *
-     * @param mixed|Expr $expression
      */
-    public function first($expression): static;
+    public function first(mixed $expression): static;
 
     /**
      * Returns a specified number of elements from the beginning of an array.
      * Distinct from the $firstN group accumulator.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN-array-element/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr $n
      */
-    public function firstN($expression, $n): static;
+    public function firstN(mixed $expression, mixed $n): static;
 
     /**
      * Returns a boolean indicating whether a specified value is in an array.
@@ -96,11 +80,8 @@ interface ArrayOperators
      * support matching by regular expressions.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/in/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr $arrayExpression
      */
-    public function in($expression, $arrayExpression): static;
+    public function in(mixed $expression, mixed $arrayExpression): static;
 
     /**
      * Searches an array for an occurrence of a specified value and returns the
@@ -114,7 +95,7 @@ interface ArrayOperators
      * @param mixed|Expr $start            Optional. An integer, or a number that can be represented as integers (such as 2.0), that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      * @param mixed|Expr $end              An integer, or a number that can be represented as integers (such as 2.0), that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      */
-    public function indexOfArray($arrayExpression, $searchExpression, $start = null, $end = null): static;
+    public function indexOfArray(mixed $arrayExpression, mixed $searchExpression, mixed $start = null, mixed $end = null): static;
 
     /**
      * Determines if the operand is an array. Returns a boolean.
@@ -122,30 +103,23 @@ interface ArrayOperators
      * The <expression> can be any valid expression.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isArray/
-     *
-     * @param mixed|Expr $expression
      */
-    public function isArray($expression): static;
+    public function isArray(mixed $expression): static;
 
     /**
      * Returns the last array element. Distinct from the $last group accumulator.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/last-array-element/
-     *
-     * @param mixed|Expr $expression
      */
-    public function last($expression): static;
+    public function last(mixed $expression): static;
 
     /**
      * Returns a specified number of elements from the end of an array. Distinct
      * from the $lastN accumulator.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/lastN-array-element/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr $n
      */
-    public function lastN($expression, $n): static;
+    public function lastN(mixed $expression, mixed $n): static;
 
     /**
      * Applies an expression to each item in an array and returns an array with
@@ -157,29 +131,23 @@ interface ArrayOperators
      * @param string     $as    The variable name for the items in the input array. The in expression accesses each item in the input array by this variable.
      * @param mixed|Expr $in    The expression to apply to each item in the input array. The expression accesses the item by its variable name.
      */
-    public function map($input, $as, $in): static;
+    public function map(mixed $input, string $as, mixed $in): static;
 
     /**
      * Returns the n largest values in an array. Distinct from the $maxN group
      * accumulator.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/maxN/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr $n
      */
-    public function maxN($expression, $n): static;
+    public function maxN(mixed $expression, mixed $n): static;
 
     /**
      * Returns the n smallest values in an array. Distinct from the $minN group
      * accumulator.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/minN/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr $n
      */
-    public function minN($expression, $n): static;
+    public function minN(mixed $expression, mixed $n): static;
 
     /**
      * Converts a document to an array. The return array contains an element for
@@ -189,10 +157,8 @@ interface ArrayOperators
      *      The v field contains the value of the field in the original document.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/objectToArray/
-     *
-     * @param mixed|Expr $object
      */
-    public function objectToArray($object): static;
+    public function objectToArray(mixed $object): static;
 
     /**
      * Returns an array whose elements are a generated sequence of numbers.
@@ -207,7 +173,7 @@ interface ArrayOperators
      * @param mixed|Expr $end   An integer that specifies the exclusive upper limit of the sequence. Can be any valid expression that resolves to an integer.
      * @param mixed|Expr $step  Optional. An integer that specifies the increment value. Can be any valid expression that resolves to a non-zero integer. Defaults to 1.
      */
-    public function range($start, $end, $step = null): static;
+    public function range(mixed $start, mixed $end, mixed $step = null): static;
 
     /**
      * Applies an expression to each element in an array and combines them into
@@ -219,17 +185,15 @@ interface ArrayOperators
      * @param mixed|Expr $initialValue the initial cumulative value set before in is applied to the first element of the input array
      * @param mixed|Expr $in           A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
      */
-    public function reduce($input, $initialValue, $in): static;
+    public function reduce(mixed $input, mixed $initialValue, mixed $in): static;
 
     /**
      * Accepts an array expression as an argument and returns an array with the
      * elements in reverse order.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/reverseArray/
-     *
-     * @param mixed|Expr $expression
      */
-    public function reverseArray($expression): static;
+    public function reverseArray(mixed $expression): static;
 
     /**
      * Counts and returns the total the number of items in an array.
@@ -237,31 +201,24 @@ interface ArrayOperators
      * The argument can be any expression as long as it resolves to an array.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/size/
-     *
-     * @param mixed|Expr $expression
      */
-    public function size($expression): static;
+    public function size(mixed $expression): static;
 
     /**
      * Returns a subset of an array.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/slice/
-     *
-     * @param mixed|Expr      $array
-     * @param mixed|Expr      $n
-     * @param mixed|Expr|null $position
      */
-    public function slice($array, $n, $position = null): static;
+    public function slice(mixed $array, mixed $n, mixed $position = null): static;
 
     /**
      * Sorts an array based on its elements. The sort order is user specified.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sortArray/
      *
-     * @param mixed|Expr                $input
      * @param array<string, int|string> $sortBy
      */
-    public function sortArray($input, $sortBy): static;
+    public function sortArray(mixed $input, array $sortBy): static;
 
     /**
      * Transposes an array of input arrays so that the first element of the
@@ -274,5 +231,5 @@ interface ArrayOperators
      * @param bool|null       $useLongestLength a boolean which specifies whether the length of the longest array determines the number of arrays in the output array
      * @param mixed|Expr|null $defaults         An array of default element values to use if the input arrays have different lengths. You must specify useLongestLength: true along with this field, or else $zip will return an error.
      */
-    public function zip($inputs, ?bool $useLongestLength = null, $defaults = null): static;
+    public function zip(mixed $inputs, ?bool $useLongestLength = null, mixed $defaults = null): static;
 }

--- a/src/Aggregation/Operator/BooleanOperators.php
+++ b/src/Aggregation/Operator/BooleanOperators.php
@@ -24,16 +24,14 @@ interface BooleanOperators
      * @param array<string, mixed>|Expr $expression
      * @param array<string, mixed>|Expr ...$expressions
      */
-    public function and($expression, ...$expressions): static;
+    public function and(mixed $expression, mixed ...$expressions): static;
 
     /**
      * Evaluates a boolean and returns the opposite boolean value.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/not/
-     *
-     * @param mixed|Expr $expression
      */
-    public function not($expression): static;
+    public function not(mixed $expression): static;
 
     /**
      * Adds one or more $or clause to the current expression.
@@ -43,5 +41,5 @@ interface BooleanOperators
      * @param array<string, mixed>|Expr $expression
      * @param array<string, mixed>|Expr ...$expressions
      */
-    public function or($expression, ...$expressions): static;
+    public function or(mixed $expression, mixed ...$expressions): static;
 }

--- a/src/Aggregation/Operator/ComparisonOperators.php
+++ b/src/Aggregation/Operator/ComparisonOperators.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Operator;
 
-use Doctrine\ODM\MongoDB\Aggregation\Expr;
-
 /**
  * Interface containing all comparison aggregation pipeline operators.
  *
@@ -23,21 +21,15 @@ interface ComparisonOperators
      * 0 if the two values are equivalent.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/cmp/
-     *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      */
-    public function cmp($expression1, $expression2): static;
+    public function cmp(mixed $expression1, mixed $expression2): static;
 
     /**
      * Compares two values and returns whether the are equivalent.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/eq/
-     *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      */
-    public function eq($expression1, $expression2): static;
+    public function eq(mixed $expression1, mixed $expression2): static;
 
     /**
      * Compares two values and returns:
@@ -46,11 +38,8 @@ interface ComparisonOperators
      * value.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/gt/
-     *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      */
-    public function gt($expression1, $expression2): static;
+    public function gt(mixed $expression1, mixed $expression2): static;
 
     /**
      * Compares two values and returns:
@@ -59,11 +48,8 @@ interface ComparisonOperators
      * false when the first value is less than the second value.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/gte/
-     *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      */
-    public function gte($expression1, $expression2): static;
+    public function gte(mixed $expression1, mixed $expression2): static;
 
     /**
      * Compares two values and returns:
@@ -72,11 +58,8 @@ interface ComparisonOperators
      * value.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/lt/
-     *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      */
-    public function lt($expression1, $expression2): static;
+    public function lt(mixed $expression1, mixed $expression2): static;
 
     /**
      * Compares two values and returns:
@@ -84,11 +67,8 @@ interface ComparisonOperators
      * false when the first value is greater than the second value.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/lte/
-     *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      */
-    public function lte($expression1, $expression2): static;
+    public function lte(mixed $expression1, mixed $expression2): static;
 
     /**
      * Compares two values and returns:
@@ -96,9 +76,6 @@ interface ComparisonOperators
      * false when the values are equivalent.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/ne/
-     *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      */
-    public function ne($expression1, $expression2): static;
+    public function ne(mixed $expression1, mixed $expression2): static;
 }

--- a/src/Aggregation/Operator/ConditionalOperators.php
+++ b/src/Aggregation/Operator/ConditionalOperators.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Operator;
 
-use Doctrine\ODM\MongoDB\Aggregation\Expr;
-
 /**
  * Interface containing all conditional aggregation pipeline operators.
  *
@@ -24,10 +22,8 @@ interface ConditionalOperators
      * boolean, it is coerced to a boolean value.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/switch/
-     *
-     * @param mixed|Expr $expression
      */
-    public function case($expression): static;
+    public function case(mixed $expression): static;
 
     /**
      * Evaluates a boolean expression to return one of the two specified return
@@ -36,12 +32,8 @@ interface ConditionalOperators
      * The arguments can be any valid expression.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/cond/
-     *
-     * @param mixed|Expr $if
-     * @param mixed|Expr $then
-     * @param mixed|Expr $else
      */
-    public function cond($if, $then, $else): static;
+    public function cond(mixed $if, mixed $then, mixed $else): static;
 
     /**
      * Adds a default statement for the current $switch operator.
@@ -53,10 +45,8 @@ interface ConditionalOperators
      * $switch operator throws an error.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/switch/
-     *
-     * @param mixed|Expr $expression
      */
-    public function default($expression): static;
+    public function default(mixed $expression): static;
 
     /**
      * Evaluates an expression and returns the value of the expression if the
@@ -67,11 +57,8 @@ interface ConditionalOperators
      * The arguments can be any valid expression.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/ifNull/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr $replacementExpression
      */
-    public function ifNull($expression, $replacementExpression): static;
+    public function ifNull(mixed $expression, mixed $replacementExpression): static;
 
     /**
      * Evaluates a series of case expressions. When it finds an expression which
@@ -92,8 +79,6 @@ interface ConditionalOperators
      * expression.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/switch/
-     *
-     * @param mixed|Expr $expression
      */
-    public function then($expression): static;
+    public function then(mixed $expression): static;
 }

--- a/src/Aggregation/Operator/CustomOperators.php
+++ b/src/Aggregation/Operator/CustomOperators.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Operator;
 
-use Doctrine\ODM\MongoDB\Aggregation\Expr;
 use MongoDB\BSON\Javascript;
 
 /**
@@ -28,16 +27,8 @@ interface CustomOperators
      * Language.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/accumulator/
-     *
-     * @param string|Javascript      $init
-     * @param string|Javascript      $accumulate
-     * @param mixed|Expr             $accumulateArgs
-     * @param string|Javascript      $merge
-     * @param mixed|Expr|null        $initArgs
-     * @param string|Javascript|null $finalize
-     * @param string                 $lang
      */
-    public function accumulator($init, $accumulate, $accumulateArgs, $merge, $initArgs = null, $finalize = null, $lang = 'js'): static;
+    public function accumulator(string|Javascript $init, string|Javascript $accumulate, mixed $accumulateArgs, string|Javascript $merge, mixed $initArgs = null, string|Javascript|null $finalize = null, string $lang = 'js'): static;
 
     /**
      * Defines a custom aggregation function or expression in JavaScript.
@@ -46,10 +37,6 @@ interface CustomOperators
      * implement behavior not supported by the MongoDB Query Language.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/function/
-     *
-     * @param string|Javascript $body
-     * @param mixed|Expr        $args
-     * @param string            $lang
      */
-    public function function($body, $args, $lang = 'js'): static;
+    public function function(string|Javascript $body, mixed $args, string $lang = 'js'): static;
 }

--- a/src/Aggregation/Operator/DataSizeOperators.php
+++ b/src/Aggregation/Operator/DataSizeOperators.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Operator;
 
-use Doctrine\ODM\MongoDB\Aggregation\Expr;
-
 /**
  * Interface containing all data size aggregation pipeline operators.
  *
@@ -20,17 +18,13 @@ interface DataSizeOperators
      * Returns the size of a given string or binary data value's content in bytes.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/binarySize/
-     *
-     * @param mixed|Expr $expression
      */
-    public function binarySize($expression): static;
+    public function binarySize(mixed $expression): static;
 
     /**
      * Returns the size in bytes of a given document (i.e. bsontype Object) when encoded as BSON.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/bsonSize/
-     *
-     * @param mixed|Expr $expression
      */
-    public function bsonSize($expression): static;
+    public function bsonSize(mixed $expression): static;
 }

--- a/src/Aggregation/Operator/DateOperators.php
+++ b/src/Aggregation/Operator/DateOperators.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Operator;
 
-use Doctrine\ODM\MongoDB\Aggregation\Expr;
-
 /**
  * Interface containing all date aggregation pipeline operators.
  *
@@ -20,70 +18,36 @@ interface DateOperators
      * Increments a date object by a specified number of time units
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dateAdd/
-     *
-     * @param mixed|Expr $startDate
-     * @param mixed|Expr $unit
-     * @param mixed|Expr $amount
-     * @param mixed|Expr $timezone
      */
-    public function dateAdd($startDate, $unit, $amount, $timezone = null): static;
+    public function dateAdd(mixed $startDate, mixed $unit, mixed $amount, mixed $timezone = null): static;
 
     /**
      * Returns the difference between two dates
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dateDiff/
-     *
-     * @param mixed|Expr $startDate
-     * @param mixed|Expr $endDate
-     * @param mixed|Expr $unit
-     * @param mixed|Expr $timezone
-     * @param mixed|Expr $startOfWeek
      */
-    public function dateDiff($startDate, $endDate, $unit, $timezone = null, $startOfWeek = null): static;
+    public function dateDiff(mixed $startDate, mixed $endDate, mixed $unit, mixed $timezone = null, mixed $startOfWeek = null): static;
 
     /**
      * Constructs and returns a date object given the date's constituent properties
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dateFromParts/
-     *
-     * @param mixed|Expr $year
-     * @param mixed|Expr $isoWeekYear
-     * @param mixed|Expr $month
-     * @param mixed|Expr $isoWeek
-     * @param mixed|Expr $day
-     * @param mixed|Expr $isoDayOfWeek
-     * @param mixed|Expr $hour
-     * @param mixed|Expr $minute
-     * @param mixed|Expr $second
-     * @param mixed|Expr $millisecond
-     * @param mixed|Expr $timezone
      */
-    public function dateFromParts($year = null, $isoWeekYear = null, $month = null, $isoWeek = null, $day = null, $isoDayOfWeek = null, $hour = null, $minute = null, $second = null, $millisecond = null, $timezone = null): static;
+    public function dateFromParts(mixed $year = null, mixed $isoWeekYear = null, mixed $month = null, mixed $isoWeek = null, mixed $day = null, mixed $isoDayOfWeek = null, mixed $hour = null, mixed $minute = null, mixed $second = null, mixed $millisecond = null, mixed $timezone = null): static;
 
     /**
      * Converts a date/time string to a date object.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dateFromString/
-     *
-     * @param mixed|Expr $dateString
-     * @param mixed|Expr $format
-     * @param mixed|Expr $timezone
-     * @param mixed|Expr $onError
-     * @param mixed|Expr $onNull
      */
-    public function dateFromString($dateString, $format = null, $timezone = null, $onError = null, $onNull = null): static;
+    public function dateFromString(mixed $dateString, mixed $format = null, mixed $timezone = null, mixed $onError = null, mixed $onNull = null): static;
 
     /**
      * Decrements a date object by a specified number of time units
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dateSubtract/
-     *
-     * @param mixed|Expr $startDate
-     * @param mixed|Expr $unit
-     * @param mixed|Expr $amount
-     * @param mixed|Expr $timezone
      */
-    public function dateSubtract($startDate, $unit, $amount, $timezone = null): static;
+    public function dateSubtract(mixed $startDate, mixed $unit, mixed $amount, mixed $timezone = null): static;
 
     /**
      * Returns a document that contains the constituent parts of a given BSON
@@ -91,12 +55,8 @@ interface DateOperators
      * month, day, hour, minute, second and millisecond.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dateToParts/
-     *
-     * @param mixed|Expr $date
-     * @param mixed|Expr $timezone
-     * @param mixed|Expr $iso8601
      */
-    public function dateToParts($date, $timezone = null, $iso8601 = null): static;
+    public function dateToParts(mixed $date, mixed $timezone = null, mixed $iso8601 = null): static;
 
     /**
      * Converts a date object to a string according to a user-specified format.
@@ -106,25 +66,15 @@ interface DateOperators
      * The date argument can be any expression as long as it resolves to a date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dateToString/
-     *
-     * @param mixed|Expr      $expression
-     * @param mixed|Expr|null $timezone
-     * @param mixed|Expr|null $onNull
      */
-    public function dateToString(string $format, $expression, $timezone = null, $onNull = null): static;
+    public function dateToString(string $format, mixed $expression, mixed $timezone = null, mixed $onNull = null): static;
 
     /**
      * Truncates a date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dateTrunc/
-     *
-     * @param mixed|Expr $date
-     * @param mixed|Expr $unit
-     * @param mixed|Expr $binSize
-     * @param mixed|Expr $timezone
-     * @param mixed|Expr $startOfWeek
      */
-    public function dateTrunc($date, $unit, $binSize = null, $timezone = null, $startOfWeek = null): static;
+    public function dateTrunc(mixed $date, mixed $unit, mixed $binSize = null, mixed $timezone = null, mixed $startOfWeek = null): static;
 
     /**
      * Returns the day of the month for a date as a number between 1 and 31.
@@ -132,10 +82,8 @@ interface DateOperators
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dayOfMonth/
-     *
-     * @param mixed|Expr $expression
      */
-    public function dayOfMonth($expression): static;
+    public function dayOfMonth(mixed $expression): static;
 
     /**
      * Returns the day of the week for a date as a number between 1 (Sunday) and
@@ -144,10 +92,8 @@ interface DateOperators
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dayOfWeek/
-     *
-     * @param mixed|Expr $expression
      */
-    public function dayOfWeek($expression): static;
+    public function dayOfWeek(mixed $expression): static;
 
     /**
      * Returns the day of the year for a date as a number between 1 and 366.
@@ -155,10 +101,8 @@ interface DateOperators
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dayOfYear/
-     *
-     * @param mixed|Expr $expression
      */
-    public function dayOfYear($expression): static;
+    public function dayOfYear(mixed $expression): static;
 
     /**
      * Returns the hour portion of a date as a number between 0 and 23.
@@ -166,10 +110,8 @@ interface DateOperators
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/hour/
-     *
-     * @param mixed|Expr $expression
      */
-    public function hour($expression): static;
+    public function hour(mixed $expression): static;
 
     /**
      * Returns the weekday number in ISO 8601 format, ranging from 1 (for
@@ -178,10 +120,8 @@ interface DateOperators
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isoDayOfWeek/
-     *
-     * @param mixed|Expr $expression
      */
-    public function isoDayOfWeek($expression): static;
+    public function isoDayOfWeek(mixed $expression): static;
 
     /**
      * Returns the week number in ISO 8601 format, ranging from 1 to 53.
@@ -192,10 +132,8 @@ interface DateOperators
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isoWeek/
-     *
-     * @param mixed|Expr $expression
      */
-    public function isoWeek($expression): static;
+    public function isoWeek(mixed $expression): static;
 
     /**
      * Returns the year number in ISO 8601 format.
@@ -206,10 +144,8 @@ interface DateOperators
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isoWeek/
-     *
-     * @param mixed|Expr $expression
      */
-    public function isoWeekYear($expression): static;
+    public function isoWeekYear(mixed $expression): static;
 
     /**
      * Returns the millisecond portion of a date as an integer between 0 and 999.
@@ -217,10 +153,8 @@ interface DateOperators
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/millisecond/
-     *
-     * @param mixed|Expr $expression
      */
-    public function millisecond($expression): static;
+    public function millisecond(mixed $expression): static;
 
     /**
      * Returns the minute portion of a date as a number between 0 and 59.
@@ -228,10 +162,8 @@ interface DateOperators
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/minute/
-     *
-     * @param mixed|Expr $expression
      */
-    public function minute($expression): static;
+    public function minute(mixed $expression): static;
 
     /**
      * Returns the month of a date as a number between 1 and 12.
@@ -239,10 +171,8 @@ interface DateOperators
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/month/
-     *
-     * @param mixed|Expr $expression
      */
-    public function month($expression): static;
+    public function month(mixed $expression): static;
 
     /**
      * Returns the second portion of a date as a number between 0 and 59, but
@@ -251,19 +181,15 @@ interface DateOperators
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/second/
-     *
-     * @param mixed|Expr $expression
      */
-    public function second($expression): static;
+    public function second(mixed $expression): static;
 
     /**
      * Converts value to a Date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/toDate/
-     *
-     * @param mixed|Expr $expression
      */
-    public function toDate($expression): static;
+    public function toDate(mixed $expression): static;
 
     /**
      * Returns the week of the year for a date as a number between 0 and 53.
@@ -271,10 +197,8 @@ interface DateOperators
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/week/
-     *
-     * @param mixed|Expr $expression
      */
-    public function week($expression): static;
+    public function week(mixed $expression): static;
 
     /**
      * Returns the year portion of a date.
@@ -282,8 +206,6 @@ interface DateOperators
      * The argument can be any expression as long as it resolves to a date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/year/
-     *
-     * @param mixed|Expr $expression
      */
-    public function year($expression): static;
+    public function year(mixed $expression): static;
 }

--- a/src/Aggregation/Operator/GroupAccumulatorOperators.php
+++ b/src/Aggregation/Operator/GroupAccumulatorOperators.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Operator;
 
-use Doctrine\ODM\MongoDB\Aggregation\Expr;
-
 /**
  * Interface containing all accumulator aggregation pipeline operators.
  *
@@ -20,19 +18,15 @@ interface GroupAccumulatorOperators extends CustomOperators
      * Returns an array of unique expression values for each group.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/addToSet/
-     *
-     * @param mixed|Expr $expression
      */
-    public function addToSet($expression): static;
+    public function addToSet(mixed $expression): static;
 
     /**
      * Returns the average value of numeric values. Ignores non-numeric values.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/avg/
-     *
-     * @param mixed|Expr $expression
      */
-    public function avg($expression): static;
+    public function avg(mixed $expression): static;
 
     /**
      * Returns the bottom element within a group according to the specified sort
@@ -40,10 +34,9 @@ interface GroupAccumulatorOperators extends CustomOperators
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/bottom/
      *
-     * @param mixed|Expr                $output
      * @param array<string, int|string> $sortBy
      */
-    public function bottom($output, $sortBy): static;
+    public function bottom(mixed $output, array $sortBy): static;
 
     /**
      * Returns the n bottom elements within a group according to the specified
@@ -51,11 +44,9 @@ interface GroupAccumulatorOperators extends CustomOperators
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/bottomN/
      *
-     * @param mixed|Expr                $output
      * @param array<string, int|string> $sortBy
-     * @param mixed|Expr                $n
      */
-    public function bottomN($output, $sortBy, $n): static;
+    public function bottomN(mixed $output, array $sortBy, mixed $n): static;
 
     /**
      * Returns the number of documents in a group.
@@ -70,10 +61,8 @@ interface GroupAccumulatorOperators extends CustomOperators
      * a defined order.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/first/
-     *
-     * @param mixed|Expr $expression
      */
-    public function first($expression): static;
+    public function first(mixed $expression): static;
 
     /**
      * Returns the value that results from applying an expression to the first n
@@ -81,11 +70,8 @@ interface GroupAccumulatorOperators extends CustomOperators
      * a defined order.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/firstN/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr $n
      */
-    public function firstN($expression, $n): static;
+    public function firstN(mixed $expression, mixed $n): static;
 
     /**
      * Returns the value that results from applying an expression to the last
@@ -93,10 +79,8 @@ interface GroupAccumulatorOperators extends CustomOperators
      * a defined order.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/last/
-     *
-     * @param mixed|Expr $expression
      */
-    public function last($expression): static;
+    public function last(mixed $expression): static;
 
     /**
      * Returns the value that results from applying an expression to the last n
@@ -104,96 +88,73 @@ interface GroupAccumulatorOperators extends CustomOperators
      * a defined order.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/lastN/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr $n
      */
-    public function lastN($expression, $n): static;
+    public function lastN(mixed $expression, mixed $n): static;
 
     /**
      * Returns the highest expression value for each group.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/max/
-     *
-     * @param mixed|Expr $expression
      */
-    public function max($expression): static;
+    public function max(mixed $expression): static;
 
     /**
      * Returns the highest n expression values for each group.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/maxN/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr $n
      */
-    public function maxN($expression, $n): static;
+    public function maxN(mixed $expression, mixed $n): static;
 
     /**
      * Returns a document created by combining the input documents for each
      * group.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/mergeObjects/
-     *
-     * @param mixed|Expr $expression
      */
-    public function mergeObjects($expression): static;
+    public function mergeObjects(mixed $expression): static;
 
     /**
      * Returns the lowest expression value for each group.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/min/
-     *
-     * @param mixed|Expr $expression
      */
-    public function min($expression): static;
+    public function min(mixed $expression): static;
 
     /**
      * Returns the lowest n expression values for each group.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/minN/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr $n
      */
-    public function minN($expression, $n): static;
+    public function minN(mixed $expression, mixed $n): static;
 
     /**
      * Returns an array of expression values for documents in each group.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/push/
-     *
-     * @param mixed|Expr $expression
      */
-    public function push($expression): static;
+    public function push(mixed $expression): static;
 
     /**
      * Returns the population standard deviation of the input values.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevPop/
-     *
-     * @param mixed|Expr $expression
      */
-    public function stdDevPop($expression): static;
+    public function stdDevPop(mixed $expression): static;
 
     /**
      * Returns the sample standard deviation of the input values.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevSamp/
-     *
-     * @param mixed|Expr $expression
      */
-    public function stdDevSamp($expression): static;
+    public function stdDevSamp(mixed $expression): static;
 
     /**
      * Calculates the collective sum of numeric values. Ignores non-numeric
      * values.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sum/
-     *
-     * @param mixed|Expr $expression
      */
-    public function sum($expression): static;
+    public function sum(mixed $expression): static;
 
     /**
      * Returns the top element within a group according to the specified sort
@@ -201,10 +162,9 @@ interface GroupAccumulatorOperators extends CustomOperators
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/top/
      *
-     * @param mixed|Expr                $output
      * @param array<string, int|string> $sortBy
      */
-    public function top($output, $sortBy): static;
+    public function top(mixed $output, array $sortBy): static;
 
     /**
      * Returns the n top elements within a group according to the specified sort
@@ -212,9 +172,7 @@ interface GroupAccumulatorOperators extends CustomOperators
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/topN/
      *
-     * @param mixed|Expr                $output
      * @param array<string, int|string> $sortBy
-     * @param mixed|Expr                $n
      */
-    public function topN($output, $sortBy, $n): static;
+    public function topN(mixed $output, array $sortBy, mixed $n): static;
 }

--- a/src/Aggregation/Operator/MiscOperators.php
+++ b/src/Aggregation/Operator/MiscOperators.php
@@ -20,10 +20,8 @@ interface MiscOperators
      * Allows any expression to be used as a field value.
      *
      * @see https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions
-     *
-     * @param mixed|Expr $value
      */
-    public function expression($value): static;
+    public function expression(mixed $value): static;
 
     /**
      * Binds variables for use in the specified expression, and returns the
@@ -34,26 +32,22 @@ interface MiscOperators
      * @param mixed|Expr $vars Assignment block for the variables accessible in the in expression. To assign a variable, specify a string for the variable name and assign a valid expression for the value.
      * @param mixed|Expr $in   the expression to evaluate
      */
-    public function let($vars, $in): static;
+    public function let(mixed $vars, mixed $in): static;
 
     /**
      * Returns a value without parsing. Use for values that the aggregation
      * pipeline may interpret as an expression.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/literal/
-     *
-     * @param mixed|Expr $value
      */
-    public function literal($value): static;
+    public function literal(mixed $value): static;
 
     /**
      * Returns the metadata associated with a document in a pipeline operations.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/meta/
-     *
-     * @param mixed|Expr $metaDataKeyword
      */
-    public function meta($metaDataKeyword): static;
+    public function meta(mixed $metaDataKeyword): static;
 
     /**
      * Returns a random float between 0 and 1 each time it is called.

--- a/src/Aggregation/Operator/ObjectOperators.php
+++ b/src/Aggregation/Operator/ObjectOperators.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Operator;
 
-use Doctrine\ODM\MongoDB\Aggregation\Expr;
-
 /**
  * Interface containing all object aggregation pipeline operators.
  *
@@ -22,21 +20,15 @@ interface ObjectOperators
      * $$CURRENT.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/getField/
-     *
-     * @param mixed|Expr $field
-     * @param mixed|Expr $input
      */
-    public function getField($field, $input = null): static;
+    public function getField(mixed $field, mixed $input = null): static;
 
     /**
      * Combines multiple documents into a single document.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/mergeObjects/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr ...$expressions
      */
-    public function mergeObjects($expression, ...$expressions): static;
+    public function mergeObjects(mixed $expression, mixed ...$expressions): static;
 
     /**
      * Converts a document to an array. The return array contains an element for
@@ -46,19 +38,13 @@ interface ObjectOperators
      *      The v field contains the value of the field in the original document.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/objectToArray/
-     *
-     * @param mixed|Expr $object
      */
-    public function objectToArray($object): static;
+    public function objectToArray(mixed $object): static;
 
     /**
      * Adds, updates, or removes a specified field in a document.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/setField/
-     *
-     * @param mixed|Expr $field
-     * @param mixed|Expr $input
-     * @param mixed|Expr $value
      */
-    public function setField($field, $input, $value): static;
+    public function setField(mixed $field, mixed $input, mixed $value): static;
 }

--- a/src/Aggregation/Operator/ProvidesGroupAccumulatorOperators.php
+++ b/src/Aggregation/Operator/ProvidesGroupAccumulatorOperators.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Aggregation\Operator;
 
 use Doctrine\ODM\MongoDB\Aggregation\Expr;
+use MongoDB\BSON\Javascript;
 
 use function func_get_args;
 
@@ -13,35 +14,35 @@ trait ProvidesGroupAccumulatorOperators
 {
     abstract protected function getExpr(): Expr;
 
-    public function accumulator($init, $accumulate, $accumulateArgs, $merge, $initArgs = null, $finalize = null, $lang = 'js'): static
+    public function accumulator(string|Javascript $init, string|Javascript $accumulate, mixed $accumulateArgs, string|Javascript $merge, mixed $initArgs = null, string|Javascript|null $finalize = null, string $lang = 'js'): static
     {
         $this->getExpr()->accumulator(...func_get_args());
 
         return $this;
     }
 
-    public function addToSet($expression): static
+    public function addToSet(mixed $expression): static
     {
         $this->getExpr()->addToSet(...func_get_args());
 
         return $this;
     }
 
-    public function avg($expression, ...$expressions): static
+    public function avg(mixed $expression, mixed ...$expressions): static
     {
         $this->getExpr()->avg(...func_get_args());
 
         return $this;
     }
 
-    public function bottom($output, $sortBy): static
+    public function bottom(mixed $output, array $sortBy): static
     {
         $this->getExpr()->bottom(...func_get_args());
 
         return $this;
     }
 
-    public function bottomN($output, $sortBy, $n): static
+    public function bottomN(mixed $output, array $sortBy, mixed $n): static
     {
         $this->getExpr()->bottomN(...func_get_args());
 
@@ -55,112 +56,112 @@ trait ProvidesGroupAccumulatorOperators
         return $this;
     }
 
-    public function first($expression): static
+    public function first(mixed $expression): static
     {
         $this->getExpr()->first(...func_get_args());
 
         return $this;
     }
 
-    public function firstN($expression, $n): static
+    public function firstN(mixed $expression, mixed $n): static
     {
         $this->getExpr()->firstN(...func_get_args());
 
         return $this;
     }
 
-    public function function($body, $args, $lang = 'js'): static
+    public function function(string|Javascript $body, mixed $args, string $lang = 'js'): static
     {
         $this->getExpr()->function(...func_get_args());
 
         return $this;
     }
 
-    public function last($expression): static
+    public function last(mixed $expression): static
     {
         $this->getExpr()->last(...func_get_args());
 
         return $this;
     }
 
-    public function lastN($expression, $n): static
+    public function lastN(mixed $expression, mixed $n): static
     {
         $this->getExpr()->lastN(...func_get_args());
 
         return $this;
     }
 
-    public function max($expression, ...$expressions): static
+    public function max(mixed $expression, mixed ...$expressions): static
     {
         $this->getExpr()->max(...func_get_args());
 
         return $this;
     }
 
-    public function maxN($expression, $n): static
+    public function maxN(mixed $expression, mixed $n): static
     {
         $this->getExpr()->maxN(...func_get_args());
 
         return $this;
     }
 
-    public function mergeObjects($expression, ...$expressions): static
+    public function mergeObjects(mixed $expression, mixed ...$expressions): static
     {
         $this->getExpr()->mergeObjects(...func_get_args());
 
         return $this;
     }
 
-    public function min($expression, ...$expressions): static
+    public function min(mixed $expression, mixed ...$expressions): static
     {
         $this->getExpr()->min(...func_get_args());
 
         return $this;
     }
 
-    public function minN($expression, $n): static
+    public function minN(mixed $expression, mixed $n): static
     {
         $this->getExpr()->minN(...func_get_args());
 
         return $this;
     }
 
-    public function push($expression): static
+    public function push(mixed $expression): static
     {
         $this->getExpr()->push(...func_get_args());
 
         return $this;
     }
 
-    public function stdDevPop($expression, ...$expressions): static
+    public function stdDevPop(mixed $expression, mixed ...$expressions): static
     {
         $this->getExpr()->stdDevPop(...func_get_args());
 
         return $this;
     }
 
-    public function stdDevSamp($expression, ...$expressions): static
+    public function stdDevSamp(mixed $expression, mixed ...$expressions): static
     {
         $this->getExpr()->stdDevSamp(...func_get_args());
 
         return $this;
     }
 
-    public function sum($expression, ...$expressions): static
+    public function sum(mixed $expression, mixed ...$expressions): static
     {
         $this->getExpr()->sum(...func_get_args());
 
         return $this;
     }
 
-    public function top($output, $sortBy): static
+    public function top(mixed $output, array $sortBy): static
     {
         $this->getExpr()->top(...func_get_args());
 
         return $this;
     }
 
-    public function topN($output, $sortBy, $n): static
+    public function topN(mixed $output, array $sortBy, mixed $n): static
     {
         $this->getExpr()->topN(...func_get_args());
 

--- a/src/Aggregation/Operator/ProvidesWindowOperators.php
+++ b/src/Aggregation/Operator/ProvidesWindowOperators.php
@@ -13,28 +13,28 @@ trait ProvidesWindowOperators
 {
     abstract protected function getExpr(): Expr;
 
-    public function addToSet($expression): static
+    public function addToSet(mixed $expression): static
     {
         $this->getExpr()->addToSet(...func_get_args());
 
         return $this;
     }
 
-    public function avg($expression, ...$expressions): static
+    public function avg(mixed $expression, mixed ...$expressions): static
     {
         $this->getExpr()->avg(...func_get_args());
 
         return $this;
     }
 
-    public function bottom($output, $sortBy): static
+    public function bottom(mixed $output, array $sortBy): static
     {
         $this->getExpr()->bottom(...func_get_args());
 
         return $this;
     }
 
-    public function bottomN($output, $sortBy, $n): static
+    public function bottomN(mixed $output, array $sortBy, mixed $n): static
     {
         $this->getExpr()->bottomN(...func_get_args());
 
@@ -48,14 +48,14 @@ trait ProvidesWindowOperators
         return $this;
     }
 
-    public function covariancePop($expression1, $expression2): static
+    public function covariancePop(mixed $expression1, mixed $expression2): static
     {
         $this->getExpr()->covariancePop(...func_get_args());
 
         return $this;
     }
 
-    public function covarianceSamp($expression1, $expression2): static
+    public function covarianceSamp(mixed $expression1, mixed $expression2): static
     {
         $this->getExpr()->covarianceSamp(...func_get_args());
 
@@ -69,7 +69,7 @@ trait ProvidesWindowOperators
         return $this;
     }
 
-    public function derivative($input, string $unit): static
+    public function derivative(mixed $input, string $unit): static
     {
         $this->getExpr()->derivative(...func_get_args());
 
@@ -83,91 +83,91 @@ trait ProvidesWindowOperators
         return $this;
     }
 
-    public function expMovingAvg($input, ?int $n = null, ?float $alpha = null): static
+    public function expMovingAvg(mixed $input, ?int $n = null, ?float $alpha = null): static
     {
         $this->getExpr()->expMovingAvg(...func_get_args());
 
         return $this;
     }
 
-    public function first($expression): static
+    public function first(mixed $expression): static
     {
         $this->getExpr()->first(...func_get_args());
 
         return $this;
     }
 
-    public function firstN($expression, $n): static
+    public function firstN(mixed $expression, mixed $n): static
     {
         $this->getExpr()->firstN(...func_get_args());
 
         return $this;
     }
 
-    public function integral($input, string $unit): static
+    public function integral(mixed $input, string $unit): static
     {
         $this->getExpr()->integral(...func_get_args());
 
         return $this;
     }
 
-    public function last($expression): static
+    public function last(mixed $expression): static
     {
         $this->getExpr()->last(...func_get_args());
 
         return $this;
     }
 
-    public function lastN($expression, $n): static
+    public function lastN(mixed $expression, mixed $n): static
     {
         $this->getExpr()->lastN(...func_get_args());
 
         return $this;
     }
 
-    public function linearFill($expression): static
+    public function linearFill(mixed $expression): static
     {
         $this->getExpr()->linearFill(...func_get_args());
 
         return $this;
     }
 
-    public function locf($expression): static
+    public function locf(mixed $expression): static
     {
         $this->getExpr()->locf(...func_get_args());
 
         return $this;
     }
 
-    public function max($expression, ...$expressions): static
+    public function max(mixed $expression, mixed ...$expressions): static
     {
         $this->getExpr()->max(...func_get_args());
 
         return $this;
     }
 
-    public function maxN($expression, $n): static
+    public function maxN(mixed $expression, mixed $n): static
     {
         $this->getExpr()->maxN(...func_get_args());
 
         return $this;
     }
 
-    public function min($expression, ...$expressions): static
+    public function min(mixed $expression, mixed ...$expressions): static
     {
         $this->getExpr()->min(...func_get_args());
 
         return $this;
     }
 
-    public function minN($expression, $n): static
+    public function minN(mixed $expression, mixed $n): static
     {
         $this->getExpr()->minN(...func_get_args());
 
         return $this;
     }
 
-    public function push($expression): static
+    public function push(mixed $expression): static
     {
         $this->getExpr()->push(...func_get_args());
 
@@ -181,42 +181,42 @@ trait ProvidesWindowOperators
         return $this;
     }
 
-    public function shift($output, int $by, $default = null): static
+    public function shift(mixed $output, int $by, mixed $default = null): static
     {
         $this->getExpr()->shift(...func_get_args());
 
         return $this;
     }
 
-    public function stdDevPop($expression, ...$expressions): static
+    public function stdDevPop(mixed $expression, mixed ...$expressions): static
     {
         $this->getExpr()->stdDevPop(...func_get_args());
 
         return $this;
     }
 
-    public function stdDevSamp($expression, ...$expressions): static
+    public function stdDevSamp(mixed $expression, mixed ...$expressions): static
     {
         $this->getExpr()->stdDevSamp(...func_get_args());
 
         return $this;
     }
 
-    public function sum($expression, ...$expressions): static
+    public function sum(mixed $expression, mixed ...$expressions): static
     {
         $this->getExpr()->sum(...func_get_args());
 
         return $this;
     }
 
-    public function top($output, $sortBy): static
+    public function top(mixed $output, array $sortBy): static
     {
         $this->getExpr()->top(...func_get_args());
 
         return $this;
     }
 
-    public function topN($output, $sortBy, $n): static
+    public function topN(mixed $output, array $sortBy, mixed $n): static
     {
         $this->getExpr()->topN(...func_get_args());
 

--- a/src/Aggregation/Operator/SetOperators.php
+++ b/src/Aggregation/Operator/SetOperators.php
@@ -23,10 +23,8 @@ interface SetOperators
      * The expression must resolve to an array.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/allElementsTrue/
-     *
-     * @param mixed|Expr $expression
      */
-    public function allElementsTrue($expression): static;
+    public function allElementsTrue(mixed $expression): static;
 
     /**
      * Evaluates an array as a set and returns true if any of the elements are
@@ -38,7 +36,7 @@ interface SetOperators
      *
      * @param mixed[]|Expr $expression
      */
-    public function anyElementTrue($expression): static;
+    public function anyElementTrue(mixed $expression): static;
 
     /**
      * Takes two sets and returns an array containing the elements that only
@@ -47,11 +45,8 @@ interface SetOperators
      * The arguments can be any valid expression as long as they each resolve to an array.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/setDifference/
-     *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      */
-    public function setDifference($expression1, $expression2): static;
+    public function setDifference(mixed $expression1, mixed $expression2): static;
 
     /**
      * Compares two or more arrays and returns true if they have the same
@@ -61,11 +56,9 @@ interface SetOperators
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/setEquals/
      *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      * @param mixed|Expr ...$expressions Additional sets
      */
-    public function setEquals($expression1, $expression2, ...$expressions): static;
+    public function setEquals(mixed $expression1, mixed $expression2, mixed ...$expressions): static;
 
     /**
      * Takes two or more arrays and returns an array that contains the elements
@@ -75,11 +68,9 @@ interface SetOperators
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/setIntersection/
      *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      * @param mixed|Expr ...$expressions Additional sets
      */
-    public function setIntersection($expression1, $expression2, ...$expressions): static;
+    public function setIntersection(mixed $expression1, mixed $expression2, mixed ...$expressions): static;
 
     /**
      * Takes two arrays and returns true when the first array is a subset of the
@@ -89,11 +80,8 @@ interface SetOperators
      * The arguments can be any valid expression as long as they each resolve to an array.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/setIsSubset/
-     *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      */
-    public function setIsSubset($expression1, $expression2): static;
+    public function setIsSubset(mixed $expression1, mixed $expression2): static;
 
     /**
      * Takes two or more arrays and returns an array containing the elements
@@ -104,9 +92,7 @@ interface SetOperators
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/setUnion/
      *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      * @param mixed|Expr ...$expressions Additional sets
      */
-    public function setUnion($expression1, $expression2, ...$expressions): static;
+    public function setUnion(mixed $expression1, mixed $expression2, mixed ...$expressions): static;
 }

--- a/src/Aggregation/Operator/StringOperators.php
+++ b/src/Aggregation/Operator/StringOperators.php
@@ -25,24 +25,16 @@ interface StringOperators
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/concat/
      *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      * @param mixed|Expr ...$expressions Additional expressions
      */
-    public function concat($expression1, $expression2, ...$expressions): static;
+    public function concat(mixed $expression1, mixed $expression2, mixed ...$expressions): static;
 
     /**
      * Converts a date/time string to a date object.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dateFromString/
-     *
-     * @param mixed|Expr $dateString
-     * @param mixed|Expr $format
-     * @param mixed|Expr $timezone
-     * @param mixed|Expr $onError
-     * @param mixed|Expr $onNull
      */
-    public function dateFromString($dateString, $format = null, $timezone = null, $onError = null, $onNull = null): static;
+    public function dateFromString(mixed $dateString, mixed $format = null, mixed $timezone = null, mixed $onError = null, mixed $onNull = null): static;
 
     /**
      * Converts a date object to a string according to a user-specified format.
@@ -52,12 +44,8 @@ interface StringOperators
      * The date argument can be any expression as long as it resolves to a date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/dateToString/
-     *
-     * @param mixed|Expr      $expression
-     * @param mixed|Expr|null $timezone
-     * @param mixed|Expr|null $onNull
      */
-    public function dateToString(string $format, $expression, $timezone = null, $onNull = null): static;
+    public function dateToString(string $format, mixed $expression, mixed $timezone = null, mixed $onNull = null): static;
 
     /**
      * Searches a string for an occurrence of a substring and returns the UTF-8
@@ -71,7 +59,7 @@ interface StringOperators
      * @param string|int|null $start               An integral number that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      * @param string|int|null $end                 An integral number that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      */
-    public function indexOfBytes($stringExpression, $substringExpression, $start = null, $end = null): static;
+    public function indexOfBytes(mixed $stringExpression, mixed $substringExpression, string|int|null $start = null, string|int|null $end = null): static;
 
     /**
      * Searches a string for an occurrence of a substring and returns the UTF-8
@@ -85,18 +73,15 @@ interface StringOperators
      * @param string|int|null $start               An integral number that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      * @param string|int|null $end                 An integral number that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      */
-    public function indexOfCP($stringExpression, $substringExpression, $start = null, $end = null): static;
+    public function indexOfCP(mixed $stringExpression, mixed $substringExpression, string|int|null $start = null, string|int|null $end = null): static;
 
     /**
      * Removes whitespace characters, including null, or the specified
      * characters from the beginning and end of a string.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/ltrim/
-     *
-     * @param mixed|Expr $input
-     * @param mixed|Expr $chars
      */
-    public function ltrim($input, $chars = null): static;
+    public function ltrim(mixed $input, mixed $chars = null): static;
 
     /**
      * Provides regular expression (regex) pattern matching capability in
@@ -106,12 +91,8 @@ interface StringOperators
      * first match. If a match is not found, returns null.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/regexFind/
-     *
-     * @param mixed|Expr  $input
-     * @param mixed|Expr  $regex
-     * @param string|null $options
      */
-    public function regexFind($input, $regex, $options = null): static;
+    public function regexFind(mixed $input, mixed $regex, ?string $options = null): static;
 
     /**
      * Provides regular expression (regex) pattern matching capability in
@@ -121,36 +102,24 @@ interface StringOperators
      * each match. If a match is not found, returns an empty array.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/regexFindAll/
-     *
-     * @param mixed|Expr  $input
-     * @param mixed|Expr  $regex
-     * @param string|null $options
      */
-    public function regexFindAll($input, $regex, $options = null): static;
+    public function regexFindAll(mixed $input, mixed $regex, ?string $options = null): static;
 
     /**
      * Performs a regular expression (regex) pattern matching and returns true
      * if a match exists.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/regexMatch/
-     *
-     * @param mixed|Expr  $input
-     * @param mixed|Expr  $regex
-     * @param string|null $options
      */
-    public function regexMatch($input, $regex, $options = null): static;
+    public function regexMatch(mixed $input, mixed $regex, ?string $options = null): static;
 
     /**
      * Replaces all instances of a search string in an input string with a
      * replacement string.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/replaceAll/
-     *
-     * @param mixed|Expr $input
-     * @param mixed|Expr $find
-     * @param mixed|Expr $replacement
      */
-    public function replaceAll($input, $find, $replacement): static;
+    public function replaceAll(mixed $input, mixed $find, mixed $replacement): static;
 
     /**
      * Replaces the first instance of a search string in an input string with a
@@ -158,23 +127,16 @@ interface StringOperators
      * input string.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/replaceOne/
-     *
-     * @param mixed|Expr $input
-     * @param mixed|Expr $find
-     * @param mixed|Expr $replacement
      */
-    public function replaceOne($input, $find, $replacement): static;
+    public function replaceOne(mixed $input, mixed $find, mixed $replacement): static;
 
     /**
      * Removes whitespace characters, including null, or the specified
      * characters from the end of a string.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/rtrim/
-     *
-     * @param mixed|Expr $input
-     * @param mixed|Expr $chars
      */
-    public function rtrim($input, $chars = null): static;
+    public function rtrim(mixed $input, mixed $chars = null): static;
 
     /**
      * Divides a string into an array of substrings based on a delimiter.
@@ -188,25 +150,21 @@ interface StringOperators
      * @param mixed|Expr $string    The string to be split. Can be any valid expression as long as it resolves to a string.
      * @param mixed|Expr $delimiter The delimiter to use when splitting the string expression. Can be any valid expression as long as it resolves to a string.
      */
-    public function split($string, $delimiter): static;
+    public function split(mixed $string, mixed $delimiter): static;
 
     /**
      * Returns the number of UTF-8 encoded bytes in the specified string.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/strLenBytes/
-     *
-     * @param mixed|Expr $string
      */
-    public function strLenBytes($string): static;
+    public function strLenBytes(mixed $string): static;
 
     /**
      * Returns the number of UTF-8 code points in the specified string.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/strLenCP/
-     *
-     * @param mixed|Expr $string
      */
-    public function strLenCP($string): static;
+    public function strLenCP(mixed $string): static;
 
     /**
      * Performs case-insensitive comparison of two strings. Returns
@@ -218,11 +176,8 @@ interface StringOperators
      * strings.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/strcasecmp/
-     *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      */
-    public function strcasecmp($expression1, $expression2): static;
+    public function strcasecmp(mixed $expression1, mixed $expression2): static;
 
     /**
      * Returns a substring of a string, starting at a specified index position
@@ -233,12 +188,8 @@ interface StringOperators
      * to integers.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/substr/
-     *
-     * @param mixed|Expr $string
-     * @param mixed|Expr $start
-     * @param mixed|Expr $length
      */
-    public function substr($string, $start, $length): static;
+    public function substr(mixed $string, mixed $start, mixed $length): static;
 
     /**
      * Returns the substring of a string.
@@ -253,7 +204,7 @@ interface StringOperators
      * @param mixed|Expr $start  Indicates the starting point of the substring. Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
      * @param mixed|Expr $count  can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer
      */
-    public function substrBytes($string, $start, $count): static;
+    public function substrBytes(mixed $string, mixed $start, mixed $count): static;
 
     /**
      * Returns the substring of a string.
@@ -268,7 +219,7 @@ interface StringOperators
      * @param mixed|Expr $start  Indicates the starting point of the substring. Can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer.
      * @param mixed|Expr $count  can be any valid expression as long as it resolves to a non-negative integer or number that can be represented as an integer
      */
-    public function substrCP($string, $start, $count): static;
+    public function substrCP(mixed $string, mixed $start, mixed $count): static;
 
     /**
      * Converts a string to lowercase, returning the result.
@@ -276,19 +227,15 @@ interface StringOperators
      * The argument can be any expression as long as it resolves to a string.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/toLower/
-     *
-     * @param mixed|Expr $expression
      */
-    public function toLower($expression): static;
+    public function toLower(mixed $expression): static;
 
     /**
      * Converts value to a string.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/toString/
-     *
-     * @param mixed|Expr $expression
      */
-    public function toString($expression): static;
+    public function toString(mixed $expression): static;
 
     /**
      * Converts a string to uppercase, returning the result.
@@ -296,19 +243,14 @@ interface StringOperators
      * The argument can be any expression as long as it resolves to a string.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/toUpper/
-     *
-     * @param mixed|Expr $expression
      */
-    public function toUpper($expression): static;
+    public function toUpper(mixed $expression): static;
 
     /**
      * Removes whitespace characters, including null, or the specified
      * characters from the beginning and end of a string.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/trim/
-     *
-     * @param mixed|Expr      $input
-     * @param mixed|Expr|null $chars
      */
-    public function trim($input, $chars = null): static;
+    public function trim(mixed $input, mixed $chars = null): static;
 }

--- a/src/Aggregation/Operator/TimestampOperators.php
+++ b/src/Aggregation/Operator/TimestampOperators.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Operator;
 
-use Doctrine\ODM\MongoDB\Aggregation\Expr;
-
 /**
  * Interface containing timestamp aggregation pipeline operators.
  *
@@ -20,17 +18,13 @@ interface TimestampOperators
      * Returns the incrementing ordinal from a timestamp as a long.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/tsIncrement/
-     *
-     * @param mixed|Expr $expression
      */
-    public function tsIncrement($expression): static;
+    public function tsIncrement(mixed $expression): static;
 
     /**
      * Returns the seconds from a timestamp as a long.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/tsSecond/
-     *
-     * @param mixed|Expr $expression
      */
-    public function tsSecond($expression): static;
+    public function tsSecond(mixed $expression): static;
 }

--- a/src/Aggregation/Operator/TrigonometryOperators.php
+++ b/src/Aggregation/Operator/TrigonometryOperators.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Operator;
 
-use Doctrine\ODM\MongoDB\Aggregation\Expr;
-
 /**
  * Interface containing all trigonometry aggregation pipeline operators.
  *
@@ -20,139 +18,108 @@ interface TrigonometryOperators
      * Returns the inverse cosine (arc cosine) of a value in radians.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/acos/
-     *
-     * @param mixed|Expr $expression
      */
-    public function acos($expression): static;
+    public function acos(mixed $expression): static;
 
     /**
      * Returns the inverse hyperbolic cosine (hyperbolic arc cosine) of a value
      * in radians.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/acosh/
-     *
-     * @param mixed|Expr $expression
      */
-    public function acosh($expression): static;
+    public function acosh(mixed $expression): static;
 
     /**
      * Returns the inverse sin (arc sine) of a value in radians.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/asin/
-     *
-     * @param mixed|Expr $expression
      */
-    public function asin($expression): static;
+    public function asin(mixed $expression): static;
 
     /**
      * Returns the inverse hyperbolic sine (hyperbolic arc sine) of a value in
      * radians.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/asinh/
-     *
-     * @param mixed|Expr $expression
      */
-    public function asinh($expression): static;
+    public function asinh(mixed $expression): static;
 
     /**
      * Returns the inverse tangent (arc tangent) of a value in radians.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/atan/
-     *
-     * @param mixed|Expr $expression
      */
-    public function atan($expression): static;
+    public function atan(mixed $expression): static;
 
     /**
      * Returns the inverse tangent (arc tangent) of y / x in radians, where y
      * and x are the first and second values passed to the expression respectively.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/atan2/
-     *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      */
-    public function atan2($expression1, $expression2): static;
+    public function atan2(mixed $expression1, mixed $expression2): static;
 
     /**
      * Returns the inverse hyperbolic tangent (hyperbolic arc tangent) of a
      * value in radians.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/atanh/
-     *
-     * @param mixed|Expr $expression
      */
-    public function atanh($expression): static;
+    public function atanh(mixed $expression): static;
 
     /**
      * Returns the cosine of a value that is measured in radians.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/cos/
-     *
-     * @param mixed|Expr $expression
      */
-    public function cos($expression): static;
+    public function cos(mixed $expression): static;
 
     /**
      * Returns the hyperbolic cosine of a value that is measured in radians.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/cosh/
-     *
-     * @param mixed|Expr $expression
      */
-    public function cosh($expression): static;
+    public function cosh(mixed $expression): static;
 
     /**
      * Converts a value from degrees to radians.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/degreesToRadians/
-     *
-     * @param mixed|Expr $expression
      */
-    public function degreesToRadians($expression): static;
+    public function degreesToRadians(mixed $expression): static;
 
     /**
      * Converts a value from radians to degrees.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/radiansToDegrees/
-     *
-     * @param mixed|Expr $expression
      */
-    public function radiansToDegrees($expression): static;
+    public function radiansToDegrees(mixed $expression): static;
 
     /**
      * Returns the sine of a value that is measured in radians.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sin/
-     *
-     * @param mixed|Expr $expression
      */
-    public function sin($expression): static;
+    public function sin(mixed $expression): static;
 
     /**
      * Returns the hyperbolic sine of a value that is measured in radians.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sinh/
-     *
-     * @param mixed|Expr $expression
      */
-    public function sinh($expression): static;
+    public function sinh(mixed $expression): static;
 
     /**
      * Returns the tangent of a value that is measured in radians.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/tan/
-     *
-     * @param mixed|Expr $expression
      */
-    public function tan($expression): static;
+    public function tan(mixed $expression): static;
 
     /**
      * Returns the hyperbolic tangent of a value that is measured in radians.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/tanh/
-     *
-     * @param mixed|Expr $expression
      */
-    public function tanh($expression): static;
+    public function tanh(mixed $expression): static;
 }

--- a/src/Aggregation/Operator/TypeOperators.php
+++ b/src/Aggregation/Operator/TypeOperators.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Operator;
 
-use Doctrine\ODM\MongoDB\Aggregation\Expr;
-
 /**
  * Interface containing all type aggregation pipeline operators.
  *
@@ -20,13 +18,8 @@ interface TypeOperators
      * Converts a value to a specified type.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/convert/
-     *
-     * @param mixed|Expr      $input
-     * @param mixed|Expr      $to
-     * @param mixed|Expr|null $onError
-     * @param mixed|Expr|null $onNull
      */
-    public function convert($input, $to, $onError = null, $onNull = null): static;
+    public function convert(mixed $input, mixed $to, mixed $onError = null, mixed $onNull = null): static;
 
     /**
      * Determines if the operand is an array. Returns a boolean.
@@ -34,10 +27,8 @@ interface TypeOperators
      * The <expression> can be any valid expression.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isArray/
-     *
-     * @param mixed|Expr $expression
      */
-    public function isArray($expression): static;
+    public function isArray(mixed $expression): static;
 
     /**
      * Returns boolean true if the specified expression resolves to an integer,
@@ -45,82 +36,64 @@ interface TypeOperators
      * resolves to any other BSON type, null, or a missing field.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/isNumber/
-     *
-     * @param mixed|Expr $expression
      */
-    public function isNumber($expression): static;
+    public function isNumber(mixed $expression): static;
 
     /**
      * Converts value to a boolean.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/toBool/
-     *
-     * @param mixed|Expr $expression
      */
-    public function toBool($expression): static;
+    public function toBool(mixed $expression): static;
 
     /**
      * Converts value to a Date.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/toDate/
-     *
-     * @param mixed|Expr $expression
      */
-    public function toDate($expression): static;
+    public function toDate(mixed $expression): static;
 
     /**
      * Converts value to a Decimal128.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/toDecimal/
-     *
-     * @param mixed|Expr $expression
      */
-    public function toDecimal($expression): static;
+    public function toDecimal(mixed $expression): static;
 
     /**
      * Converts value to a double.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/toDouble/
-     *
-     * @param mixed|Expr $expression
      */
-    public function toDouble($expression): static;
+    public function toDouble(mixed $expression): static;
 
     /**
      * Converts value to an integer.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/toInt/
-     *
-     * @param mixed|Expr $expression
      */
-    public function toInt($expression): static;
+    public function toInt(mixed $expression): static;
 
     /**
      * Converts value to a long.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/toLong/
-     *
-     * @param mixed|Expr $expression
      */
-    public function toLong($expression): static;
+    public function toLong(mixed $expression): static;
 
     /**
      * Converts value to an ObjectId.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/toObjectId/
-     *
-     * @param mixed|Expr $expression
      */
-    public function toObjectId($expression): static;
+    public function toObjectId(mixed $expression): static;
 
     /**
      * Converts value to a string.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/toString/
-     *
-     * @param mixed|Expr $expression
      */
-    public function toString($expression): static;
+    public function toString(mixed $expression): static;
 
     /**
      * Returns a string that specifies the BSON type of the argument.
@@ -128,8 +101,6 @@ interface TypeOperators
      * The argument can be any valid expression.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/type/
-     *
-     * @param mixed|Expr $expression
      */
-    public function type($expression): static;
+    public function type(mixed $expression): static;
 }

--- a/src/Aggregation/Operator/WindowOperators.php
+++ b/src/Aggregation/Operator/WindowOperators.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Operator;
 
-use Doctrine\ODM\MongoDB\Aggregation\Expr;
-
 /**
  * Interface containing all window aggregation pipeline operators.
  *
@@ -20,19 +18,15 @@ interface WindowOperators
      * Returns an array of unique expression values for each group.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/addToSet/
-     *
-     * @param mixed|Expr $expression
      */
-    public function addToSet($expression): static;
+    public function addToSet(mixed $expression): static;
 
     /**
      * Returns the average value of numeric values. Ignores non-numeric values.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/avg/
-     *
-     * @param mixed|Expr $expression
      */
-    public function avg($expression): static;
+    public function avg(mixed $expression): static;
 
     /**
      * Returns the bottom element within a group according to the specified sort
@@ -40,10 +34,9 @@ interface WindowOperators
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/bottom/
      *
-     * @param mixed|Expr                $output
      * @param array<string, int|string> $sortBy
      */
-    public function bottom($output, $sortBy): static;
+    public function bottom(mixed $output, array $sortBy): static;
 
     /**
      * Returns the n bottom elements within a group according to the specified
@@ -51,11 +44,9 @@ interface WindowOperators
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/bottomN/
      *
-     * @param mixed|Expr                $output
      * @param array<string, int|string> $sortBy
-     * @param mixed|Expr                $n
      */
-    public function bottomN($output, $sortBy, $n): static;
+    public function bottomN(mixed $output, array $sortBy, mixed $n): static;
 
     /**
      * Returns the number of documents in a group.
@@ -68,21 +59,15 @@ interface WindowOperators
      * Returns the population covariance of two numeric expressions.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/covariancePop/
-     *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      */
-    public function covariancePop($expression1, $expression2): static;
+    public function covariancePop(mixed $expression1, mixed $expression2): static;
 
     /**
      * Returns the sample covariance of two numeric expressions.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/covarianceSamp/
-     *
-     * @param mixed|Expr $expression1
-     * @param mixed|Expr $expression2
      */
-    public function covarianceSamp($expression1, $expression2): static;
+    public function covarianceSamp(mixed $expression1, mixed $expression2): static;
 
     /**
      * Returns the document position (rank) relative to other documents in the
@@ -97,10 +82,8 @@ interface WindowOperators
      * Returns the average rate of change within the specified window.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/derivative/
-     *
-     * @param mixed|Expr $input
      */
-    public function derivative($input, string $unit): static;
+    public function derivative(mixed $input, string $unit): static;
 
     /**
      * Returns the position of a document in the current partition. Ties result
@@ -117,11 +100,10 @@ interface WindowOperators
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/expMovingAvg/
      *
-     * @param mixed|Expr $input
      * @param int|null   $n     An integer that specifies the number of historical documents that have a significant mathematical weight in the exponential moving average calculation, with the most recent documents contributing the most weight.
      * @param float|null $alpha A double that specifies the exponential decay value to use in the exponential moving average calculation. A higher alpha value assigns a lower mathematical significance to previous results from the calculation.
      */
-    public function expMovingAvg($input, ?int $n = null, ?float $alpha = null): static;
+    public function expMovingAvg(mixed $input, ?int $n = null, ?float $alpha = null): static;
 
     /**
      * Returns the value that results from applying an expression to the first
@@ -129,10 +111,8 @@ interface WindowOperators
      * a defined order.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/first/
-     *
-     * @param mixed|Expr $expression
      */
-    public function first($expression): static;
+    public function first(mixed $expression): static;
 
     /**
      * Returns the value that results from applying an expression to the first n
@@ -140,20 +120,15 @@ interface WindowOperators
      * a defined order.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/firstN/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr $n
      */
-    public function firstN($expression, $n): static;
+    public function firstN(mixed $expression, mixed $n): static;
 
     /**
      * Returns the approximation of the area under a curve.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/integral/
-     *
-     * @param mixed|Expr $input
      */
-    public function integral($input, string $unit): static;
+    public function integral(mixed $input, string $unit): static;
 
     /**
      * Returns the value that results from applying an expression to the last
@@ -161,10 +136,8 @@ interface WindowOperators
      * a defined order.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/last/
-     *
-     * @param mixed|Expr $expression
      */
-    public function last($expression): static;
+    public function last(mixed $expression): static;
 
     /**
      * Returns the value that results from applying an expression to the last n
@@ -172,78 +145,59 @@ interface WindowOperators
      * a defined order.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/lastN/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr $n
      */
-    public function lastN($expression, $n): static;
+    public function lastN(mixed $expression, mixed $n): static;
 
     /**
      * Fills null and missing fields in a window using linear interpolation
      * based on surrounding field values.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/linearFill/
-     *
-     * @param mixed|Expr $expression
      */
-    public function linearFill($expression): static;
+    public function linearFill(mixed $expression): static;
 
     /**
      * Last observation carried forward. Sets values for null and missing fields
      * in a window to the last non-null value for the field.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/locf/
-     *
-     * @param mixed|Expr $expression
      */
-    public function locf($expression): static;
+    public function locf(mixed $expression): static;
 
     /**
      * Returns the highest expression value for each group.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/max/
-     *
-     * @param mixed|Expr $expression
      */
-    public function max($expression): static;
+    public function max(mixed $expression): static;
 
     /**
      * Returns the highest n expression values for each group.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/maxN/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr $n
      */
-    public function maxN($expression, $n): static;
+    public function maxN(mixed $expression, mixed $n): static;
 
     /**
      * Returns the lowest expression value for each group.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/min/
-     *
-     * @param mixed|Expr $expression
      */
-    public function min($expression): static;
+    public function min(mixed $expression): static;
 
     /**
      * Returns the lowest n expression values for each group.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/minN/
-     *
-     * @param mixed|Expr $expression
-     * @param mixed|Expr $n
      */
-    public function minN($expression, $n): static;
+    public function minN(mixed $expression, mixed $n): static;
 
     /**
      * Returns an array of expression values for documents in each group.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/push/
-     *
-     * @param mixed|Expr $expression
      */
-    public function push($expression): static;
+    public function push(mixed $expression): static;
 
     /**
      * Returns the document position (rank) relative to other documents in the
@@ -259,39 +213,30 @@ interface WindowOperators
      * position relative to the current document in the current partition.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/shift/
-     *
-     * @param mixed|Expr      $output
-     * @param mixed|Expr|null $default
      */
-    public function shift($output, int $by, $default = null): static;
+    public function shift(mixed $output, int $by, mixed $default = null): static;
 
     /**
      * Returns the population standard deviation of the input values.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevPop/
-     *
-     * @param mixed|Expr $expression
      */
-    public function stdDevPop($expression): static;
+    public function stdDevPop(mixed $expression): static;
 
     /**
      * Returns the sample standard deviation of the input values.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevSamp/
-     *
-     * @param mixed|Expr $expression
      */
-    public function stdDevSamp($expression): static;
+    public function stdDevSamp(mixed $expression): static;
 
     /**
      * Calculates the collective sum of numeric values. Ignores non-numeric
      * values.
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sum/
-     *
-     * @param mixed|Expr $expression
      */
-    public function sum($expression): static;
+    public function sum(mixed $expression): static;
 
     /**
      * Returns the top element within a group according to the specified sort
@@ -299,10 +244,9 @@ interface WindowOperators
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/top/
      *
-     * @param mixed|Expr                $output
      * @param array<string, int|string> $sortBy
      */
-    public function top($output, $sortBy): static;
+    public function top(mixed $output, array $sortBy): static;
 
     /**
      * Returns the n top elements within a group according to the specified sort
@@ -310,9 +254,7 @@ interface WindowOperators
      *
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/topN/
      *
-     * @param mixed|Expr                $output
      * @param array<string, int|string> $sortBy
-     * @param mixed|Expr                $n
      */
-    public function topN($output, $sortBy, $n): static;
+    public function topN(mixed $output, array $sortBy, mixed $n): static;
 }

--- a/src/Aggregation/Stage.php
+++ b/src/Aggregation/Stage.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation;
 
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
+use Doctrine\ODM\MongoDB\Aggregation\Stage\Sort;
 use GeoJson\Geometry\Point;
 
 /**
@@ -13,6 +15,9 @@ use GeoJson\Geometry\Point;
  *
  * @phpstan-import-type PipelineExpression from Builder
  * @phpstan-import-type StageExpression from Builder
+ * @phpstan-import-type SortDirectionKeywords from Sort
+ * @phpstan-import-type SortMetaKeywords from Search
+ * @phpstan-import-type SortMeta from Search
  */
 abstract class Stage
 {
@@ -152,9 +157,8 @@ abstract class Stage
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/geoNear/
      *
      * @param float|array<string, mixed>|Point $x
-     * @param float                            $y
      */
-    public function geoNear($x, $y = null): Stage\GeoNear
+    public function geoNear(float|array|Point $x, ?float $y = null): Stage\GeoNear
     {
         return $this->builder->geoNear($x, $y);
     }
@@ -291,10 +295,10 @@ abstract class Stage
      * including the _id field. You can promote an existing embedded document to
      * the top level, or create a new document for promotion.
      *
-     * @param string|mixed[]|null $expression Optional. A replacement expression that
+     * @param string|mixed[]|Expr|null $expression Optional. A replacement expression that
      * resolves to a document.
      */
-    public function replaceRoot($expression = null): Stage\ReplaceRoot
+    public function replaceRoot(string|array|Expr|null $expression = null): Stage\ReplaceRoot
     {
         return $this->builder->replaceRoot($expression);
     }
@@ -312,7 +316,7 @@ abstract class Stage
      * @param string|mixed[]|Expr|null $expression Optional. A replacement expression that
      * resolves to a document.
      */
-    public function replaceWith($expression = null): Stage\ReplaceWith
+    public function replaceWith(string|array|Expr|null $expression = null): Stage\ReplaceWith
     {
         return $this->builder->replaceWith($expression);
     }
@@ -393,9 +397,10 @@ abstract class Stage
      * @see https://docs.mongodb.com/manual/reference/operator/aggregation/sort/
      *
      * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
-     * @param int|string                       $order     Field order (if one field is specified)
+     * @param int|string|array|null            $order     Field order (if one field is specified)
+     * @phpstan-param int|SortMeta|SortDirectionKeywords|null $order
      */
-    public function sort($fieldName, $order = null): self
+    public function sort(array|string $fieldName, int|string|array|null $order = null): self
     {
         return $this->builder->sort($fieldName, $order);
     }

--- a/src/Aggregation/Stage/Bucket.php
+++ b/src/Aggregation/Stage/Bucket.php
@@ -20,10 +20,8 @@ class Bucket extends AbstractBucket
      * exclusive upper boundary for the bucket. You must specify at least two
      * boundaries. The specified values must be in ascending order and all of
      * the same type. The exception is if the values are of mixed numeric types.
-     *
-     * @param mixed $boundaries
      */
-    public function boundaries(...$boundaries): static
+    public function boundaries(mixed ...$boundaries): static
     {
         $this->boundaries = $boundaries;
 
@@ -34,10 +32,8 @@ class Bucket extends AbstractBucket
      * A literal that specifies the _id of an additional bucket that contains
      * all documents whose groupBy expression result does not fall into a bucket
      * specified by boundaries.
-     *
-     * @param mixed $default
      */
-    public function defaultBucket($default): static
+    public function defaultBucket(mixed $default): static
     {
         $this->default = $default;
 

--- a/src/Aggregation/Stage/Bucket/BucketAutoOutput.php
+++ b/src/Aggregation/Stage/Bucket/BucketAutoOutput.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Bucket;
 
-use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Expr;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
 
@@ -15,18 +14,13 @@ use function assert;
  */
 class BucketAutoOutput extends AbstractOutput
 {
-    public function __construct(Builder $builder, Stage\BucketAuto $bucket)
-    {
-        parent::__construct($builder, $bucket);
-    }
-
     /**
      * An expression to group documents by. To specify a field path, prefix the
      * field name with a dollar sign $ and enclose it in quotes.
      *
      * @param array<string, mixed>|Expr|string $expression
      */
-    public function groupBy($expression): Stage\BucketAuto
+    public function groupBy(array|Expr|string $expression): Stage\BucketAuto
     {
         assert($this->bucket instanceof Stage\BucketAuto);
 

--- a/src/Aggregation/Stage/Bucket/BucketOutput.php
+++ b/src/Aggregation/Stage/Bucket/BucketOutput.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Bucket;
 
-use Doctrine\ODM\MongoDB\Aggregation\Builder;
-use Doctrine\ODM\MongoDB\Aggregation\Expr;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use function assert;
@@ -15,20 +13,11 @@ use function assert;
  */
 class BucketOutput extends AbstractOutput
 {
-    public function __construct(Builder $builder, Stage\Bucket $bucket)
-    {
-        parent::__construct($builder, $bucket);
-    }
-
     /**
      * An expression to group documents by. To specify a field path, prefix the
      * field name with a dollar sign $ and enclose it in quotes.
-     *
-     * @param mixed|Expr $expression
-     *
-     * @return Stage\Bucket
      */
-    public function groupBy($expression)
+    public function groupBy(mixed $expression): Stage\Bucket
     {
         assert($this->bucket instanceof Stage\Bucket);
 
@@ -43,12 +32,8 @@ class BucketOutput extends AbstractOutput
      * exclusive upper boundary for the bucket. You must specify at least two
      * boundaries. The specified values must be in ascending order and all of
      * the same type. The exception is if the values are of mixed numeric types.
-     *
-     * @param mixed ...$boundaries
-     *
-     * @return Stage\Bucket
      */
-    public function boundaries(...$boundaries)
+    public function boundaries(mixed ...$boundaries): Stage\Bucket
     {
         assert($this->bucket instanceof Stage\Bucket);
 
@@ -59,12 +44,8 @@ class BucketOutput extends AbstractOutput
      * A literal that specifies the _id of an additional bucket that contains
      * all documents whose groupBy expression result does not fall into a bucket
      * specified by boundaries.
-     *
-     * @param mixed $default
-     *
-     * @return Stage\Bucket
      */
-    public function defaultBucket($default)
+    public function defaultBucket(mixed $default): Stage\Bucket
     {
         assert($this->bucket instanceof Stage\Bucket);
 

--- a/src/Aggregation/Stage/Densify.php
+++ b/src/Aggregation/Stage/Densify.php
@@ -52,12 +52,10 @@ class Densify extends Stage
     }
 
     /**
-     * @param array|string $bounds
-     * @param int|float    $step
      * @phpstan-param BoundsType  $bounds
      * @phpstan-param ""|UnitType $unit
      */
-    public function range($bounds, $step, string $unit = ''): static
+    public function range(array|string $bounds, int|float $step, string $unit = ''): static
     {
         $this->range = (object) [
             'bounds' => $bounds,

--- a/src/Aggregation/Stage/Facet.php
+++ b/src/Aggregation/Stage/Facet.php
@@ -6,7 +6,6 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage;
 
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Aggregation\Stage;
-use InvalidArgumentException;
 use LogicException;
 
 use function array_map;
@@ -43,10 +42,8 @@ class Facet extends Stage
 
     /**
      * Use the given pipeline for the current field.
-     *
-     * @param Builder|Stage $builder
      */
-    public function pipeline($builder): static
+    public function pipeline(Builder|Stage $builder): static
     {
         if (! isset($this->field)) {
             throw new LogicException(__METHOD__ . ' requires setting a current field using field().');
@@ -54,10 +51,6 @@ class Facet extends Stage
 
         if ($builder instanceof Stage) {
             $builder = $builder->builder;
-        }
-
-        if (! $builder instanceof Builder) {
-            throw new InvalidArgumentException(__METHOD__ . ' expects either an aggregation builder or an aggregation stage.');
         }
 
         $this->pipelines[$this->field] = $builder;

--- a/src/Aggregation/Stage/Fill.php
+++ b/src/Aggregation/Stage/Fill.php
@@ -49,8 +49,7 @@ class Fill extends Stage
         $this->output = new Output($this->builder, $this);
     }
 
-    /** @param mixed|Expr $expression */
-    public function partitionBy($expression): static
+    public function partitionBy(mixed $expression): static
     {
         $this->partitionBy = $expression;
 
@@ -66,11 +65,11 @@ class Fill extends Stage
 
     /**
      * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
-     * @param int|string                       $order     Field order (if one field is specified)
-     * @phpstan-param SortShape|string           $fieldName
-     * @phpstan-param SortDirection|null         $order
+     * @param int|string|null                  $order     Field order (if one field is specified)
+     * @phpstan-param SortShape|string         $fieldName
+     * @phpstan-param SortDirection|null       $order
      */
-    public function sortBy($fieldName, $order = null): static
+    public function sortBy(array|string $fieldName, int|string|null $order = null): static
     {
         $fields = is_array($fieldName) ? $fieldName : [$fieldName => $order ?? 1];
 

--- a/src/Aggregation/Stage/Fill/Output.php
+++ b/src/Aggregation/Stage/Fill/Output.php
@@ -25,13 +25,12 @@ class Output extends Stage
     /** @var array<string, array<string, mixed>> */
     private array $output = [];
 
-    public function __construct(Builder $builder, private Fill $fill)
+    public function __construct(Builder $builder, private readonly Fill $fill)
     {
         parent::__construct($builder);
     }
 
-    /** @param mixed|Expr $expression */
-    public function partitionBy($expression): Fill
+    public function partitionBy(mixed $expression): Fill
     {
         return $this->fill->partitionBy($expression);
     }
@@ -43,10 +42,10 @@ class Output extends Stage
 
     /**
      * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
-     * @param int|string                       $order     Field order (if one field is specified)
-     * @phpstan-param SortShape|string           $fieldName
+     * @param int|string|null                  $order     Field order (if one field is specified)
+     * @phpstan-param SortShape|string         $fieldName
      */
-    public function sortBy($fieldName, $order = null): Fill
+    public function sortBy(array|string $fieldName, int|string|null $order = null): Fill
     {
         return $this->fill->sortBy(...func_get_args());
     }
@@ -77,8 +76,7 @@ class Output extends Stage
         return $this;
     }
 
-    /** @param mixed|Expr $expression */
-    public function value($expression): static
+    public function value(mixed $expression): static
     {
         $this->requiresCurrentField(__METHOD__);
         $this->output[$this->currentField] = [

--- a/src/Aggregation/Stage/GeoNear.php
+++ b/src/Aggregation/Stage/GeoNear.php
@@ -34,11 +34,8 @@ class GeoNear extends MatchStage
 
     private ?bool $uniqueDocs = null;
 
-    /**
-     * @param float|array<string, mixed>|Point $x
-     * @param float                            $y
-     */
-    public function __construct(Builder $builder, $x, $y = null)
+    /** @param float|array<string, mixed>|Point $x */
+    public function __construct(Builder $builder, float|array|Point $x, ?float $y = null)
     {
         parent::__construct($builder);
 
@@ -138,9 +135,8 @@ class GeoNear extends MatchStage
      * used, the "spherical" option will default to true.
      *
      * @param float|array<string, mixed>|Point $x
-     * @param float                            $y
      */
-    public function near($x, $y = null): static
+    public function near(float|array|Point $x, ?float $y = null): static
     {
         if ($x instanceof Point) {
             $x = $x->jsonSerialize();

--- a/src/Aggregation/Stage/GraphLookup.php
+++ b/src/Aggregation/Stage/GraphLookup.php
@@ -26,7 +26,7 @@ class GraphLookup extends Stage
     private ?string $from;
 
     /** @var string|Expr|mixed[]|null */
-    private string|Expr|array|null $startWith;
+    private string|Expr|array|null $startWith = null;
 
     private ?string $connectFromField = null;
 
@@ -46,7 +46,7 @@ class GraphLookup extends Stage
      * @param string $from Target collection for the $graphLookup operation to
      * search, recursively matching the connectFromField to the connectToField.
      */
-    public function __construct(Builder $builder, string $from, private DocumentManager $dm, private ClassMetadata $class)
+    public function __construct(Builder $builder, string $from, private readonly DocumentManager $dm, private readonly ClassMetadata $class)
     {
         parent::__construct($builder);
 
@@ -210,7 +210,7 @@ class GraphLookup extends Stage
      *
      * @param string|mixed[]|Expr $expression
      */
-    public function startWith($expression): static
+    public function startWith(string|array|Expr $expression): static
     {
         $this->startWith = $expression;
 
@@ -249,12 +249,7 @@ class GraphLookup extends Stage
         return $this;
     }
 
-    /**
-     * @param array|mixed|string $expression
-     *
-     * @return array|mixed|string
-     */
-    private function convertExpression($expression)
+    private function convertExpression(mixed $expression): mixed
     {
         if (is_array($expression)) {
             return array_map($this->convertExpression(...), $expression);

--- a/src/Aggregation/Stage/GraphLookup/MatchStage.php
+++ b/src/Aggregation/Stage/GraphLookup/MatchStage.php
@@ -42,7 +42,7 @@ class MatchStage extends BaseMatchStage
      *
      * @param string|mixed[]|Expr $expression
      */
-    public function startWith($expression): GraphLookup
+    public function startWith(string|array|Expr $expression): GraphLookup
     {
         return $this->graphLookup->startWith($expression);
     }

--- a/src/Aggregation/Stage/Lookup.php
+++ b/src/Aggregation/Stage/Lookup.php
@@ -52,7 +52,7 @@ class Lookup extends Stage
 
     private bool $excludeLocalAndForeignField = false;
 
-    public function __construct(Builder $builder, string $from, private DocumentManager $dm, private ClassMetadata $class)
+    public function __construct(Builder $builder, string $from, private readonly DocumentManager $dm, private readonly ClassMetadata $class)
     {
         parent::__construct($builder);
 
@@ -195,7 +195,7 @@ class Lookup extends Stage
      * @param Builder|Stage|array<array<string, mixed>> $pipeline
      * @phpstan-param PipelineParamType $pipeline
      */
-    public function pipeline($pipeline): static
+    public function pipeline(Builder|Stage|array $pipeline): static
     {
         if ($pipeline instanceof Stage) {
             $this->pipeline = $pipeline->builder;

--- a/src/Aggregation/Stage/Merge.php
+++ b/src/Aggregation/Stage/Merge.php
@@ -47,7 +47,7 @@ class Merge extends Stage
 
     private ?string $whenNotMatched = null;
 
-    public function __construct(Builder $builder, private DocumentManager $dm)
+    public function __construct(Builder $builder, private readonly DocumentManager $dm)
     {
         parent::__construct($builder);
     }
@@ -80,11 +80,8 @@ class Merge extends Stage
         return ['$merge' => $params];
     }
 
-    /**
-     * @param string|array $collection
-     * @phpstan-param OutputCollection $collection
-     */
-    public function into($collection): static
+    /** @phpstan-param OutputCollection $collection */
+    public function into(string|array $collection): static
     {
         if (is_array($collection)) {
             $this->into = $collection;
@@ -124,11 +121,8 @@ class Merge extends Stage
         return $this;
     }
 
-    /**
-     * @param string|array|Builder|Stage $whenMatched
-     * @phpstan-param WhenMatchedParamType $whenMatched
-     */
-    public function whenMatched($whenMatched): static
+    /** @phpstan-param WhenMatchedParamType $whenMatched */
+    public function whenMatched(string|array|Builder|Stage $whenMatched): static
     {
         if ($whenMatched instanceof Stage) {
             $this->whenMatched = $whenMatched->builder;

--- a/src/Aggregation/Stage/Operator.php
+++ b/src/Aggregation/Stage/Operator.php
@@ -56,28 +56,28 @@ abstract class Operator extends Stage implements
         $this->expr = $builder->expr();
     }
 
-    public function abs($number): static
+    public function abs(mixed $number): static
     {
         $this->expr->abs(...func_get_args());
 
         return $this;
     }
 
-    public function acos($expression): static
+    public function acos(mixed $expression): static
     {
         $this->expr->acos(...func_get_args());
 
         return $this;
     }
 
-    public function acosh($expression): static
+    public function acosh(mixed $expression): static
     {
         $this->expr->acosh(...func_get_args());
 
         return $this;
     }
 
-    public function add($expression1, $expression2, ...$expressions): static
+    public function add(mixed $expression1, mixed $expression2, mixed ...$expressions): static
     {
         $this->expr->add(...func_get_args());
 
@@ -116,273 +116,273 @@ abstract class Operator extends Stage implements
         return $this;
     }
 
-    public function allElementsTrue($expression): static
+    public function allElementsTrue(mixed $expression): static
     {
         $this->expr->allElementsTrue(...func_get_args());
 
         return $this;
     }
 
-    public function and($expression, ...$expressions): static
+    public function and(mixed $expression, mixed ...$expressions): static
     {
         $this->expr->and(...func_get_args());
 
         return $this;
     }
 
-    public function anyElementTrue($expression): static
+    public function anyElementTrue(mixed $expression): static
     {
         $this->expr->anyElementTrue(...func_get_args());
 
         return $this;
     }
 
-    public function arrayElemAt($array, $index): static
+    public function arrayElemAt(mixed $array, mixed $index): static
     {
         $this->expr->arrayElemAt(...func_get_args());
 
         return $this;
     }
 
-    public function arrayToObject($array): static
+    public function arrayToObject(mixed $array): static
     {
         $this->expr->arrayToObject(...func_get_args());
 
         return $this;
     }
 
-    public function atan($expression): static
+    public function atan(mixed $expression): static
     {
         $this->expr->atan(...func_get_args());
 
         return $this;
     }
 
-    public function asin($expression): static
+    public function asin(mixed $expression): static
     {
         $this->expr->asin(...func_get_args());
 
         return $this;
     }
 
-    public function asinh($expression): static
+    public function asinh(mixed $expression): static
     {
         $this->expr->asinh(...func_get_args());
 
         return $this;
     }
 
-    public function atan2($expression1, $expression2): static
+    public function atan2(mixed $expression1, mixed $expression2): static
     {
         $this->expr->atan2(...func_get_args());
 
         return $this;
     }
 
-    public function atanh($expression): static
+    public function atanh(mixed $expression): static
     {
         $this->expr->atanh(...func_get_args());
 
         return $this;
     }
 
-    public function avg($expression, ...$expressions): static
+    public function avg(mixed $expression, mixed ...$expressions): static
     {
         $this->expr->avg(...func_get_args());
 
         return $this;
     }
 
-    public function binarySize($expression): static
+    public function binarySize(mixed $expression): static
     {
         $this->expr->binarySize(...func_get_args());
 
         return $this;
     }
 
-    public function bsonSize($expression): static
+    public function bsonSize(mixed $expression): static
     {
         $this->expr->bsonSize(...func_get_args());
 
         return $this;
     }
 
-    public function case($expression): static
+    public function case(mixed $expression): static
     {
         $this->expr->case(...func_get_args());
 
         return $this;
     }
 
-    public function ceil($number): static
+    public function ceil(mixed $number): static
     {
         $this->expr->ceil(...func_get_args());
 
         return $this;
     }
 
-    public function cmp($expression1, $expression2): static
+    public function cmp(mixed $expression1, mixed $expression2): static
     {
         $this->expr->cmp(...func_get_args());
 
         return $this;
     }
 
-    public function concat($expression1, $expression2, ...$expressions): static
+    public function concat(mixed $expression1, mixed $expression2, mixed ...$expressions): static
     {
         $this->expr->concat(...func_get_args());
 
         return $this;
     }
 
-    public function concatArrays($array1, $array2, ...$arrays): static
+    public function concatArrays(mixed $array1, mixed $array2, mixed ...$arrays): static
     {
         $this->expr->concatArrays(...func_get_args());
 
         return $this;
     }
 
-    public function cond($if, $then, $else): static
+    public function cond(mixed $if, mixed $then, mixed $else): static
     {
         $this->expr->cond(...func_get_args());
 
         return $this;
     }
 
-    public function convert($input, $to, $onError = null, $onNull = null): static
+    public function convert(mixed $input, mixed $to, mixed $onError = null, mixed $onNull = null): static
     {
         $this->expr->convert(...func_get_args());
 
         return $this;
     }
 
-    public function cos($expression): static
+    public function cos(mixed $expression): static
     {
         $this->expr->cos(...func_get_args());
 
         return $this;
     }
 
-    public function cosh($expression): static
+    public function cosh(mixed $expression): static
     {
         $this->expr->cosh(...func_get_args());
 
         return $this;
     }
 
-    public function dateAdd($startDate, $unit, $amount, $timezone = null): static
+    public function dateAdd(mixed $startDate, mixed $unit, mixed $amount, mixed $timezone = null): static
     {
         $this->expr->dateAdd(...func_get_args());
 
         return $this;
     }
 
-    public function dateDiff($startDate, $endDate, $unit, $timezone = null, $startOfWeek = null): static
+    public function dateDiff(mixed $startDate, mixed $endDate, mixed $unit, mixed $timezone = null, mixed $startOfWeek = null): static
     {
         $this->expr->dateDiff(...func_get_args());
 
         return $this;
     }
 
-    public function dateFromParts($year = null, $isoWeekYear = null, $month = null, $isoWeek = null, $day = null, $isoDayOfWeek = null, $hour = null, $minute = null, $second = null, $millisecond = null, $timezone = null): static
+    public function dateFromParts(mixed $year = null, mixed $isoWeekYear = null, mixed $month = null, mixed $isoWeek = null, mixed $day = null, mixed $isoDayOfWeek = null, mixed $hour = null, mixed $minute = null, mixed $second = null, mixed $millisecond = null, mixed $timezone = null): static
     {
         $this->expr->dateFromParts(...func_get_args());
 
         return $this;
     }
 
-    public function dateFromString($dateString, $format = null, $timezone = null, $onError = null, $onNull = null): static
+    public function dateFromString(mixed $dateString, mixed $format = null, mixed $timezone = null, mixed $onError = null, mixed $onNull = null): static
     {
         $this->expr->dateFromString(...func_get_args());
 
         return $this;
     }
 
-    public function dateSubtract($startDate, $unit, $amount, $timezone = null): static
+    public function dateSubtract(mixed $startDate, mixed $unit, mixed $amount, mixed $timezone = null): static
     {
         $this->expr->dateSubtract(...func_get_args());
 
         return $this;
     }
 
-    public function dateToParts($date, $timezone = null, $iso8601 = null): static
+    public function dateToParts(mixed $date, mixed $timezone = null, mixed $iso8601 = null): static
     {
         $this->expr->dateToParts(...func_get_args());
 
         return $this;
     }
 
-    public function dateToString(string $format, $expression, $timezone = null, $onNull = null): static
+    public function dateToString(string $format, mixed $expression, mixed $timezone = null, mixed $onNull = null): static
     {
         $this->expr->dateToString(...func_get_args());
 
         return $this;
     }
 
-    public function dateTrunc($date, $unit, $binSize = null, $timezone = null, $startOfWeek = null): static
+    public function dateTrunc(mixed $date, mixed $unit, mixed $binSize = null, mixed $timezone = null, mixed $startOfWeek = null): static
     {
         $this->expr->dateTrunc(...func_get_args());
 
         return $this;
     }
 
-    public function dayOfMonth($expression): static
+    public function dayOfMonth(mixed $expression): static
     {
         $this->expr->dayOfMonth(...func_get_args());
 
         return $this;
     }
 
-    public function dayOfWeek($expression): static
+    public function dayOfWeek(mixed $expression): static
     {
         $this->expr->dayOfWeek(...func_get_args());
 
         return $this;
     }
 
-    public function dayOfYear($expression): static
+    public function dayOfYear(mixed $expression): static
     {
         $this->expr->dayOfYear(...func_get_args());
 
         return $this;
     }
 
-    public function default($expression): static
+    public function default(mixed $expression): static
     {
         $this->expr->default(...func_get_args());
 
         return $this;
     }
 
-    public function degreesToRadians($expression): static
+    public function degreesToRadians(mixed $expression): static
     {
         $this->expr->degreesToRadians(...func_get_args());
 
         return $this;
     }
 
-    public function divide($expression1, $expression2): static
+    public function divide(mixed $expression1, mixed $expression2): static
     {
         $this->expr->divide(...func_get_args());
 
         return $this;
     }
 
-    public function eq($expression1, $expression2): static
+    public function eq(mixed $expression1, mixed $expression2): static
     {
         $this->expr->eq(...func_get_args());
 
         return $this;
     }
 
-    public function exp($exponent): static
+    public function exp(mixed $exponent): static
     {
         $this->expr->exp(...func_get_args());
 
         return $this;
     }
 
-    public function expression($value): static
+    public function expression(mixed $value): static
     {
         $this->expr->expression(...func_get_args());
 
@@ -401,392 +401,392 @@ abstract class Operator extends Stage implements
         return $this;
     }
 
-    public function filter($input, $as, $cond): static
+    public function filter(mixed $input, mixed $as, mixed $cond): static
     {
         $this->expr->filter(...func_get_args());
 
         return $this;
     }
 
-    public function first($expression): static
+    public function first(mixed $expression): static
     {
         $this->expr->first(...func_get_args());
 
         return $this;
     }
 
-    public function firstN($expression, $n): static
+    public function firstN(mixed $expression, mixed $n): static
     {
         $this->expr->firstN(...func_get_args());
 
         return $this;
     }
 
-    public function floor($number): static
+    public function floor(mixed $number): static
     {
         $this->expr->floor(...func_get_args());
 
         return $this;
     }
 
-    public function getField($field, $input = null): static
+    public function getField(mixed $field, mixed $input = null): static
     {
         $this->expr->getField(...func_get_args());
 
         return $this;
     }
 
-    public function gt($expression1, $expression2): static
+    public function gt(mixed $expression1, mixed $expression2): static
     {
         $this->expr->gt(...func_get_args());
 
         return $this;
     }
 
-    public function gte($expression1, $expression2): static
+    public function gte(mixed $expression1, mixed $expression2): static
     {
         $this->expr->gte(...func_get_args());
 
         return $this;
     }
 
-    public function hour($expression): static
+    public function hour(mixed $expression): static
     {
         $this->expr->hour(...func_get_args());
 
         return $this;
     }
 
-    public function in($expression, $arrayExpression): static
+    public function in(mixed $expression, mixed $arrayExpression): static
     {
         $this->expr->in(...func_get_args());
 
         return $this;
     }
 
-    public function indexOfArray($arrayExpression, $searchExpression, $start = null, $end = null): static
+    public function indexOfArray(mixed $arrayExpression, mixed $searchExpression, mixed $start = null, mixed $end = null): static
     {
         $this->expr->indexOfArray(...func_get_args());
 
         return $this;
     }
 
-    public function indexOfBytes($stringExpression, $substringExpression, $start = null, $end = null): static
+    public function indexOfBytes(mixed $stringExpression, mixed $substringExpression, mixed $start = null, mixed $end = null): static
     {
         $this->expr->indexOfBytes(...func_get_args());
 
         return $this;
     }
 
-    public function indexOfCP($stringExpression, $substringExpression, $start = null, $end = null): static
+    public function indexOfCP(mixed $stringExpression, mixed $substringExpression, mixed $start = null, mixed $end = null): static
     {
         $this->expr->indexOfCP(...func_get_args());
 
         return $this;
     }
 
-    public function ifNull($expression, $replacementExpression): static
+    public function ifNull(mixed $expression, mixed $replacementExpression): static
     {
         $this->expr->ifNull(...func_get_args());
 
         return $this;
     }
 
-    public function isArray($expression): static
+    public function isArray(mixed $expression): static
     {
         $this->expr->isArray(...func_get_args());
 
         return $this;
     }
 
-    public function isNumber($expression): static
+    public function isNumber(mixed $expression): static
     {
         $this->expr->isNumber(...func_get_args());
 
         return $this;
     }
 
-    public function isoDayOfWeek($expression): static
+    public function isoDayOfWeek(mixed $expression): static
     {
         $this->expr->isoDayOfWeek(...func_get_args());
 
         return $this;
     }
 
-    public function isoWeek($expression): static
+    public function isoWeek(mixed $expression): static
     {
         $this->expr->isoWeek(...func_get_args());
 
         return $this;
     }
 
-    public function isoWeekYear($expression): static
+    public function isoWeekYear(mixed $expression): static
     {
         $this->expr->isoWeekYear(...func_get_args());
 
         return $this;
     }
 
-    public function last($expression): static
+    public function last(mixed $expression): static
     {
         $this->expr->last(...func_get_args());
 
         return $this;
     }
 
-    public function lastN($expression, $n): static
+    public function lastN(mixed $expression, mixed $n): static
     {
         $this->expr->lastN(...func_get_args());
 
         return $this;
     }
 
-    public function let($vars, $in): static
+    public function let(mixed $vars, mixed $in): static
     {
         $this->expr->let(...func_get_args());
 
         return $this;
     }
 
-    public function literal($value): static
+    public function literal(mixed $value): static
     {
         $this->expr->literal(...func_get_args());
 
         return $this;
     }
 
-    public function ln($number): static
+    public function ln(mixed $number): static
     {
         $this->expr->ln(...func_get_args());
 
         return $this;
     }
 
-    public function log($number, $base): static
+    public function log(mixed $number, mixed $base): static
     {
         $this->expr->log(...func_get_args());
 
         return $this;
     }
 
-    public function log10($number): static
+    public function log10(mixed $number): static
     {
         $this->expr->log10(...func_get_args());
 
         return $this;
     }
 
-    public function lt($expression1, $expression2): static
+    public function lt(mixed $expression1, mixed $expression2): static
     {
         $this->expr->lt(...func_get_args());
 
         return $this;
     }
 
-    public function lte($expression1, $expression2): static
+    public function lte(mixed $expression1, mixed $expression2): static
     {
         $this->expr->lte(...func_get_args());
 
         return $this;
     }
 
-    public function ltrim($input, $chars = null): static
+    public function ltrim(mixed $input, mixed $chars = null): static
     {
         $this->expr->ltrim(...func_get_args());
 
         return $this;
     }
 
-    public function map($input, $as, $in): static
+    public function map(mixed $input, mixed $as, mixed $in): static
     {
         $this->expr->map(...func_get_args());
 
         return $this;
     }
 
-    public function max($expression, ...$expressions): static
+    public function max(mixed $expression, mixed ...$expressions): static
     {
         $this->expr->max(...func_get_args());
 
         return $this;
     }
 
-    public function maxN($expression, $n): static
+    public function maxN(mixed $expression, mixed $n): static
     {
         $this->expr->maxN(...func_get_args());
 
         return $this;
     }
 
-    public function mergeObjects($expression, ...$expressions): static
+    public function mergeObjects(mixed $expression, mixed ...$expressions): static
     {
         $this->expr->mergeObjects(...func_get_args());
 
         return $this;
     }
 
-    public function meta($metaDataKeyword): static
+    public function meta(mixed $metaDataKeyword): static
     {
         $this->expr->meta(...func_get_args());
 
         return $this;
     }
 
-    public function millisecond($expression): static
+    public function millisecond(mixed $expression): static
     {
         $this->expr->millisecond(...func_get_args());
 
         return $this;
     }
 
-    public function min($expression, ...$expressions): static
+    public function min(mixed $expression, mixed ...$expressions): static
     {
         $this->expr->min(...func_get_args());
 
         return $this;
     }
 
-    public function minN($expression, $n): static
+    public function minN(mixed $expression, mixed $n): static
     {
         $this->expr->minN(...func_get_args());
 
         return $this;
     }
 
-    public function minute($expression): static
+    public function minute(mixed $expression): static
     {
         $this->expr->minute(...func_get_args());
 
         return $this;
     }
 
-    public function mod($expression1, $expression2): static
+    public function mod(mixed $expression1, mixed $expression2): static
     {
         $this->expr->mod(...func_get_args());
 
         return $this;
     }
 
-    public function month($expression): static
+    public function month(mixed $expression): static
     {
         $this->expr->month(...func_get_args());
 
         return $this;
     }
 
-    public function multiply($expression1, $expression2, ...$expressions): static
+    public function multiply(mixed $expression1, mixed $expression2, mixed ...$expressions): static
     {
         $this->expr->multiply(...func_get_args());
 
         return $this;
     }
 
-    public function ne($expression1, $expression2): static
+    public function ne(mixed $expression1, mixed $expression2): static
     {
         $this->expr->ne(...func_get_args());
 
         return $this;
     }
 
-    public function not($expression): static
+    public function not(mixed $expression): static
     {
         $this->expr->not(...func_get_args());
 
         return $this;
     }
 
-    public function objectToArray($object): static
+    public function objectToArray(mixed $object): static
     {
         $this->expr->objectToArray(...func_get_args());
 
         return $this;
     }
 
-    public function or($expression, ...$expressions): static
+    public function or(mixed $expression, mixed ...$expressions): static
     {
         $this->expr->or(...func_get_args());
 
         return $this;
     }
 
-    public function pow($number, $exponent): static
+    public function pow(mixed $number, mixed $exponent): static
     {
         $this->expr->pow(...func_get_args());
 
         return $this;
     }
 
-    public function range($start, $end, $step = null): static
+    public function range(mixed $start, mixed $end, mixed $step = null): static
     {
         $this->expr->range(...func_get_args());
 
         return $this;
     }
 
-    public function reduce($input, $initialValue, $in): static
+    public function reduce(mixed $input, mixed $initialValue, mixed $in): static
     {
         $this->expr->reduce(...func_get_args());
 
         return $this;
     }
 
-    public function regexFind($input, $regex, $options = null): static
+    public function regexFind(mixed $input, mixed $regex, mixed $options = null): static
     {
         $this->expr->regexFind(...func_get_args());
 
         return $this;
     }
 
-    public function regexFindAll($input, $regex, $options = null): static
+    public function regexFindAll(mixed $input, mixed $regex, mixed $options = null): static
     {
         $this->expr->regexFindAll(...func_get_args());
 
         return $this;
     }
 
-    public function regexMatch($input, $regex, $options = null): static
+    public function regexMatch(mixed $input, mixed $regex, mixed $options = null): static
     {
         $this->expr->regexMatch(...func_get_args());
 
         return $this;
     }
 
-    public function replaceAll($input, $find, $replacement): static
+    public function replaceAll(mixed $input, mixed $find, mixed $replacement): static
     {
         $this->expr->replaceAll(...func_get_args());
 
         return $this;
     }
 
-    public function replaceOne($input, $find, $replacement): static
+    public function replaceOne(mixed $input, mixed $find, mixed $replacement): static
     {
         $this->expr->replaceOne(...func_get_args());
 
         return $this;
     }
 
-    public function reverseArray($expression): static
+    public function reverseArray(mixed $expression): static
     {
         $this->expr->reverseArray(...func_get_args());
 
         return $this;
     }
 
-    public function rtrim($input, $chars = null): static
+    public function rtrim(mixed $input, mixed $chars = null): static
     {
         $this->expr->rtrim(...func_get_args());
 
         return $this;
     }
 
-    public function round($number, $place = null): static
+    public function round(mixed $number, mixed $place = null): static
     {
         $this->expr->round(...func_get_args());
 
         return $this;
     }
 
-    public function radiansToDegrees($expression): static
+    public function radiansToDegrees(mixed $expression): static
     {
         $this->expr->radiansToDegrees(...func_get_args());
 
@@ -807,168 +807,168 @@ abstract class Operator extends Stage implements
         return $this;
     }
 
-    public function second($expression): static
+    public function second(mixed $expression): static
     {
         $this->expr->second(...func_get_args());
 
         return $this;
     }
 
-    public function setDifference($expression1, $expression2): static
+    public function setDifference(mixed $expression1, mixed $expression2): static
     {
         $this->expr->setDifference(...func_get_args());
 
         return $this;
     }
 
-    public function setEquals($expression1, $expression2, ...$expressions): static
+    public function setEquals(mixed $expression1, mixed $expression2, mixed ...$expressions): static
     {
         $this->expr->setEquals(...func_get_args());
 
         return $this;
     }
 
-    public function setField($field, $input, $value): static
+    public function setField(mixed $field, mixed $input, mixed $value): static
     {
         $this->expr->setField(...func_get_args());
 
         return $this;
     }
 
-    public function setIntersection($expression1, $expression2, ...$expressions): static
+    public function setIntersection(mixed $expression1, mixed $expression2, mixed ...$expressions): static
     {
         $this->expr->setIntersection(...func_get_args());
 
         return $this;
     }
 
-    public function setIsSubset($expression1, $expression2): static
+    public function setIsSubset(mixed $expression1, mixed $expression2): static
     {
         $this->expr->setIsSubset(...func_get_args());
 
         return $this;
     }
 
-    public function setUnion($expression1, $expression2, ...$expressions): static
+    public function setUnion(mixed $expression1, mixed $expression2, mixed ...$expressions): static
     {
         $this->expr->setUnion(...func_get_args());
 
         return $this;
     }
 
-    public function sin($expression): static
+    public function sin(mixed $expression): static
     {
         $this->expr->sin(...func_get_args());
 
         return $this;
     }
 
-    public function sinh($expression): static
+    public function sinh(mixed $expression): static
     {
         $this->expr->sinh(...func_get_args());
 
         return $this;
     }
 
-    public function size($expression): static
+    public function size(mixed $expression): static
     {
         $this->expr->size(...func_get_args());
 
         return $this;
     }
 
-    public function slice($array, $n, $position = null): static
+    public function slice(mixed $array, mixed $n, mixed $position = null): static
     {
         $this->expr->slice(...func_get_args());
 
         return $this;
     }
 
-    public function sortArray($input, $sortBy): static
+    public function sortArray(mixed $input, mixed $sortBy): static
     {
         $this->expr->sortArray(...func_get_args());
 
         return $this;
     }
 
-    public function split($string, $delimiter): static
+    public function split(mixed $string, mixed $delimiter): static
     {
         $this->expr->split(...func_get_args());
 
         return $this;
     }
 
-    public function sqrt($expression): static
+    public function sqrt(mixed $expression): static
     {
         $this->expr->sqrt(...func_get_args());
 
         return $this;
     }
 
-    public function stdDevPop($expression, ...$expressions): static
+    public function stdDevPop(mixed $expression, mixed ...$expressions): static
     {
         $this->expr->stdDevPop(...func_get_args());
 
         return $this;
     }
 
-    public function stdDevSamp($expression, ...$expressions): static
+    public function stdDevSamp(mixed $expression, mixed ...$expressions): static
     {
         $this->expr->stdDevSamp(...func_get_args());
 
         return $this;
     }
 
-    public function strcasecmp($expression1, $expression2): static
+    public function strcasecmp(mixed $expression1, mixed $expression2): static
     {
         $this->expr->strcasecmp(...func_get_args());
 
         return $this;
     }
 
-    public function strLenBytes($string): static
+    public function strLenBytes(mixed $string): static
     {
         $this->expr->strLenBytes(...func_get_args());
 
         return $this;
     }
 
-    public function strLenCP($string): static
+    public function strLenCP(mixed $string): static
     {
         $this->expr->strLenCP(...func_get_args());
 
         return $this;
     }
 
-    public function substr($string, $start, $length): static
+    public function substr(mixed $string, mixed $start, mixed $length): static
     {
         $this->expr->substr(...func_get_args());
 
         return $this;
     }
 
-    public function substrBytes($string, $start, $count): static
+    public function substrBytes(mixed $string, mixed $start, mixed $count): static
     {
         $this->expr->substrBytes(...func_get_args());
 
         return $this;
     }
 
-    public function substrCP($string, $start, $count): static
+    public function substrCP(mixed $string, mixed $start, mixed $count): static
     {
         $this->expr->substrCP(...func_get_args());
 
         return $this;
     }
 
-    public function subtract($expression1, $expression2): static
+    public function subtract(mixed $expression1, mixed $expression2): static
     {
         $this->expr->subtract(...func_get_args());
 
         return $this;
     }
 
-    public function sum($expression, ...$expressions): static
+    public function sum(mixed $expression, mixed ...$expressions): static
     {
         $this->expr->sum(...func_get_args());
 
@@ -982,147 +982,147 @@ abstract class Operator extends Stage implements
         return $this;
     }
 
-    public function tan($expression): static
+    public function tan(mixed $expression): static
     {
         $this->expr->tan(...func_get_args());
 
         return $this;
     }
 
-    public function tanh($expression): static
+    public function tanh(mixed $expression): static
     {
         $this->expr->tanh(...func_get_args());
 
         return $this;
     }
 
-    public function then($expression): static
+    public function then(mixed $expression): static
     {
         $this->expr->then(...func_get_args());
 
         return $this;
     }
 
-    public function toBool($expression): static
+    public function toBool(mixed $expression): static
     {
         $this->expr->toBool(...func_get_args());
 
         return $this;
     }
 
-    public function toDate($expression): static
+    public function toDate(mixed $expression): static
     {
         $this->expr->toDate(...func_get_args());
 
         return $this;
     }
 
-    public function toDecimal($expression): static
+    public function toDecimal(mixed $expression): static
     {
         $this->expr->toDecimal(...func_get_args());
 
         return $this;
     }
 
-    public function toDouble($expression): static
+    public function toDouble(mixed $expression): static
     {
         $this->expr->toDouble(...func_get_args());
 
         return $this;
     }
 
-    public function toInt($expression): static
+    public function toInt(mixed $expression): static
     {
         $this->expr->toInt(...func_get_args());
 
         return $this;
     }
 
-    public function toLong($expression): static
+    public function toLong(mixed $expression): static
     {
         $this->expr->toLong(...func_get_args());
 
         return $this;
     }
 
-    public function toObjectId($expression): static
+    public function toObjectId(mixed $expression): static
     {
         $this->expr->toObjectId(...func_get_args());
 
         return $this;
     }
 
-    public function toString($expression): static
+    public function toString(mixed $expression): static
     {
         $this->expr->toString(...func_get_args());
 
         return $this;
     }
 
-    public function toLower($expression): static
+    public function toLower(mixed $expression): static
     {
         $this->expr->toLower(...func_get_args());
 
         return $this;
     }
 
-    public function toUpper($expression): static
+    public function toUpper(mixed $expression): static
     {
         $this->expr->toUpper(...func_get_args());
 
         return $this;
     }
 
-    public function trim($input, $chars = null): static
+    public function trim(mixed $input, mixed $chars = null): static
     {
         $this->expr->trim(...func_get_args());
 
         return $this;
     }
 
-    public function trunc($number): static
+    public function trunc(mixed $number): static
     {
         $this->expr->trunc(...func_get_args());
 
         return $this;
     }
 
-    public function tsIncrement($expression): static
+    public function tsIncrement(mixed $expression): static
     {
         $this->expr->tsIncrement(...func_get_args());
 
         return $this;
     }
 
-    public function tsSecond($expression): static
+    public function tsSecond(mixed $expression): static
     {
         $this->expr->tsSecond(...func_get_args());
 
         return $this;
     }
 
-    public function type($expression): static
+    public function type(mixed $expression): static
     {
         $this->expr->type(...func_get_args());
 
         return $this;
     }
 
-    public function week($expression): static
+    public function week(mixed $expression): static
     {
         $this->expr->week(...func_get_args());
 
         return $this;
     }
 
-    public function year($expression): static
+    public function year(mixed $expression): static
     {
         $this->expr->year(...func_get_args());
 
         return $this;
     }
 
-    public function zip($inputs, ?bool $useLongestLength = null, $defaults = null): static
+    public function zip(mixed $inputs, ?bool $useLongestLength = null, mixed $defaults = null): static
     {
         $this->expr->zip(...func_get_args());
 

--- a/src/Aggregation/Stage/Operator.php
+++ b/src/Aggregation/Stage/Operator.php
@@ -471,14 +471,14 @@ abstract class Operator extends Stage implements
         return $this;
     }
 
-    public function indexOfBytes(mixed $stringExpression, mixed $substringExpression, mixed $start = null, mixed $end = null): static
+    public function indexOfBytes(mixed $stringExpression, mixed $substringExpression, string|int|null $start = null, string|int|null $end = null): static
     {
         $this->expr->indexOfBytes(...func_get_args());
 
         return $this;
     }
 
-    public function indexOfCP(mixed $stringExpression, mixed $substringExpression, mixed $start = null, mixed $end = null): static
+    public function indexOfCP(mixed $stringExpression, mixed $substringExpression, string|int|null $start = null, string|int|null $end = null): static
     {
         $this->expr->indexOfCP(...func_get_args());
 
@@ -597,7 +597,7 @@ abstract class Operator extends Stage implements
         return $this;
     }
 
-    public function map(mixed $input, mixed $as, mixed $in): static
+    public function map(mixed $input, string $as, mixed $in): static
     {
         $this->expr->map(...func_get_args());
 
@@ -730,21 +730,21 @@ abstract class Operator extends Stage implements
         return $this;
     }
 
-    public function regexFind(mixed $input, mixed $regex, mixed $options = null): static
+    public function regexFind(mixed $input, mixed $regex, ?string $options = null): static
     {
         $this->expr->regexFind(...func_get_args());
 
         return $this;
     }
 
-    public function regexFindAll(mixed $input, mixed $regex, mixed $options = null): static
+    public function regexFindAll(mixed $input, mixed $regex, ?string $options = null): static
     {
         $this->expr->regexFindAll(...func_get_args());
 
         return $this;
     }
 
-    public function regexMatch(mixed $input, mixed $regex, mixed $options = null): static
+    public function regexMatch(mixed $input, mixed $regex, ?string $options = null): static
     {
         $this->expr->regexMatch(...func_get_args());
 

--- a/src/Aggregation/Stage/Out.php
+++ b/src/Aggregation/Stage/Out.php
@@ -22,7 +22,7 @@ class Out extends Stage
     /** @phpstan-var OutputCollection */
     private array|string $out;
 
-    public function __construct(Builder $builder, string $collection, private DocumentManager $dm)
+    public function __construct(Builder $builder, string $collection, private readonly DocumentManager $dm)
     {
         parent::__construct($builder);
 
@@ -36,11 +36,8 @@ class Out extends Stage
         ];
     }
 
-    /**
-     * @param string|array $collection
-     * @phpstan-param OutputCollection $collection
-     */
-    public function out($collection): Stage\Out
+    /** @phpstan-param OutputCollection $collection */
+    public function out(string|array $collection): Stage\Out
     {
         if (is_array($collection)) {
             $this->out = $collection;

--- a/src/Aggregation/Stage/Search.php
+++ b/src/Aggregation/Stage/Search.php
@@ -71,7 +71,7 @@ class Search extends Stage implements SupportsAllSearchOperators
     /** @var array<string, -1|1|SortMeta> */
     private array $sort = [];
 
-    public function __construct(Builder $builder, private DocumentPersister $persister)
+    public function __construct(Builder $builder, private readonly DocumentPersister $persister)
     {
         parent::__construct($builder);
     }
@@ -174,11 +174,11 @@ class Search extends Stage implements SupportsAllSearchOperators
 
     /**
      * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
-     * @param int|string                       $order     Field order (if one field is specified)
+     * @param int|string|array|null            $order     Field order (if one field is specified)
      * @phpstan-param SortShape|string $fieldName
      * @phpstan-param int|SortMeta|SortDirectionKeywords|null $order
      */
-    public function sort($fieldName, $order = null): static
+    public function sort(array|string $fieldName, int|string|array|null $order = null): static
     {
         $allowedMetaSort = ['searchScore'];
 

--- a/src/Aggregation/Stage/Search/AbstractSearchOperator.php
+++ b/src/Aggregation/Stage/Search/AbstractSearchOperator.php
@@ -22,7 +22,7 @@ use function is_array;
  */
 abstract class AbstractSearchOperator extends Stage implements SearchOperator
 {
-    public function __construct(private Search $search, private DocumentPersister $persister)
+    public function __construct(private readonly Search $search, private readonly DocumentPersister $persister)
     {
         parent::__construct($search->builder);
     }
@@ -49,11 +49,11 @@ abstract class AbstractSearchOperator extends Stage implements SearchOperator
 
     /**
      * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
-     * @param int|string                       $order     Field order (if one field is specified)
+     * @param int|string|array|null            $order     Field order (if one field is specified)
      * @phpstan-param SortShape|string $fieldName
      * @phpstan-param int|SortMeta|SortDirectionKeywords|null $order
      */
-    public function sort($fieldName, $order = null): Search
+    public function sort(array|string $fieldName, int|string|array|null $order = null): Search
     {
         return $this->search->sort($fieldName, $order);
     }

--- a/src/Aggregation/Stage/Search/CompoundSearchOperatorInterface.php
+++ b/src/Aggregation/Stage/Search/CompoundSearchOperatorInterface.php
@@ -8,7 +8,6 @@ use GeoJson\Geometry\LineString;
 use GeoJson\Geometry\MultiPolygon;
 use GeoJson\Geometry\Point;
 use GeoJson\Geometry\Polygon;
-use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
 
 interface CompoundSearchOperatorInterface extends SupportsCompoundableSearchOperators
@@ -25,24 +24,20 @@ interface CompoundSearchOperatorInterface extends SupportsCompoundableSearchOper
 
     public function embeddedDocument(string $path = ''): EmbeddedDocument&CompoundSearchOperatorInterface;
 
-    /** @param string|int|float|ObjectId|UTCDateTime|null $value */
-    public function equals(string $path = '', $value = null): Equals&CompoundSearchOperatorInterface;
+    public function equals(string $path = '', mixed $value = null): Equals&CompoundSearchOperatorInterface;
 
     public function exists(string $path): Exists&CompoundSearchOperatorInterface;
 
     /** @param LineString|Point|Polygon|MultiPolygon|array<string, mixed>|null $geometry */
-    public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape&CompoundSearchOperatorInterface;
+    public function geoShape(LineString|Point|Polygon|MultiPolygon|array|null $geometry = null, string $relation = '', string ...$path): GeoShape&CompoundSearchOperatorInterface;
 
     public function geoWithin(string ...$path): GeoWithin&CompoundSearchOperatorInterface;
 
     /** @param array<string, mixed>|object $documents */
-    public function moreLikeThis(...$documents): MoreLikeThis&CompoundSearchOperatorInterface;
+    public function moreLikeThis(array|object ...$documents): MoreLikeThis&CompoundSearchOperatorInterface;
 
-    /**
-     * @param int|float|UTCDateTime|array<string, mixed>|Point|null $origin
-     * @param int|float|null                                        $pivot
-     */
-    public function near($origin = null, $pivot = null, string ...$path): Near&CompoundSearchOperatorInterface;
+    /** @param int|float|UTCDateTime|array<string, mixed>|Point|null $origin */
+    public function near(int|float|UTCDateTime|array|Point|null $origin = null, int|float|null $pivot = null, string ...$path): Near&CompoundSearchOperatorInterface;
 
     public function phrase(): Phrase&CompoundSearchOperatorInterface;
 

--- a/src/Aggregation/Stage/Search/CompoundedSearchOperatorTrait.php
+++ b/src/Aggregation/Stage/Search/CompoundedSearchOperatorTrait.php
@@ -12,7 +12,7 @@ use function sprintf;
 /** @internal */
 trait CompoundedSearchOperatorTrait
 {
-    public function __construct(private Compound $compound, private Closure $addOperator, ...$args)
+    public function __construct(private readonly Compound $compound, private readonly Closure $addOperator, mixed ...$args)
     {
         if (! $this instanceof CompoundSearchOperatorInterface) {
             throw new LogicException(sprintf('Can only use %s on classes extending %s.', self::class, CompoundSearchOperatorInterface::class));

--- a/src/Aggregation/Stage/Search/Equals.php
+++ b/src/Aggregation/Stage/Search/Equals.php
@@ -6,8 +6,6 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
-use MongoDB\BSON\ObjectId;
-use MongoDB\BSON\UTCDateTime;
 
 /**
  * @internal
@@ -22,8 +20,7 @@ class Equals extends AbstractSearchOperator implements ScoredSearchOperator
 
     private mixed $value;
 
-    /** @param string|int|float|ObjectId|UTCDateTime|null $value */
-    public function __construct(Search $search, DocumentPersister $persister, string $path = '', $value = null)
+    public function __construct(Search $search, DocumentPersister $persister, string $path = '', mixed $value = null)
     {
         parent::__construct($search, $persister);
 
@@ -39,8 +36,7 @@ class Equals extends AbstractSearchOperator implements ScoredSearchOperator
         return $this;
     }
 
-    /** @param string|int|float|ObjectId|UTCDateTime|null $value */
-    public function value($value): static
+    public function value(mixed $value): static
     {
         $this->value = $value;
 

--- a/src/Aggregation/Stage/Search/GeoShape.php
+++ b/src/Aggregation/Stage/Search/GeoShape.php
@@ -27,8 +27,7 @@ class GeoShape extends AbstractSearchOperator implements ScoredSearchOperator
 
     private LineString|Point|Polygon|MultiPolygon|array|null $geometry = null;
 
-    /** @param LineString|Point|Polygon|MultiPolygon|array|null $geometry */
-    public function __construct(Search $search, DocumentPersister $persister, $geometry = null, string $relation = '', string ...$path)
+    public function __construct(Search $search, DocumentPersister $persister, LineString|Point|Polygon|MultiPolygon|array|null $geometry = null, string $relation = '', string ...$path)
     {
         parent::__construct($search, $persister);
 
@@ -52,8 +51,7 @@ class GeoShape extends AbstractSearchOperator implements ScoredSearchOperator
         return $this;
     }
 
-    /** @param LineString|Point|Polygon|MultiPolygon|array|null $geometry */
-    public function geometry($geometry): static
+    public function geometry(LineString|Point|Polygon|MultiPolygon|array|null $geometry): static
     {
         $this->geometry = $geometry;
 

--- a/src/Aggregation/Stage/Search/GeoWithin.php
+++ b/src/Aggregation/Stage/Search/GeoWithin.php
@@ -42,11 +42,7 @@ class GeoWithin extends AbstractSearchOperator implements ScoredSearchOperator
         return $this;
     }
 
-    /**
-     * @param array|Point $bottomLeft
-     * @param array|Point $topRight
-     */
-    public function box($bottomLeft, $topRight): static
+    public function box(array|Point $bottomLeft, array|Point $topRight): static
     {
         $this->box = (object) [
             'bottomLeft' => $this->convertGeometry($bottomLeft),
@@ -56,11 +52,7 @@ class GeoWithin extends AbstractSearchOperator implements ScoredSearchOperator
         return $this;
     }
 
-    /**
-     * @param array|Point $center
-     * @param int|float   $radius
-     */
-    public function circle($center, $radius): static
+    public function circle(array|Point $center, int|float $radius): static
     {
         $this->circle = (object) [
             'center' => $this->convertGeometry($center),
@@ -70,8 +62,7 @@ class GeoWithin extends AbstractSearchOperator implements ScoredSearchOperator
         return $this;
     }
 
-    /** @param Polygon|MultiPolygon|array $geometry */
-    public function geometry($geometry): static
+    public function geometry(Polygon|MultiPolygon|array $geometry): static
     {
         $this->geometry = $geometry;
 
@@ -102,8 +93,7 @@ class GeoWithin extends AbstractSearchOperator implements ScoredSearchOperator
         return $this->appendScore($params);
     }
 
-    /** @param array|Geometry $geometry */
-    private function convertGeometry($geometry): array
+    private function convertGeometry(array|Geometry $geometry): array
     {
         if (! $geometry instanceof Geometry) {
             return $geometry;

--- a/src/Aggregation/Stage/Search/MoreLikeThis.php
+++ b/src/Aggregation/Stage/Search/MoreLikeThis.php
@@ -20,7 +20,7 @@ class MoreLikeThis extends AbstractSearchOperator
     private array $like = [];
 
     /** @param array<string, mixed>|object $documents */
-    public function __construct(Search $search, DocumentPersister $persister, ...$documents)
+    public function __construct(Search $search, DocumentPersister $persister, array|object ...$documents)
     {
         parent::__construct($search, $persister);
 

--- a/src/Aggregation/Stage/Search/Near.php
+++ b/src/Aggregation/Stage/Search/Near.php
@@ -26,11 +26,7 @@ class Near extends AbstractSearchOperator implements ScoredSearchOperator
     /** @var list<string> */
     private array $path;
 
-    /**
-     * @param int|float|UTCDateTime|array|Point|null $origin
-     * @param int|float|null                         $pivot
-     */
-    public function __construct(Search $search, DocumentPersister $persister, $origin = null, $pivot = null, string ...$path)
+    public function __construct(Search $search, DocumentPersister $persister, int|float|UTCDateTime|array|Point|null $origin = null, int|float|null $pivot = null, string ...$path)
     {
         parent::__construct($search, $persister);
 
@@ -40,16 +36,14 @@ class Near extends AbstractSearchOperator implements ScoredSearchOperator
             ->path(...$path);
     }
 
-    /** @param int|float|UTCDateTime|array|Point|null $origin */
-    public function origin($origin): static
+    public function origin(int|float|UTCDateTime|array|Point|null $origin): static
     {
         $this->origin = $origin;
 
         return $this;
     }
 
-    /** @param int|float|null $pivot */
-    public function pivot($pivot): static
+    public function pivot(int|float|null $pivot): static
     {
         $this->pivot = $pivot;
 

--- a/src/Aggregation/Stage/Search/Range.php
+++ b/src/Aggregation/Stage/Search/Range.php
@@ -18,13 +18,11 @@ class Range extends AbstractSearchOperator implements ScoredSearchOperator
     private int|float|UTCDateTime|null $gt = null;
     private int|float|UTCDateTime|null $lt = null;
     private bool $includeLowerBound        = false;
-    private bool $includeUpperBound        = false;
 
     /** @var list<string> */
     private array $path;
 
-    /** @param int|float|UTCDateTime|null $value */
-    public function gt($value): static
+    public function gt(int|float|UTCDateTime|null $value): static
     {
         $this->gt                = $value;
         $this->includeLowerBound = false;
@@ -32,8 +30,7 @@ class Range extends AbstractSearchOperator implements ScoredSearchOperator
         return $this;
     }
 
-    /** @param int|float|UTCDateTime|null $value */
-    public function gte($value): static
+    public function gte(int|float|UTCDateTime|null $value): static
     {
         $this->gt                = $value;
         $this->includeLowerBound = true;
@@ -41,8 +38,7 @@ class Range extends AbstractSearchOperator implements ScoredSearchOperator
         return $this;
     }
 
-    /** @param int|float|UTCDateTime|null $value */
-    public function lt($value): static
+    public function lt(int|float|UTCDateTime|null $value): static
     {
         $this->lt                = $value;
         $this->includeLowerBound = false;
@@ -50,8 +46,7 @@ class Range extends AbstractSearchOperator implements ScoredSearchOperator
         return $this;
     }
 
-    /** @param int|float|UTCDateTime|null $value */
-    public function lte($value): static
+    public function lte(int|float|UTCDateTime|null $value): static
     {
         $this->lt                = $value;
         $this->includeLowerBound = true;

--- a/src/Aggregation/Stage/Search/SupportsAllSearchOperatorsTrait.php
+++ b/src/Aggregation/Stage/Search/SupportsAllSearchOperatorsTrait.php
@@ -10,7 +10,6 @@ use GeoJson\Geometry\LineString;
 use GeoJson\Geometry\MultiPolygon;
 use GeoJson\Geometry\Point;
 use GeoJson\Geometry\Polygon;
-use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
 
 /** @internal */
@@ -44,8 +43,7 @@ trait SupportsAllSearchOperatorsTrait
         return $this->addOperator(new EmbeddedDocument($this->getSearchStage(), $this->getDocumentPersister(), $path));
     }
 
-    /** @param string|int|float|ObjectId|UTCDateTime|null $value */
-    public function equals(string $path = '', $value = null): Equals
+    public function equals(string $path = '', mixed $value = null): Equals
     {
         return $this->addOperator(new Equals($this->getSearchStage(), $this->getDocumentPersister(), $path, $value));
     }
@@ -56,7 +54,7 @@ trait SupportsAllSearchOperatorsTrait
     }
 
     /** @param LineString|Point|Polygon|MultiPolygon|array<string, mixed>|null $geometry */
-    public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape
+    public function geoShape(LineString|Point|Polygon|MultiPolygon|array|null $geometry = null, string $relation = '', string ...$path): GeoShape
     {
         return $this->addOperator(new GeoShape($this->getSearchStage(), $this->getDocumentPersister(), $geometry, $relation, ...$path));
     }
@@ -67,16 +65,13 @@ trait SupportsAllSearchOperatorsTrait
     }
 
     /** @param array<string, mixed>|object $documents */
-    public function moreLikeThis(...$documents): MoreLikeThis
+    public function moreLikeThis(array|object ...$documents): MoreLikeThis
     {
         return $this->addOperator(new MoreLikeThis($this->getSearchStage(), $this->getDocumentPersister(), ...$documents));
     }
 
-    /**
-     * @param int|float|UTCDateTime|array<string, mixed>|Point|null $origin
-     * @param int|float|null                                        $pivot
-     */
-    public function near($origin = null, $pivot = null, string ...$path): Near
+    /** @param int|float|UTCDateTime|array<string, mixed>|Point|null $origin */
+    public function near(int|float|UTCDateTime|array|Point|null $origin = null, int|float|null $pivot = null, string ...$path): Near
     {
         return $this->addOperator(new Near($this->getSearchStage(), $this->getDocumentPersister(), $origin, $pivot, ...$path));
     }

--- a/src/Aggregation/Stage/Search/SupportsCompoundableOperatorsTrait.php
+++ b/src/Aggregation/Stage/Search/SupportsCompoundableOperatorsTrait.php
@@ -25,7 +25,6 @@ use GeoJson\Geometry\LineString;
 use GeoJson\Geometry\MultiPolygon;
 use GeoJson\Geometry\Point;
 use GeoJson\Geometry\Polygon;
-use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
 
 /** @internal */
@@ -58,8 +57,7 @@ trait SupportsCompoundableOperatorsTrait
         return $this->addOperator(new CompoundedEmbeddedDocument($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister(), $path));
     }
 
-    /** @param string|int|float|ObjectId|UTCDateTime|null $value */
-    public function equals(string $path = '', $value = null): Equals&CompoundSearchOperatorInterface
+    public function equals(string $path = '', mixed $value = null): Equals&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedEquals($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister(), $path, $value));
     }
@@ -70,7 +68,7 @@ trait SupportsCompoundableOperatorsTrait
     }
 
     /** @param LineString|Point|Polygon|MultiPolygon|array<string, mixed>|null $geometry */
-    public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape&CompoundSearchOperatorInterface
+    public function geoShape(LineString|Point|Polygon|MultiPolygon|array|null $geometry = null, string $relation = '', string ...$path): GeoShape&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedGeoShape($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister(), $geometry, $relation, ...$path));
     }
@@ -81,16 +79,13 @@ trait SupportsCompoundableOperatorsTrait
     }
 
     /** @param array<string, mixed>|object $documents */
-    public function moreLikeThis(...$documents): MoreLikeThis&CompoundSearchOperatorInterface
+    public function moreLikeThis(array|object ...$documents): MoreLikeThis&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedMoreLikeThis($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister(), ...$documents));
     }
 
-    /**
-     * @param int|float|UTCDateTime|array<string, mixed>|Point|null $origin
-     * @param int|float|null                                        $pivot
-     */
-    public function near($origin = null, $pivot = null, string ...$path): Near&CompoundSearchOperatorInterface
+    /** @param int|float|UTCDateTime|array<string, mixed>|Point|null $origin */
+    public function near(int|float|UTCDateTime|array|Point|null $origin = null, int|float|null $pivot = null, string ...$path): Near&CompoundSearchOperatorInterface
     {
         return $this->addOperator(new CompoundedNear($this->getCompoundStage(), $this->getAddOperatorClosure(), $this->getSearchStage(), $this->getDocumentPersister(), $origin, $pivot, ...$path));
     }

--- a/src/Aggregation/Stage/Search/SupportsEqualsOperator.php
+++ b/src/Aggregation/Stage/Search/SupportsEqualsOperator.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 
-use MongoDB\BSON\ObjectId;
-use MongoDB\BSON\UTCDateTime;
-
 interface SupportsEqualsOperator
 {
-    /** @param string|int|float|ObjectId|UTCDateTime|null $value */
-    public function equals(string $path = '', $value = null): Equals;
+    public function equals(string $path = '', mixed $value = null): Equals;
 }

--- a/src/Aggregation/Stage/Search/SupportsGeoShapeOperator.php
+++ b/src/Aggregation/Stage/Search/SupportsGeoShapeOperator.php
@@ -12,5 +12,5 @@ use GeoJson\Geometry\Polygon;
 interface SupportsGeoShapeOperator
 {
     /** @param LineString|Point|Polygon|MultiPolygon|array<string, mixed>|null $geometry */
-    public function geoShape($geometry = null, string $relation = '', string ...$path): GeoShape;
+    public function geoShape(LineString|Point|Polygon|MultiPolygon|array|null $geometry = null, string $relation = '', string ...$path): GeoShape;
 }

--- a/src/Aggregation/Stage/Search/SupportsMoreLikeThisOperator.php
+++ b/src/Aggregation/Stage/Search/SupportsMoreLikeThisOperator.php
@@ -7,5 +7,5 @@ namespace Doctrine\ODM\MongoDB\Aggregation\Stage\Search;
 interface SupportsMoreLikeThisOperator
 {
     /** @param array<string, mixed>|object $documents */
-    public function moreLikeThis(...$documents): MoreLikeThis;
+    public function moreLikeThis(array|object ...$documents): MoreLikeThis;
 }

--- a/src/Aggregation/Stage/Search/SupportsNearOperator.php
+++ b/src/Aggregation/Stage/Search/SupportsNearOperator.php
@@ -9,9 +9,6 @@ use MongoDB\BSON\UTCDateTime;
 
 interface SupportsNearOperator
 {
-    /**
-     * @param int|float|UTCDateTime|array<string, mixed>|Point|null $origin
-     * @param int|float|null                                        $pivot
-     */
-    public function near($origin = null, $pivot = null, string ...$path): Near;
+    /** @param int|float|UTCDateTime|array<string, mixed>|Point|null $origin */
+    public function near(int|float|UTCDateTime|array|Point|null $origin = null, int|float|null $pivot = null, string ...$path): Near;
 }

--- a/src/Aggregation/Stage/SetWindowFields.php
+++ b/src/Aggregation/Stage/SetWindowFields.php
@@ -42,8 +42,7 @@ class SetWindowFields extends Stage
         $this->output = new Output($this->builder, $this);
     }
 
-    /** @param mixed|Expr $expression */
-    public function partitionBy($expression): static
+    public function partitionBy(mixed $expression): static
     {
         $this->partitionBy = $expression;
 
@@ -52,11 +51,11 @@ class SetWindowFields extends Stage
 
     /**
      * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
-     * @param int|string                       $order     Field order (if one field is specified)
-     * @phpstan-param SortShape|string           $fieldName
-     * @phpstan-param SortDirection|null         $order
+     * @param int|string|null                  $order     Field order (if one field is specified)
+     * @phpstan-param SortShape|string         $fieldName
+     * @phpstan-param SortDirection|null       $order
      */
-    public function sortBy($fieldName, $order = null): static
+    public function sortBy(array|string $fieldName, int|string|null $order = null): static
     {
         $fields = is_array($fieldName) ? $fieldName : [$fieldName => $order ?? 1];
 

--- a/src/Aggregation/Stage/SetWindowFields/Output.php
+++ b/src/Aggregation/Stage/SetWindowFields/Output.php
@@ -45,18 +45,17 @@ class Output extends Operator implements WindowOperators
         parent::__construct($builder);
     }
 
-    /** @param mixed|Expr $expression */
-    public function partitionBy($expression): SetWindowFields
+    public function partitionBy(mixed $expression): SetWindowFields
     {
         return $this->setWindowFields->partitionBy($expression);
     }
 
     /**
      * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
-     * @param int|string                       $order     Field order (if one field is specified)
-     * @phpstan-param SortShape|string           $fieldName
+     * @param int|string|null                  $order     Field order (if one field is specified)
+     * @phpstan-param SortShape|string         $fieldName
      */
-    public function sortBy($fieldName, $order = null): SetWindowFields
+    public function sortBy(array|string $fieldName, int|string|null $order = null): SetWindowFields
     {
         return $this->setWindowFields->sortBy(...func_get_args());
     }

--- a/src/Aggregation/Stage/Sort.php
+++ b/src/Aggregation/Stage/Sort.php
@@ -30,11 +30,11 @@ class Sort extends Stage
 
     /**
      * @param array<string, int|string|array<string, string>>|string $fieldName Field name or array of field/order pairs
-     * @param int|string                                             $order     Field order (if one field is specified)
+     * @param int|string|array|null                                  $order     Field order (if one field is specified)
      * @phpstan-param SortShape|string                        $fieldName
      * @phpstan-param int|SortMeta|SortDirectionKeywords|null $order
      */
-    public function __construct(Builder $builder, $fieldName, $order = null)
+    public function __construct(Builder $builder, array|string $fieldName, int|string|array|null $order = null)
     {
         parent::__construct($builder);
 

--- a/src/Aggregation/Stage/UnionWith.php
+++ b/src/Aggregation/Stage/UnionWith.php
@@ -27,7 +27,7 @@ class UnionWith extends Stage
     /** @phpstan-var ?PipelineParamType */
     private array|Builder|Stage|null $pipeline = null;
 
-    public function __construct(Builder $builder, private DocumentManager $dm, private string $collection)
+    public function __construct(Builder $builder, private readonly DocumentManager $dm, private string $collection)
     {
         parent::__construct($builder);
 
@@ -38,11 +38,8 @@ class UnionWith extends Stage
         }
     }
 
-    /**
-     * @param array|Builder|Stage $pipeline
-     * @phpstan-param PipelineParamType $pipeline
-     */
-    public function pipeline($pipeline): static
+    /** @phpstan-param PipelineParamType $pipeline */
+    public function pipeline(array|Builder|Stage $pipeline): static
     {
         if ($pipeline instanceof Stage) {
             $this->pipeline = $pipeline->builder;

--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -38,7 +38,7 @@ class AttributeDriver implements MappingDriver
     private AttributeReader $reader;
 
     /** @param string|string[]|ClassLocator|null $paths */
-    public function __construct($paths = null)
+    public function __construct(string|array|ClassLocator|null $paths = null)
     {
         $this->reader = new AttributeReader();
 
@@ -49,7 +49,7 @@ class AttributeDriver implements MappingDriver
         }
     }
 
-    public function isTransient($className): bool
+    public function isTransient(string $className): bool
     {
         $classAttributes = $this->getClassAttributes(new ReflectionClass($className));
 
@@ -62,7 +62,7 @@ class AttributeDriver implements MappingDriver
         return true;
     }
 
-    public function loadMetadataForClass($className, PersistenceClassMetadata $metadata): void
+    public function loadMetadataForClass(string $className, PersistenceClassMetadata $metadata): void
     {
         assert($metadata instanceof ClassMetadata);
         $reflClass = $metadata->getReflectionClass();
@@ -361,10 +361,8 @@ class AttributeDriver implements MappingDriver
      * Factory method for the Attribute Driver
      *
      * @param string|string[]|ClassLocator $paths
-     *
-     * @return self
      */
-    public static function create($paths = [])
+    public static function create(string|array|ClassLocator $paths = []): self
     {
         return new self($paths);
     }

--- a/src/Mapping/Driver/XmlDriver.php
+++ b/src/Mapping/Driver/XmlDriver.php
@@ -83,7 +83,7 @@ class XmlDriver extends FileDriver
     }
 
     // phpcs:disable SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
-    public function loadMetadataForClass($className, \Doctrine\Persistence\Mapping\ClassMetadata $metadata): void
+    public function loadMetadataForClass(string $className, \Doctrine\Persistence\Mapping\ClassMetadata $metadata): void
     {
         assert($metadata instanceof ClassMetadata);
         $xmlRoot = $this->getElement($className);
@@ -819,10 +819,8 @@ class XmlDriver extends FileDriver
      * Special strings "false", "true", and "null" are converted to their
      * respective values. Numeric strings are cast to int or float depending on
      * whether they contain decimal separators or not.
-     *
-     * @return scalar|null
      */
-    private function convertXMLElementValue(string $value)
+    private function convertXMLElementValue(string $value): string|bool|int|float|null
     {
         $value = trim($value);
 
@@ -896,7 +894,7 @@ class XmlDriver extends FileDriver
         return [(string) $xmlReadPreference['mode'], $tags];
     }
 
-    protected function loadMappingFile($file): array
+    protected function loadMappingFile(string $file): array
     {
         $result = [];
 

--- a/src/Mapping/PropertyAccessors/EnumPropertyAccessor.php
+++ b/src/Mapping/PropertyAccessors/EnumPropertyAccessor.php
@@ -44,7 +44,7 @@ class EnumPropertyAccessor implements PropertyAccessor
      *
      * @return ($enum is BackedEnum ? (string|int) : (string[]|int[]))
      */
-    private function fromEnum($enum) // phpcs:ignore
+    private function fromEnum(BackedEnum|array $enum):string|int|array // phpcs:ignore
     {
         if (is_array($enum)) {
             return array_map(static function (BackedEnum $enum) {
@@ -60,7 +60,7 @@ class EnumPropertyAccessor implements PropertyAccessor
      *
      * @return ($value is int|string|BackedEnum ? BackedEnum : BackedEnum[])
      */
-    private function toEnum($value): BackedEnum|array
+    private function toEnum(BackedEnum|array|string|int $value): BackedEnum|array
     {
         if ($value instanceof BackedEnum) {
             return $value;

--- a/tests/Tests/Aggregation/Stage/FacetTest.php
+++ b/tests/Tests/Aggregation/Stage/FacetTest.php
@@ -7,9 +7,7 @@ namespace Doctrine\ODM\MongoDB\Tests\Aggregation\Stage;
 use Doctrine\ODM\MongoDB\Aggregation\Stage\Facet;
 use Doctrine\ODM\MongoDB\Tests\Aggregation\AggregationTestTrait;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
-use InvalidArgumentException;
 use LogicException;
-use stdClass;
 
 class FacetTest extends BaseTestCase
 {
@@ -64,16 +62,5 @@ class FacetTest extends BaseTestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('requires setting a current field using field().');
         $facetStage->pipeline($this->getTestAggregationBuilder());
-    }
-
-    public function testThrowsExceptionOnInvalidPipeline(): void
-    {
-        $facetStage = new Facet($this->getTestAggregationBuilder());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('expects either an aggregation builder or an aggregation stage.');
-        $facetStage
-            ->field('someField')
-            ->pipeline(new stdClass());
     }
 }

--- a/tests/Tests/Aggregation/Stage/GeoNearTest.php
+++ b/tests/Tests/Aggregation/Stage/GeoNearTest.php
@@ -22,7 +22,7 @@ class GeoNearTest extends BaseTestCase
             ->field('someField')
             ->equals('someValue');
 
-        $stage = ['near' => [0, 0], 'spherical' => false, 'distanceField' => 'distance', 'query' => ['someField' => 'someValue']];
+        $stage = ['near' => [0.0, 0.0], 'spherical' => false, 'distanceField' => 'distance', 'query' => ['someField' => 'someValue']];
         self::assertSame(['$geoNear' => $stage], $geoNearStage->getExpression());
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | 

#### Summary

Adds missing type hints, mainly in `Aggregation` namespace. Most `Aggregation` types are actually `mixed` because they usually accept an `Expr`, `array` or any other scalar - I left the `mixed|Expr` phpdoc there as it gives a bit more hints on how to use it.
