### PR TITLE
[3.0] Change default implementation of `Type::closureToPHP` and remove `closureToMongo`

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -93,3 +93,10 @@ have been removed in favor of `Configuration::getMetadataCache()` and
 - $dm->getConfiguration()->getMetadataCacheImpl();
 + $dm->getConfiguration()->getMetadataCache();
 ```
+
+## `ClosureToPHP` in custom types
+
+The default implementation of `Type::closureToPHP` has been modified to call
+`convertToPHPValue` on the type class. This implementation was provided by
+the `ClosureToPHP` trait, which is deprecated. If you have custom types
+that use the `ClosureToPHP` trait, remove the trait.

--- a/src/Types/AbstractVectorType.php
+++ b/src/Types/AbstractVectorType.php
@@ -72,25 +72,6 @@ abstract class AbstractVectorType extends Type
         return $value->toArray();
     }
 
-    public function closureToMongo(): string
-    {
-        return str_replace('%%vectorType%%', $this->getVectorType()->name, <<<'PHP'
-            if ($value === null) {
-                $return = null;
-            } elseif (\is_array($value)) {
-                $return = \MongoDB\BSON\Binary::fromVector($value, \MongoDB\BSON\VectorType::%%vectorType%%);
-            } elseif (! $value instanceof \MongoDB\BSON\Binary) {
-                throw new InvalidArgumentException(sprintf('Invalid data type %s received for vector field, expected null, array or MongoDB\BSON\Binary', get_debug_type($value)));
-            } elseif ($value->getType() !== \MongoDB\BSON\Binary::TYPE_VECTOR) {
-                throw new InvalidArgumentException(sprintf('Invalid binary data of type %d received for vector field, expected binary type %d', $value->getType(), \MongoDB\BSON\Binary::TYPE_VECTOR));
-            } elseif ($value->getVectorType() !== \MongoDB\BSON\VectorType::%%vectorType%%) {
-                throw new \InvalidArgumentException(sprintf('Invalid binary vector data of vector type %s received for vector field, expected vector type %%vectorType%%', $value->getVectorType()->name));
-            } else {
-                $return = $value;
-            }
-PHP);
-    }
-
     public function closureToPHP(): string
     {
         return str_replace('%%vectorType%%', $this->getVectorType()->name, <<<'PHP'

--- a/src/Types/BinDataType.php
+++ b/src/Types/BinDataType.php
@@ -6,8 +6,6 @@ namespace Doctrine\ODM\MongoDB\Types;
 
 use MongoDB\BSON\Binary;
 
-use function sprintf;
-
 /**
  * The BinData type for generic data.
  */
@@ -40,11 +38,6 @@ class BinDataType extends Type
     public function convertToPHPValue(mixed $value): mixed
     {
         return $value !== null ? ($value instanceof Binary ? $value->getData() : $value) : null;
-    }
-
-    public function closureToMongo(): string
-    {
-        return sprintf('$return = $value !== null ? new \MongoDB\BSON\Binary($value, %d) : null;', $this->binDataType);
     }
 
     public function closureToPHP(): string

--- a/src/Types/BinaryUuidType.php
+++ b/src/Types/BinaryUuidType.php
@@ -42,19 +42,6 @@ class BinaryUuidType extends Type
         return Uuid::fromBinary($value->getData());
     }
 
-    public function closureToMongo(): string
-    {
-        return <<<'PHP'
-$return = match (true) {
-    $value === null => null,
-    $value instanceof \MongoDB\BSON\Binary => $value,
-    $value instanceof \Symfony\Component\Uid\Uuid => new \MongoDB\BSON\Binary($value->toBinary(), \MongoDB\BSON\Binary::TYPE_UUID),
-    is_string($value) => new \MongoDB\BSON\Binary(\Symfony\Component\Uid\Uuid::fromString($value)->toBinary(), \MongoDB\BSON\Binary::TYPE_UUID),
-    default => throw new \InvalidArgumentException(sprintf('Invalid data type %s received for UUID', get_debug_type($value))),
-};
-PHP;
-    }
-
     public function closureToPHP(): string
     {
         return <<<'PHP'

--- a/src/Types/BooleanType.php
+++ b/src/Types/BooleanType.php
@@ -19,11 +19,6 @@ class BooleanType extends Type
         return $value !== null ? (bool) $value : null;
     }
 
-    public function closureToMongo(): string
-    {
-        return '$return = (bool) $value;';
-    }
-
     public function closureToPHP(): string
     {
         return '$return = (bool) $value;';

--- a/src/Types/ClosureToPHP.php
+++ b/src/Types/ClosureToPHP.php
@@ -6,7 +6,11 @@ namespace Doctrine\ODM\MongoDB\Types;
 
 use function sprintf;
 
-/** This trait will be deprecated in 3.0 as this behavior will be used by default */
+/**
+ * @deprecated Since 3.0, the default {@see Type::closureToPHP()} implementation is identical and this trait is no longer needed.
+ *
+ * @phpstan-ignore trait.unused
+ */
 trait ClosureToPHP
 {
     /** @return string Redirects to the method convertToPHPValue from child class */

--- a/src/Types/CustomIdType.php
+++ b/src/Types/CustomIdType.php
@@ -19,11 +19,6 @@ class CustomIdType extends Type
         return $value;
     }
 
-    public function closureToMongo(): string
-    {
-        return '$return = $value;';
-    }
-
     public function closureToPHP(): string
     {
         return '$return = $value;';

--- a/src/Types/DateType.php
+++ b/src/Types/DateType.php
@@ -101,11 +101,6 @@ class DateType extends Type implements Versionable
         return static::getDateTime($value);
     }
 
-    public function closureToMongo(): string
-    {
-        return 'if ($value === null || $value instanceof \MongoDB\BSON\UTCDateTime) { $return = $value; } else { $datetime = \\' . static::class . '::getDateTime($value); $return = new \MongoDB\BSON\UTCDateTime($datetime); }';
-    }
-
     public function closureToPHP(): string
     {
         return 'if ($value === null) { $return = null; } else { $return = \\' . static::class . '::getDateTime($value); }';

--- a/src/Types/Decimal128Type.php
+++ b/src/Types/Decimal128Type.php
@@ -11,8 +11,6 @@ use function bcsub;
 
 class Decimal128Type extends Type implements Incrementable, Versionable
 {
-    use ClosureToPHP;
-
     public function convertToDatabaseValue(mixed $value): ?Decimal128
     {
         if ($value === null) {

--- a/src/Types/FloatType.php
+++ b/src/Types/FloatType.php
@@ -19,11 +19,6 @@ class FloatType extends Type implements Incrementable
         return $value !== null ? (float) $value : null;
     }
 
-    public function closureToMongo(): string
-    {
-        return '$return = (float) $value;';
-    }
-
     public function closureToPHP(): string
     {
         return '$return = (float) $value;';

--- a/src/Types/IdType.php
+++ b/src/Types/IdType.php
@@ -34,11 +34,6 @@ class IdType extends Type
         return $value instanceof ObjectId ? (string) $value : $value;
     }
 
-    public function closureToMongo(): string
-    {
-        return '$return = new MongoDB\BSON\ObjectId($value);';
-    }
-
     public function closureToPHP(): string
     {
         return '$return = $value instanceof \MongoDB\BSON\ObjectId ? (string) $value : $value;';

--- a/src/Types/Int64Type.php
+++ b/src/Types/Int64Type.php
@@ -27,11 +27,6 @@ class Int64Type extends Type implements Incrementable, Versionable
         return $value !== null ? (int) $value : null;
     }
 
-    public function closureToMongo(): string
-    {
-        return '$return = new \MongoDB\BSON\Int64($value);';
-    }
-
     public function closureToPHP(): string
     {
         return '$return = (int) $value;';

--- a/src/Types/IntType.php
+++ b/src/Types/IntType.php
@@ -21,11 +21,6 @@ class IntType extends Type implements Incrementable, Versionable
         return $value !== null ? (int) $value : null;
     }
 
-    public function closureToMongo(): string
-    {
-        return '$return = (int) $value;';
-    }
-
     public function closureToPHP(): string
     {
         return '$return = (int) $value;';

--- a/src/Types/KeyType.php
+++ b/src/Types/KeyType.php
@@ -12,8 +12,6 @@ use MongoDB\BSON\MinKey;
  */
 class KeyType extends Type
 {
-    use ClosureToPHP;
-
     public function convertToDatabaseValue(mixed $value): MinKey|MaxKey|null
     {
         if ($value === null) {

--- a/src/Types/ObjectIdType.php
+++ b/src/Types/ObjectIdType.php
@@ -29,11 +29,6 @@ class ObjectIdType extends Type implements Versionable
         return $value !== null ? (string) $value : null;
     }
 
-    public function closureToMongo(): string
-    {
-        return '$return = new MongoDB\BSON\ObjectId($value);';
-    }
-
     public function closureToPHP(): string
     {
         return '$return = (string) $value;';

--- a/src/Types/RawType.php
+++ b/src/Types/RawType.php
@@ -19,11 +19,6 @@ class RawType extends Type
         return $value;
     }
 
-    public function closureToMongo(): string
-    {
-        return '$return = $value;';
-    }
-
     public function closureToPHP(): string
     {
         return '$return = $value;';

--- a/src/Types/StringType.php
+++ b/src/Types/StringType.php
@@ -21,11 +21,6 @@ class StringType extends Type
         return $value !== null ? (string) $value : null;
     }
 
-    public function closureToMongo(): string
-    {
-        return '$return = (string) $value;';
-    }
-
     public function closureToPHP(): string
     {
         return '$return = (string) $value;';

--- a/src/Types/TimestampType.php
+++ b/src/Types/TimestampType.php
@@ -14,8 +14,6 @@ use function substr;
  */
 class TimestampType extends Type
 {
-    use ClosureToPHP;
-
     public function convertToDatabaseValue(mixed $value): ?Timestamp
     {
         if ($value instanceof Timestamp) {

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -15,8 +15,8 @@ use function end;
 use function explode;
 use function gettype;
 use function is_object;
+use function sprintf;
 use function str_replace;
-use function trigger_deprecation;
 
 /**
  * The Type interface.
@@ -117,29 +117,15 @@ abstract class Type implements Stringable
     }
 
     /**
-     * Get the PHP code equivalent to {@see convertToDatabaseValue()}, used in code generator.
-     * Use variables $value for input and $return for output.
-     *
-     * @deprecated Since 2.16, will be removed in 3.0.
-     */
-    public function closureToMongo(): string
-    {
-        trigger_deprecation('doctrine/mongodb-odm', '2.16', 'Type::closureToMongo() is deprecated and will be removed in 3.0.');
-
-        return '$return = $value;';
-    }
-
-    /**
      * Get the PHP code equivalent to {@see convertToPHPValue()}, used in code generator.
+     * By default, it calls the convertToPHPValue from child class.
      * Use variables $value for input and $return for output.
-     *
-     * @abstract The default implementation will change in 3.0.
      */
     public function closureToPHP(): string
     {
-        trigger_deprecation('doctrine/mongodb-odm', '2.16', 'The method Type::closureToPHP() will change its default implementation in 3.0 to use convertToPHPValue(). Override this method if you need custom behavior before upgrading to 3.0 or use the trait ClosureToPHP to get the upcoming behavior now.');
-
-        return '$return = $value;';
+        return sprintf('
+            $type = \%s::getType($typeIdentifier);
+            $return = $type->convertToPHPValue($value);', self::class);
     }
 
     /**

--- a/tests/Documentation/CustomMapping/DateTimeWithTimezoneType.php
+++ b/tests/Documentation/CustomMapping/DateTimeWithTimezoneType.php
@@ -6,7 +6,6 @@ namespace Documentation\CustomMapping;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\Type;
 use MongoDB\BSON\UTCDateTime;
 use RuntimeException;
@@ -16,9 +15,6 @@ use function sprintf;
 
 class DateTimeWithTimezoneType extends Type
 {
-    // This trait provides default closureToPHP used during data hydration
-    use ClosureToPHP;
-
     /** @param array{utc: UTCDateTime, tz: string} $value */
     public function convertToPHPValue($value): DateTimeImmutable
     {

--- a/tests/Tests/Functional/CustomTypeTest.php
+++ b/tests/Tests/Functional/CustomTypeTest.php
@@ -8,7 +8,6 @@ use DateTime;
 use DateTimeInterface;
 use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
-use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Exception;
 use MongoDB\BSON\UTCDateTime;
@@ -92,22 +91,10 @@ class CustomTypeTest extends BaseTestCase
         $databaseValue = Type::convertPHPToDatabaseValue($lang);
         self::assertSame(['name' => 'French', 'code' => 'fr'], $databaseValue);
     }
-
-    public function testNotOverridingClosureToPHPIsDeprecated(): void
-    {
-        $type = Type::getType('custom_type_without_closure_to_php');
-        $this->expectUserDeprecationMessage('Since doctrine/mongodb-odm 2.16: The method Type::closureToPHP() will change its default implementation in 3.0 to use convertToPHPValue(). Override this method if you need custom behavior before upgrading to 3.0 or use the trait ClosureToPHP to get the upcoming behavior now.');
-
-        $code = $type->closureToPHP();
-
-        self::assertSame('$return = $value;', $code);
-    }
 }
 
 class DateCollectionType extends Type
 {
-    use ClosureToPHP;
-
     /**
      * Method called by PersistenceBuilder
      *
@@ -147,15 +134,6 @@ class DateCollectionType extends Type
 
         return $value;
     }
-
-    /**
-     * Method never called
-     */
-    public function closureToMongo(): string
-    {
-        // todo: microseconds o.O
-        return '$return = array_map(function($v) { if ($v instanceof \MongoDB\BSON\UTCDateTime) { $v = $v->getTimestamp(); } else if (is_string($v)) { $v = strtotime($v); } return new \MongoDB\BSON\UTCDateTime($v); }, $value);';
-    }
 }
 
 class CustomTypeException extends Exception
@@ -188,8 +166,6 @@ class Language
 
 class LanguageType extends Type
 {
-    use ClosureToPHP;
-
     /** @return array{name:string,code:string}|null */
     public function convertToDatabaseValue(mixed $value): ?array
     {

--- a/tests/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Tests/Functional/DocumentPersisterTest.php
@@ -11,7 +11,6 @@ use Doctrine\ODM\MongoDB\LockException;
 use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
 use Doctrine\ODM\MongoDB\Persisters\DocumentPersister;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
-use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Documents\Article;
 use Generator;
@@ -1000,8 +999,6 @@ final class DocumentPersisterCustomTypedId
 
 final class DocumentPersisterCustomIdType extends Type
 {
-    use ClosureToPHP;
-
     public function convertToDatabaseValue(mixed $value): ObjectId
     {
         if ($value instanceof ObjectId) {

--- a/tests/Tests/Types/BinaryUuidTypeTest.php
+++ b/tests/Tests/Types/BinaryUuidTypeTest.php
@@ -60,26 +60,6 @@ class BinaryUuidTypeTest extends TestCase
         $type->convertToPHPValue(new Binary('invalid', Binary::TYPE_GENERIC));
     }
 
-    public function testClosureToMongo(): void
-    {
-        $type       = Type::getType(Type::UUID);
-        $uuid       = new UuidV4();
-        $stringUuid = $uuid->toRfc4122();
-        $binaryUuid = new Binary($uuid->toBinary(), Binary::TYPE_UUID);
-
-        $convertToDatabaseValue = static function ($value) use ($type) {
-            $return = null;
-            eval($type->closureToMongo());
-
-            return $return;
-        };
-
-        self::assertNull($convertToDatabaseValue(null), 'null is not converted');
-        self::assertEquals($binaryUuid, $convertToDatabaseValue($uuid), 'Uuid objects are converted to Binary objects');
-        self::assertEquals($binaryUuid, $convertToDatabaseValue($stringUuid), 'String UUIDs are converted to Binary objects');
-        self::assertSame($binaryUuid, $convertToDatabaseValue($binaryUuid), 'Binary UUIDs are returned as is');
-    }
-
     public function testClosureToPhp(): void
     {
         $type       = Type::getType(Type::UUID);

--- a/tests/Tests/Types/VectorTypeTest.php
+++ b/tests/Tests/Types/VectorTypeTest.php
@@ -23,15 +23,6 @@ class VectorTypeTest extends TestCase
         $this->assertSameTypeAndValue($expectedValue, Type::getType($name)->convertToDatabaseValue($value));
     }
 
-    #[DataProvider('providePhpVectors')]
-    public function testClosureToDatabase(string $name, mixed $value, mixed $expectedValue): void
-    {
-        $return = $this;
-        eval(Type::getType($name)->closureToMongo());
-
-        $this->assertSameTypeAndValue($expectedValue, $return);
-    }
-
     /** @return iterable<array{0: Type::VECTOR_*, 1: mixed, 2: mixed}> */
     public static function providePhpVectors(): iterable
     {
@@ -107,16 +98,6 @@ class VectorTypeTest extends TestCase
         $type->convertToDatabaseValue($value);
     }
 
-    #[DataProvider('provideDatabaseValueException')]
-    public function testClosureToPHPValueException(mixed $value, string $message): void
-    {
-        $type = Type::getType(Type::VECTOR_FLOAT32);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage($message);
-        eval($type->closureToMongo());
-    }
-
     /** @return iterable<array{0: mixed, 1: string}> */
     public static function provideDatabaseValueException(): iterable
     {
@@ -133,16 +114,6 @@ class VectorTypeTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($message);
         $type->convertToPHPValue($value);
-    }
-
-    #[DataProvider('providePHPValueException')]
-    public function testClosureToDatabaseException(mixed $value, string $message): void
-    {
-        $type = Type::getType(Type::VECTOR_FLOAT32);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage($message);
-        eval($type->closureToPHP());
     }
 
     public static function providePHPValueException(): iterable


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | yes
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->
