### PR TITLE
Fix CollectionPersister::delete() param type in test instead of baseline

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1021,12 +1021,6 @@ parameters:
 			path: tests/Tests/DocumentRepositoryTest.php
 
 		-
-			message: '#^Parameter \#2 \$collections of method Doctrine\\ODM\\MongoDB\\Persisters\\CollectionPersister\:\:delete\(\) expects array\<Doctrine\\ODM\\MongoDB\\PersistentCollection\\PersistentCollectionInterface\>, array\<int, array\<Doctrine\\ODM\\MongoDB\\Tests\\Functional\\CollectionPersisterCategory\>\|Doctrine\\Common\\Collections\\Collection\<int, Doctrine\\ODM\\MongoDB\\Tests\\Functional\\CollectionPersisterCategory\>\> given\.$#'
-			identifier: argument.type
-			count: 3
-			path: tests/Tests/Functional/CollectionPersisterTest.php
-
-		-
 			message: '#^PHPDoc type Doctrine\\Common\\Collections\\Collection\<int, Doctrine\\ODM\\MongoDB\\Tests\\Functional\\ChildDocumentWithDiscriminator\> of property Doctrine\\ODM\\MongoDB\\Tests\\Functional\\ParentDocumentWithDiscriminator\:\:\$embeddedChildren is not covariant with PHPDoc type array\<Doctrine\\ODM\\MongoDB\\Tests\\Functional\\ChildDocument\>\|Doctrine\\Common\\Collections\\Collection\<int, Doctrine\\ODM\\MongoDB\\Tests\\Functional\\ChildDocument\> of overridden property Doctrine\\ODM\\MongoDB\\Tests\\Functional\\ParentDocument\:\:\$embeddedChildren\.$#'
 			identifier: property.phpDocType
 			count: 1

--- a/tests/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Tests/Functional/CollectionPersisterTest.php
@@ -89,7 +89,7 @@ class CollectionPersisterTest extends BaseTestCase
         $this->logger->clear();
         $persister->delete(
             $user,
-            $this->persistentCollections([$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children]),
+            $this->assertPersistentCollections([$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children]),
             [],
         );
         self::assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
@@ -102,7 +102,7 @@ class CollectionPersisterTest extends BaseTestCase
         $this->logger->clear();
         $persister->delete(
             $user,
-            $this->persistentCollections([$user->categories[0]->children, $user->categories[1]->children]),
+            $this->assertPersistentCollections([$user->categories[0]->children, $user->categories[1]->children]),
             [],
         );
         self::assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
@@ -124,7 +124,7 @@ class CollectionPersisterTest extends BaseTestCase
         $this->logger->clear();
         $persister->delete(
             $user,
-            $this->persistentCollections([$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children]),
+            $this->assertPersistentCollections([$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children]),
             [],
         );
         self::assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
@@ -136,10 +136,9 @@ class CollectionPersisterTest extends BaseTestCase
 
         $this->logger->clear();
         $firstCategoryChildren = $user->categories[0]->children;
-        self::assertInstanceOf(PersistentCollectionInterface::class, $firstCategoryChildren);
         $persister->delete(
             $user,
-            $this->persistentCollections([$firstCategoryChildren, $firstCategoryChildren[1]->children, $user->categories]),
+            $this->assertPersistentCollections([$firstCategoryChildren, $firstCategoryChildren[1]->children, $user->categories]),
             [],
         );
         self::assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
@@ -275,7 +274,7 @@ class CollectionPersisterTest extends BaseTestCase
      *
      * @return list<PersistentCollectionInterface<array-key, object>>
      */
