### PR TITLE
Add Pagination classes to ODM

### DIFF
--- a/src/Pagination/AggregationCursorPaginator.php
+++ b/src/Pagination/AggregationCursorPaginator.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Pagination;
+
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Iterator\Iterator;
+
+/**
+ * @template-covariant TValue
+ * @template-extends Paginator<TValue>
+ */
+final class AggregationCursorPaginator extends Paginator
+{
+    public function __construct(
+        private readonly Builder $aggregation,
+        public readonly mixed $after = null,
+        public readonly int $perPage = 24,
+        public readonly string $field = 'id',
+    ) {
+    }
+
+    /** @return Iterator<TValue> */
+    protected function getResultsForCurrentPage(): Iterator
+    {
+        $builder = clone $this->aggregation;
+
+        if ($this->after) {
+            $builder
+                ->match()
+                    ->field($this->field)->gt($this->after);
+        }
+
+        return $builder
+            ->limit($this->perPage)
+            ->getAggregation()
+            ->getIterator();
+    }
+}

--- a/src/Pagination/AggregationOffsetPaginator.php
+++ b/src/Pagination/AggregationOffsetPaginator.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Pagination;
+
+use Countable;
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Iterator\Iterator;
+
+use function ceil;
+use function iterator_to_array;
+
+/**
+ * @template-covariant TValue
+ * @template-extends Paginator<TValue>
+ */
+final class AggregationOffsetPaginator extends Paginator implements Countable
+{
+    private int $pageCount;
+
+    /** @psalm-param positive-int $page */
+    public function __construct(
+        private readonly Builder $aggregation,
+        public readonly int $page,
+        public readonly int $perPage = 24,
+    ) {
+    }
+
+    public function count(): int
+    {
+        return $this->pageCount ??= $this->getNumberOfPages();
+    }
+
+    private function getNumberOfPages(): int
+    {
+        $builder    = clone $this->aggregation;
+        $results    = $builder
+            ->hydrate(null)
+            ->count('numDocuments')
+            ->getAggregation()
+            ->getIterator();
+        $numResults = iterator_to_array($results)[0]['numDocuments'] ?? 0;
+
+        return (int) ceil($numResults / $this->perPage);
+    }
+
+    /** @return Iterator<TValue> */
+    protected function getResultsForCurrentPage(): Iterator
+    {
+        $builder = clone $this->aggregation;
+        $builder
+            ->skip(($this->page - 1) * $this->perPage)
+            ->limit($this->perPage);
+
+        return $builder->getAggregation()->getIterator();
+    }
+}

--- a/src/Pagination/Paginator.php
+++ b/src/Pagination/Paginator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Pagination;
+
+use Doctrine\ODM\MongoDB\Iterator\Iterator;
+use IteratorAggregate;
+
+/**
+ * @template-covariant TValue
+ * @template-implements IteratorAggregate<mixed, TValue>
+ */
+abstract class Paginator implements IteratorAggregate
+{
+    /** @return Iterator<TValue> */
+    abstract protected function getResultsForCurrentPage(): Iterator;
+
+    /** @return Iterator<TValue> */
+    final public function getIterator(): Iterator
+    {
+        return $this->getResultsForCurrentPage();
+    }
+}

--- a/src/Pagination/QueryCursorPaginator.php
+++ b/src/Pagination/QueryCursorPaginator.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Pagination;
+
+use Doctrine\ODM\MongoDB\Iterator\Iterator;
+use Doctrine\ODM\MongoDB\Query\Builder;
+
+/**
+ * @template-covariant TValue
+ * @template-extends Paginator<TValue>
+ */
+final class QueryCursorPaginator extends Paginator
+{
+    public function __construct(
+        private readonly Builder $query,
+        public readonly mixed $after = null,
+        public readonly int $perPage = 24,
+        public readonly string $field = 'id',
+    ) {
+    }
+
+    /** @return Iterator<TValue> */
+    protected function getResultsForCurrentPage(): Iterator
+    {
+        $builder = clone $this->query;
+
+        if ($this->after) {
+            $builder
+                ->field($this->field)->gt($this->after);
+        }
+
+        return $builder
+            ->limit($this->perPage)
+            ->getQuery()
+            ->getIterator();
+    }
+}

