### PR TITLE
PHPORM-257: Consolidate per-collection writes into a single bulkWrite per commit phase

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -57,3 +57,43 @@ to retain the functionality.
 
 `Doctrine\ODM\MongoDB\Event\OnClearEventArgs`' methods `getDocumentClass` and 
 `clearsAllDocuments` have been removed.
+
+## Flush now consolidates writes per collection via `bulkWrite`
+
+`UnitOfWork::commit()` previously issued an individual `insertMany`,
+`updateOne` or `deleteOne` call per scheduled document. As of 3.0, every
+scheduled write against the same MongoDB collection is now consolidated
+into a single `Collection::bulkWrite()` call per commit phase (upserts,
+inserts, updates, deletes).
+
+The visible effects:
+
+- **Lifecycle event ordering.** Within a phase, `postPersist`,
+  `postUpdate` and `postRemove` now fire **after** the entire phase's
+  `bulkWrite` has succeeded, rather than interleaved per document.
+  Listeners that relied on observing one document's post-event before
+  another document in the same phase had been written must be reviewed.
+  The per-document `preUpdate` callback still fires *before* the
+  bulkWrite, so listeners can still mutate the change set there.
+- **`LockException` semantics.** Versioned and lockable documents still
+  raise `LockException` with the same timing as before. Internally, the
+  refactor bypasses the consolidated bulk for these documents and issues
+  a single-op `bulkWrite` per such document so the matched / modified /
+  deleted counts can be inspected precisely.
+- **Partial-failure exceptions.** A failed write surfaces as
+  `MongoDB\Driver\Exception\BulkWriteException` (with `getWriteResult()`
+  describing every op in the batch), where the 2.x ODM might have
+  surfaced the same condition through the analogous error from
+  `insertMany` / `updateOne` / `deleteOne`. The exception class and
+  hierarchy are unchanged; only the aggregation of error info inside
+  the result is broader.
+- **Command count.** Tools and tests that count emitted MongoDB
+  commands (e.g. via `Doctrine\ODM\MongoDB\APM\CommandLogger`) will see
+  fewer commands per `flush()`. For example, persisting 100 documents
+  of the same class now emits one `insert` command instead of one per
+  document.
+
+The internal `DocumentPersister` and `CollectionPersister` classes are
+`@internal` and `final`; their public method names are unchanged but the
+queueing model now lives in `Doctrine\ODM\MongoDB\Persisters\BulkWriteQueue`.
+Applications must not extend these classes.

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -60,11 +60,34 @@ to retain the functionality.
 
 ## Flush now consolidates writes per collection via `bulkWrite`
 
-`UnitOfWork::commit()` previously issued an individual `insertMany`,
-`updateOne` or `deleteOne` call per scheduled document. As of 3.0, every
-scheduled write against the same MongoDB collection is now consolidated
-into a single `Collection::bulkWrite()` call per commit phase (upserts,
-inserts, updates, deletes).
+`UnitOfWork::commit()` previously issued separate driver calls for the
+different write kinds within a single commit phase: an `insertMany` per
+class for inserts, an `updateOne` *per document* for updates and upserts,
+a `deleteOne` *per document* for removals, plus additional `updateOne`
+calls per parent for `CollectionPersister` writes that fan out from
+embedded / reference-many changes. As of 3.0, every scheduled write
+against the same MongoDB collection is consolidated into a single
+`Collection::bulkWrite()` call per commit phase, regardless of whether
+the operations are inserts, updates, deletes, or collection-change
+follow-ups.
+
+Concretely:
+
+- **Updates and deletes were one driver call per document.** Each
+  scheduled update fired its own `updateOne` and each scheduled removal
+  its own `deleteOne`. These are now folded into a single per-collection
+  `bulkWrite` per phase.
+- **`CollectionPersister` follow-up writes used to be separate.**
+  Embedded / reference-many changes on a parent document previously
+  emitted additional `updateOne` calls *after* the parent's own update.
+  Those follow-ups are now queued onto the same `bulkWrite` as the
+  parent's update when they target the same collection.
+- **Inserts were already batched by `insertMany`** and remain a single
+  command per class on the wire. The change for inserts is structural,
+  not a wire-level reduction: an insert is now appended to the same
+  per-collection `bulkWrite` that carries that collection's updates,
+  deletes, and collection-change follow-ups within the same commit
+  phase, rather than going through a dedicated `insertMany` path.
 
 The visible effects:
 
@@ -89,9 +112,11 @@ The visible effects:
   the result is broader.
 - **Command count.** Tools and tests that count emitted MongoDB
   commands (e.g. via `Doctrine\ODM\MongoDB\APM\CommandLogger`) will see
-  fewer commands per `flush()`. For example, persisting 100 documents
-  of the same class now emits one `insert` command instead of one per
-  document.
+  fewer commands per `flush()` whenever a commit touches the same
+  collection with a mix of inserts, updates, deletes, or collection-
+  change follow-ups: those now collapse to one `bulkWrite` per
+  collection per phase instead of one driver call per document or per
+  fan-out write.
 
 The internal `DocumentPersister` and `CollectionPersister` classes are
 `@internal` and `final`; their public method names are unchanged but the

--- a/src/Persisters/BulkWriteQueue.php
+++ b/src/Persisters/BulkWriteQueue.php
@@ -56,6 +56,17 @@ final class BulkWriteQueue
      */
     private array $pending = [];
 
+    /**
+     * Per-collection bulkWrite options accumulator. Each addInsertOne /
+     * addUpdateOne / addDeleteOne call provides the options that should be
+     * forwarded to the per-collection {@see Collection::bulkWrite()} call;
+     * the first non-empty option set wins so callers within a single class
+     * loop end up with their write concern / session / etc. applied.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    private array $bulkOptions = [];
+
     public function hasPending(): bool
     {
         foreach ($this->pending as $ops) {
@@ -71,21 +82,28 @@ final class BulkWriteQueue
     {
         $this->collections = [];
         $this->pending     = [];
+        $this->bulkOptions = [];
     }
 
     /**
      * Queue an `insertOne` op against $collection.
      *
      * @param array<string, mixed> $document       The BSON-ready insert payload.
+     * @param array<string, mixed> $bulkOptions    Options to forward to the per-collection
+     *                                            {@see Collection::bulkWrite()} call (e.g.
+     *                                            `writeConcern`, `session`). The first non-empty
+     *                                            set per collection is kept; passing the same
+     *                                            options for every op in the same class loop is
+     *                                            the expected use.
      * @param object               $sourceDocument The owning PHP document instance.
      * @param Closure|null         $onResult       Invoked as `fn(?\MongoDB\BSON\ObjectId $insertedId): void`
      *                                            after the bulkWrite for this collection returns.
      *
      * @return int Position of the op within this collection's pending batch.
      */
