### PR TITLE
Drop support for `doctrine/collections` v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8.1",
         "ext-mongodb": "^1.21 || ^2.0",
-        "doctrine/collections": "^1.5 || ^2.0",
+        "doctrine/collections": "^2.1",
         "doctrine/event-manager": "^1.0 || ^2.0",
         "doctrine/instantiator": "^1.1 || ^2",
         "doctrine/persistence": "^3.2 || ^4",

--- a/src/PersistentCollection/PersistentCollectionTrait.php
+++ b/src/PersistentCollection/PersistentCollectionTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\PersistentCollection;
 
-use BadMethodCallException;
 use Closure;
 use Doctrine\Common\Collections\Collection as BaseCollection;
 use Doctrine\Common\Collections\Criteria;
@@ -26,7 +25,6 @@ use function array_values;
 use function count;
 use function get_class;
 use function is_object;
-use function method_exists;
 use function sprintf;
 
 /**
@@ -763,10 +761,6 @@ trait PersistentCollectionTrait
      */
     public function findFirst(Closure $p)
     {
-        if (! method_exists($this->coll, 'findFirst')) {
-            throw new BadMethodCallException('findFirst() is only available since doctrine/collections v2');
-        }
-
         return $this->coll->findFirst($p);
     }
 
@@ -781,10 +775,6 @@ trait PersistentCollectionTrait
      */
     public function reduce(Closure $func, $initial = null)
     {
-        if (! method_exists($this->coll, 'reduce')) {
-            throw new BadMethodCallException('reduce() is only available since doctrine/collections v2');
-        }
-
         return $this->coll->reduce($func, $initial);
     }
 

--- a/src/PersistentCollection/PersistentCollectionTrait.php
+++ b/src/PersistentCollection/PersistentCollectionTrait.php
@@ -8,7 +8,6 @@ use BadMethodCallException;
 use Closure;
 use Doctrine\Common\Collections\Collection as BaseCollection;
 use Doctrine\Common\Collections\Criteria;
-use Doctrine\Common\Collections\ReadableCollection;
 use Doctrine\Common\Collections\Selectable;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
@@ -28,6 +27,7 @@ use function count;
 use function get_class;
 use function is_object;
 use function method_exists;
+use function sprintf;
 
 /**
  * Trait with methods needed to implement PersistentCollectionInterface.
@@ -414,6 +414,14 @@ trait PersistentCollectionTrait
         $this->doSet($key, $value, false);
     }
 
+    /**
+     * Adds an element at the end of the collection.
+     *
+     * @param mixed $element The element to add.
+     * @phpstan-param T $element
+     *
+     * @return true The return value is kept for BC reasons, but will be void in doctrine/mongodb-odm 3.0.
+     */
     public function add($element)
     {
         return $this->doAdd($element, false);
@@ -780,7 +788,8 @@ trait PersistentCollectionTrait
         return $this->coll->reduce($func, $initial);
     }
 
-    public function matching(Criteria $criteria): ReadableCollection
+    /** @return BaseCollection<TKey, T> */
+    public function matching(Criteria $criteria): BaseCollection
     {
         $this->initialize();
 
@@ -788,6 +797,12 @@ trait PersistentCollectionTrait
             throw new LogicException('The backed collection must implement Selectable to use matching().');
         }
 
-        return $this->coll->matching($criteria);
+        $coll = $this->coll->matching($criteria);
+
+        if (! $coll instanceof BaseCollection) {
+            throw new LogicException(sprintf('The matching() method of the backed collection must return an instance of "%s".', BaseCollection::class));
+        }
+
+        return $coll;
     }
 }

--- a/src/Persisters/DocumentPersister.php
+++ b/src/Persisters/DocumentPersister.php
@@ -47,7 +47,6 @@ use function array_map;
 use function array_merge;
 use function array_search;
 use function array_slice;
-use function array_values;
 use function assert;
 use function count;
 use function explode;
@@ -766,7 +765,7 @@ final class DocumentPersister
             $class           = $this->dm->getClassMetadata($className);
             $mongoCollection = $this->dm->getDocumentCollection($className);
             $criteria        = $this->cm->merge(
-                ['_id' => ['$in' => array_values($ids)]],
+                ['_id' => ['$in' => $ids]],
                 $this->dm->getFilterCollection()->getFilterCriteria($class),
                 $mapping['criteria'] ?? [],
             );

--- a/tests/Tests/PersistentCollectionTest.php
+++ b/tests/Tests/PersistentCollectionTest.php
@@ -341,7 +341,7 @@ class PersistentCollectionTest extends BaseTestCase
         $expectedResult = new ArrayCollection([new stdClass()]);
 
         // ArrayCollection implements both Collection and Selectable
-        // When doctrine/collections 2.6+ is required, we can mock Collection directly
+        // When doctrine/collections 3.0 is required, we can mock Collection directly
         $collection = $this->createMock(ArrayCollection::class);
         $collection->expects($this->once())
             ->method('matching')


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | https://github.com/doctrine/mongodb-odm/pull/2982#discussion_r2699383799

#### Summary

doctrine/collections v1 can't be installed already because of the PHP version compatibility.

`doctrine/collections` 3.0 adds return types, this PR ensure we have the correct types documented.

- `Collection::add()` returns `void`, we currently return `true`. BC break will be done in mongodb-odm 3.0
- The `ArrayCollection::matching(): Collection` method is more restrictive than `Selectable::matching(): ReadableCollection`.