--- a/src/Pagination/QueryOffsetPaginator.php
+++ b/src/Pagination/QueryOffsetPaginator.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Pagination;
+
+use Countable;
+use Doctrine\ODM\MongoDB\Iterator\Iterator;
+use Doctrine\ODM\MongoDB\Query\Builder;
+
+use function ceil;
+
+/**
+ * @template-covariant TValue
+ * @template-extends Paginator<TValue>
+ */
+final class QueryOffsetPaginator extends Paginator implements Countable
+{
+    private int $pageCount;
+
+    /** @psalm-param positive-int $page */
+    public function __construct(
+        private readonly Builder $query,
+        public readonly int $page,
+        public readonly int $perPage = 24,
+    ) {
+    }
+
+    public function count(): int
+    {
+        return $this->pageCount ??= $this->getNumberOfPages();
+    }
+
+    private function getNumberOfPages(): int
+    {
+        $builder = clone $this->query;
+
+        return (int) ceil($builder
+            ->hydrate(false)
+            ->count()
+            ->getQuery()
+            ->execute() / $this->perPage);
+    }
+
+    /** @return Iterator<TValue> */
+    protected function getResultsForCurrentPage(): Iterator
+    {
+        $builder = clone $this->query;
+        $builder
+            ->skip(($this->page - 1) * $this->perPage)
+            ->limit($this->perPage);
+
+        return $builder->getQuery()->getIterator();
+    }
+}

--- a/tests/Tests/Pagination/AggregationCursorPaginatorTest.php
+++ b/tests/Tests/Pagination/AggregationCursorPaginatorTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ODM\MongoDB\Pagination;
+
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Pagination\AggregationCursorPaginator;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\Tag;
+
+use function array_fill;
+use function iterator_to_array;
+
+class AggregationCursorPaginatorTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareData();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dm->getDocumentCollection(Tag::class)->drop();
+
+        parent::tearDown();
+    }
+
+    public function testFirstPage(): void
+    {
+        $paginator = new AggregationCursorPaginator($this->createBuilder());
+
+        $results = iterator_to_array($paginator);
+        $this->assertCount(24, $results);
+
+        $this->assertSame('0', $results[0]->name);
+        $this->assertSame('3', $results[2]->name);
+    }
+
+    public function testThirdPage(): void
+    {
+        $last = $this->createBuilder()->skip(47)->limit(24)->getAggregation()->getSingleResult();
+        $this->assertInstanceOf(Tag::class, $last);
+
+        $results = iterator_to_array(new AggregationCursorPaginator($this->createBuilder(), $last->id));
+        $this->assertCount(24, $results);
+
+        $this->assertSame('49', $results[0]->name);
+    }
+
+    public function testPartialPage(): void
+    {
+        $last = $this->createBuilder()->skip(95)->limit(24)->getAggregation()->getSingleResult();
+        $this->assertInstanceOf(Tag::class, $last);
+
+        $paginator = new AggregationCursorPaginator($this->createBuilder(), $last->id);
+
+        $results = iterator_to_array($paginator);
+        $this->assertCount(3, $results);
+
+        $this->assertSame('97', $results[0]->name);
+    }
+
+    public function testDifferentPerPage(): void
+    {
+        $paginator = new AggregationCursorPaginator($this->createBuilder(), perPage: 12);
+
+        $results = iterator_to_array($paginator);
+        $this->assertCount(12, $results);
+    }
+
+    public function testDifferentField(): void
+    {
+        $paginator = new AggregationCursorPaginator($this->createBuilder(), after: '5', field: 'name');
+
+        $results = iterator_to_array($paginator);
+        $this->assertCount(24, $results);
+
+        $this->assertSame('6', $results[0]->name);
+    }
+
+    private function prepareData(): void
+    {
+        foreach (array_fill(0, 100, true) as $key => $t) {
+            $this->dm->persist(new Tag((string) $key));
+        }
+
+        $this->dm->flush();
+    }
+
+    private function createBuilder(): Builder
+    {
+        $builder = $this->dm->createAggregationBuilder(Tag::class);
+        $builder
+            ->hydrate(Tag::class)
+            ->match()
+                ->field('name')->notEqual('2')
+                ->sort('id', 1);
+
+        return $builder;
+    }
+}

