### PR TITLE
Fix PHPStan errors detected with PHP 8.4 and Symfony 7.4

### DIFF
--- a/.github/workflows/atlas-ci.yml
+++ b/.github/workflows/atlas-ci.yml
@@ -27,7 +27,7 @@ jobs:
             os: "ubuntu-latest"
           # Test with ProxyManager
           - php-version: "8.1"
-            symfony-version: "6.4"
+            symfony-version: "^6.4"
             proxy: "proxy-manager"
             os: "ubuntu-latest"
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,7 +34,7 @@ jobs:
         dependencies:
           - "highest"
         symfony-version:
-          - "7.4"
+          - "^7.4"
         proxy:
           - "lazy-ghost"
         include:
@@ -52,7 +52,7 @@ jobs:
             mongodb-version: "6.0"
             driver-version: "stable"
             dependencies: "highest"
-            symfony-version: "6.4"
+            symfony-version: "^6.4"
             proxy: "lazy-ghost"
           # Test with a 6.0 replica set
           - topology: "replica_set"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -50,6 +50,11 @@ parameters:
         identifier: property.unusedType
         path: tests/
 
+      # PHP 8.4 native lazy objects: PHPStan infers the parameter type as never when it can prove
+      # the class is not lazy, but at runtime these are lazy proxies
+      - message: '#^Parameter \#1 \$object of method ReflectionClass<.*>::markLazyObjectAsInitialized\(\) expects never#'
+        identifier: argument.type
+
       # Requires ext-mongodb 2.2+
       - message: '#MongoDB\\BSON\\VectorType#'
       - message: '#MongoDB\\BSON\\Binary\:\:(TYPE_VECTOR|getVectorType|toArray|fromVector)#'

--- a/src/Aggregation/Stage/GraphLookup.php
+++ b/src/Aggregation/Stage/GraphLookup.php
@@ -217,13 +217,8 @@ class GraphLookup extends Stage
         return $this;
     }
 
-    /** @throws MappingException */
     private function fromReference(string $fieldName): static
     {
-        if (! $this->class->hasReference($fieldName)) {
-            MappingException::referenceMappingNotFound($this->class->name, $fieldName);
-        }
-
         $referenceMapping  = $this->class->getFieldMapping($fieldName);
         $this->targetClass = $this->dm->getClassMetadata($referenceMapping['targetDocument']);
 

--- a/src/Aggregation/Stage/Lookup.php
+++ b/src/Aggregation/Stage/Lookup.php
@@ -229,13 +229,8 @@ class Lookup extends Stage
         return $this->getDocumentPersister($class)->prepareFieldName($fieldName);
     }
 
-    /** @throws MappingException */
     private function fromReference(string $fieldName): static
     {
-        if (! $this->class->hasReference($fieldName)) {
-            MappingException::referenceMappingNotFound($this->class->name, $fieldName);
-        }
-
         $referenceMapping  = $this->class->getFieldMapping($fieldName);
         $this->targetClass = $this->dm->getClassMetadata($referenceMapping['targetDocument']);
 

--- a/src/Mapping/Driver/XmlDriver.php
+++ b/src/Mapping/Driver/XmlDriver.php
@@ -29,7 +29,6 @@ use function current;
 use function explode;
 use function implode;
 use function in_array;
-use function interface_exists;
 use function is_numeric;
 use function iterator_to_array;
 use function libxml_clear_errors;
@@ -984,4 +983,4 @@ class XmlDriver extends FileDriver
     }
 }
 
-interface_exists(ClassMetadata::class);
+class_exists(ClassMetadata::class);


### PR DESCRIPTION
Remove dead code guard in `GraphLookup::fromReference()` and `Lookup::fromReference()` — the check `! $this->class->hasReference($fieldName)` can never be true since `from()` already verifies `hasReference()` before calling `fromReference()`.

Fix `XmlDriver` using `class_exists()` instead of `interface_exists()` to trigger autoloading of `ClassMetadata`, which is a class not an interface.

Ignore false-positive PHPStan error on `ReflectionClass::markLazyObjectAsInitialized()` for proxy classes whose lazy nature is only known at runtime (PHP 8.4).

Quote the `symfony-version` matrix values with a caret (`^7.4` instead of `7.4`). A bare `SYMFONY_REQUIRE=7.4` makes Flex pin symfony/* to exactly 7.4.0, which is affected by the symfony/cache advisory PKSA-z7t6-zt6p-wtng and gets blocked by Composer 2.10's `policy.advisories.block`. The caret keeps the full 7.4.x range so the resolver picks an unaffected patch.