### PR TITLE
Fix wrong class metadata used if adding a reference using query builder

### DIFF
--- a/src/Query/Expr.php
+++ b/src/Query/Expr.php
@@ -1450,6 +1450,7 @@ class Expr
 
         $convertedQuery = [];
         foreach ($query as $key => $value) {
+            unset($fieldMetadata);
             if (is_string($key) && $classMetadata->hasAssociation($key)) {
                 $targetDocument = $classMetadata->getAssociationTargetClass($key);
 

--- a/tests/Documents/Profile.php
+++ b/tests/Documents/Profile.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Documents;
 
+use DateTimeInterface;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\UTCDateTime;
 
 #[ODM\Document]
 class Profile
@@ -24,6 +26,10 @@ class Profile
     /** @var File|null */
     #[ODM\ReferenceOne(targetDocument: File::class, cascade: ['all'])]
     private $image;
+
+    /** @var UTCDateTime|DateTimeInterface|string */
+    #[ODM\Field(type: 'date')]
+    protected $deletedAt;
 
     public function setProfileId(string|ObjectId $profileId): void
     {

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -34,6 +34,10 @@ class User extends BaseDocument
     #[ODM\Field(type: 'date')]
     protected $createdAt;
 
+    /** @var int */
+    #[ODM\Field(type: 'int')]
+    protected $deletedAt;
+
     #[ODM\Field(type: 'date', nullable: true, name: 'disable-at')]
     protected ?DateTimeInterface $disabledAt;
 

--- a/tests/Tests/Mapping/LegacyReflectionFieldsTest.php
+++ b/tests/Tests/Mapping/LegacyReflectionFieldsTest.php
@@ -53,7 +53,7 @@ class LegacyReflectionFieldsTest extends BaseTestCase
         self::assertSame($newAddress, $class->getReflectionProperty('address')->getValue($user));
 
         // ArrayAccess and Countable interfaces
-        self::assertCount(32, $class->reflFields);
+        self::assertCount(33, $class->reflFields);
         self::assertArrayHasKey('username', $class->reflFields);
         self::assertArrayNotHasKey('nonExistentField', $class->reflFields);
     }

--- a/tests/Tests/Query/ExprTest.php
+++ b/tests/Tests/Query/ExprTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Tests\Query;
 
 use BadMethodCallException;
+use DateTime;
 use Doctrine\ODM\MongoDB\Query\Expr;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\Profile;
@@ -243,6 +244,35 @@ class ExprTest extends BaseTestCase
             ],
             $expr->getQuery(),
             '->references() uses some keys if storeAs=dbRef is set',
+        );
+    }
+
+    public function testReferencesAndAdditionalSearch(): void
+    {
+        $profile = new Profile();
+        $profile->setProfileId(new ObjectId());
+        $this->dm->persist($profile);
+
+        $now = new DateTime();
+        $qb  = $this->dm->createQueryBuilder(User::class);
+        $qb->field('profile')->equals($profile);
+        $qb->addOr(
+            $qb->expr()->field('deletedAt')->equals(null),
+            $qb->expr()->field('deletedAt')->gte($now->getTimestamp()),
+        );
+
+        self::assertEquals(
+            [
+                'profile.$id' => $profile->getProfileId(),
+                'profile.$ref' => 'Profile',
+                '$or' => [
+                    ['deletedAt' => null],
+                    ['deletedAt' => ['$gte' => $now->getTimestamp()]],
+                ],
+
+            ],
+            $qb->getQuery()->debug('query'),
+            '->references() uses all keys if no targetDocument is set',
         );
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

We noticed that when using a reference and then adding a complex expression afterwards. Inside the expression the class meta data of the reference object is used and not from the original document.

Added a tests to show this behaviour. Without the fix this will throw a fatal error `Object of class MongoDB\BSON\UTCDateTime could not be converted to int`

That we have two fields with the same name on two models, but with different types is kinda a fuck up on our side. But I think the ODM still should support this.

If you do not use the `$or` and do only a `$gte`, then it works without the fix. Or what we did in our case as a workaround, adding the equals after the expression.

The fix is small, but getting the test to work was some work.
