### PR TITLE
Mark `SearchIndex`, `Validation` and `VectorSearchIndex` as soft-final

### DIFF
--- a/src/Mapping/Attribute/SearchIndex.php
+++ b/src/Mapping/Attribute/SearchIndex.php
@@ -14,6 +14,8 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
  *
  * @phpstan-import-type SearchIndexStoredSource from ClassMetadata
  * @phpstan-import-type SearchIndexSynonym from ClassMetadata
+ *
+ * @final
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 class SearchIndex implements MappingAttribute

--- a/src/Mapping/Attribute/Validation.php
+++ b/src/Mapping/Attribute/Validation.php
@@ -7,7 +7,10 @@ namespace Doctrine\ODM\MongoDB\Mapping\Attribute;
 use Attribute;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 
-/** @Target({"CLASS"}) */
+/**
+ * @Target({"CLASS"})
+ * @final
+ */
 #[Attribute(Attribute::TARGET_CLASS)]
 class Validation implements MappingAttribute
 {

--- a/src/Mapping/Attribute/VectorSearchIndex.php
+++ b/src/Mapping/Attribute/VectorSearchIndex.php
@@ -13,6 +13,8 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
  * @see https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/
  *
  * @phpstan-import-type VectorSearchIndexField from ClassMetadata
+ *
+ * @final
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 class VectorSearchIndex implements MappingAttribute


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

As highlighted in #2976, `SearchIndex`, `Validation` and `VectorSearchIndex` should be marked as `@final`
