### PR TITLE
PHPORM-254: Fix failing sharding tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -110,14 +110,13 @@ jobs:
             proxy: "native"
             remove-optional-dependencies: true
           # Test with a sharded cluster
-          # Currently disabled due to a bug where MongoDB reports "sharding status unknown"
-#          - topology: "sharded_cluster"
-#            php-version: "8.2"
-#            mongodb-version: "6.0"
-#            driver-version: "stable"
-#            dependencies: "highest"
-#            symfony-version: ""
-#            proxy: "lazy-ghost"
+          - topology: "sharded_cluster"
+            php-version: "8.2"
+            mongodb-version: "6.0"
+            driver-version: "stable"
+            dependencies: "highest"
+            symfony-version: ""
+            proxy: "lazy-ghost"
 
     steps:
       - name: "Checkout"

--- a/tests/Tests/Aggregation/Stage/LookupTest.php
+++ b/tests/Tests/Aggregation/Stage/LookupTest.php
@@ -466,6 +466,13 @@ class LookupTest extends BaseTestCase
 
     private function insertTestData(): void
     {
+        // Creating collections before inserting data helps avoid aborted transactions on sharded clusters
+        // Without this, the transaction fails because an "error from cluster data placement"
+        $sm = $this->dm->getSchemaManager();
+        $sm->createDocumentCollection(User::class);
+        $sm->createDocumentCollection(SimpleReferenceUser::class);
+        $sm->createDocumentCollection(ReferenceUser::class);
+
         $user1 = new User();
         $user1->setUsername('alcaeus');
         $user2 = new User();

--- a/tests/Tests/Functional/CustomIdTest.php
+++ b/tests/Tests/Functional/CustomIdTest.php
@@ -49,6 +49,13 @@ class CustomIdTest extends BaseTestCase
 
     public function testBatchInsertCustomId(): void
     {
+        // Creating collections before inserting data helps avoid aborted transactions on sharded clusters
+        // Without this, the transaction fails because an "error from cluster data placement"
+        $sm = $this->dm->getSchemaManager();
+        $sm->createDocumentCollection(Account::class);
+        $sm->createDocumentCollection(CustomUser::class);
+        $sm->createDocumentCollection(User::class);
+
         $account = new Account();
         $account->setName('Jon Test Account');
 
@@ -110,6 +117,13 @@ class CustomIdTest extends BaseTestCase
 
     public function testFindUser(): void
     {
+        // Creating collections before inserting data helps avoid aborted transactions on sharded clusters
+        // Without this, the transaction fails because an "error from cluster data placement"
+        $sm = $this->dm->getSchemaManager();
+        $sm->createDocumentCollection(Account::class);
+        $sm->createDocumentCollection(CustomUser::class);
+        $sm->createDocumentCollection(User::class);
+
         $account = new Account();
         $account->setName('Jon Test Account');
 

--- a/tests/Tests/Functional/EcommerceTest.php
+++ b/tests/Tests/Functional/EcommerceTest.php
@@ -18,6 +18,11 @@ class EcommerceTest extends BaseTestCase
     {
         parent::setUp();
 
+        // Creating collections before inserting data helps avoid aborted transactions on sharded clusters
+        // Without this, the transaction fails because an "error from cluster data placement"
+        $sm = $this->dm->getSchemaManager();
+        $sm->createDocumentCollection(ConfigurableProduct::class);
+
         $currencies  = [];
         $multipliers = ['USD' => 1, 'EURO' => 1.7, 'JPN' => 0.0125];
 

--- a/tests/Tests/Functional/FilterTest.php
+++ b/tests/Tests/Functional/FilterTest.php
@@ -25,6 +25,13 @@ class FilterTest extends BaseTestCase
     {
         parent::setUp();
 
+        // Creating collections before inserting data helps avoid aborted transactions on sharded clusters
+        // Without this, the transaction fails because an "error from cluster data placement"
+        $sm = $this->dm->getSchemaManager();
+        $sm->createDocumentCollection(Group::class);
+        $sm->createDocumentCollection(Profile::class);
+        $sm->createDocumentCollection(User::class);
+
         $this->ids = [];
 
         $groupA = new Group('groupA');

--- a/tests/Tests/Functional/FunctionalTest.php
+++ b/tests/Tests/Functional/FunctionalTest.php
@@ -417,6 +417,13 @@ class FunctionalTest extends BaseTestCase
 
     public function testTest(): void
     {
+        // Creating collections before inserting data helps avoid aborted transactions on sharded clusters
+        // Without this, the transaction fails because an "error from cluster data placement"
+        $sm = $this->dm->getSchemaManager();
+        $sm->createDocumentCollection(Employee::class);
+        $sm->createDocumentCollection(Project::class);
+        $sm->createDocumentCollection(Manager::class);
+
         $employee = new Employee();
         $employee->setName('Employee');
         $employee->setSalary(50000.00);
@@ -830,6 +837,13 @@ class FunctionalTest extends BaseTestCase
 
     public function testModifyGroupsArrayDirectly(): void
     {
+        // Creating collections before inserting data helps avoid aborted transactions on sharded clusters
+        // Without this, the transaction fails because an "error from cluster data placement"
+        $sm = $this->dm->getSchemaManager();
+        $sm->createDocumentCollection(Account::class);
+        $sm->createDocumentCollection(User::class);
+        $sm->createDocumentCollection(Group::class);
+
         $account = new Account();
         $account->setName('Jon Test Account');
 
@@ -867,6 +881,13 @@ class FunctionalTest extends BaseTestCase
 
     public function testReplaceEntireGroupsArray(): void
     {
+        // Creating collections before inserting data helps avoid aborted transactions on sharded clusters
+        // Without this, the transaction fails because an "error from cluster data placement"
+        $sm = $this->dm->getSchemaManager();
+        $sm->createDocumentCollection(Account::class);
+        $sm->createDocumentCollection(User::class);
+        $sm->createDocumentCollection(Group::class);
+
         $account = new Account();
         $account->setName('Jon Test Account');
 

--- a/tests/Tests/Functional/ReferencePrimerTest.php
+++ b/tests/Tests/Functional/ReferencePrimerTest.php
@@ -39,6 +39,31 @@ use function func_get_args;
 
 class ReferencePrimerTest extends BaseTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Creating collections before inserting data helps avoid aborted transactions on sharded clusters
+        // Without this, the transaction fails because an "error from cluster data placement"
+        $sm = $this->dm->getSchemaManager();
+        $sm->createDocumentCollection(Account::class);
+        $sm->createDocumentCollection(Agent::class);
+        $sm->createDocumentCollection(BlogPost::class);
+        $sm->createDocumentCollection(Comment::class);
+        $sm->createDocumentCollection(ConfigurableProduct::class);
+        $sm->createDocumentCollection(Currency::class);
+        $sm->createDocumentCollection(StockItem::class);
+        $sm->createDocumentCollection(EmbedNamed::class);
+        $sm->createDocumentCollection(FavoritesUser::class);
+        $sm->createDocumentCollection(Reference::class);
+        $sm->createDocumentCollection(Group::class);
+        $sm->createDocumentCollection(GuestServer::class);
+        $sm->createDocumentCollection(Project::class);
+        $sm->createDocumentCollection(ReferenceUser::class);
+        $sm->createDocumentCollection(SimpleReferenceUser::class);
+        $sm->createDocumentCollection(User::class);
+    }
+
     public function testPrimeReferencesShouldRequireReferenceMapping(): void
     {
         $user = new User();


### PR DESCRIPTION
#### Summary

Sharding tests failed with an error message similar to this:
> MongoDB\Driver\Exception\BulkWriteException: Transaction eb207f73-80ec-4bb0-8ed9-7e23da50315f - 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU= -  - :249 was aborted on statement 2 due to: an error from cluster data placement change :: caused by :: Encountered error from localhost:27217 during a transaction :: caused by :: sharding status of collection doctrine_odm_tests.users is not currently known and needs to be recovered

This occurred if collections were implicitly created from within a transaction. Since this is not a typical use case, we can work around this by explicitly creating collections before flushing the document manager.