--- a/tests/Tests/Pagination/AggregationOffsetPaginatorTest.php
+++ b/tests/Tests/Pagination/AggregationOffsetPaginatorTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ODM\MongoDB\Pagination;
+
+use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\ODM\MongoDB\Pagination\AggregationOffsetPaginator;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\Tag;
+
+use function array_fill;
+use function count;
+use function iterator_to_array;
+
+class AggregationOffsetPaginatorTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareData();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dm->getDocumentCollection(Tag::class)->drop();
+
+        parent::tearDown();
+    }
+
+    public function testFirstPage(): void
+    {
+        $paginator = new AggregationOffsetPaginator($this->createBuilder(), 1);
+
+        $this->assertSame(5, count($paginator));
+
+        $results = iterator_to_array($paginator);
+        $this->assertCount(24, $results);
+
+        $this->assertSame('0', $results[0]->name);
+        $this->assertSame('3', $results[2]->name);
+    }
+
+    public function testThirdPage(): void
+    {
+        $this->assertSame(5, count(new AggregationOffsetPaginator($this->createBuilder(), 3)));
+
+        $results = iterator_to_array(new AggregationOffsetPaginator($this->createBuilder(), 3));
+        $this->assertCount(24, $results);
+
+        $this->assertSame('49', $results[0]->name);
+    }
+
+    public function testPartialPage(): void
+    {
+        $paginator = new AggregationOffsetPaginator($this->createBuilder(), 5);
+
+        $this->assertSame(5, count($paginator));
+
+        $results = iterator_to_array($paginator);
+        $this->assertCount(3, $results);
+
+        $this->assertSame('97', $results[0]->name);
+    }
+
+    public function testDifferentPerPage(): void
+    {
+        $paginator = new AggregationOffsetPaginator($this->createBuilder(), 1, 12);
+
+        $this->assertSame(9, count($paginator));
+
+        $results = iterator_to_array($paginator);
+        $this->assertCount(12, $results);
+    }
+
+    private function prepareData(): void
+    {
+        foreach (array_fill(0, 100, true) as $key => $t) {
+            $this->dm->persist(new Tag((string) $key));
+        }
+
+        $this->dm->flush();
+    }
+
+    private function createBuilder(): Builder
+    {
+        $builder = $this->dm->createAggregationBuilder(Tag::class);
+        $builder
+            ->hydrate(Tag::class)
+            ->match()
+                ->field('name')->notEqual('2')
+                ->sort('id', 1);
+
+        return $builder;
+    }
+}

--- a/tests/Tests/Pagination/PaginatorTest.php
+++ b/tests/Tests/Pagination/PaginatorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ODM\MongoDB\Pagination;
+
+use Closure;
+use Doctrine\ODM\MongoDB\Iterator\Iterator;
+use Doctrine\ODM\MongoDB\Iterator\UnrewindableIterator;
+use Doctrine\ODM\MongoDB\Pagination\Paginator;
+use Generator;
+use PHPUnit\Framework\TestCase;
+
+use function iterator_to_array;
+
+class PaginatorTest extends TestCase
+{
+    public function testPaginator(): void
+    {
+        $paginator = $this->createMock(Paginator::class);
+        $paginator
+            ->expects($this->once())
+            ->method('getResultsForCurrentPage')
+            ->willReturnCallback(
+                static fn (): Iterator => new UnrewindableIterator(self::createGenerator()()),
+            );
+
+        $this->assertSame(['1', '2', '3'], iterator_to_array($paginator->getIterator()));
+    }
+
+    /** @param array<array-key, mixed> $values */
+    private static function createGenerator(array $values = ['1', '2', '3']): Closure
+    {
+        return static function () use ($values): Generator {
+            yield from $values;
+        };
+    }
+}

--- a/tests/Tests/Pagination/QueryCursorPaginatorTest.php
+++ b/tests/Tests/Pagination/QueryCursorPaginatorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ODM\MongoDB\Pagination;
+
+use Doctrine\ODM\MongoDB\Pagination\QueryCursorPaginator;
+use Doctrine\ODM\MongoDB\Query\Builder;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\Tag;
+
+use function array_fill;
+use function iterator_to_array;
+
+class QueryCursorPaginatorTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareData();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dm->getDocumentCollection(Tag::class)->drop();
+
+        parent::tearDown();
+    }
+
+    public function testFirstPage(): void
+    {
+        $paginator = new QueryCursorPaginator($this->createBuilder());
+
+        $results = iterator_to_array($paginator);
+        $this->assertCount(24, $results);
+
+        $this->assertSame('0', $results[0]->name);
+        $this->assertSame('3', $results[2]->name);
+    }
+
+    public function testThirdPage(): void
+    {
+        $last = $this->createBuilder()->skip(47)->limit(24)->getQuery()->getSingleResult();
+        $this->assertInstanceOf(Tag::class, $last);
+
+        $results = iterator_to_array(new QueryCursorPaginator($this->createBuilder(), $last->id));
+        $this->assertCount(24, $results);
+
+        $this->assertSame('49', $results[0]->name);
+    }
+
+    public function testPartialPage(): void
+    {
+        $last = $this->createBuilder()->skip(95)->limit(24)->getQuery()->getSingleResult();
+        $this->assertInstanceOf(Tag::class, $last);
+
+        $paginator = new QueryCursorPaginator($this->createBuilder(), $last->id);
+
+        $results = iterator_to_array($paginator);
+        $this->assertCount(3, $results);
+
+        $this->assertSame('97', $results[0]->name);
+    }
+
+    public function testDifferentPerPage(): void
+    {
+        $paginator = new QueryCursorPaginator($this->createBuilder(), perPage: 12);
+
+        $results = iterator_to_array($paginator);
+        $this->assertCount(12, $results);
+    }
+
+    public function testDifferentField(): void
+    {
+        $paginator = new QueryCursorPaginator($this->createBuilder(), after: '5', field: 'name');
+
+        $results = iterator_to_array($paginator);
+        $this->assertCount(24, $results);
+
+        $this->assertSame('6', $results[0]->name);
+    }
+
+    private function prepareData(): void
+    {
+        foreach (array_fill(0, 100, true) as $key => $t) {
+            $this->dm->persist(new Tag((string) $key));
+        }
+
+        $this->dm->flush();
+    }
+
+    private function createBuilder(): Builder
+    {
+        $builder = $this->dm->createQueryBuilder(Tag::class);
+        $builder
+            ->find()
+                ->field('name')->notEqual('2')
+                ->sort('id', 1);
+
+        return $builder;
+    }
+}