-    private function persistentCollections(array $collections): array
+    private function assertPersistentCollections(array $collections): array
     {
         return array_map(static function (mixed $collection): PersistentCollectionInterface {
             self::assertInstanceOf(PersistentCollectionInterface::class, $collection);

--- a/tests/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Tests/Functional/CollectionPersisterTest.php
@@ -13,6 +13,8 @@ use Doctrine\ODM\MongoDB\Persisters\CollectionPersister;
 use Doctrine\ODM\MongoDB\Persisters\PersistenceBuilder;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 
+use function array_map;
+
 class CollectionPersisterTest extends BaseTestCase
 {
     // This test counts executed commands and thus doesn't work with transactions
@@ -87,7 +89,7 @@ class CollectionPersisterTest extends BaseTestCase
         $this->logger->clear();
         $persister->delete(
             $user,
-            [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
+            $this->persistentCollections($user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children),
             [],
         );
         self::assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
@@ -100,7 +102,7 @@ class CollectionPersisterTest extends BaseTestCase
         $this->logger->clear();
         $persister->delete(
             $user,
-            [$user->categories[0]->children, $user->categories[1]->children],
+            $this->persistentCollections($user->categories[0]->children, $user->categories[1]->children),
             [],
         );
         self::assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
@@ -122,7 +124,7 @@ class CollectionPersisterTest extends BaseTestCase
         $this->logger->clear();
         $persister->delete(
             $user,
-            [$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children],
+            $this->persistentCollections($user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children),
             [],
         );
         self::assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
@@ -135,11 +137,9 @@ class CollectionPersisterTest extends BaseTestCase
         $this->logger->clear();
         $firstCategoryChildren = $user->categories[0]->children;
         self::assertInstanceOf(PersistentCollectionInterface::class, $firstCategoryChildren);
-        self::assertInstanceOf(PersistentCollectionInterface::class, $firstCategoryChildren[1]->children);
-        self::assertInstanceOf(PersistentCollectionInterface::class, $user->categories);
         $persister->delete(
             $user,
-            [$firstCategoryChildren, $firstCategoryChildren[1]->children, $user->categories],
+            $this->persistentCollections($firstCategoryChildren, $firstCategoryChildren[1]->children, $user->categories),
             [],
         );
         self::assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
@@ -266,6 +266,20 @@ class CollectionPersisterTest extends BaseTestCase
         $pb  = new PersistenceBuilder($this->dm, $uow);
 
         return new CollectionPersister($this->dm, $pb, $uow);
+    }
+
+    /**
+     * Asserts that each managed collection is a PersistentCollection and narrows the type for the persister.
+     *
+     * @return list<PersistentCollectionInterface<array-key, object>>
+     */
+    private function persistentCollections(mixed ...$collections): array
+    {
+        return array_map(static function (mixed $collection): PersistentCollectionInterface {
+            self::assertInstanceOf(PersistentCollectionInterface::class, $collection);
+
+            return $collection;
+        }, $collections);
     }
 
     public function testNestedEmbedManySetStrategy(): void

--- a/tests/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Tests/Functional/CollectionPersisterTest.php
@@ -89,7 +89,7 @@ class CollectionPersisterTest extends BaseTestCase
         $this->logger->clear();
         $persister->delete(
             $user,
-            $this->persistentCollections($user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children),
+            $this->persistentCollections([$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children]),
             [],
         );
         self::assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
@@ -102,7 +102,7 @@ class CollectionPersisterTest extends BaseTestCase
         $this->logger->clear();
         $persister->delete(
             $user,
-            $this->persistentCollections($user->categories[0]->children, $user->categories[1]->children),
+            $this->persistentCollections([$user->categories[0]->children, $user->categories[1]->children]),
             [],
         );
         self::assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
@@ -124,7 +124,7 @@ class CollectionPersisterTest extends BaseTestCase
         $this->logger->clear();
         $persister->delete(
             $user,
-            $this->persistentCollections($user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children),
+            $this->persistentCollections([$user->categories[0]->children[0]->children, $user->categories[0]->children[1]->children]),
             [],
         );
         self::assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
@@ -139,7 +139,7 @@ class CollectionPersisterTest extends BaseTestCase
         self::assertInstanceOf(PersistentCollectionInterface::class, $firstCategoryChildren);
         $persister->delete(
             $user,
-            $this->persistentCollections($firstCategoryChildren, $firstCategoryChildren[1]->children, $user->categories),
+            $this->persistentCollections([$firstCategoryChildren, $firstCategoryChildren[1]->children, $user->categories]),
             [],
         );
         self::assertCount(1, $this->logger, 'Deletion of several embedded-many collections of one document requires one query');
@@ -271,9 +271,11 @@ class CollectionPersisterTest extends BaseTestCase
     /**
      * Asserts that each managed collection is a PersistentCollection and narrows the type for the persister.
      *
+     * @param array<mixed> $collections
+     *
      * @return list<PersistentCollectionInterface<array-key, object>>
      */
-    private function persistentCollections(mixed ...$collections): array
+    private function persistentCollections(array $collections): array
     {
         return array_map(static function (mixed $collection): PersistentCollectionInterface {
             self::assertInstanceOf(PersistentCollectionInterface::class, $collection);


### PR DESCRIPTION
Fixes #2796.

The baselined PHPStan error came from the test passing chained document property accesses (typed `Collection|array`) to `CollectionPersister::delete()`, which requires `PersistentCollectionInterface[]`.

The signature is correct and the analysis should not be weakened: the only caller, `DocumentPersister::handleCollections()`, builds the list from `UnitOfWork::getScheduledCollections()`, which yields `PersistentCollection` instances. So the fix belongs in the test, not the production type.

The multi-collection `delete()` calls now route their arguments through an asserting helper that narrows `mixed` to `PersistentCollectionInterface`, and the baseline entry is removed.