### PR TITLE
Make `PersistentCollection` implement `Selectable`

### DIFF
--- a/UPGRADE-2.16.md
+++ b/UPGRADE-2.16.md
@@ -59,3 +59,8 @@ implement `closureToPHP()`.
 The method `Doctrine\ODM\MongoDB\Types\Type::closureToMongo()` is not used,
 and will be removed in MongoDB ODM 3.0. Don't call this method, but use
 `convertToDatabaseValue()` instead.
+
+## `PersistentCollection` implements `Selectable`
+
+The `PersistentCollection` and all generated persistent collection classes
+implement the `Doctrine\Common\Collections\Selectable::matching()` method.

--- a/src/PersistentCollection.php
+++ b/src/PersistentCollection.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB;
 
 use Doctrine\Common\Collections\Collection as BaseCollection;
+use Doctrine\Common\Collections\Selectable;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionTrait;
 

--- a/src/PersistentCollection.php
+++ b/src/PersistentCollection.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB;
 
 use Doctrine\Common\Collections\Collection as BaseCollection;
-use Doctrine\Common\Collections\Selectable;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionTrait;
 

--- a/src/PersistentCollection/PersistentCollectionInterface.php
+++ b/src/PersistentCollection/PersistentCollectionInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\PersistentCollection;
 
 use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Selectable;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\UnitOfWork;
@@ -21,8 +22,9 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
  * @template TKey of array-key
  * @template T of object
  * @template-extends Collection<TKey, T>
+ * @template-extends Selectable<TKey, T>
  */
-interface PersistentCollectionInterface extends Collection
+interface PersistentCollectionInterface extends Collection, Selectable
 {
     /**
      * Sets the document manager and unit of work (used during merge operations).

--- a/src/PersistentCollection/PersistentCollectionTrait.php
+++ b/src/PersistentCollection/PersistentCollectionTrait.php
@@ -7,11 +7,14 @@ namespace Doctrine\ODM\MongoDB\PersistentCollection;
 use BadMethodCallException;
 use Closure;
 use Doctrine\Common\Collections\Collection as BaseCollection;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Selectable;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
+use LogicException;
 use ReturnTypeWillChange;
 use Traversable;
 
@@ -774,5 +777,16 @@ trait PersistentCollectionTrait
         }
 
         return $this->coll->reduce($func, $initial);
+    }
+
+    public function matching(Criteria $criteria)
+    {
+        $this->initialize();
+
+        if (! $this->coll instanceof Selectable) {
+            throw new LogicException('The backed collection must implement Selectable to use matching().');
+        }
+
+        return $this->coll->matching($criteria);
     }
 }

--- a/src/PersistentCollection/PersistentCollectionTrait.php
+++ b/src/PersistentCollection/PersistentCollectionTrait.php
@@ -8,6 +8,7 @@ use BadMethodCallException;
 use Closure;
 use Doctrine\Common\Collections\Collection as BaseCollection;
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\ReadableCollection;
 use Doctrine\Common\Collections\Selectable;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
@@ -779,7 +780,7 @@ trait PersistentCollectionTrait
         return $this->coll->reduce($func, $initial);
     }
 
-    public function matching(Criteria $criteria)
+    public function matching(Criteria $criteria): ReadableCollection
     {
         $this->initialize();
 

--- a/tests/Tests/PersistentCollectionTest.php
+++ b/tests/Tests/PersistentCollectionTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\ODM\MongoDB\Tests;
 use Closure;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Criteria;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\PersistentCollection;
@@ -330,6 +331,27 @@ class PersistentCollectionTest extends BaseTestCase
         $pcoll = new PersistentCollection($collection, $this->dm, $this->uow);
         $pcoll->setInitialized(false);
         self::assertTrue($pcoll->isEmpty());
+    }
+
+    public function testMatchingIsForwarded(): void
+    {
+        $criteria = new Criteria();
+        $criteria->where($criteria->expr()->eq('field', 'value'));
+
+        $expectedResult = new ArrayCollection([new stdClass()]);
+
+        // ArrayCollection implements both Collection and Selectable
+        // When doctrine/collections 2.6+ is required, we can mock Collection directly
+        $collection = $this->createMock(ArrayCollection::class);
+        $collection->expects($this->once())
+            ->method('matching')
+            ->with($criteria)
+            ->willReturn($expectedResult);
+
+        $pcoll  = new PersistentCollection($collection, $this->dm, $this->uow);
+        $result = $pcoll->matching($criteria);
+
+        self::assertSame($expectedResult, $result);
     }
 
     /** @return Collection<int, object>&MockObject */

--- a/tests/Tests/PersistentCollectionTest.php
+++ b/tests/Tests/PersistentCollectionTest.php
@@ -30,7 +30,7 @@ class PersistentCollectionTest extends BaseTestCase
         $collection->expects($this->once())
             ->method('slice')
             ->with($start, $limit)
-            ->willReturn(true);
+            ->willReturn([]);
         $pCollection = new PersistentCollection($collection, $this->dm, $this->uow);
         $pCollection->slice($start, $limit);
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | Fix #2981

#### Summary

Implementing ReadableCollection without Selectable is deprecated https://github.com/doctrine/collections/pull/518
