### PR TITLE
Fix ClassMetadata type for `SearchIndexMapping`

### DIFF
--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -269,7 +269,7 @@ use const PHP_VERSION_ID;
  * @phpstan-type SearchIndexMapping array{
  *      type: "search"|"vectorSearch",
  *      name: string,
- *      definition: SearchIndexDefinition
+ *      definition: SearchIndexDefinition|VectorSearchIndexDefinition
  * }
  * @phpstan-type VectorSearchIndexField array{
  *     type: "vector"|"filter",


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no


#### Summary
A `SearchIndexMapping` can have either `SearchIndexDefinition` or `VectorSearchIndexDefinition` for `definition`. Currently it is missing the latter.