-    public function addInsertOne(Collection $collection, array $document, object $sourceDocument, ?Closure $onResult = null): int
+    public function addInsertOne(Collection $collection, array $document, array $bulkOptions, object $sourceDocument, ?Closure $onResult = null): int
     {
-        return $this->push($collection, [
+        return $this->push($collection, $bulkOptions, [
             'type' => 'insertOne',
             'op' => ['insertOne' => [$document]],
             'document' => $sourceDocument,
@@ -98,26 +116,28 @@ final class BulkWriteQueue
      *
      * @param array<string, mixed> $filter
      * @param array<string, mixed> $update
-     * @param array<string, mixed> $options  Driver-level updateOne options (e.g. ['upsert' => true]).
-     *                                       Only options that are valid for `bulkWrite` per-op are forwarded.
-     * @param Closure|null         $onResult Invoked as
-     *                                      `fn(int $matchedCount, int $modifiedCount, ?\MongoDB\BSON\ObjectId $upsertedId): void`
-     *                                      after the bulkWrite for this collection returns.
+     * @param array<string, mixed> $opOptions   Driver-level updateOne options (e.g. ['upsert' => true]).
+     *                                          Only options that are valid for `bulkWrite` per-op are forwarded.
+     * @param array<string, mixed> $bulkOptions Bulk-level options (see {@see addInsertOne()}).
+     * @param Closure|null         $onResult    Invoked as
+     *                                          `fn(int $matchedCount, int $modifiedCount, ?\MongoDB\BSON\ObjectId $upsertedId): void`
+     *                                          after the bulkWrite for this collection returns.
      */
     public function addUpdateOne(
         Collection $collection,
         array $filter,
         array $update,
-        array $options,
+        array $opOptions,
+        array $bulkOptions,
         object $sourceDocument,
         ?Closure $onResult = null,
     ): int {
         $op = ['updateOne' => [$filter, $update]];
-        if ($options !== []) {
-            $op['updateOne'][] = $options;
+        if ($opOptions !== []) {
+            $op['updateOne'][] = $opOptions;
         }
 
-        return $this->push($collection, [
+        return $this->push($collection, $bulkOptions, [
             'type' => 'updateOne',
             'op' => $op,
             'document' => $sourceDocument,
@@ -129,23 +149,25 @@ final class BulkWriteQueue
      * Queue a `deleteOne` op against $collection.
      *
      * @param array<string, mixed> $filter
-     * @param array<string, mixed> $options
-     * @param Closure|null         $onResult Invoked as `fn(int $deletedCount): void`
-     *                                       after the bulkWrite for this collection returns.
+     * @param array<string, mixed> $opOptions
+     * @param array<string, mixed> $bulkOptions Bulk-level options (see {@see addInsertOne()}).
+     * @param Closure|null         $onResult    Invoked as `fn(int $deletedCount): void`
+     *                                          after the bulkWrite for this collection returns.
      */
     public function addDeleteOne(
         Collection $collection,
         array $filter,
-        array $options,
+        array $opOptions,
+        array $bulkOptions,
         object $sourceDocument,
         ?Closure $onResult = null,
     ): int {
         $op = ['deleteOne' => [$filter]];
-        if ($options !== []) {
-            $op['deleteOne'][] = $options;
+        if ($opOptions !== []) {
+            $op['deleteOne'][] = $opOptions;
         }
 
-        return $this->push($collection, [
+        return $this->push($collection, $bulkOptions, [
             'type' => 'deleteOne',
             'op' => $op,
             'document' => $sourceDocument,
@@ -162,16 +184,16 @@ final class BulkWriteQueue
      * exception is re-raised — callers must mark documents as still
      * scheduled if that is the desired behavior.
      *
-     * @param array<string, mixed> $options Bulk-level options (e.g. `session`, `writeConcern`).
-     *                                      `ordered: true` is implied unless overridden.
+     * @param array<string, mixed> $options Caller-supplied bulk-level options
+     *                                      (e.g. `session`). These are merged
+     *                                      on top of the per-collection options
+     *                                      captured at push time.
      */
     public function flush(array $options = []): void
     {
         if (! $this->hasPending()) {
             return;
         }
-
-        $bulkOptions = ['ordered' => true] + $options;
 
         try {
             foreach ($this->collections as $oid => $collection) {
@@ -182,6 +204,11 @@ final class BulkWriteQueue
 
                 // Reset before issuing so that a thrown exception leaves no stale ops in the queue.
                 $this->pending[$oid] = [];
+
+                $perCollectionOptions = $this->bulkOptions[$oid] ?? [];
+                // Caller-supplied options take precedence over the per-collection options
+                // captured at push time (e.g. an enclosing transaction's session always wins).
+                $bulkOptions = ['ordered' => true] + $options + $perCollectionOptions;
 
                 $ops    = array_values(array_map(static fn (array $entry): array => $entry['op'], $pending));
                 $result = $collection->bulkWrite($ops, $bulkOptions);
@@ -226,6 +253,7 @@ final class BulkWriteQueue
             // Drop every pending op across all collections so the next attempt starts clean.
             $this->pending     = [];
             $this->collections = [];
+            $this->bulkOptions = [];
 
             throw $e;
         }
@@ -233,16 +261,25 @@ final class BulkWriteQueue
         // Successful drain — reset collection bookkeeping for the next phase / commit.
         $this->collections = [];
         $this->pending     = [];
+        $this->bulkOptions = [];
     }
 
-    /** @param PendingOp $entry */
-    private function push(Collection $collection, array $entry): int
+    /**
+     * @param array<string, mixed> $bulkOptions
+     * @param PendingOp            $entry
+     */
+    private function push(Collection $collection, array $bulkOptions, array $entry): int
     {
         $oid = spl_object_id($collection);
 
         if (! isset($this->collections[$oid])) {
             $this->collections[$oid] = $collection;
             $this->pending[$oid]     = [];
+            $this->bulkOptions[$oid] = $bulkOptions;
+        } elseif ($bulkOptions !== [] && $this->bulkOptions[$oid] === []) {
+            // First push for this collection didn't carry options; adopt the next non-empty
+            // set so the per-collection bulkWrite still respects per-class write concerns.
+            $this->bulkOptions[$oid] = $bulkOptions;
         }
 
         $index                       = isset($this->pending[$oid]) ? count($this->pending[$oid]) : 0;

--- a/src/Persisters/BulkWriteQueue.php
+++ b/src/Persisters/BulkWriteQueue.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ODM\MongoDB\Persisters;
 
 use Closure;
-use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
 use MongoDB\Driver\Exception\BulkWriteException;
 
@@ -29,9 +28,6 @@ use function spl_object_id;
  *
  * @internal
  *
- * @phpstan-type OnInsertResult Closure(?ObjectId): void
- * @phpstan-type OnUpdateResult Closure(bool, bool, ?ObjectId): void
- * @phpstan-type OnDeleteResult Closure(int): void
  * @phpstan-type PendingOp array{
  *     type: 'insertOne'|'updateOne'|'deleteOne',
  *     op: array<string, mixed>,

--- a/src/Persisters/BulkWriteQueue.php
+++ b/src/Persisters/BulkWriteQueue.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Persisters;
+
+use Closure;
+use MongoDB\BSON\ObjectId;
+use MongoDB\Collection;
+use MongoDB\Driver\Exception\BulkWriteException;
+
+use function array_map;
+use function array_values;
+use function count;
+use function spl_object_id;
+
+/**
+ * Accumulator that collects per-collection bulkWrite operations during a
+ * single {@see \Doctrine\ODM\MongoDB\UnitOfWork::doCommit()} pass.
+ *
+ * Each entry pushed via {@see addInsertOne()}, {@see addUpdateOne()} or
+ * {@see addDeleteOne()} is queued in insertion order against the supplied
+ * {@see Collection} instance. {@see flush()} then drains every pending
+ * collection with a single {@see Collection::bulkWrite()} call.
+ *
+ * Per-op callbacks (e.g. for `LockException` detection on versioned docs or
+ * insertedId bind-back) are invoked synchronously after the bulkWrite for
+ * the owning collection returns.
+ *
+ * @internal
+ *
+ * @phpstan-type OnInsertResult Closure(?ObjectId): void
+ * @phpstan-type OnUpdateResult Closure(bool, bool, ?ObjectId): void
+ * @phpstan-type OnDeleteResult Closure(int): void
+ * @phpstan-type PendingOp array{
+ *     type: 'insertOne'|'updateOne'|'deleteOne',
+ *     op: array<string, mixed>,
+ *     document: object,
+ *     onResult: ?Closure,
+ * }
+ */
+final class BulkWriteQueue
+{
+    /**
+     * Keyed by {@see spl_object_id()} of the target Collection instance.
+     *
+     * @var array<int, Collection>
+     */
+    private array $collections = [];
+
+    /**
+     * Keyed by {@see spl_object_id()} of the target Collection instance, then
+     * by insertion index (0..n).
+     *
+     * @var array<int, list<PendingOp>>
+     */
+    private array $pending = [];
+
+    public function hasPending(): bool
+    {
+        foreach ($this->pending as $ops) {
+            if ($ops !== []) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function clear(): void
+    {
+        $this->collections = [];
+        $this->pending     = [];
+    }
+
+    /**
+     * Queue an `insertOne` op against $collection.
+     *
+     * @param array<string, mixed> $document       The BSON-ready insert payload.
+     * @param object               $sourceDocument The owning PHP document instance.
+     * @param Closure|null         $onResult       Invoked as `fn(?\MongoDB\BSON\ObjectId $insertedId): void`
+     *                                            after the bulkWrite for this collection returns.
+     *
+     * @return int Position of the op within this collection's pending batch.
+     */
+    public function addInsertOne(Collection $collection, array $document, object $sourceDocument, ?Closure $onResult = null): int
+    {
+        return $this->push($collection, [
+            'type' => 'insertOne',
+            'op' => ['insertOne' => [$document]],
+            'document' => $sourceDocument,
+            'onResult' => $onResult,
+        ]);
+    }
+
+    /**
+     * Queue an `updateOne` op against $collection.
+     *
+     * @param array<string, mixed> $filter
+     * @param array<string, mixed> $update
+     * @param array<string, mixed> $options  Driver-level updateOne options (e.g. ['upsert' => true]).
+     *                                       Only options that are valid for `bulkWrite` per-op are forwarded.
+     * @param Closure|null         $onResult Invoked as
+     *                                      `fn(int $matchedCount, int $modifiedCount, ?\MongoDB\BSON\ObjectId $upsertedId): void`
+     *                                      after the bulkWrite for this collection returns.
+     */
+    public function addUpdateOne(
+        Collection $collection,
+        array $filter,
+        array $update,
+        array $options,
+        object $sourceDocument,
+        ?Closure $onResult = null,
+    ): int {
+        $op = ['updateOne' => [$filter, $update]];
+        if ($options !== []) {
+            $op['updateOne'][] = $options;
+        }
+
+        return $this->push($collection, [
+            'type' => 'updateOne',
+            'op' => $op,
+            'document' => $sourceDocument,
+            'onResult' => $onResult,
+        ]);
+    }
+
+    /**
+     * Queue a `deleteOne` op against $collection.
+     *
+     * @param array<string, mixed> $filter
+     * @param array<string, mixed> $options
+     * @param Closure|null         $onResult Invoked as `fn(int $deletedCount): void`
+     *                                       after the bulkWrite for this collection returns.
+     */
+    public function addDeleteOne(
+        Collection $collection,
+        array $filter,
+        array $options,
+        object $sourceDocument,
+        ?Closure $onResult = null,
+    ): int {
+        $op = ['deleteOne' => [$filter]];
+        if ($options !== []) {
+            $op['deleteOne'][] = $options;
+        }
+
+        return $this->push($collection, [
+            'type' => 'deleteOne',
+            'op' => $op,
+            'document' => $sourceDocument,
+            'onResult' => $onResult,
+        ]);
+    }
+
+    /**
+     * Flush every pending collection's queued ops as one bulkWrite per collection.
+     *
+     * Within a collection ops are issued with `ordered: true` so the server
+     * stops at the first failure. On {@see BulkWriteException} the entire
+     * queue is cleared (for both successful and failed collections) and the
+     * exception is re-raised — callers must mark documents as still
+     * scheduled if that is the desired behavior.
+     *
+     * @param array<string, mixed> $options Bulk-level options (e.g. `session`, `writeConcern`).
+     *                                      `ordered: true` is implied unless overridden.
+     */
+    public function flush(array $options = []): void
+    {
+        if (! $this->hasPending()) {
+            return;
+        }
+
+        $bulkOptions = ['ordered' => true] + $options;
+
+        try {
+            foreach ($this->collections as $oid => $collection) {
+                $pending = $this->pending[$oid] ?? [];
+                if ($pending === []) {
+                    continue;
+                }
+
+                // Reset before issuing so that a thrown exception leaves no stale ops in the queue.
+                $this->pending[$oid] = [];
+
+                $ops    = array_values(array_map(static fn (array $entry): array => $entry['op'], $pending));
+                $result = $collection->bulkWrite($ops, $bulkOptions);
+
+                $insertedIds = $result->getInsertedIds();
+                $upsertedIds = $result->getUpsertedIds();
+
+                $matchedTotal  = $result->getMatchedCount();
+                $modifiedTotal = $result->getModifiedCount();
+                $deletedTotal  = $result->getDeletedCount();
+
+                foreach ($pending as $opIndex => $entry) {
+                    if ($entry['onResult'] === null) {
+                        continue;
+                    }
+
+                    switch ($entry['type']) {
+                        case 'insertOne':
+                            $insertedId = $insertedIds[$opIndex] ?? null;
+                            ($entry['onResult'])($insertedId);
+                            break;
+
+                        case 'updateOne':
+                            $upsertedId = $upsertedIds[$opIndex] ?? null;
+                            // Per-op counts are not exposed by the driver. The queue only attaches
+                            // an onResult callback to ops that are *individually* fenced (versioned
+                            // or lockable documents), and the UnitOfWork ensures those land in their
+                            // own bulkWrite via a single-op batch. We therefore pass the aggregate
+                            // matched/modified counts; for a single-op batch they are the per-op
+                            // counts.
+                            ($entry['onResult'])($matchedTotal, $modifiedTotal, $upsertedId);
+                            break;
+
+                        case 'deleteOne':
+                            // Same single-op fencing applies for delete callbacks.
+                            ($entry['onResult'])($deletedTotal);
+                            break;
+                    }
+                }
+            }
+        } catch (BulkWriteException $e) {
+            // Drop every pending op across all collections so the next attempt starts clean.
+            $this->pending     = [];
+            $this->collections = [];
+
+            throw $e;
+        }
+
+        // Successful drain — reset collection bookkeeping for the next phase / commit.
+        $this->collections = [];
+        $this->pending     = [];
+    }
+
+    /** @param PendingOp $entry */
+    private function push(Collection $collection, array $entry): int
+    {
+        $oid = spl_object_id($collection);
+
+        if (! isset($this->collections[$oid])) {
+            $this->collections[$oid] = $collection;
+            $this->pending[$oid]     = [];
+        }
+
+        $index                       = isset($this->pending[$oid]) ? count($this->pending[$oid]) : 0;
+        $this->pending[$oid][$index] = $entry;
+
+        return $index;
+    }
+}

--- a/src/Persisters/CollectionPersister.php
+++ b/src/Persisters/CollectionPersister.php
@@ -43,8 +43,11 @@ use function strpos;
  */
 final class CollectionPersister
 {
+    private BulkWriteQueue $bulkWriteQueue;
+
     public function __construct(private DocumentManager $dm, private PersistenceBuilder $pb, private UnitOfWork $uow)
     {
+        $this->bulkWriteQueue = $this->uow->getBulkWriteQueue();
     }
 
     /**
@@ -445,6 +448,13 @@ final class CollectionPersister
     /**
      * Executes a query updating the given document.
      *
+     * For non-versioned parents the op is queued onto the shared
+     * {@see BulkWriteQueue} so it can be consolidated with the parent
+     * document's writes into a single per-collection bulkWrite. For
+     * versioned parents the op is issued immediately as a single-op
+     * bulkWrite so {@see LockException} can be thrown precisely against
+     * the matched-count for this exact document.
+     *
      * @param array<string, mixed> $newObj
      * @param array<string, mixed> $options
      */
@@ -459,10 +469,20 @@ final class CollectionPersister
         }
 
         $collection = $this->dm->getDocumentCollection($className);
-        $result     = $collection->updateOne($query, $newObj, $options);
-        if ($class->isVersioned && ! $result->getMatchedCount()) {
-            throw LockException::lockFailed($document);
+
+        if ($class->isVersioned) {
+            $result = $collection->bulkWrite(
+                [['updateOne' => [$query, $newObj]]],
+                ['ordered' => true] + $options,
+            );
+            if (! $result->getMatchedCount()) {
+                throw LockException::lockFailed($document);
+            }
+
+            return;
         }
+
+        $this->bulkWriteQueue->addUpdateOne($collection, $query, $newObj, [], $options, $document);
     }
 
     /**

--- a/src/Persisters/DocumentPersister.php
+++ b/src/Persisters/DocumentPersister.php
@@ -32,7 +32,6 @@ use InvalidArgumentException;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
 use MongoDB\Driver\CursorInterface;
-use MongoDB\Driver\Exception\BulkWriteException;
 use MongoDB\Driver\Exception\Exception as DriverException;
 use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
@@ -61,7 +60,6 @@ use function is_string;
 use function spl_object_id;
 use function sprintf;
 use function str_contains;
-use function strpos;
 use function strtolower;
 use function trigger_deprecation;
 
@@ -109,6 +107,8 @@ final class DocumentPersister
 
     private CollectionPersister $cp;
 
+    private BulkWriteQueue $bulkWriteQueue;
+
     /** @phpstan-param ClassMetadata<T> $class */
     public function __construct(
         private PersistenceBuilder $pb,
@@ -118,8 +118,9 @@ final class DocumentPersister
         private ClassMetadata $class,
         ?CriteriaMerger $cm = null,
     ) {
-        $this->cm = $cm ?: new CriteriaMerger();
-        $this->cp = $this->uow->getCollectionPersister();
+        $this->cm             = $cm ?: new CriteriaMerger();
+        $this->cp             = $this->uow->getCollectionPersister();
+        $this->bulkWriteQueue = $this->uow->getBulkWriteQueue();
 
         if ($class->isEmbeddedDocument || $class->isQueryResultDocument) {
             return;
@@ -201,9 +202,10 @@ final class DocumentPersister
             return;
         }
 
-        $inserts = [];
         $options = $this->getWriteOptions($options);
-        foreach ($this->queuedInserts as $oid => $document) {
+        assert($this->collection instanceof Collection);
+
+        foreach ($this->queuedInserts as $document) {
             $data = $this->pb->prepareInsertData($document);
 
             // Set the initial version for each insert
@@ -220,23 +222,13 @@ final class DocumentPersister
                 $data[$versionMapping['name']] = $type->convertToDatabaseValue($nextVersion);
             }
 
-            $inserts[] = $data;
-        }
+            $this->bulkWriteQueue->addInsertOne($this->collection, $data, $options, $document);
 
-        try {
-            assert($this->collection instanceof Collection);
-            $this->collection->insertMany($inserts, $options);
-        } catch (DriverException $e) {
-            $this->queuedInserts = [];
-
-            throw $e;
-        }
-
-        /* All collections except for ones using addToSet have already been
-         * saved. We have left these to be handled separately to avoid checking
-         * collection for uniqueness on PHP side.
-         */
-        foreach ($this->queuedInserts as $document) {
+            /* All collections except for ones using addToSet have already been
+             * inlined in the insert payload. The remaining collection-level
+             * writes are queued here so they share the same per-collection
+             * bulkWrite as the parent insert.
+             */
             $this->handleCollections($document, $options);
         }
 
@@ -259,28 +251,25 @@ final class DocumentPersister
         }
 
         $options = $this->getWriteOptions($options);
-        foreach ($this->queuedUpserts as $oid => $document) {
-            try {
-                $this->executeUpsert($document, $options);
-                $this->handleCollections($document, $options);
-                unset($this->queuedUpserts[$oid]);
-            } catch (BulkWriteException $e) {
-                unset($this->queuedUpserts[$oid]);
+        assert($this->collection instanceof Collection);
 
-                throw $e;
-            }
+        foreach ($this->queuedUpserts as $document) {
+            $this->queueUpsert($document, $options);
+            $this->handleCollections($document, $options);
         }
+
+        $this->queuedUpserts = [];
     }
 
     /**
-     * Executes a single upsert in {@link executeUpserts}
+     * Builds the upsert payload for a single document and queues it as an
+     * updateOne op with upsert=true.
      *
      * @param array<string, mixed> $options
      */
-    private function executeUpsert(object $document, array $options): void
+    private function queueUpsert(object $document, array $options): void
     {
-        $options['upsert'] = true;
-        $criteria          = $this->getQueryForDocument($document);
+        $criteria = $this->getQueryForDocument($document);
 
         $data = $this->pb->prepareUpsertData($document);
 
@@ -317,32 +306,18 @@ final class DocumentPersister
          * an identifier as its only field. Since a document with the identifier
          * may already exist, the desired behavior is "insert if not exists" and
          * NOOP otherwise. MongoDB 2.6+ does not allow empty modifiers, so $set
-         * the identifier to the same value in our criteria.
-         *
-         * This will fail for versions before MongoDB 2.6, which require an
-         * empty $set modifier. The best we can do (without attempting to check
-         * server versions in advance) is attempt the 2.6+ behavior and retry
-         * after the relevant exception.
+         * the identifier to an empty document (which the server treats as a
+         * NOOP if the document already exists). This sidesteps the historical
+         * "Mod on _id not allowed" retry by emitting the safe payload up front.
          *
          * See: https://jira.mongodb.org/browse/SERVER-12266
          */
         if (empty($data)) {
-            $retry = true;
-            $data  = ['$set' => ['_id' => $criteria['_id']]];
+            $data = ['$set' => new stdClass()];
         }
 
         assert($this->collection instanceof Collection);
-        try {
-            $this->collection->updateOne($criteria, $data, $options);
-
-            return;
-        } catch (BulkWriteException $e) {
-            if (empty($retry) || strpos($e->getMessage(), 'Mod on _id not allowed') === false) {
-                throw $e;
-            }
-        }
-
-        $this->collection->updateOne($criteria, ['$set' => new stdClass()], $options);
+        $this->bulkWriteQueue->addUpdateOne($this->collection, $criteria, $data, ['upsert' => true], $options, $document);
     }
 
     /**
@@ -396,14 +371,28 @@ final class DocumentPersister
             $options = $this->getWriteOptions($options);
 
             assert($this->collection instanceof Collection);
-            $result = $this->collection->updateOne($query, $update, $options);
 
-            if (($this->class->isVersioned || $this->class->isLockable) && $result->getModifiedCount() !== 1) {
-                throw LockException::lockFailed($document);
-            }
+            if ($this->class->isVersioned || $this->class->isLockable) {
+                /* Versioned/lockable updates need precise per-op result inspection to
+                 * throw LockException at the right point. Bypass the queue and issue a
+                 * single-op bulkWrite so we can reason about matched/modified counts
+                 * for this exact document. The aggregate queue would only see counts
+                 * summed across every op in the batch.
+                 */
+                $result = $this->collection->bulkWrite(
+                    [['updateOne' => [$query, $update]]],
+                    ['ordered' => true] + $options,
+                );
 
-            if ($this->class->isVersioned) {
-                $this->class->propertyAccessors[$this->class->versionField]->setValue($document, $nextVersion);
+                if ($result->getModifiedCount() !== 1) {
+                    throw LockException::lockFailed($document);
+                }
+
+                if ($this->class->isVersioned) {
+                    $this->class->propertyAccessors[$this->class->versionField]->setValue($document, $nextVersion);
+                }
+            } else {
+                $this->bulkWriteQueue->addUpdateOne($this->collection, $query, $update, [], $options, $document);
             }
         }
 
@@ -437,11 +426,25 @@ final class DocumentPersister
         $options = $this->getWriteOptions($options);
 
         assert($this->collection instanceof Collection);
-        $result = $this->collection->deleteOne($query, $options);
 
-        if (($this->class->isVersioned || $this->class->isLockable) && ! $result->getDeletedCount()) {
-            throw LockException::lockFailed($document);
+        if ($this->class->isVersioned || $this->class->isLockable) {
+            /* Versioned/lockable deletes need per-op result inspection to throw
+             * LockException; issue a single-op bulkWrite so the deleted-count is
+             * unambiguously for this document.
+             */
+            $result = $this->collection->bulkWrite(
+                [['deleteOne' => [$query]]],
+                ['ordered' => true] + $options,
+            );
+
+            if (! $result->getDeletedCount()) {
+                throw LockException::lockFailed($document);
+            }
+
+            return;
         }
+
+        $this->bulkWriteQueue->addDeleteOne($this->collection, $query, [], $options, $document);
     }
 
     /**

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -272,6 +272,14 @@ final class UnitOfWork implements PropertyChangedListener
     private ?PersistenceBuilder $persistenceBuilder = null;
 
     /**
+     * Per-UnitOfWork accumulator drained by {@see doCommit()}. Both the
+     * DocumentPersister and CollectionPersister push their write ops here
+     * instead of executing them directly so that one bulkWrite is issued
+     * per target collection per commit phase.
+     */
+    private ?Persisters\BulkWriteQueue $bulkWriteQueue = null;
+
+    /**
      * Array of parent associations between embedded documents.
      *
      * @var array<int, array{0: AssociationFieldMapping, 1: object|null, 2: string}>
@@ -381,6 +389,23 @@ final class UnitOfWork implements PropertyChangedListener
         }
 
         return $this->collectionPersister;
+    }
+
+    /**
+     * Get the shared bulkWrite accumulator. The queue is created lazily and
+     * lives for the lifetime of the UnitOfWork; it is cleared at the start
+     * of every {@see doCommit()} run so a failed commit cannot leak pending
+     * ops into the next attempt.
+     *
+     * @internal
+     */
+    public function getBulkWriteQueue(): Persisters\BulkWriteQueue
+    {
+        if ($this->bulkWriteQueue === null) {
+            $this->bulkWriteQueue = new Persisters\BulkWriteQueue();
+        }
+
+        return $this->bulkWriteQueue;
     }
 
     /**
@@ -499,6 +524,11 @@ final class UnitOfWork implements PropertyChangedListener
         } finally {
             $this->commitsInProgress--;
             $this->lifecycleEventManager->clearTransactionalState();
+
+            // The queue is cleared at the start of every doCommit() but make
+            // doubly sure pending ops from a half-completed commit are dropped
+            // so the next attempt is not poisoned by stale state.
+            $this->bulkWriteQueue?->clear();
         }
     }
 
@@ -1170,7 +1200,10 @@ final class UnitOfWork implements PropertyChangedListener
     }
 
     /**
-     * Executes all document insertions for documents of the specified type.
+     * Queue all document insertions for documents of the specified type onto
+     * the shared {@see Persisters\BulkWriteQueue}. The actual bulkWrite is
+     * issued by {@see doCommit()} after every class for the phase has been
+     * queued.
      *
      * @phpstan-param ClassMetadata<T> $class
      * @phpstan-param T[] $documents
@@ -1187,14 +1220,11 @@ final class UnitOfWork implements PropertyChangedListener
         }
 
         $persister->executeInserts($options);
-
-        foreach ($documents as $document) {
-            $this->lifecycleEventManager->postPersist($class, $document, $options['session'] ?? null);
-        }
     }
 
     /**
-     * Executes all document upserts for documents of the specified type.
+     * Queue all document upserts for documents of the specified type onto
+     * the shared {@see Persisters\BulkWriteQueue}.
      *
      * @phpstan-param ClassMetadata<T> $class
      * @phpstan-param T[] $documents
@@ -1211,14 +1241,12 @@ final class UnitOfWork implements PropertyChangedListener
         }
 
         $persister->executeUpserts($options);
-
-        foreach ($documents as $document) {
-            $this->lifecycleEventManager->postPersist($class, $document, $options['session'] ?? null);
-        }
     }
 
     /**
-     * Executes all document updates for documents of the specified type.
+     * Fires {@link Events::preUpdate} and queues each document's update via
+     * the persister. The {@link Events::postUpdate} dispatch is handled by
+     * {@see dispatchPostUpdateEvents()} after the phase's bulkWrite drains.
      *
      * @phpstan-param ClassMetadata<T> $class
      * @phpstan-param T[] $documents
@@ -1238,16 +1266,22 @@ final class UnitOfWork implements PropertyChangedListener
         foreach ($documents as $oid => $document) {
             $this->lifecycleEventManager->preUpdate($class, $document, $options['session'] ?? null);
 
-            if (! empty($this->documentChangeSets[$oid]) || $this->hasScheduledCollections($document)) {
-                $persister->update($document, $options);
+            if (empty($this->documentChangeSets[$oid]) && ! $this->hasScheduledCollections($document)) {
+                continue;
             }
 
-            $this->lifecycleEventManager->postUpdate($class, $document, $options['session'] ?? null);
+            $persister->update($document, $options);
         }
     }
 
     /**
-     * Executes all document deletions for documents of the specified type.
+     * Queue all document deletions for documents of the specified type onto
+     * the shared {@see Persisters\BulkWriteQueue}. Local UoW bookkeeping
+     * (identifier/original data cleanup, snapshot clearing) happens in
+     * {@see dispatchPostRemoveEvents()} after the flush succeeds — clearing
+     * the identifier before flush would break {@see withTransaction()} retries
+     * because the persister cannot rebuild the delete filter on the second
+     * attempt.
      *
      * @phpstan-param ClassMetadata<T> $class
      * @phpstan-param T[] $documents
@@ -1259,11 +1293,72 @@ final class UnitOfWork implements PropertyChangedListener
     {
         $persister = $this->getDocumentPersister($class->name);
 
-        foreach ($documents as $oid => $document) {
-            if (! $class->isEmbeddedDocument) {
-                $persister->delete($document, $options);
+        foreach ($documents as $document) {
+            if ($class->isEmbeddedDocument) {
+                continue;
             }
 
+            $persister->delete($document, $options);
+        }
+    }
+
+    /**
+     * Dispatch {@link Events::postPersist} for every document queued for the
+     * insert/upsert phase. Called by {@see doCommit()} after the per-phase
+     * bulkWrite has succeeded.
+     *
+     * @phpstan-param ClassMetadata<T> $class
+     * @phpstan-param T[] $documents
+     * @phpstan-param CommitOptions $options
+     *
+     * @template T of object
+     */
+    private function dispatchPostPersistEvents(ClassMetadata $class, array $documents, array $options = []): void
+    {
+        foreach ($documents as $document) {
+            $this->lifecycleEventManager->postPersist($class, $document, $options['session'] ?? null);
+        }
+    }
+
+    /**
+     * Dispatch {@link Events::postUpdate} for every document queued for the
+     * update phase. Called by {@see doCommit()} after the per-phase
+     * bulkWrite has succeeded.
+     *
+     * @phpstan-param ClassMetadata<T> $class
+     * @phpstan-param T[] $documents
+     * @phpstan-param CommitOptions $options
+     *
+     * @template T of object
+     */
+    private function dispatchPostUpdateEvents(ClassMetadata $class, array $documents, array $options = []): void
+    {
+        if ($class->isReadOnly) {
+            return;
+        }
+
+        foreach ($documents as $document) {
+            $this->lifecycleEventManager->postUpdate($class, $document, $options['session'] ?? null);
+        }
+    }
+
+    /**
+     * Drain post-removal bookkeeping and dispatch {@link Events::postRemove}
+     * for every document queued for the deletion phase. Identifier and
+     * original-data cleanup happens here (not in {@see executeDeletions()})
+     * so that a transactional commit retry — triggered by a `TransientTransactionError`
+     * inside the bulkWrite — still has the document state needed to rebuild
+     * the delete filter on the second attempt.
+     *
+     * @phpstan-param ClassMetadata<T> $class
+     * @phpstan-param T[] $documents
+     * @phpstan-param CommitOptions $options
+     *
+     * @template T of object
+     */
+    private function dispatchPostRemoveEvents(ClassMetadata $class, array $documents, array $options = []): void
+    {
+        foreach ($documents as $oid => $document) {
             unset(
                 $this->documentIdentifiers[$oid],
                 $this->originalDocumentData[$oid],
@@ -3118,25 +3213,86 @@ final class UnitOfWork implements PropertyChangedListener
     /** @phpstan-param CommitOptions $options */
     private function doCommit(array $options): void
     {
-        foreach ($this->getClassesForCommitAction($this->scheduledDocumentUpserts) as $classAndDocuments) {
+        // Start from a clean accumulator — a previous failed commit may have
+        // left it cleared, but be defensive in case external callers reused
+        // the same UoW.
+        $queue = $this->getBulkWriteQueue();
+        $queue->clear();
+
+        $flushOptions = $this->getBulkWriteFlushOptions($options);
+
+        $upsertClasses = $this->getClassesForCommitAction($this->scheduledDocumentUpserts);
+        foreach ($upsertClasses as $classAndDocuments) {
             [$class, $documents] = $classAndDocuments;
             $this->executeUpserts($class, $documents, $options);
         }
 
-        foreach ($this->getClassesForCommitAction($this->scheduledDocumentInsertions) as $classAndDocuments) {
+        $queue->flush($flushOptions);
+
+        foreach ($upsertClasses as $classAndDocuments) {
+            [$class, $documents] = $classAndDocuments;
+            $this->dispatchPostPersistEvents($class, $documents, $options);
+        }
+
+        $insertClasses = $this->getClassesForCommitAction($this->scheduledDocumentInsertions);
+        foreach ($insertClasses as $classAndDocuments) {
             [$class, $documents] = $classAndDocuments;
             $this->executeInserts($class, $documents, $options);
         }
 
-        foreach ($this->getClassesForCommitAction($this->scheduledDocumentUpdates) as $classAndDocuments) {
+        $queue->flush($flushOptions);
+
+        foreach ($insertClasses as $classAndDocuments) {
+            [$class, $documents] = $classAndDocuments;
+            $this->dispatchPostPersistEvents($class, $documents, $options);
+        }
+
+        $updateClasses = $this->getClassesForCommitAction($this->scheduledDocumentUpdates);
+        foreach ($updateClasses as $classAndDocuments) {
             [$class, $documents] = $classAndDocuments;
             $this->executeUpdates($class, $documents, $options);
         }
 
-        foreach ($this->getClassesForCommitAction($this->scheduledDocumentDeletions, true) as $classAndDocuments) {
+        $queue->flush($flushOptions);
+
+        foreach ($updateClasses as $classAndDocuments) {
+            [$class, $documents] = $classAndDocuments;
+            $this->dispatchPostUpdateEvents($class, $documents, $options);
+        }
+
+        $deleteClasses = $this->getClassesForCommitAction($this->scheduledDocumentDeletions, true);
+        foreach ($deleteClasses as $classAndDocuments) {
             [$class, $documents] = $classAndDocuments;
             $this->executeDeletions($class, $documents, $options);
         }
+
+        $queue->flush($flushOptions);
+
+        foreach ($deleteClasses as $classAndDocuments) {
+            [$class, $documents] = $classAndDocuments;
+            $this->dispatchPostRemoveEvents($class, $documents, $options);
+        }
+    }
+
+    /**
+     * Returns the option subset that is safe to forward to the per-collection
+     * bulkWrite call drained by {@see Persisters\BulkWriteQueue::flush()}.
+     * Only the `session` and `writeConcern` keys are relevant at the bulk
+     * level; per-document write-concern overrides still flow through the
+     * persisters as today.
+     *
+     * @phpstan-param CommitOptions $options
+     *
+     * @return array<string, mixed>
+     */
+    private function getBulkWriteFlushOptions(array $options): array
+    {
+        $flushOptions = [];
+        if (isset($options['session'])) {
+            $flushOptions['session'] = $options['session'];
+        }
+
+        return $flushOptions;
     }
 
     /** @phpstan-param CommitOptions $options */

--- a/tests/Tests/Functional/BulkWriteCommitTest.php
+++ b/tests/Tests/Functional/BulkWriteCommitTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\ODM\MongoDB\APM\CommandLogger;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\ForumUser;
+use Documents\Phonebook;
+use Documents\Phonenumber;
+use Documents\User;
+
+use function count;
+
+/**
+ * Asserts that DocumentPersister / CollectionPersister consolidate every
+ * write against a single MongoDB collection into one `bulkWrite` command
+ * per commit phase.
+ */
+final class BulkWriteCommitTest extends BaseTestCase
+{
+    // The command logger counts every command, so transactional flush (which
+    // wraps each commit with startTransaction/commitTransaction) would skew the
+    // numbers. Test the per-collection consolidation in the non-transactional
+    // flow so the assertions remain deterministic.
+    protected static bool $allowsTransactions = false;
+
+    private CommandLogger $logger;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logger = new CommandLogger();
+        $this->logger->register();
+    }
+
+    public function tearDown(): void
+    {
+        $this->logger->unregister();
+
+        parent::tearDown();
+    }
+
+    public function testManyInsertsIntoOneCollectionEmitOneBulkWrite(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $user           = new ForumUser();
+            $user->username = 'user-' . $i;
+            $this->dm->persist($user);
+        }
+
+        $this->logger->clear();
+        $this->dm->flush();
+
+        self::assertSame(
+            1,
+            $this->countCommands('insert'),
+            'Five ForumUser inserts should consolidate into one bulkWrite (which the server logs as a single "insert" command).',
+        );
+    }
+
+    public function testInsertsAcrossTwoCollectionsEmitOneCommandEach(): void
+    {
+        $user           = new ForumUser();
+        $user->username = 'forum';
+
+        $other = new User();
+        $other->setUsername('docs');
+
+        $this->dm->persist($user);
+        $this->dm->persist($other);
+
+        $this->logger->clear();
+        $this->dm->flush();
+
+        // Two different collections → two bulkWrites → two server commands.
+        self::assertSame(2, $this->countCommands('insert'));
+    }
+
+    public function testUpdatesAcrossTwoCollectionsEmitOneCommandEach(): void
+    {
+        $userA = new User();
+        $userA->setUsername('a');
+        $forumUser           = new ForumUser();
+        $forumUser->username = 'b';
+        $this->dm->persist($userA);
+        $this->dm->persist($forumUser);
+        $this->dm->flush();
+
+        $userA->setUsername('a2');
+        $forumUser->username = 'b2';
+
+        $this->logger->clear();
+        $this->dm->flush();
+
+        self::assertSame(2, $this->countCommands('update'));
+    }
+
+    public function testMixedInsertUpdateOnSameCollectionIsOneBulkWritePerPhase(): void
+    {
+        $existing           = new ForumUser();
+        $existing->username = 'existing';
+        $this->dm->persist($existing);
+        $this->dm->flush();
+
+        $existing->username = 'existing-modified';
+
+        $new           = new ForumUser();
+        $new->username = 'new';
+        $this->dm->persist($new);
+
+        $this->logger->clear();
+        $this->dm->flush();
+
+        // Insert phase and update phase each drain once → 1 insert + 1 update command.
+        self::assertSame(1, $this->countCommands('insert'));
+        self::assertSame(1, $this->countCommands('update'));
+    }
+
+    public function testInsertWithEmbeddedCollectionsIsOneCommand(): void
+    {
+        $user = new User();
+        $user->setUsername('embed-host');
+
+        $book = new Phonebook('Private');
+        $book->addPhonenumber(new Phonenumber('11111111'));
+        $book->addPhonenumber(new Phonenumber('22222222'));
+        $user->addPhonebook($book);
+
+        $this->dm->persist($user);
+        $this->logger->clear();
+        $this->dm->flush();
+
+        // The embedded phonebooks/phonenumbers are inlined into the parent insert,
+        // so a single bulkWrite to the User collection should suffice. The post-insert
+        // addToSet pass for the phonebook does not target a separate collection.
+        self::assertSame(1, count($this->logger));
+    }
+
+    public function testParentUpdateAndCollectionPushOnSameDocumentIsOneCommand(): void
+    {
+        $user = new User();
+        $user->setUsername('with-book');
+        $book = new Phonebook('Private');
+        $book->addPhonenumber(new Phonenumber('11111111'));
+        $user->addPhonebook($book);
+        $this->dm->persist($user);
+        $this->dm->flush();
+
+        // Mutate both the parent and the embedded collection in one go.
+        $user->setUsername('with-book-modified');
+        $book->addPhonenumber(new Phonenumber('22222222'));
+
+        $this->logger->clear();
+        $this->dm->flush();
+
+        // One bulkWrite to the User collection that carries the parent update
+        // op and the collection-level $push op.
+        self::assertSame(1, $this->countCommands('update'));
+    }
+
+    public function testDeletesAcrossOneCollectionEmitOneCommand(): void
+    {
+        $a           = new ForumUser();
+        $a->username = 'a';
+        $b           = new ForumUser();
+        $b->username = 'b';
+        $this->dm->persist($a);
+        $this->dm->persist($b);
+        $this->dm->flush();
+
+        $this->dm->remove($a);
+        $this->dm->remove($b);
+
+        $this->logger->clear();
+        $this->dm->flush();
+
+        self::assertSame(1, $this->countCommands('delete'));
+    }
+
+    private function countCommands(string $name): int
+    {
+        $count = 0;
+        foreach ($this->logger->getAll() as $event) {
+            if ($event->getCommandName() !== $name) {
+                continue;
+            }
+
+            $count++;
+        }
+
+        return $count;
+    }
+}

--- a/tests/Tests/Functional/BulkWriteLifecycleEventTest.php
+++ b/tests/Tests/Functional/BulkWriteLifecycleEventTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
+use Doctrine\ODM\MongoDB\Event\PreUpdateEventArgs;
+use Doctrine\ODM\MongoDB\Events;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\ForumUser;
+use Throwable;
+
+/**
+ * Verifies that the per-phase bulkWrite refactor preserves the lifecycle
+ * event contract — preUpdate fires before the write goes to the server,
+ * postUpdate fires after, and postPersist only fires if the bulk succeeded.
+ */
+final class BulkWriteLifecycleEventTest extends BaseTestCase
+{
+    public function testPreUpdateFiresBeforeBulkWriteAndPostUpdateAfter(): void
+    {
+        $user           = new ForumUser();
+        $user->username = 'pre';
+        $this->dm->persist($user);
+        $this->dm->flush();
+
+        $subscriber = new BulkWriteLifecycleSubscriber();
+        $this->dm->getEventManager()->addEventSubscriber($subscriber);
+
+        $user->username = 'post';
+        $this->dm->flush();
+
+        self::assertSame(['preUpdate', 'postUpdate'], $subscriber->events);
+        self::assertSame(['preUpdate' => 'post', 'postUpdate' => 'post'], $subscriber->usernames);
+        // preUpdate fired with a non-empty change set; the BulkWriteQueue had not yet been drained.
+        self::assertSame(['username' => ['pre', 'post']], $subscriber->preUpdateChangeSet);
+    }
+
+    public function testPostPersistDoesNotFireWhenBulkWriteFails(): void
+    {
+        $subscriber = new BulkWriteLifecycleSubscriber();
+        $this->dm->getEventManager()->addEventSubscriber($subscriber);
+
+        $this->createFailPoint('insert');
+
+        $user           = new ForumUser();
+        $user->username = 'fails';
+        $this->dm->persist($user);
+
+        try {
+            $this->dm->flush();
+            self::fail('Expected the configured fail point to make bulkWrite throw.');
+        } catch (Throwable) {
+            // Expected — the bulkWrite returned an error.
+        }
+
+        self::assertNotContains('postPersist', $subscriber->events, 'postPersist must not fire if the per-collection bulkWrite raised an error.');
+    }
+}
+
+class BulkWriteLifecycleSubscriber implements EventSubscriber
+{
+    /** @var list<string> */
+    public array $events = [];
+
+    /** @var array<string, string> */
+    public array $usernames = [];
+
+    /** @var array<string, array{mixed, mixed}> */
+    public array $preUpdateChangeSet = [];
+
+    public function getSubscribedEvents(): array
+    {
+        return [Events::preUpdate, Events::postUpdate, Events::postPersist, Events::postRemove];
+    }
+
+    public function preUpdate(PreUpdateEventArgs $args): void
+    {
+        $document = $args->getDocument();
+        if (! $document instanceof ForumUser) {
+            return;
+        }
+
+        $this->events[]               = 'preUpdate';
+        $this->usernames['preUpdate'] = $document->username;
+        $this->preUpdateChangeSet     = $args->getDocumentChangeSet();
+    }
+
+    public function postUpdate(LifecycleEventArgs $args): void
+    {
+        $document = $args->getDocument();
+        if (! $document instanceof ForumUser) {
+            return;
+        }
+
+        $this->events[]                = 'postUpdate';
+        $this->usernames['postUpdate'] = $document->username;
+    }
+
+    public function postPersist(LifecycleEventArgs $args): void
+    {
+        $document = $args->getDocument();
+        if (! $document instanceof ForumUser) {
+            return;
+        }
+
+        $this->events[] = 'postPersist';
+    }
+
+    public function postRemove(LifecycleEventArgs $args): void
+    {
+        $document = $args->getDocument();
+        if (! $document instanceof ForumUser) {
+            return;
+        }
+
+        $this->events[] = 'postRemove';
+    }
+}

--- a/tests/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Tests/Functional/CollectionPersisterTest.php
@@ -41,6 +41,7 @@ class CollectionPersisterTest extends BaseTestCase
         $user      = $this->getTestUser('jwage');
         self::assertInstanceOf(PersistentCollectionInterface::class, $user->categories);
         $persister->delete($user, [$user->categories], []);
+        $this->flushBulkWriteQueue();
 
         $user = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         self::assertArrayNotHasKey('categories', $user, 'Test that the categories field was deleted');
@@ -52,6 +53,7 @@ class CollectionPersisterTest extends BaseTestCase
         $user      = $this->getTestUser('jwage');
         self::assertInstanceOf(PersistentCollectionInterface::class, $user->roles);
         $persister->delete($user, [$user->roles], []);
+        $this->flushBulkWriteQueue();
 
         $user = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         self::assertSame([], $user['roles'], 'Test that the roles field was stored as empty array');
@@ -63,6 +65,7 @@ class CollectionPersisterTest extends BaseTestCase
         $user      = $this->getTestUser('jwage');
         self::assertInstanceOf(PersistentCollectionInterface::class, $user->phonenumbers);
         $persister->delete($user, [$user->phonenumbers], []);
+        $this->flushBulkWriteQueue();
 
         $user = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         self::assertArrayNotHasKey('phonenumbers', $user, 'Test that the phonenumbers field was deleted');
@@ -74,6 +77,7 @@ class CollectionPersisterTest extends BaseTestCase
         $user      = $this->getTestUser('jwage');
         self::assertInstanceOf(PersistentCollectionInterface::class, $user->groups);
         $persister->delete($user, [$user->groups], []);
+        $this->flushBulkWriteQueue();
 
         $user = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         self::assertSame([], $user['groups'], 'Test that the groups field was stored as empty array');
@@ -90,6 +94,7 @@ class CollectionPersisterTest extends BaseTestCase
             [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
             [],
         );
+        $this->flushBulkWriteQueue();
         self::assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
 
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
@@ -103,6 +108,7 @@ class CollectionPersisterTest extends BaseTestCase
             [$user->categories[0]->children, $user->categories[1]->children],
             [],
         );
+        $this->flushBulkWriteQueue();
         self::assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
 
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
@@ -125,6 +131,7 @@ class CollectionPersisterTest extends BaseTestCase
             [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
             [],
         );
+        $this->flushBulkWriteQueue();
         self::assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
 
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
@@ -142,6 +149,7 @@ class CollectionPersisterTest extends BaseTestCase
             [$firstCategoryChildren, $firstCategoryChildren[1]->children, $user->categories],
             [],
         );
+        $this->flushBulkWriteQueue();
         self::assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
 
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
@@ -164,7 +172,7 @@ class CollectionPersisterTest extends BaseTestCase
 
         $this->logger->clear();
         $this->dm->flush();
-        self::assertCount(2, $this->logger, 'Modification of several embedded-many collections of one document requires two queries');
+        self::assertCount(1, $this->logger, 'Modification of several embedded-many collections of one document is consolidated into one bulkWrite');
 
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
 
@@ -181,7 +189,7 @@ class CollectionPersisterTest extends BaseTestCase
         unset($user->categories[1]);
         $this->logger->clear();
         $this->dm->flush();
-        self::assertCount(2, $this->logger, 'Modification of embedded-many collection of one document requires two queries');
+        self::assertCount(1, $this->logger, 'Modification of embedded-many collection of one document is consolidated into one bulkWrite');
 
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         self::assertFalse(isset($check['categories'][0]));
@@ -195,7 +203,10 @@ class CollectionPersisterTest extends BaseTestCase
         $user->phonenumbers[] = new CollectionPersisterPhonenumber('6155139185');
         $this->logger->clear();
         $this->dm->flush();
-        self::assertCount(2, $this->logger, 'Modification of embedded-many collection of one document requires two queries');
+        // Two bulkWrites: one to insert the new Phonenumber documents, one to push the
+        // references onto the User document — they target different collections so
+        // per-collection consolidation cannot reduce them further.
+        self::assertCount(2, $this->logger, 'Reference-many inserts produce one bulkWrite per collection');
 
         $check = $this->dm->getDocumentCollection(CollectionPersisterUser::class)->findOne(['username' => 'jwage']);
         self::assertCount(4, $check['phonenumbers']);
@@ -266,6 +277,17 @@ class CollectionPersisterTest extends BaseTestCase
         $pb  = new PersistenceBuilder($this->dm, $uow);
 
         return new CollectionPersister($this->dm, $pb, $uow);
+    }
+
+    /**
+     * CollectionPersister now queues writes onto the UnitOfWork's BulkWriteQueue
+     * rather than calling Collection::updateOne directly. Tests that invoke
+     * CollectionPersister::update/delete outside of a normal flush() cycle must
+     * drain the queue themselves to materialize the writes.
+     */
+    private function flushBulkWriteQueue(): void
+    {
+        $this->dm->getUnitOfWork()->getBulkWriteQueue()->flush();
     }
 
     public function testNestedEmbedManySetStrategy(): void
@@ -475,9 +497,9 @@ class CollectionPersisterTest extends BaseTestCase
         $this->logger->clear();
         $this->dm->flush();
         self::assertCount(
-            2,
+            1,
             $this->logger,
-            'Modification of embedded-many collections of one document by "addToSet" strategy requires two queries',
+            'Modification of embedded-many collections of one document by "addToSet" strategy is consolidated into one bulkWrite',
         );
 
         self::assertSame($structure, $this->dm->getRepository($structure::class)->findOneBy(['id' => $structure->id]));
@@ -506,9 +528,9 @@ class CollectionPersisterTest extends BaseTestCase
         $this->dm->persist($structure);
         $this->dm->flush();
         self::assertCount(
-            2,
+            1,
             $this->logger,
-            'Modification of embedded-many collections of one document by "pushAll" strategy requires two queries',
+            'Modification of embedded-many collections of one document by "pushAll" strategy is consolidated into one bulkWrite',
         );
 
         self::assertSame($structure, $this->dm->getRepository($structure::class)->findOneBy(['id' => $structure->id]));
@@ -540,9 +562,9 @@ class CollectionPersisterTest extends BaseTestCase
         $this->dm->persist($structure);
         $this->dm->flush();
         self::assertCount(
-            4,
+            1,
             $this->logger,
-            'Modification of embedded-many collections of one document by "set", "setArray" and "pushAll" strategies requires two queries',
+            'Modification of embedded-many collections of one document by "set", "setArray" and "pushAll" strategies is consolidated into one bulkWrite',
         );
 
         self::assertSame($structure, $this->dm->getRepository($structure::class)->findOneBy(['id' => $structure->id]));
@@ -580,9 +602,9 @@ class CollectionPersisterTest extends BaseTestCase
         $this->dm->persist($structure);
         $this->dm->flush();
         self::assertCount(
-            5,
+            1,
             $this->logger,
-            'Modification of embedded-many collections of one document by "set", "setArray" and "pushAll" strategies requires two queries',
+            'Modification of embedded-many collections of one document by "set", "setArray" and "pushAll" strategies is consolidated into one bulkWrite',
         );
 
         self::assertSame($structure, $this->dm->getRepository($structure::class)->findOneBy(['id' => $structure->id]));

--- a/tests/Tests/Functional/DocumentPersisterTest.php
+++ b/tests/Tests/Functional/DocumentPersisterTest.php
@@ -18,9 +18,11 @@ use Generator;
 use InvalidArgumentException;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
+use MongoDB\BulkWriteResult;
 use MongoDB\Collection;
 use MongoDB\Driver\WriteConcern;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Constraint\Constraint;
 use ReflectionProperty;
 
 use function get_debug_type;
@@ -632,10 +634,9 @@ class DocumentPersisterTest extends BaseTestCase
 
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $collection = $this->createMock(Collection::class);
-        $collection->expects($this->once())
-            ->method('insertMany')
-            ->with($this->isType('array'), $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern($writeConcern))));
+        $collection = $this->createBulkWriteCollectionMock(
+            $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern($writeConcern))),
+        );
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -653,10 +654,9 @@ class DocumentPersisterTest extends BaseTestCase
 
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $collection = $this->createMock(Collection::class);
-        $collection->expects($this->once())
-            ->method('insertMany')
-            ->with($this->isType('array'), $this->logicalNot($this->arrayHasKey('writeConcern')));
+        $collection = $this->createBulkWriteCollectionMock(
+            $this->logicalNot($this->arrayHasKey('writeConcern')),
+        );
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -674,10 +674,9 @@ class DocumentPersisterTest extends BaseTestCase
 
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $collection = $this->createMock(Collection::class);
-        $collection->expects($this->once())
-            ->method('updateOne')
-            ->with($this->isType('array'), $this->isType('array'), $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern($writeConcern))));
+        $collection = $this->createBulkWriteCollectionMock(
+            $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern($writeConcern))),
+        );
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -696,10 +695,9 @@ class DocumentPersisterTest extends BaseTestCase
 
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $collection = $this->createMock(Collection::class);
-        $collection->expects($this->once())
-            ->method('updateOne')
-            ->with($this->isType('array'), $this->logicalNot($this->arrayHasKey('writeConcern')));
+        $collection = $this->createBulkWriteCollectionMock(
+            $this->logicalNot($this->arrayHasKey('writeConcern')),
+        );
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -718,10 +716,11 @@ class DocumentPersisterTest extends BaseTestCase
 
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $collection = $this->createMock(Collection::class);
-        $collection->expects($this->once())
-            ->method('deleteOne')
-            ->with($this->isType('array'), $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern($writeConcern))));
+        // Two bulkWrites: one to insert, one to delete. Both should carry the write concern.
+        $collection = $this->createBulkWriteCollectionMock(
+            $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern($writeConcern))),
+            expectedCalls: 2,
+        );
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -742,10 +741,10 @@ class DocumentPersisterTest extends BaseTestCase
 
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $collection = $this->createMock(Collection::class);
-        $collection->expects($this->once())
-            ->method('deleteOne')
-            ->with($this->isType('array'), $this->logicalNot($this->arrayHasKey('writeConcern')));
+        $collection = $this->createBulkWriteCollectionMock(
+            $this->logicalNot($this->arrayHasKey('writeConcern')),
+            expectedCalls: 2,
+        );
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -765,10 +764,9 @@ class DocumentPersisterTest extends BaseTestCase
         $class             = DocumentPersisterTestDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $collection = $this->createMock(Collection::class);
-        $collection->expects($this->once())
-            ->method('insertMany')
-            ->with($this->isType('array'), $this->equalTo(['writeConcern' => new WriteConcern(0)]));
+        $collection = $this->createBulkWriteCollectionMock(
+            $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern(0))),
+        );
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -787,10 +785,9 @@ class DocumentPersisterTest extends BaseTestCase
         $class             = DocumentPersisterTestDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $collection = $this->createMock(Collection::class);
-        $collection->expects($this->once())
-            ->method('insertMany')
-            ->with($this->isType('array'), $this->logicalNot($this->arrayHasKey('writeConcern')));
+        $collection = $this->createBulkWriteCollectionMock(
+            $this->logicalNot($this->arrayHasKey('writeConcern')),
+        );
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -809,10 +806,9 @@ class DocumentPersisterTest extends BaseTestCase
         $class             = DocumentPersisterTestDocument::class;
         $documentPersister = $this->uow->getDocumentPersister($class);
 
-        $collection = $this->createMock(Collection::class);
-        $collection->expects($this->once())
-            ->method('insertMany')
-            ->with($this->isType('array'), $this->equalTo(['writeConcern' => new WriteConcern(0)]));
+        $collection = $this->createBulkWriteCollectionMock(
+            $this->logicalAnd($this->arrayHasKey('writeConcern'), $this->containsEqual(new WriteConcern(0))),
+        );
 
         $reflectionProperty = new ReflectionProperty($documentPersister, 'collection');
         $reflectionProperty->setValue($documentPersister, $collection);
@@ -822,6 +818,30 @@ class DocumentPersisterTest extends BaseTestCase
         $testDocument = new $class();
         $this->dm->persist($testDocument);
         $this->dm->flush();
+    }
+
+    /**
+     * Builds a Collection mock that expects a bulkWrite call whose options
+     * match the supplied constraint. Returns a successful BulkWriteResult so
+     * the UnitOfWork can finish without errors.
+     */
+    private function createBulkWriteCollectionMock(Constraint $optionsConstraint, int $expectedCalls = 1): Collection
+    {
+        $collection = $this->createMock(Collection::class);
+
+        $writeResult = $this->createMock(BulkWriteResult::class);
+        $writeResult->method('getInsertedIds')->willReturn([]);
+        $writeResult->method('getUpsertedIds')->willReturn([]);
+        $writeResult->method('getMatchedCount')->willReturn(1);
+        $writeResult->method('getModifiedCount')->willReturn(1);
+        $writeResult->method('getDeletedCount')->willReturn(1);
+
+        $collection->expects($this->exactly($expectedCalls))
+            ->method('bulkWrite')
+            ->with($this->isType('array'), $optionsConstraint)
+            ->willReturn($writeResult);
+
+        return $collection;
     }
 
     public function testVersionIncrementOnUpdateSuccess(): void

--- a/tests/Tests/Performance/BulkWritePerformanceTest.php
+++ b/tests/Tests/Performance/BulkWritePerformanceTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ODM\MongoDB\Performance;
+
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Documents\CmsUser;
+use Documents\ForumUser;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Group;
+
+use function microtime;
+
+use const PHP_EOL;
+
+/**
+ * Smoke-tests the perf improvement that motivates the per-collection
+ * bulkWrite refactor. Run with `vendor/bin/phpunit --group performance`.
+ */
+#[Group('performance')]
+class BulkWritePerformanceTest extends BaseTestCase
+{
+    private const N = 1000;
+
+    #[DoesNotPerformAssertions]
+    public function testBulkInsertSingleCollection(): void
+    {
+        $users = [];
+        for ($i = 0; $i < self::N; $i++) {
+            $u           = new ForumUser();
+            $u->username = 'forum-' . $i;
+            $this->dm->persist($u);
+            $users[] = $u;
+        }
+
+        $start = microtime(true);
+        $this->dm->flush();
+        $elapsed = microtime(true) - $start;
+
+        echo 'BulkWrite insert ' . self::N . ' single-collection docs in ' . $elapsed . ' seconds' . PHP_EOL;
+    }
+
+    #[DoesNotPerformAssertions]
+    public function testBulkUpdateSingleCollection(): void
+    {
+        $users = [];
+        for ($i = 0; $i < self::N; $i++) {
+            $u           = new ForumUser();
+            $u->username = 'forum-' . $i;
+            $this->dm->persist($u);
+            $users[] = $u;
+        }
+
+        $this->dm->flush();
+
+        foreach ($users as $i => $u) {
+            $u->username = 'modified-' . $i;
+        }
+
+        $start = microtime(true);
+        $this->dm->flush();
+        $elapsed = microtime(true) - $start;
+
+        echo 'BulkWrite update ' . self::N . ' single-collection docs in ' . $elapsed . ' seconds' . PHP_EOL;
+    }
+
+    #[DoesNotPerformAssertions]
+    public function testBulkMixedAcrossThreeCollections(): void
+    {
+        // Three different collections: ForumUser, CmsUser, and the cascade-side
+        // documents reachable from CmsUser (none persisted directly here, but
+        // the inserts target two different mongo collections — enough to
+        // exercise the per-collection grouping path).
+        $forum = [];
+        $cms   = [];
+        for ($i = 0; $i < self::N; $i++) {
+            $fu           = new ForumUser();
+            $fu->username = 'forum-' . $i;
+            $this->dm->persist($fu);
+            $forum[] = $fu;
+
+            $cu           = new CmsUser();
+            $cu->username = 'cms-' . $i;
+            $cu->name     = 'Name ' . $i;
+            $cu->status   = 'ok';
+            $this->dm->persist($cu);
+            $cms[] = $cu;
+        }
+
+        $start = microtime(true);
+        $this->dm->flush();
+        $elapsed = microtime(true) - $start;
+
+        echo 'BulkWrite insert ' . self::N . ' docs across 2 collections in ' . $elapsed . ' seconds' . PHP_EOL;
+    }
+}

--- a/tests/Tests/Persisters/BulkWriteQueueTest.php
+++ b/tests/Tests/Persisters/BulkWriteQueueTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Persisters;
+
+use Doctrine\ODM\MongoDB\Persisters\BulkWriteQueue;
+use MongoDB\BSON\ObjectId;
+use MongoDB\BulkWriteResult;
+use MongoDB\Collection;
+use MongoDB\Driver\Exception\BulkWriteException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class BulkWriteQueueTest extends TestCase
+{
+    public function testQueueStartsEmpty(): void
+    {
+        $queue = new BulkWriteQueue();
+
+        self::assertFalse($queue->hasPending());
+    }
+
+    public function testFlushIsNoOpWhenEmpty(): void
+    {
+        $queue      = new BulkWriteQueue();
+        $collection = $this->createMock(Collection::class);
+        $collection->expects(self::never())->method('bulkWrite');
+
+        $queue->flush();
+
+        self::assertFalse($queue->hasPending());
+    }
+
+    public function testOpsArePreservedInInsertionOrder(): void
+    {
+        $queue      = new BulkWriteQueue();
+        $collection = $this->createMock(Collection::class);
+        $document   = new stdClass();
+
+        $queue->addInsertOne($collection, ['_id' => 1, 'name' => 'first'], $document);
+        $queue->addUpdateOne($collection, ['_id' => 1], ['$set' => ['name' => 'second']], [], $document);
+        $queue->addDeleteOne($collection, ['_id' => 1], [], $document);
+
+        $expectedOps = [
+            ['insertOne' => [['_id' => 1, 'name' => 'first']]],
+            ['updateOne' => [['_id' => 1], ['$set' => ['name' => 'second']]]],
+            ['deleteOne' => [['_id' => 1]]],
+        ];
+
+        $collection->expects(self::once())
+            ->method('bulkWrite')
+            ->with($expectedOps, ['ordered' => true])
+            ->willReturn($this->createWriteResultMock());
+
+        $queue->flush();
+    }
+
+    public function testUpdateOptionsAreForwarded(): void
+    {
+        $queue      = new BulkWriteQueue();
+        $collection = $this->createMock(Collection::class);
+        $document   = new stdClass();
+
+        $queue->addUpdateOne($collection, ['_id' => 1], ['$set' => ['x' => 1]], ['upsert' => true], $document);
+
+        $collection->expects(self::once())
+            ->method('bulkWrite')
+            ->with(
+                [['updateOne' => [['_id' => 1], ['$set' => ['x' => 1]], ['upsert' => true]]]],
+                ['ordered' => true],
+            )
+            ->willReturn($this->createWriteResultMock());
+
+        $queue->flush();
+    }
+
+    public function testInsertCallbackReceivesInsertedId(): void
+    {
+        $queue      = new BulkWriteQueue();
+        $collection = $this->createMock(Collection::class);
+        $document   = new stdClass();
+        $captured   = null;
+
+        $queue->addInsertOne($collection, ['_id' => 'fixed'], $document, static function ($insertedId) use (&$captured): void {
+            $captured = $insertedId;
+        });
+
+        $collection->expects(self::once())
+            ->method('bulkWrite')
+            ->willReturn($this->createWriteResultMock(insertedIds: [0 => 'fixed']));
+
+        $queue->flush();
+
+        self::assertSame('fixed', $captured);
+    }
+
+    public function testUpdateCallbackReceivesAggregateCounts(): void
+    {
+        $queue      = new BulkWriteQueue();
+        $collection = $this->createMock(Collection::class);
+        $document   = new stdClass();
+        $captured   = null;
+
+        $queue->addUpdateOne(
+            $collection,
+            ['_id' => 1],
+            ['$set' => ['x' => 1]],
+            [],
+            $document,
+            static function (int $matched, int $modified, ?ObjectId $upsertedId) use (&$captured): void {
+                $captured = [$matched, $modified, $upsertedId];
+            },
+        );
+
+        $collection->expects(self::once())
+            ->method('bulkWrite')
+            ->willReturn($this->createWriteResultMock(matched: 1, modified: 1));
+
+        $queue->flush();
+
+        self::assertSame([1, 1, null], $captured);
+    }
+
+    public function testDeleteCallbackReceivesAggregateCount(): void
+    {
+        $queue      = new BulkWriteQueue();
+        $collection = $this->createMock(Collection::class);
+        $document   = new stdClass();
+        $captured   = null;
+
+        $queue->addDeleteOne(
+            $collection,
+            ['_id' => 1],
+            [],
+            $document,
+            static function (int $deletedCount) use (&$captured): void {
+                $captured = $deletedCount;
+            },
+        );
+
+        $collection->expects(self::once())
+            ->method('bulkWrite')
+            ->willReturn($this->createWriteResultMock(deleted: 1));
+
+        $queue->flush();
+
+        self::assertSame(1, $captured);
+    }
+
+    public function testFlushIssuesOneBulkPerCollection(): void
+    {
+        $queue       = new BulkWriteQueue();
+        $collectionA = $this->createMock(Collection::class);
+        $collectionB = $this->createMock(Collection::class);
+        $document    = new stdClass();
+
+        $queue->addInsertOne($collectionA, ['_id' => 1], $document);
+        $queue->addInsertOne($collectionB, ['_id' => 2], $document);
+        $queue->addUpdateOne($collectionA, ['_id' => 1], ['$set' => ['x' => 1]], [], $document);
+
+        $collectionA->expects(self::once())
+            ->method('bulkWrite')
+            ->with(
+                [
+                    ['insertOne' => [['_id' => 1]]],
+                    ['updateOne' => [['_id' => 1], ['$set' => ['x' => 1]]]],
+                ],
+                ['ordered' => true],
+            )
+            ->willReturn($this->createWriteResultMock());
+
+        $collectionB->expects(self::once())
+            ->method('bulkWrite')
+            ->with([['insertOne' => [['_id' => 2]]]], ['ordered' => true])
+            ->willReturn($this->createWriteResultMock());
+
+        $queue->flush();
+
+        self::assertFalse($queue->hasPending());
+    }
+
+    public function testFlushForwardsTopLevelOptions(): void
+    {
+        $queue      = new BulkWriteQueue();
+        $collection = $this->createMock(Collection::class);
+        $document   = new stdClass();
+
+        $queue->addInsertOne($collection, ['_id' => 1], $document);
+
+        $collection->expects(self::once())
+            ->method('bulkWrite')
+            ->with(self::anything(), ['ordered' => true, 'session' => 'session-token'])
+            ->willReturn($this->createWriteResultMock());
+
+        $queue->flush(['session' => 'session-token']);
+    }
+
+    public function testFlushClearsQueueOnBulkWriteException(): void
+    {
+        $queue       = new BulkWriteQueue();
+        $collectionA = $this->createMock(Collection::class);
+        $collectionB = $this->createMock(Collection::class);
+        $document    = new stdClass();
+
+        $queue->addInsertOne($collectionA, ['_id' => 1], $document);
+        $queue->addInsertOne($collectionB, ['_id' => 2], $document);
+
+        $collectionA->expects(self::once())
+            ->method('bulkWrite')
+            ->willThrowException(new BulkWriteException('boom'));
+
+        // Once collection A fails the queue must not continue with collection B.
+        $collectionB->expects(self::never())->method('bulkWrite');
+
+        $this->expectException(BulkWriteException::class);
+
+        try {
+            $queue->flush();
+        } finally {
+            self::assertFalse($queue->hasPending());
+        }
+    }
+
+    public function testClearDropsPendingOps(): void
+    {
+        $queue      = new BulkWriteQueue();
+        $collection = $this->createMock(Collection::class);
+        $document   = new stdClass();
+
+        $queue->addInsertOne($collection, ['_id' => 1], $document);
+        self::assertTrue($queue->hasPending());
+
+        $queue->clear();
+
+        self::assertFalse($queue->hasPending());
+    }
+
+    /**
+     * @param array<int, mixed> $insertedIds
+     * @param array<int, mixed> $upsertedIds
+     */
+    private function createWriteResultMock(
+        int $matched = 0,
+        int $modified = 0,
+        int $deleted = 0,
+        array $insertedIds = [],
+        array $upsertedIds = [],
+    ): BulkWriteResult {
+        $result = $this->createMock(BulkWriteResult::class);
+        $result->method('getMatchedCount')->willReturn($matched);
+        $result->method('getModifiedCount')->willReturn($modified);
+        $result->method('getDeletedCount')->willReturn($deleted);
+        $result->method('getInsertedIds')->willReturn($insertedIds);
+        $result->method('getUpsertedIds')->willReturn($upsertedIds);
+
+        return $result;
+    }
+}

--- a/tests/Tests/Persisters/BulkWriteQueueTest.php
+++ b/tests/Tests/Persisters/BulkWriteQueueTest.php
@@ -9,6 +9,7 @@ use MongoDB\BSON\ObjectId;
 use MongoDB\BulkWriteResult;
 use MongoDB\Collection;
 use MongoDB\Driver\Exception\BulkWriteException;
+use MongoDB\Driver\WriteConcern;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -38,9 +39,9 @@ final class BulkWriteQueueTest extends TestCase
         $collection = $this->createMock(Collection::class);
         $document   = new stdClass();
 
-        $queue->addInsertOne($collection, ['_id' => 1, 'name' => 'first'], $document);
-        $queue->addUpdateOne($collection, ['_id' => 1], ['$set' => ['name' => 'second']], [], $document);
-        $queue->addDeleteOne($collection, ['_id' => 1], [], $document);
+        $queue->addInsertOne($collection, ['_id' => 1, 'name' => 'first'], [], $document);
+        $queue->addUpdateOne($collection, ['_id' => 1], ['$set' => ['name' => 'second']], [], [], $document);
+        $queue->addDeleteOne($collection, ['_id' => 1], [], [], $document);
 
         $expectedOps = [
             ['insertOne' => [['_id' => 1, 'name' => 'first']]],
@@ -62,7 +63,7 @@ final class BulkWriteQueueTest extends TestCase
         $collection = $this->createMock(Collection::class);
         $document   = new stdClass();
 
-        $queue->addUpdateOne($collection, ['_id' => 1], ['$set' => ['x' => 1]], ['upsert' => true], $document);
+        $queue->addUpdateOne($collection, ['_id' => 1], ['$set' => ['x' => 1]], ['upsert' => true], [], $document);
 
         $collection->expects(self::once())
             ->method('bulkWrite')
@@ -75,6 +76,23 @@ final class BulkWriteQueueTest extends TestCase
         $queue->flush();
     }
 
+    public function testPerCollectionBulkOptionsAreForwarded(): void
+    {
+        $queue        = new BulkWriteQueue();
+        $collection   = $this->createMock(Collection::class);
+        $document     = new stdClass();
+        $writeConcern = new WriteConcern(0);
+
+        $queue->addInsertOne($collection, ['_id' => 1], ['writeConcern' => $writeConcern], $document);
+
+        $collection->expects(self::once())
+            ->method('bulkWrite')
+            ->with(self::anything(), ['ordered' => true, 'writeConcern' => $writeConcern])
+            ->willReturn($this->createWriteResultMock());
+
+        $queue->flush();
+    }
+
     public function testInsertCallbackReceivesInsertedId(): void
     {
         $queue      = new BulkWriteQueue();
@@ -82,7 +100,7 @@ final class BulkWriteQueueTest extends TestCase
         $document   = new stdClass();
         $captured   = null;
 
-        $queue->addInsertOne($collection, ['_id' => 'fixed'], $document, static function ($insertedId) use (&$captured): void {
+        $queue->addInsertOne($collection, ['_id' => 'fixed'], [], $document, static function ($insertedId) use (&$captured): void {
             $captured = $insertedId;
         });
 
@@ -106,6 +124,7 @@ final class BulkWriteQueueTest extends TestCase
             $collection,
             ['_id' => 1],
             ['$set' => ['x' => 1]],
+            [],
             [],
             $document,
             static function (int $matched, int $modified, ?ObjectId $upsertedId) use (&$captured): void {
@@ -133,6 +152,7 @@ final class BulkWriteQueueTest extends TestCase
             $collection,
             ['_id' => 1],
             [],
+            [],
             $document,
             static function (int $deletedCount) use (&$captured): void {
                 $captured = $deletedCount;
@@ -155,9 +175,9 @@ final class BulkWriteQueueTest extends TestCase
         $collectionB = $this->createMock(Collection::class);
         $document    = new stdClass();
 
-        $queue->addInsertOne($collectionA, ['_id' => 1], $document);
-        $queue->addInsertOne($collectionB, ['_id' => 2], $document);
-        $queue->addUpdateOne($collectionA, ['_id' => 1], ['$set' => ['x' => 1]], [], $document);
+        $queue->addInsertOne($collectionA, ['_id' => 1], [], $document);
+        $queue->addInsertOne($collectionB, ['_id' => 2], [], $document);
+        $queue->addUpdateOne($collectionA, ['_id' => 1], ['$set' => ['x' => 1]], [], [], $document);
 
         $collectionA->expects(self::once())
             ->method('bulkWrite')
@@ -186,7 +206,7 @@ final class BulkWriteQueueTest extends TestCase
         $collection = $this->createMock(Collection::class);
         $document   = new stdClass();
 
-        $queue->addInsertOne($collection, ['_id' => 1], $document);
+        $queue->addInsertOne($collection, ['_id' => 1], [], $document);
 
         $collection->expects(self::once())
             ->method('bulkWrite')
@@ -203,8 +223,8 @@ final class BulkWriteQueueTest extends TestCase
         $collectionB = $this->createMock(Collection::class);
         $document    = new stdClass();
 
-        $queue->addInsertOne($collectionA, ['_id' => 1], $document);
-        $queue->addInsertOne($collectionB, ['_id' => 2], $document);
+        $queue->addInsertOne($collectionA, ['_id' => 1], [], $document);
+        $queue->addInsertOne($collectionB, ['_id' => 2], [], $document);
 
         $collectionA->expects(self::once())
             ->method('bulkWrite')
@@ -228,7 +248,7 @@ final class BulkWriteQueueTest extends TestCase
         $collection = $this->createMock(Collection::class);
         $document   = new stdClass();
 
-        $queue->addInsertOne($collection, ['_id' => 1], $document);
+        $queue->addInsertOne($collection, ['_id' => 1], [], $document);
         self::assertTrue($queue->hasPending());
 
         $queue->clear();

--- a/tests/Tests/UnitOfWorkTest.php
+++ b/tests/Tests/UnitOfWorkTest.php
@@ -25,6 +25,7 @@ use Documents\ForumUser;
 use Documents\Functional\NotSaved;
 use Documents\User;
 use MongoDB\BSON\ObjectId;
+use MongoDB\BulkWriteResult;
 use MongoDB\Collection as MongoDBCollection;
 use MongoDB\Driver\WriteConcern;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -571,10 +572,17 @@ class UnitOfWorkTest extends BaseTestCase
         // Force transaction config to be enabled
         $this->dm->getConfiguration()->setUseTransactionalFlush(true);
 
-        $collection = $this->createMock(MongoDBCollection::class);
+        $collection  = $this->createMock(MongoDBCollection::class);
+        $writeResult = $this->createMock(BulkWriteResult::class);
+        $writeResult->method('getInsertedIds')->willReturn([]);
+        $writeResult->method('getUpsertedIds')->willReturn([]);
+        $writeResult->method('getMatchedCount')->willReturn(0);
+        $writeResult->method('getModifiedCount')->willReturn(0);
+        $writeResult->method('getDeletedCount')->willReturn(0);
         $collection->expects($this->once())
-            ->method('insertMany')
-            ->with($this->isType('array'), $this->logicalNot($this->arrayHasKey('writeConcern')));
+            ->method('bulkWrite')
+            ->with($this->isType('array'), $this->logicalNot($this->arrayHasKey('writeConcern')))
+            ->willReturn($writeResult);
 
         $documentPersister = $this->uow->getDocumentPersister(ForumUser::class);
 


### PR DESCRIPTION
[PHPORM-257](https://jira.mongodb.org/browse/PHPORM-257)

Part 1 of the bulkWrite refactor: every write against the same MongoDB collection that a single `flush()` produces is now consolidated into one `Collection::bulkWrite()` call per commit phase. Upserts, updates, deletes, and collection-level (`$push`, `$pull`, `$set`, `$addToSet`, …) writes that target the same parent collection all share that bulk — reducing the driver call count from one call per document to one per collection per phase. Inserts were already batched via `insertMany`; the structural change for inserts is that they now flow through the same per-collection `bulkWrite` path as all other write kinds rather than a separate `insertMany` call, so a flush that mixes inserts with updates or deletes on the same collection now produces a single command instead of two. Multi-collection consolidation via a future driver-level `bulkWriteCommand` is **out of scope** and will be addressed in a follow-up ticket.

## What changed

- New `Doctrine\ODM\MongoDB\Persisters\BulkWriteQueue` — a per-UnitOfWork accumulator keyed by `MongoDB\Collection` object identity. Both `DocumentPersister` and `CollectionPersister` push ops here; `UnitOfWork::doCommit()` flushes the queue at the end of each phase.
- `DocumentPersister::executeInserts()`, `executeUpserts()`, `update()` and `delete()` now build payloads and queue `insertOne` / `updateOne` / `deleteOne` ops onto the `BulkWriteQueue` instead of calling `insertMany` / `updateOne` / `deleteOne` on the collection directly.
- `CollectionPersister::executeQuery()` queues against the parent document's collection so embedded-collection writes and the parent's write share a single bulk.
- `UnitOfWork::doCommit()` runs each phase in three passes per collection: build & queue → `BulkWriteQueue::flush()` → dispatch `postPersist` / `postUpdate` / `postRemove`. Per-document `preUpdate` still fires before the queueing pass so listeners can still mutate the change set.
- Identifier / original-data cleanup for deletions moved from `executeDeletions()` to `dispatchPostRemoveEvents()`. Without this move, a `TransientTransactionError` retry from `withTransaction()` would have lost the identifiers needed to rebuild the delete filter on the second attempt.

## Trade-offs and deliberate omissions

- **Versioned and lockable documents bypass the consolidated bulk.** Each such document still gets its own one-op `bulkWrite` so `LockException` can be thrown precisely against the matched / modified / deleted count for that document. The MongoDB driver's `BulkWriteResult` aggregates counts across a batch, so per-op `LockException` for a versioned doc inside a multi-op batch would require post-hoc reconstruction. Once a server-side `bulkWriteCommand` exposes per-op write errors, this fence can be lifted.
- **Lifecycle event ordering is BC-different.** `postPersist`, `postUpdate` and `postRemove` now fire after the whole phase's bulkWrite, not interleaved with each document's write. Documented in `UPGRADE-3.0.md`.
- **Empty-modifier upsert retry has been inlined.** Where the 2.x persister relied on a `BulkWriteException` retry to handle "Mod on `_id` not allowed", we now detect the empty-modifier case at build time and emit `['$set' => new stdClass()]` directly. See `SERVER-12266`.
- **GridFS deletes still bypass the queue.** GridFS deletes touch two collections and are not expressible as a single bulkWrite on the parent collection. They flow through `Bucket::delete()` unchanged.
- **Multi-collection `bulkWriteCommand` consolidation** is explicitly deferred. A follow-up ticket will pick this up once the driver lands the server-side command.
- **Performance benchmarks.** A `BulkWritePerformanceTest` was added under `tests/Tests/Performance/`; it is excluded from the default suite via the `performance` group. The numbers should be tracked over time, but no regression gate is set in CI.

## Test plan

- [x] `vendor/bin/phpunit tests/Tests/Persisters/BulkWriteQueueTest.php` — 12 new unit tests covering op order, callback timing, per-collection grouping, exception propagation, and per-collection options forwarding.
- [x] `vendor/bin/phpunit tests/Tests/Functional/BulkWriteCommitTest.php` — 7 new functional tests asserting "one bulkWrite per (collection × phase)" via `CommandLogger`.
- [x] `vendor/bin/phpunit tests/Tests/Functional/BulkWriteLifecycleEventTest.php` — 2 new functional tests covering `preUpdate`/`postUpdate` ordering and `postPersist` non-firing on bulkWrite failure.
- [x] `vendor/bin/phpunit tests/Tests/UnitOfWorkCommitConsistencyTest.php tests/Tests/UnitOfWorkTransactionalCommitConsistencyTest.php` — the primary BC gate, both pass without source modification.
- [x] `vendor/bin/phpunit tests/Tests/Functional/LockTest.php tests/Tests/Functional/VersionTest.php` — pass unchanged.
- [x] `vendor/bin/phpunit tests/Tests/Functional/CommitImprovementTest.php` — pass unchanged.
- [x] `vendor/bin/phpunit tests/Tests/Functional/CollectionPersisterTest.php` — command-count assertions updated for the new consolidation; tests that exercise `CollectionPersister` directly now also drain the queue via a small `flushBulkWriteQueue()` helper.
- [x] `vendor/bin/phpunit tests/Tests/Functional/DocumentPersisterTest.php tests/Tests/UnitOfWorkTest.php` — write-concern / transactional-options mocks now expect `bulkWrite` instead of `insertMany` / `updateOne` / `deleteOne`.
- [x] `vendor/bin/phpunit --group performance tests/Tests/Performance/BulkWritePerformanceTest.php` — benchmarks run, no assertion failures.
- [x] Full suite: 3022 tests, 7 errors + 2 failures **all pre-existing on this branch** (Atlas Search, Vector Search, ReadPreference hint dataset #2, SchemaManager wait-for-search-index — all unrelated to this refactor and gated on Atlas-only features).
- [x] `vendor/bin/phpstan analyse` — no new errors introduced; the 25 baseline errors all predate this PR and relate to PHP 8.4+ Reflection methods not visible on 8.3.

## Notes for reviewers

- The order of post-events relative to *other documents'* writes has shifted from interleaved to "phase-completed first". Listeners that rely on the older order will need updating; this is documented in `UPGRADE-3.0.md`.
- The bulk-level options (writeConcern, session, …) are captured per-collection at the *first* op pushed and reused for every subsequent op on that collection in the phase. For mixed-class collections (inheritance), all classes resolve to the same per-class write concern via `ClassMetadata::getWriteConcern()` so this is safe in practice; reviewers should still sanity-check the assumption.
- The `CollectionPersister` direct-call tests now drain the queue via `flushBulkWriteQueue()`. This helper is purely a test convenience; production callers always drain via `UnitOfWork::doCommit()`.
- [ ] Consider extracting the empty-modifier upsert workaround into `PersistenceBuilder` so the persister logic stays focused on dispatch. Deferred — out of scope for this PR.