--- a/tests/Tests/Pagination/QueryOffsetPaginatorTest.php
+++ b/tests/Tests/Pagination/QueryOffsetPaginatorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ODM\MongoDB\Pagination;
+
+use Doctrine\ODM\MongoDB\Pagination\QueryOffsetPaginator;
+use Doctrine\ODM\MongoDB\Query\Builder;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\Tag;
+
+use function array_fill;
+use function count;
+use function iterator_to_array;
+
+class QueryOffsetPaginatorTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareData();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dm->getDocumentCollection(Tag::class)->drop();
+
+        parent::tearDown();
+    }
+
+    public function testFirstPage(): void
+    {
+        $paginator = new QueryOffsetPaginator($this->createBuilder(), 1);
+
+        $this->assertSame(5, count($paginator));
+
+        $results = iterator_to_array($paginator);
+        $this->assertCount(24, $results);
+
+        $this->assertSame('0', $results[0]->name);
+        $this->assertSame('3', $results[2]->name);
+    }
+
+    public function testThirdPage(): void
+    {
+        $this->assertSame(5, count(new QueryOffsetPaginator($this->createBuilder(), 3)));
+
+        $results = iterator_to_array(new QueryOffsetPaginator($this->createBuilder(), 3));
+        $this->assertCount(24, $results);
+
+        $this->assertSame('49', $results[0]->name);
+    }
+
+    public function testPartialPage(): void
+    {
+        $paginator = new QueryOffsetPaginator($this->createBuilder(), 5);
+
+        $this->assertSame(5, count($paginator));
+
+        $results = iterator_to_array($paginator);
+        $this->assertCount(3, $results);
+
+        $this->assertSame('97', $results[0]->name);
+    }
+
+    public function testDifferentPerPage(): void
+    {
+        $paginator = new QueryOffsetPaginator($this->createBuilder(), 1, 12);
+
+        $this->assertSame(9, count($paginator));
+
+        $results = iterator_to_array($paginator);
+        $this->assertCount(12, $results);
+    }
+
+    private function prepareData(): void
+    {
+        foreach (array_fill(0, 100, true) as $key => $t) {
+            $this->dm->persist(new Tag((string) $key));
+        }
+
+        $this->dm->flush();
+    }
+
+    private function createBuilder(): Builder
+    {
+        $builder = $this->dm->createQueryBuilder(Tag::class);
+        $builder
+            ->find()
+                ->field('name')->notEqual('2')
+                ->sort('id', 1);
+
+        return $builder;
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

This PR introduces four new paginator classes. We introduce two styles of paginator: offset-based and cursor-based. Both paginator styles come in flavours for aggregation pipeline and queries.

##### Offset-based pagination

Offset-based paginators take a page number and number of items per page (defaults to 24), along with a builder for aggregation or queries. It is `Countable` and returns the number of pages when counted. It provides an iterator for the current page. To accomplish this, it uses the `count` operation for queries, and `$numDocuments` for aggregation pipeline. When fetching items, it inserts the correct `skip` and `limit` options/stages.

##### Cursor-based pagination

Cursor-based pagination takes an ID where to continue paginating, the number of items per page, and an optional field name for the cursoring field (an `ObjectId` value in the `_id` field is usually a good choice). Together with the builder for aggregation or queries you can iterate over the items of the current "page". Iterating the paginator multiple times always returns the same items. You are responsible for extracting the ID of the last item, which is used when creating the paginator for the next page.

##### Todo

- [ ] Write documentation
- [ ] Add API to get next page from a cursor-based paginator?