### PR TITLE
Deprecate external write access to read-only metadata properties

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "docs": "composer update -d docs && ./docs/vendor/bin/build-docs.sh @additional_args"
     },
     "require": {
-        "php": "^8.4",
+        "php": "^8.1",
         "ext-mongodb": "^1.21 || ^2.0",
         "doctrine/collections": "^2.1 || ^3.1",
         "doctrine/event-manager": "^1.0 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "docs": "composer update -d docs && ./docs/vendor/bin/build-docs.sh @additional_args"
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.4",
         "ext-mongodb": "^1.21 || ^2.0",
         "doctrine/collections": "^2.1 || ^3.1",
         "doctrine/event-manager": "^1.0 || ^2.0",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -76,6 +76,8 @@
 
     <rule ref="Squiz.Classes.ClassFileName.NoMatch">
         <exclude-pattern>src/Tools/Console/Helper/DocumentManagerHelper.php</exclude-pattern>
+        <exclude-pattern>src/Mapping/ClassMetadataHookedPropertiesTrait.php</exclude-pattern>
+        <exclude-pattern>src/Mapping/ClassMetadataLegacyPropertiesTrait.php</exclude-pattern>
         <exclude-pattern>tests/*</exclude-pattern>
     </rule>
 

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -846,9 +846,9 @@ use const PHP_VERSION_ID;
     }
 
     /**
-     * READ-ONLY: Whether this class describes the mapping of a database view.
+     * Whether this class describes the mapping of a database view.
      */
-    private bool $isView = false;
+    public private(set) bool $isView = false;
 
     /**
      * READ-ONLY: Whether this class describes the mapping of a gridFS file
@@ -1112,7 +1112,7 @@ use const PHP_VERSION_ID;
      */
     public function invokeLifecycleCallbacks(string $event, object $document, ?array $arguments = null): void
     {
-        if ($this->isView()) {
+        if ($this->isView) {
             return;
         }
 
@@ -2366,8 +2366,11 @@ use const PHP_VERSION_ID;
         return $this->rootClass;
     }
 
+    /** @deprecated Use the isView property instead */
     public function isView(): bool
     {
+        trigger_deprecation('doctrine/mongodb-odm', '2.18', 'The %s::isView() method is deprecated and will be removed in version 3.0. Use the isView property instead.');
+
         return $this->isView;
     }
 

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -50,6 +50,7 @@ use function assert;
 use function class_exists;
 use function constant;
 use function count;
+use function debug_backtrace;
 use function enum_exists;
 use function extension_loaded;
 use function in_array;
@@ -63,6 +64,7 @@ use function strtolower;
 use function strtoupper;
 use function trigger_deprecation;
 
+use const DEBUG_BACKTRACE_IGNORE_ARGS;
 use const PHP_VERSION_ID;
 
 /**
@@ -496,54 +498,71 @@ use const PHP_VERSION_ID;
 
     private const ALLOWED_GRIDFS_FIELDS = ['_id', 'chunkSize', 'filename', 'length', 'metadata', 'uploadDate'];
 
+    // phpcs:disable SlevomatCodingStandard.Classes.PropertySpacing.IncorrectCountOfBlankLinesAfterProperty
+    // phpcs:disable PSR2.Classes.PropertyDeclaration.Multiple
+    // phpcs:disable PSR2.Classes.PropertyDeclaration.ScopeMissing
     /**
      * READ-ONLY: The name of the mongo database the document is mapped to.
      *
      * @var string|null
      */
-    public $db;
+    public $db {
+        set => $this->setPropertyValue('db', $value);
+    }
 
     /**
      * READ-ONLY: The name of the mongo collection the document is mapped to.
      *
      * @var string
      */
-    public $collection;
+    public $collection {
+        set => $this->setPropertyValue('collection', $value);
+    }
 
     /**
      * READ-ONLY: The name of the GridFS bucket the document is mapped to.
      *
      * @var string
      */
-    public $bucketName = 'fs';
+    public $bucketName = 'fs' {
+        set => $this->setPropertyValue('bucketName', $value);
+    }
 
     /**
      * READ-ONLY: If the collection should be a fixed size.
      *
      * @var bool
      */
-    public $collectionCapped = false;
+    public $collectionCapped = false {
+        set => $this->setPropertyValue('collectionCapped', $value);
+    }
 
     /**
      * READ-ONLY: If the collection is fixed size, its size in bytes.
      *
      * @var int|null
      */
-    public $collectionSize;
+    public $collectionSize {
+        set => $this->setPropertyValue('collectionSize', $value);
+    }
 
     /**
      * READ-ONLY: If the collection is fixed size, the maximum number of elements to store in the collection.
      *
      * @var int|null
      */
-    public $collectionMax;
+    public $collectionMax {
+        set => $this->setPropertyValue('collectionMax', $value);
+    }
 
     /**
      * READ-ONLY Describes how MongoDB clients route read operations to the members of a replica set.
      *
      * @var string|null
      */
-    public $readPreference;
+    public $readPreference {
+        set => $this->setPropertyValue('readPreference', $value);
+    }
 
     /**
      * READ-ONLY Associated with readPreference Allows to specify criteria so that your application can target read
@@ -551,21 +570,27 @@ use const PHP_VERSION_ID;
      *
      * @var array<array<string, string>>
      */
-    public $readPreferenceTags = [];
+    public $readPreferenceTags = [] {
+        set => $this->setPropertyValue('readPreferenceTags', $value);
+    }
 
     /**
      * READ-ONLY: Describes the level of acknowledgement requested from MongoDB for write operations.
      *
      * @var string|int|null
      */
-    public $writeConcern;
+    public $writeConcern {
+        set => $this->setPropertyValue('writeConcern', $value);
+    }
 
     /**
      * READ-ONLY: The field name of the document identifier.
      *
      * @var string|null
      */
-    public $identifier;
+    public $identifier {
+        set => $this->setPropertyValue('identifier', $value);
+    }
 
     /**
      * READ-ONLY: The array of indexes for the document collection.
@@ -588,19 +613,25 @@ use const PHP_VERSION_ID;
      * @var array<string, array>
      * @phpstan-var ShardKey
      */
-    public $shardKey = [];
+    public $shardKey = [] {
+        set => $this->setPropertyValue('shardKey', $value);
+    }
 
     /**
      * Allows users to specify a validation schema for the collection.
      *
      * @phpstan-var array<string, mixed>|object|null
      */
-    private array|object|null $validator = null;
+    private array|object|null $validator = null {
+        set => $this->setPropertyValue('validator', $value);
+    }
 
     /**
      * Determines whether to error on invalid documents or just warn about the violations but allow invalid documents to be inserted.
      */
-    private string $validationAction = self::SCHEMA_VALIDATION_ACTION_ERROR;
+    private string $validationAction = self::SCHEMA_VALIDATION_ACTION_ERROR {
+        set => $this->setPropertyValue('validationAction', $value);
+    }
 
     /**
      * Determines how strictly MongoDB applies the validation rules to existing documents during an update.
@@ -612,7 +643,9 @@ use const PHP_VERSION_ID;
      *
      * @var class-string<T>
      */
-    public $name;
+    public $name {
+        set => $this->setPropertyValue('name', $value);
+    }
 
     /**
      * READ-ONLY: The name of the document class that is at the root of the mapped document inheritance
@@ -621,7 +654,9 @@ use const PHP_VERSION_ID;
      *
      * @var class-string
      */
-    public $rootDocumentName;
+    public $rootDocumentName {
+        set => $this->setPropertyValue('rootDocumentName', $value);
+    }
 
     /**
      * The name of the custom repository class used for the document class.
@@ -629,14 +664,18 @@ use const PHP_VERSION_ID;
      *
      * @var class-string|null
      */
-    public $customRepositoryClassName;
+    public $customRepositoryClassName {
+        set => $this->setPropertyValue('customRepositoryClassName', $value);
+    }
 
     /**
      * READ-ONLY: The names of the parent classes (ancestors).
      *
      * @var list<class-string>
      */
-    public $parentClasses = [];
+    public $parentClasses = [] {
+        set => $this->setPropertyValue('parentClasses', $value);
+    }
 
     /**
      * READ-ONLY: The names of all subclasses (descendants).
@@ -662,14 +701,18 @@ use const PHP_VERSION_ID;
      *
      * @var int
      */
-    public $inheritanceType = self::INHERITANCE_TYPE_NONE;
+    public $inheritanceType = self::INHERITANCE_TYPE_NONE {
+        set => $this->setPropertyValue('inheritanceType', $value);
+    }
 
     /**
      * READ-ONLY: The Id generator type used by the class.
      *
      * @var int
      */
-    public $generatorType = self::GENERATOR_TYPE_AUTO;
+    public $generatorType = self::GENERATOR_TYPE_AUTO {
+        set => $this->setPropertyValue('generatorType', $value);
+    }
 
     /**
      * READ-ONLY: The Id generator options.
@@ -683,7 +726,9 @@ use const PHP_VERSION_ID;
      *
      * @var IdGenerator|null
      */
-    public $idGenerator;
+    public $idGenerator {
+        set => $this->setPropertyValue('idGenerator', $value);
+    }
 
     /**
      * READ-ONLY: The field mappings of the class.
@@ -736,7 +781,9 @@ use const PHP_VERSION_ID;
      *
      * @var class-string|null
      */
-    public $discriminatorValue;
+    public $discriminatorValue {
+        set => $this->setPropertyValue('discriminatorValue', $value);
+    }
 
     /**
      * READ-ONLY: The discriminator map of all mapped classes in the hierarchy.
@@ -756,7 +803,9 @@ use const PHP_VERSION_ID;
      *
      * @var string|null
      */
-    public $discriminatorField;
+    public $discriminatorField {
+        set => $this->setPropertyValue('discriminatorField', $value);
+    }
 
     /**
      * READ-ONLY: The default value for discriminatorField in case it's not set in the document
@@ -765,28 +814,36 @@ use const PHP_VERSION_ID;
      *
      * @var string|null
      */
-    public $defaultDiscriminatorValue;
+    public $defaultDiscriminatorValue {
+        set => $this->setPropertyValue('defaultDiscriminatorValue', $value);
+    }
 
     /**
      * READ-ONLY: Whether this class describes the mapping of a mapped superclass.
      *
      * @var bool
      */
-    public $isMappedSuperclass = false;
+    public $isMappedSuperclass = false {
+        set => $this->setPropertyValue('isMappedSuperclass', $value);
+    }
 
     /**
      * READ-ONLY: Whether this class describes the mapping of a embedded document.
      *
      * @var bool
      */
-    public $isEmbeddedDocument = false;
+    public $isEmbeddedDocument = false {
+        set => $this->setPropertyValue('isEmbeddedDocument', $value);
+    }
 
     /**
      * READ-ONLY: Whether this class describes the mapping of an aggregation result document.
      *
      * @var bool
      */
-    public $isQueryResultDocument = false;
+    public $isQueryResultDocument = false {
+        set => $this->setPropertyValue('isQueryResultDocument', $value);
+    }
 
     /**
      * READ-ONLY: Whether this class describes the mapping of a database view.
@@ -798,21 +855,27 @@ use const PHP_VERSION_ID;
      *
      * @var bool
      */
-    public $isFile = false;
+    public $isFile = false {
+        set => $this->setPropertyValue('isFile', $value);
+    }
 
     /**
      * READ-ONLY: The default chunk size in bytes for the file
      *
      * @var int|null
      */
-    public $chunkSizeBytes;
+    public $chunkSizeBytes {
+        set => $this->setPropertyValue('chunkSizeBytes', $value);
+    }
 
     /**
      * READ-ONLY: The policy used for change-tracking on entities of this class.
      *
      * @var int
      */
-    public $changeTrackingPolicy = self::CHANGETRACKING_DEFERRED_IMPLICIT;
+    public $changeTrackingPolicy = self::CHANGETRACKING_DEFERRED_IMPLICIT {
+        set => $this->setPropertyValue('changeTrackingPolicy', $value);
+    }
 
     /**
      * READ-ONLY: A flag for whether or not instances of this class are to be versioned
@@ -820,14 +883,18 @@ use const PHP_VERSION_ID;
      *
      * @var bool $isVersioned
      */
-    public $isVersioned = false;
+    public $isVersioned = false {
+        set => $this->setPropertyValue('isVersioned', $value);
+    }
 
     /**
      * READ-ONLY: The name of the field which is used for versioning in optimistic locking (if any).
      *
      * @var string|null $versionField
      */
-    public $versionField;
+    public $versionField {
+        set => $this->setPropertyValue('versionField', $value);
+    }
 
     /**
      * READ-ONLY: A flag for whether or not instances of this class are to allow pessimistic
@@ -835,36 +902,49 @@ use const PHP_VERSION_ID;
      *
      * @var bool $isLockable
      */
-    public $isLockable = false;
+    public $isLockable = false {
+        set => $this->setPropertyValue('isLockable', $value);
+    }
 
     /**
      * READ-ONLY: The name of the field which is used for locking a document.
      *
      * @var mixed $lockField
      */
-    public $lockField;
+    public $lockField {
+        set => $this->setPropertyValue('lockField', $value);
+    }
 
     /**
      * The ReflectionClass instance of the mapped class.
      *
      * @var ReflectionClass<T>
      */
-    public $reflClass;
+    public $reflClass {
+        set => $this->setPropertyValue('reflClass', $value);
+    }
 
     /**
      * READ_ONLY: A flag for whether or not this document is read-only.
      *
      * @var bool
      */
-    public $isReadOnly;
+    public $isReadOnly {
+        set => $this->setPropertyValue('isReadOnly', $value);
+    }
 
     /**
      * READ-ONLY: A flag for whether or not this document has encrypted fields.
      */
-    public bool $isEncrypted = false;
+    public bool $isEncrypted = false {
+        set => $this->setPropertyValue('isEncrypted', $value);
+    }
 
     /** READ ONLY: stores metadata about the time series collection */
-    public ?TimeSeries $timeSeriesOptions = null;
+    public ?TimeSeries $timeSeriesOptions = null {
+        set => $this->setPropertyValue('timeSeriesOptions', $value);
+    }
+    // phpcs:enable
 
     private InstantiatorInterface $instantiator;
 
@@ -2972,5 +3052,22 @@ use const PHP_VERSION_ID;
         if ($options->metaField !== null && ! $this->hasField($options->metaField)) {
             throw MappingException::timeSeriesFieldNotFound($this->name, $options->metaField, 'metadata');
         }
+    }
+
+    /**
+     * @param ValueType $value
+     *
+     * @return ValueType
+     *
+     * @template ValueType
+     */
+    private function setPropertyValue(string $property, mixed $value): mixed
+    {
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+        if ($backtrace[1]['file'] !== __FILE__) {
+            trigger_deprecation('doctrine/mongodb-odm', '2.18', 'Writing to property %s::%s is deprecated and will be removed in version 3.0.', static::class, $property);
+        }
+
+        return $value;
     }
 }

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -304,6 +304,7 @@ if (PHP_VERSION_ID >= 80400) {
  */
 /* final */ class ClassMetadata implements BaseClassMetadata
 {
+    /** @template-use ClassMetadataPropertiesTrait<T> */
     use ClassMetadataPropertiesTrait;
 
     /* The Id generator types. */

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -2369,7 +2369,7 @@ use const PHP_VERSION_ID;
     /** @deprecated Use the isView property instead */
     public function isView(): bool
     {
-        trigger_deprecation('doctrine/mongodb-odm', '2.18', 'The %s::isView() method is deprecated and will be removed in version 3.0. Use the isView property instead.');
+        trigger_deprecation('doctrine/mongodb-odm', '2.17', 'The %s::isView() method is deprecated and will be removed in version 3.0. Use the isView property instead.');
 
         return $this->isView;
     }
@@ -3068,7 +3068,7 @@ use const PHP_VERSION_ID;
     {
         $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
         if ($backtrace[1]['file'] !== __FILE__) {
-            trigger_deprecation('doctrine/mongodb-odm', '2.18', 'Writing to property %s::%s is deprecated and will be removed in version 3.0.', static::class, $property);
+            trigger_deprecation('doctrine/mongodb-odm', '2.17', 'Writing to property %s::%s is deprecated and will be removed in version 3.0.', static::class, $property);
         }
 
         return $value;

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -67,6 +67,12 @@ use function trigger_deprecation;
 use const DEBUG_BACKTRACE_IGNORE_ARGS;
 use const PHP_VERSION_ID;
 
+if (PHP_VERSION_ID >= 80400) {
+    require_once __DIR__ . '/ClassMetadataHookedPropertiesTrait.php';
+} else {
+    require_once __DIR__ . '/ClassMetadataLegacyPropertiesTrait.php';
+}
+
 /**
  * A <tt>ClassMetadata</tt> instance holds all the object-document mapping metadata
  * of a document and it's references.
@@ -298,6 +304,8 @@ use const PHP_VERSION_ID;
  */
 /* final */ class ClassMetadata implements BaseClassMetadata
 {
+    use ClassMetadataPropertiesTrait;
+
     /* The Id generator types. */
     /**
      * AUTO means Doctrine will automatically create a new \MongoDB\BSON\ObjectId instance for us.
@@ -498,100 +506,6 @@ use const PHP_VERSION_ID;
 
     private const ALLOWED_GRIDFS_FIELDS = ['_id', 'chunkSize', 'filename', 'length', 'metadata', 'uploadDate'];
 
-    // phpcs:disable SlevomatCodingStandard.Classes.PropertySpacing.IncorrectCountOfBlankLinesAfterProperty
-    // phpcs:disable PSR2.Classes.PropertyDeclaration.Multiple
-    // phpcs:disable PSR2.Classes.PropertyDeclaration.ScopeMissing
-    /**
-     * READ-ONLY: The name of the mongo database the document is mapped to.
-     *
-     * @var string|null
-     */
-    public $db {
-        set => $this->setPropertyValue('db', $value);
-    }
-
-    /**
-     * READ-ONLY: The name of the mongo collection the document is mapped to.
-     *
-     * @var string
-     */
-    public $collection {
-        set => $this->setPropertyValue('collection', $value);
-    }
-
-    /**
-     * READ-ONLY: The name of the GridFS bucket the document is mapped to.
-     *
-     * @var string
-     */
-    public $bucketName = 'fs' {
-        set => $this->setPropertyValue('bucketName', $value);
-    }
-
-    /**
-     * READ-ONLY: If the collection should be a fixed size.
-     *
-     * @var bool
-     */
-    public $collectionCapped = false {
-        set => $this->setPropertyValue('collectionCapped', $value);
-    }
-
-    /**
-     * READ-ONLY: If the collection is fixed size, its size in bytes.
-     *
-     * @var int|null
-     */
-    public $collectionSize {
-        set => $this->setPropertyValue('collectionSize', $value);
-    }
-
-    /**
-     * READ-ONLY: If the collection is fixed size, the maximum number of elements to store in the collection.
-     *
-     * @var int|null
-     */
-    public $collectionMax {
-        set => $this->setPropertyValue('collectionMax', $value);
-    }
-
-    /**
-     * READ-ONLY Describes how MongoDB clients route read operations to the members of a replica set.
-     *
-     * @var string|null
-     */
-    public $readPreference {
-        set => $this->setPropertyValue('readPreference', $value);
-    }
-
-    /**
-     * READ-ONLY Associated with readPreference Allows to specify criteria so that your application can target read
-     * operations to specific members, based on custom parameters.
-     *
-     * @var array<array<string, string>>
-     */
-    public $readPreferenceTags = [] {
-        set => $this->setPropertyValue('readPreferenceTags', $value);
-    }
-
-    /**
-     * READ-ONLY: Describes the level of acknowledgement requested from MongoDB for write operations.
-     *
-     * @var string|int|null
-     */
-    public $writeConcern {
-        set => $this->setPropertyValue('writeConcern', $value);
-    }
-
-    /**
-     * READ-ONLY: The field name of the document identifier.
-     *
-     * @var string|null
-     */
-    public $identifier {
-        set => $this->setPropertyValue('identifier', $value);
-    }
-
     /**
      * READ-ONLY: The array of indexes for the document collection.
      *
@@ -608,74 +522,9 @@ use const PHP_VERSION_ID;
     public $searchIndexes = [];
 
     /**
-     * READ-ONLY: Keys and options describing shard key. Only for sharded collections.
-     *
-     * @var array<string, array>
-     * @phpstan-var ShardKey
-     */
-    public $shardKey = [] {
-        set => $this->setPropertyValue('shardKey', $value);
-    }
-
-    /**
-     * Allows users to specify a validation schema for the collection.
-     *
-     * @phpstan-var array<string, mixed>|object|null
-     */
-    private array|object|null $validator = null {
-        set => $this->setPropertyValue('validator', $value);
-    }
-
-    /**
-     * Determines whether to error on invalid documents or just warn about the violations but allow invalid documents to be inserted.
-     */
-    private string $validationAction = self::SCHEMA_VALIDATION_ACTION_ERROR {
-        set => $this->setPropertyValue('validationAction', $value);
-    }
-
-    /**
      * Determines how strictly MongoDB applies the validation rules to existing documents during an update.
      */
     private string $validationLevel = self::SCHEMA_VALIDATION_LEVEL_STRICT;
-
-    /**
-     * READ-ONLY: The name of the document class.
-     *
-     * @var class-string<T>
-     */
-    public $name {
-        set => $this->setPropertyValue('name', $value);
-    }
-
-    /**
-     * READ-ONLY: The name of the document class that is at the root of the mapped document inheritance
-     * hierarchy. If the document is not part of a mapped inheritance hierarchy this is the same
-     * as {@link $documentName}.
-     *
-     * @var class-string
-     */
-    public $rootDocumentName {
-        set => $this->setPropertyValue('rootDocumentName', $value);
-    }
-
-    /**
-     * The name of the custom repository class used for the document class.
-     * (Optional).
-     *
-     * @var class-string|null
-     */
-    public $customRepositoryClassName {
-        set => $this->setPropertyValue('customRepositoryClassName', $value);
-    }
-
-    /**
-     * READ-ONLY: The names of the parent classes (ancestors).
-     *
-     * @var list<class-string>
-     */
-    public $parentClasses = [] {
-        set => $this->setPropertyValue('parentClasses', $value);
-    }
 
     /**
      * READ-ONLY: The names of all subclasses (descendants).
@@ -697,38 +546,11 @@ use const PHP_VERSION_ID;
     public array $propertyAccessors = [];
 
     /**
-     * READ-ONLY: The inheritance mapping type used by the class.
-     *
-     * @var int
-     */
-    public $inheritanceType = self::INHERITANCE_TYPE_NONE {
-        set => $this->setPropertyValue('inheritanceType', $value);
-    }
-
-    /**
-     * READ-ONLY: The Id generator type used by the class.
-     *
-     * @var int
-     */
-    public $generatorType = self::GENERATOR_TYPE_AUTO {
-        set => $this->setPropertyValue('generatorType', $value);
-    }
-
-    /**
      * READ-ONLY: The Id generator options.
      *
      * @var array<string, mixed>
      */
     public $generatorOptions = [];
-
-    /**
-     * READ-ONLY: The ID generator used for generating IDs for this class.
-     *
-     * @var IdGenerator|null
-     */
-    public $idGenerator {
-        set => $this->setPropertyValue('idGenerator', $value);
-    }
 
     /**
      * READ-ONLY: The field mappings of the class.
@@ -772,20 +594,6 @@ use const PHP_VERSION_ID;
     public $lifecycleCallbacks = [];
 
     /**
-     * READ-ONLY: The discriminator value of this class.
-     *
-     * <b>This does only apply to the JOINED and SINGLE_COLLECTION inheritance mapping strategies
-     * where a discriminator field is used.</b>
-     *
-     * @see discriminatorField
-     *
-     * @var class-string|null
-     */
-    public $discriminatorValue {
-        set => $this->setPropertyValue('discriminatorValue', $value);
-    }
-
-    /**
      * READ-ONLY: The discriminator map of all mapped classes in the hierarchy.
      *
      * <b>This does only apply to the SINGLE_COLLECTION inheritance mapping strategy
@@ -796,155 +604,6 @@ use const PHP_VERSION_ID;
      * @var array<string, class-string>
      */
     public $discriminatorMap = [];
-
-    /**
-     * READ-ONLY: The definition of the discriminator field used in SINGLE_COLLECTION
-     * inheritance mapping.
-     *
-     * @var string|null
-     */
-    public $discriminatorField {
-        set => $this->setPropertyValue('discriminatorField', $value);
-    }
-
-    /**
-     * READ-ONLY: The default value for discriminatorField in case it's not set in the document
-     *
-     * @see discriminatorField
-     *
-     * @var string|null
-     */
-    public $defaultDiscriminatorValue {
-        set => $this->setPropertyValue('defaultDiscriminatorValue', $value);
-    }
-
-    /**
-     * READ-ONLY: Whether this class describes the mapping of a mapped superclass.
-     *
-     * @var bool
-     */
-    public $isMappedSuperclass = false {
-        set => $this->setPropertyValue('isMappedSuperclass', $value);
-    }
-
-    /**
-     * READ-ONLY: Whether this class describes the mapping of a embedded document.
-     *
-     * @var bool
-     */
-    public $isEmbeddedDocument = false {
-        set => $this->setPropertyValue('isEmbeddedDocument', $value);
-    }
-
-    /**
-     * READ-ONLY: Whether this class describes the mapping of an aggregation result document.
-     *
-     * @var bool
-     */
-    public $isQueryResultDocument = false {
-        set => $this->setPropertyValue('isQueryResultDocument', $value);
-    }
-
-    /**
-     * Whether this class describes the mapping of a database view.
-     */
-    public private(set) bool $isView = false;
-
-    /**
-     * READ-ONLY: Whether this class describes the mapping of a gridFS file
-     *
-     * @var bool
-     */
-    public $isFile = false {
-        set => $this->setPropertyValue('isFile', $value);
-    }
-
-    /**
-     * READ-ONLY: The default chunk size in bytes for the file
-     *
-     * @var int|null
-     */
-    public $chunkSizeBytes {
-        set => $this->setPropertyValue('chunkSizeBytes', $value);
-    }
-
-    /**
-     * READ-ONLY: The policy used for change-tracking on entities of this class.
-     *
-     * @var int
-     */
-    public $changeTrackingPolicy = self::CHANGETRACKING_DEFERRED_IMPLICIT {
-        set => $this->setPropertyValue('changeTrackingPolicy', $value);
-    }
-
-    /**
-     * READ-ONLY: A flag for whether or not instances of this class are to be versioned
-     * with optimistic locking.
-     *
-     * @var bool $isVersioned
-     */
-    public $isVersioned = false {
-        set => $this->setPropertyValue('isVersioned', $value);
-    }
-
-    /**
-     * READ-ONLY: The name of the field which is used for versioning in optimistic locking (if any).
-     *
-     * @var string|null $versionField
-     */
-    public $versionField {
-        set => $this->setPropertyValue('versionField', $value);
-    }
-
-    /**
-     * READ-ONLY: A flag for whether or not instances of this class are to allow pessimistic
-     * locking.
-     *
-     * @var bool $isLockable
-     */
-    public $isLockable = false {
-        set => $this->setPropertyValue('isLockable', $value);
-    }
-
-    /**
-     * READ-ONLY: The name of the field which is used for locking a document.
-     *
-     * @var mixed $lockField
-     */
-    public $lockField {
-        set => $this->setPropertyValue('lockField', $value);
-    }
-
-    /**
-     * The ReflectionClass instance of the mapped class.
-     *
-     * @var ReflectionClass<T>
-     */
-    public $reflClass {
-        set => $this->setPropertyValue('reflClass', $value);
-    }
-
-    /**
-     * READ_ONLY: A flag for whether or not this document is read-only.
-     *
-     * @var bool
-     */
-    public $isReadOnly {
-        set => $this->setPropertyValue('isReadOnly', $value);
-    }
-
-    /**
-     * READ-ONLY: A flag for whether or not this document has encrypted fields.
-     */
-    public bool $isEncrypted = false {
-        set => $this->setPropertyValue('isEncrypted', $value);
-    }
-
-    /** READ ONLY: stores metadata about the time series collection */
-    public ?TimeSeries $timeSeriesOptions = null {
-        set => $this->setPropertyValue('timeSeriesOptions', $value);
-    }
-    // phpcs:enable
 
     private InstantiatorInterface $instantiator;
 
@@ -2369,7 +2028,9 @@ use const PHP_VERSION_ID;
     /** @deprecated Use the isView property instead */
     public function isView(): bool
     {
-        trigger_deprecation('doctrine/mongodb-odm', '2.17', 'The %s::isView() method is deprecated and will be removed in version 3.0. Use the isView property instead.');
+        if (PHP_VERSION_ID >= 80400) {
+            trigger_deprecation('doctrine/mongodb-odm', '2.17', 'The %s::isView() method is deprecated and will be removed in version 3.0. Use the isView property instead.');
+        }
 
         return $this->isView;
     }

--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -140,7 +140,7 @@ final class ClassMetadataFactory extends AbstractClassMetadataFactory implements
     {
         assert($class instanceof ClassMetadata);
 
-        return ! $class->isMappedSuperclass && ! $class->isEmbeddedDocument && ! $class->isQueryResultDocument && ! $class->isView();
+        return ! $class->isMappedSuperclass && ! $class->isEmbeddedDocument && ! $class->isQueryResultDocument && ! $class->isView;
     }
 
     /** @param bool $rootEntityFound */

--- a/src/Mapping/ClassMetadataHookedPropertiesTrait.php
+++ b/src/Mapping/ClassMetadataHookedPropertiesTrait.php
@@ -8,7 +8,12 @@ use Doctrine\ODM\MongoDB\Id\IdGenerator;
 use Doctrine\ODM\MongoDB\Mapping\Attribute\TimeSeries;
 use ReflectionClass;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @template-covariant T of object
+ * @phpstan-import-type ShardKey from ClassMetadata
+ */
 trait ClassMetadataPropertiesTrait
 {
     // phpcs:disable SlevomatCodingStandard.Classes.PropertySpacing.IncorrectCountOfBlankLinesAfterProperty

--- a/src/Mapping/ClassMetadataHookedPropertiesTrait.php
+++ b/src/Mapping/ClassMetadataHookedPropertiesTrait.php
@@ -8,6 +8,7 @@ use Doctrine\ODM\MongoDB\Id\IdGenerator;
 use Doctrine\ODM\MongoDB\Mapping\Attribute\TimeSeries;
 use ReflectionClass;
 
+/** @internal */
 trait ClassMetadataPropertiesTrait
 {
     // phpcs:disable SlevomatCodingStandard.Classes.PropertySpacing.IncorrectCountOfBlankLinesAfterProperty

--- a/src/Mapping/ClassMetadataHookedPropertiesTrait.php
+++ b/src/Mapping/ClassMetadataHookedPropertiesTrait.php
@@ -1,0 +1,370 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Mapping;
+
+use Doctrine\ODM\MongoDB\Id\IdGenerator;
+use Doctrine\ODM\MongoDB\Mapping\Attribute\TimeSeries;
+use ReflectionClass;
+
+trait ClassMetadataPropertiesTrait
+{
+    // phpcs:disable SlevomatCodingStandard.Classes.PropertySpacing.IncorrectCountOfBlankLinesAfterProperty
+    // phpcs:disable PSR2.Classes.PropertyDeclaration.Multiple
+    // phpcs:disable PSR2.Classes.PropertyDeclaration.ScopeMissing
+    /**
+     * READ-ONLY: The name of the mongo database the document is mapped to.
+     *
+     * @var string|null
+     */
+    public $db {
+        set => $this->setPropertyValue('db', $value);
+    }
+
+    /**
+     * READ-ONLY: The name of the mongo collection the document is mapped to.
+     *
+     * @var string
+     */
+    public $collection {
+        set => $this->setPropertyValue('collection', $value);
+    }
+
+    /**
+     * READ-ONLY: The name of the GridFS bucket the document is mapped to.
+     *
+     * @var string
+     */
+    public $bucketName = 'fs' {
+        set => $this->setPropertyValue('bucketName', $value);
+    }
+
+    /**
+     * READ-ONLY: If the collection should be a fixed size.
+     *
+     * @var bool
+     */
+    public $collectionCapped = false {
+        set => $this->setPropertyValue('collectionCapped', $value);
+    }
+
+    /**
+     * READ-ONLY: If the collection is fixed size, its size in bytes.
+     *
+     * @var int|null
+     */
+    public $collectionSize {
+        set => $this->setPropertyValue('collectionSize', $value);
+    }
+
+    /**
+     * READ-ONLY: If the collection is fixed size, the maximum number of elements to store in the collection.
+     *
+     * @var int|null
+     */
+    public $collectionMax {
+        set => $this->setPropertyValue('collectionMax', $value);
+    }
+
+    /**
+     * READ-ONLY Describes how MongoDB clients route read operations to the members of a replica set.
+     *
+     * @var string|null
+     */
+    public $readPreference {
+        set => $this->setPropertyValue('readPreference', $value);
+    }
+
+    /**
+     * READ-ONLY Associated with readPreference Allows to specify criteria so that your application can target read
+     * operations to specific members, based on custom parameters.
+     *
+     * @var array<array<string, string>>
+     */
+    public $readPreferenceTags = [] {
+        set => $this->setPropertyValue('readPreferenceTags', $value);
+    }
+
+    /**
+     * READ-ONLY: Describes the level of acknowledgement requested from MongoDB for write operations.
+     *
+     * @var string|int|null
+     */
+    public $writeConcern {
+        set => $this->setPropertyValue('writeConcern', $value);
+    }
+
+    /**
+     * READ-ONLY: The field name of the document identifier.
+     *
+     * @var string|null
+     */
+    public $identifier {
+        set => $this->setPropertyValue('identifier', $value);
+    }
+
+    /**
+     * READ-ONLY: Keys and options describing shard key. Only for sharded collections.
+     *
+     * @var array<string, array>
+     * @phpstan-var ShardKey
+     */
+    public $shardKey = [] {
+        set => $this->setPropertyValue('shardKey', $value);
+    }
+
+    /**
+     * Allows users to specify a validation schema for the collection.
+     *
+     * @phpstan-var array<string, mixed>|object|null
+     */
+    private array|object|null $validator = null {
+        set => $this->setPropertyValue('validator', $value);
+    }
+
+    /**
+     * Determines whether to error on invalid documents or just warn about the violations but allow invalid documents to be inserted.
+     */
+    private string $validationAction = self::SCHEMA_VALIDATION_ACTION_ERROR {
+        set => $this->setPropertyValue('validationAction', $value);
+    }
+
+    /**
+     * READ-ONLY: The name of the document class.
+     *
+     * @var class-string<T>
+     */
+    public $name {
+        set => $this->setPropertyValue('name', $value);
+    }
+
+    /**
+     * READ-ONLY: The name of the document class that is at the root of the mapped document inheritance
+     * hierarchy. If the document is not part of a mapped inheritance hierarchy this is the same
+     * as {@link $documentName}.
+     *
+     * @var class-string
+     */
+    public $rootDocumentName {
+        set => $this->setPropertyValue('rootDocumentName', $value);
+    }
+
+    /**
+     * The name of the custom repository class used for the document class.
+     * (Optional).
+     *
+     * @var class-string|null
+     */
+    public $customRepositoryClassName {
+        set => $this->setPropertyValue('customRepositoryClassName', $value);
+    }
+
+    /**
+     * READ-ONLY: The names of the parent classes (ancestors).
+     *
+     * @var list<class-string>
+     */
+    public $parentClasses = [] {
+        set => $this->setPropertyValue('parentClasses', $value);
+    }
+
+    /**
+     * READ-ONLY: The inheritance mapping type used by the class.
+     *
+     * @var int
+     */
+    public $inheritanceType = self::INHERITANCE_TYPE_NONE {
+        set => $this->setPropertyValue('inheritanceType', $value);
+    }
+
+    /**
+     * READ-ONLY: The Id generator type used by the class.
+     *
+     * @var int
+     */
+    public $generatorType = self::GENERATOR_TYPE_AUTO {
+        set => $this->setPropertyValue('generatorType', $value);
+    }
+
+    /**
+     * READ-ONLY: The ID generator used for generating IDs for this class.
+     *
+     * @var IdGenerator|null
+     */
+    public $idGenerator {
+        set => $this->setPropertyValue('idGenerator', $value);
+    }
+
+    /**
+     * READ-ONLY: The discriminator value of this class.
+     *
+     * <b>This does only apply to the JOINED and SINGLE_COLLECTION inheritance mapping strategies
+     * where a discriminator field is used.</b>
+     *
+     * @see discriminatorField
+     *
+     * @var class-string|null
+     */
+    public $discriminatorValue {
+        set => $this->setPropertyValue('discriminatorValue', $value);
+    }
+
+    /**
+     * READ-ONLY: The definition of the discriminator field used in SINGLE_COLLECTION
+     * inheritance mapping.
+     *
+     * @var string|null
+     */
+    public $discriminatorField {
+        set => $this->setPropertyValue('discriminatorField', $value);
+    }
+
+    /**
+     * READ-ONLY: The default value for discriminatorField in case it's not set in the document
+     *
+     * @see discriminatorField
+     *
+     * @var string|null
+     */
+    public $defaultDiscriminatorValue {
+        set => $this->setPropertyValue('defaultDiscriminatorValue', $value);
+    }
+
+    /**
+     * READ-ONLY: Whether this class describes the mapping of a mapped superclass.
+     *
+     * @var bool
+     */
+    public $isMappedSuperclass = false {
+        set => $this->setPropertyValue('isMappedSuperclass', $value);
+    }
+
+    /**
+     * READ-ONLY: Whether this class describes the mapping of a embedded document.
+     *
+     * @var bool
+     */
+    public $isEmbeddedDocument = false {
+        set => $this->setPropertyValue('isEmbeddedDocument', $value);
+    }
+
+    /**
+     * READ-ONLY: Whether this class describes the mapping of an aggregation result document.
+     *
+     * @var bool
+     */
+    public $isQueryResultDocument = false {
+        set => $this->setPropertyValue('isQueryResultDocument', $value);
+    }
+
+    /**
+     * Whether this class describes the mapping of a database view.
+     */
+    public private(set) bool $isView = false;
+
+    /**
+     * READ-ONLY: Whether this class describes the mapping of a gridFS file
+     *
+     * @var bool
+     */
+    public $isFile = false {
+        set => $this->setPropertyValue('isFile', $value);
+    }
+
+    /**
+     * READ-ONLY: The default chunk size in bytes for the file
+     *
+     * @var int|null
+     */
+    public $chunkSizeBytes {
+        set => $this->setPropertyValue('chunkSizeBytes', $value);
+    }
+
+    /**
+     * READ-ONLY: The policy used for change-tracking on entities of this class.
+     *
+     * @var int
+     */
+    public $changeTrackingPolicy = self::CHANGETRACKING_DEFERRED_IMPLICIT {
+        set => $this->setPropertyValue('changeTrackingPolicy', $value);
+    }
+
+    /**
+     * READ-ONLY: A flag for whether or not instances of this class are to be versioned
+     * with optimistic locking.
+     *
+     * @var bool $isVersioned
+     */
+    public $isVersioned = false {
+        set => $this->setPropertyValue('isVersioned', $value);
+    }
+
+    /**
+     * READ-ONLY: The name of the field which is used for versioning in optimistic locking (if any).
+     *
+     * @var string|null $versionField
+     */
+    public $versionField {
+        set => $this->setPropertyValue('versionField', $value);
+    }
+
+    /**
+     * READ-ONLY: A flag for whether or not instances of this class are to allow pessimistic
+     * locking.
+     *
+     * @var bool $isLockable
+     */
+    public $isLockable = false {
+        set => $this->setPropertyValue('isLockable', $value);
+    }
+
+    /**
+     * READ-ONLY: The name of the field which is used for locking a document.
+     *
+     * @var mixed $lockField
+     */
+    public $lockField {
+        set => $this->setPropertyValue('lockField', $value);
+    }
+
+    /**
+     * The ReflectionClass instance of the mapped class.
+     *
+     * @var ReflectionClass<T>
+     */
+    public $reflClass {
+        set => $this->setPropertyValue('reflClass', $value);
+    }
+
+    /**
+     * READ_ONLY: A flag for whether or not this document is read-only.
+     *
+     * @var bool
+     */
+    public $isReadOnly {
+        set => $this->setPropertyValue('isReadOnly', $value);
+    }
+
+    /**
+     * READ-ONLY: A flag for whether or not this document has encrypted fields.
+     */
+    public bool $isEncrypted = false {
+        set => $this->setPropertyValue('isEncrypted', $value);
+    }
+
+    /** READ ONLY: stores metadata about the time series collection */
+    public ?TimeSeries $timeSeriesOptions = null {
+        set => $this->setPropertyValue('timeSeriesOptions', $value);
+    }
+    // phpcs:enable
+
+    /**
+     * @param ValueType $value
+     *
+     * @return ValueType
+     *
+     * @template ValueType
+     */
+    abstract private function setPropertyValue(string $property, mixed $value): mixed;
+}

--- a/src/Mapping/ClassMetadataLegacyPropertiesTrait.php
+++ b/src/Mapping/ClassMetadataLegacyPropertiesTrait.php
@@ -8,7 +8,12 @@ use Doctrine\ODM\MongoDB\Id\IdGenerator;
 use Doctrine\ODM\MongoDB\Mapping\Attribute\TimeSeries;
 use ReflectionClass;
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @template-covariant T of object
+ * @phpstan-import-type ShardKey from ClassMetadata
+ */
 trait ClassMetadataPropertiesTrait
 {
     /**

--- a/src/Mapping/ClassMetadataLegacyPropertiesTrait.php
+++ b/src/Mapping/ClassMetadataLegacyPropertiesTrait.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Mapping;
+
+use Doctrine\ODM\MongoDB\Id\IdGenerator;
+use Doctrine\ODM\MongoDB\Mapping\Attribute\TimeSeries;
+use ReflectionClass;
+
+trait ClassMetadataPropertiesTrait
+{
+    /**
+     * READ-ONLY: The name of the mongo database the document is mapped to.
+     *
+     * @var string|null
+     */
+    public $db;
+
+    /**
+     * READ-ONLY: The name of the mongo collection the document is mapped to.
+     *
+     * @var string
+     */
+    public $collection;
+
+    /**
+     * READ-ONLY: The name of the GridFS bucket the document is mapped to.
+     *
+     * @var string
+     */
+    public $bucketName;
+
+    /**
+     * READ-ONLY: If the collection should be a fixed size.
+     *
+     * @var bool
+     */
+    public $collectionCapped = false;
+
+    /**
+     * READ-ONLY: If the collection is fixed size, its size in bytes.
+     *
+     * @var int|null
+     */
+    public $collectionSize;
+
+    /**
+     * READ-ONLY: If the collection is fixed size, the maximum number of elements to store in the collection.
+     *
+     * @var int|null
+     */
+    public $collectionMax;
+
+    /**
+     * READ-ONLY Describes how MongoDB clients route read operations to the members of a replica set.
+     *
+     * @var string|null
+     */
+    public $readPreference;
+
+    /**
+     * READ-ONLY Associated with readPreference Allows to specify criteria so that your application can target read
+     * operations to specific members, based on custom parameters.
+     *
+     * @var array<array<string, string>>
+     */
+    public $readPreferenceTags = [];
+
+    /**
+     * READ-ONLY: Describes the level of acknowledgement requested from MongoDB for write operations.
+     *
+     * @var string|int|null
+     */
+    public $writeConcern;
+
+    /**
+     * READ-ONLY: The field name of the document identifier.
+     *
+     * @var string|null
+     */
+    public $identifier;
+
+    /**
+     * READ-ONLY: Keys and options describing shard key. Only for sharded collections.
+     *
+     * @var array<string, array>
+     * @phpstan-var ShardKey
+     */
+    public $shardKey = [];
+
+    /**
+     * Allows users to specify a validation schema for the collection.
+     *
+     * @phpstan-var array<string, mixed>|object|null
+     */
+    private array|object|null $validator = null;
+
+    /**
+     * Determines whether to error on invalid documents or just warn about the violations but allow invalid documents to be inserted.
+     */
+    private string $validationAction = self::SCHEMA_VALIDATION_ACTION_ERROR;
+
+    /**
+     * READ-ONLY: The name of the document class.
+     *
+     * @var class-string<T>
+     */
+    public $name;
+
+    /**
+     * READ-ONLY: The name of the document class that is at the root of the mapped document inheritance
+     * hierarchy. If the document is not part of a mapped inheritance hierarchy this is the same
+     * as {@link $documentName}.
+     *
+     * @var class-string
+     */
+    public $rootDocumentName;
+
+    /**
+     * The name of the custom repository class used for the document class.
+     * (Optional).
+     *
+     * @var class-string|null
+     */
+    public $customRepositoryClassName;
+
+    /**
+     * READ-ONLY: The names of the parent classes (ancestors).
+     *
+     * @var list<class-string>
+     */
+    public $parentClasses = [];
+
+    /**
+     * READ-ONLY: The inheritance mapping type used by the class.
+     *
+     * @var int
+     */
+    public $inheritanceType = self::INHERITANCE_TYPE_NONE;
+
+    /**
+     * READ-ONLY: The Id generator type used by the class.
+     *
+     * @var int
+     */
+    public $generatorType = self::GENERATOR_TYPE_AUTO;
+
+    /**
+     * READ-ONLY: The ID generator used for generating IDs for this class.
+     *
+     * @var IdGenerator|null
+     */
+    public $idGenerator;
+
+    /**
+     * READ-ONLY: The discriminator value of this class.
+     *
+     * <b>This does only apply to the JOINED and SINGLE_COLLECTION inheritance mapping strategies
+     * where a discriminator field is used.</b>
+     *
+     * @see discriminatorField
+     *
+     * @var class-string|null
+     */
+    public $discriminatorValue;
+
+    /**
+     * READ-ONLY: The definition of the discriminator field used in SINGLE_COLLECTION
+     * inheritance mapping.
+     *
+     * @var string|null
+     */
+    public $discriminatorField;
+
+    /**
+     * READ-ONLY: The default value for discriminatorField in case it's not set in the document
+     *
+     * @see discriminatorField
+     *
+     * @var string|null
+     */
+    public $defaultDiscriminatorValue;
+
+    /**
+     * READ-ONLY: Whether this class describes the mapping of a mapped superclass.
+     *
+     * @var bool
+     */
+    public $isMappedSuperclass = false;
+
+    /**
+     * READ-ONLY: Whether this class describes the mapping of a embedded document.
+     *
+     * @var bool
+     */
+    public $isEmbeddedDocument = false;
+
+    /**
+     * READ-ONLY: Whether this class describes the mapping of an aggregation result document.
+     *
+     * @var bool
+     */
+    public $isQueryResultDocument = false;
+
+    /**
+     * READ-ONLY: Whether this class describes the mapping of a gridFS file
+     *
+     * @var bool
+     */
+    public $isFile = false;
+
+    /**
+     * READ-ONLY: Whether this class describes the mapping of a database view.
+     */
+    public bool $isView = false;
+
+    /**
+     * READ-ONLY: The default chunk size in bytes for the file
+     *
+     * @var int|null
+     */
+    public $chunkSizeBytes;
+
+    /**
+     * READ-ONLY: The policy used for change-tracking on entities of this class.
+     *
+     * @var int
+     */
+    public $changeTrackingPolicy = self::CHANGETRACKING_DEFERRED_IMPLICIT;
+
+    /**
+     * READ-ONLY: A flag for whether or not instances of this class are to be versioned
+     * with optimistic locking.
+     *
+     * @var bool $isVersioned
+     */
+    public $isVersioned = false;
+
+    /**
+     * READ-ONLY: The name of the field which is used for versioning in optimistic locking (if any).
+     *
+     * @var string|null $versionField
+     */
+    public $versionField;
+
+    /**
+     * READ-ONLY: A flag for whether or not instances of this class are to allow pessimistic
+     * locking.
+     *
+     * @var bool $isLockable
+     */
+    public $isLockable = false;
+
+    /**
+     * READ-ONLY: The name of the field which is used for locking a document.
+     *
+     * @var mixed $lockField
+     */
+    public $lockField;
+
+    /**
+     * The ReflectionClass instance of the mapped class.
+     *
+     * @var ReflectionClass<T>
+     */
+    public $reflClass;
+
+    /**
+     * READ_ONLY: A flag for whether or not this document is read-only.
+     *
+     * @var bool
+     */
+    public $isReadOnly;
+
+    /**
+     * READ-ONLY: A flag for whether or not this document has encrypted fields.
+     */
+    public bool $isEncrypted = false;
+
+    /** READ ONLY: stores metadata about the time series collection */
+    public ?TimeSeries $timeSeriesOptions = null;
+}

--- a/src/Mapping/ClassMetadataLegacyPropertiesTrait.php
+++ b/src/Mapping/ClassMetadataLegacyPropertiesTrait.php
@@ -30,7 +30,7 @@ trait ClassMetadataPropertiesTrait
      *
      * @var string
      */
-    public $bucketName;
+    public $bucketName = 'fs';
 
     /**
      * READ-ONLY: If the collection should be a fixed size.

--- a/src/Mapping/ClassMetadataLegacyPropertiesTrait.php
+++ b/src/Mapping/ClassMetadataLegacyPropertiesTrait.php
@@ -8,6 +8,7 @@ use Doctrine\ODM\MongoDB\Id\IdGenerator;
 use Doctrine\ODM\MongoDB\Mapping\Attribute\TimeSeries;
 use ReflectionClass;
 
+/** @internal */
 trait ClassMetadataPropertiesTrait
 {
     /**

--- a/src/Repository/AbstractRepositoryFactory.php
+++ b/src/Repository/AbstractRepositoryFactory.php
@@ -78,7 +78,7 @@ abstract class AbstractRepositoryFactory implements RepositoryFactory
 
                 break;
 
-            case $metadata->isView():
+            case $metadata->isView:
                 if (! is_a($repositoryClassName, ViewRepository::class, true)) {
                     throw MappingException::invalidRepositoryClass($documentName, $repositoryClassName, ViewRepository::class);
                 }

--- a/src/SchemaManager.php
+++ b/src/SchemaManager.php
@@ -78,7 +78,7 @@ final class SchemaManager
     public function ensureIndexes(?int $maxTimeMs = null, ?WriteConcern $writeConcern = null, bool $background = false): void
     {
         foreach ($this->metadataFactory->getAllMetadata() as $class) {
-            if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView()) {
+            if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView) {
                 continue;
             }
 
@@ -95,7 +95,7 @@ final class SchemaManager
     public function updateIndexes(?int $maxTimeMs = null, ?WriteConcern $writeConcern = null): void
     {
         foreach ($this->metadataFactory->getAllMetadata() as $class) {
-            if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView()) {
+            if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView) {
                 continue;
             }
 
@@ -117,7 +117,7 @@ final class SchemaManager
     {
         $class = $this->dm->getClassMetadata($documentName);
 
-        if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView()) {
+        if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView) {
             throw new InvalidArgumentException('Cannot update document indexes for mapped super classes, embedded documents or aggregation result documents.');
         }
 
@@ -275,7 +275,7 @@ final class SchemaManager
     public function ensureDocumentIndexes(string $documentName, ?int $maxTimeMs = null, ?WriteConcern $writeConcern = null, bool $background = false): void
     {
         $class = $this->dm->getClassMetadata($documentName);
-        if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView()) {
+        if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView) {
             throw new InvalidArgumentException('Cannot create document indexes for mapped super classes, embedded documents or query result documents.');
         }
 
@@ -301,7 +301,7 @@ final class SchemaManager
     public function deleteIndexes(?int $maxTimeMs = null, ?WriteConcern $writeConcern = null): void
     {
         foreach ($this->metadataFactory->getAllMetadata() as $class) {
-            if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView()) {
+            if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView) {
                 continue;
             }
 
@@ -319,7 +319,7 @@ final class SchemaManager
     public function deleteDocumentIndexes(string $documentName, ?int $maxTimeMs = null, ?WriteConcern $writeConcern = null): void
     {
         $class = $this->dm->getClassMetadata($documentName);
-        if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView()) {
+        if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView) {
             throw new InvalidArgumentException('Cannot delete document indexes for mapped super classes, embedded documents or query result documents.');
         }
 
@@ -332,7 +332,7 @@ final class SchemaManager
     public function createSearchIndexes(): void
     {
         foreach ($this->metadataFactory->getAllMetadata() as $class) {
-            if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView()) {
+            if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView) {
                 continue;
             }
 
@@ -411,7 +411,7 @@ final class SchemaManager
     {
         $class = $this->dm->getClassMetadata($documentName);
 
-        if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView()) {
+        if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView) {
             throw new InvalidArgumentException('Cannot create search indexes for mapped super classes, embedded documents, query result documents, or views.');
         }
 
@@ -444,7 +444,7 @@ final class SchemaManager
     public function updateSearchIndexes(): void
     {
         foreach ($this->metadataFactory->getAllMetadata() as $class) {
-            if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView()) {
+            if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView) {
                 continue;
             }
 
@@ -466,7 +466,7 @@ final class SchemaManager
     {
         $class = $this->dm->getClassMetadata($documentName);
 
-        if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView()) {
+        if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView) {
             throw new InvalidArgumentException('Cannot update search indexes for mapped super classes, embedded documents, query result documents, or views.');
         }
 
@@ -504,7 +504,7 @@ final class SchemaManager
     public function deleteSearchIndexes(): void
     {
         foreach ($this->metadataFactory->getAllMetadata() as $class) {
-            if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView()) {
+            if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView) {
                 continue;
             }
 
@@ -522,7 +522,7 @@ final class SchemaManager
     public function deleteDocumentSearchIndexes(string $documentName): void
     {
         $class = $this->dm->getClassMetadata($documentName);
-        if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView()) {
+        if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView) {
             throw new InvalidArgumentException('Cannot delete search indexes for mapped super classes, embedded documents, query result documents, or views.');
         }
 
@@ -605,7 +605,7 @@ final class SchemaManager
     public function updateValidators(?int $maxTimeMs = null, ?WriteConcern $writeConcern = null): void
     {
         foreach ($this->metadataFactory->getAllMetadata() as $class) {
-            if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView() || $class->isFile) {
+            if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView || $class->isFile) {
                 continue;
             }
 
@@ -621,7 +621,7 @@ final class SchemaManager
     public function updateDocumentValidator(string $documentName, ?int $maxTimeMs = null, ?WriteConcern $writeConcern = null): void
     {
         $class = $this->dm->getClassMetadata($documentName);
-        if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView() || $class->isFile) {
+        if ($class->isMappedSuperclass || $class->isEmbeddedDocument || $class->isQueryResultDocument || $class->isView || $class->isFile) {
             throw new InvalidArgumentException('Cannot update validators for files, views, mapped super classes, embedded documents or aggregation result documents.');
         }
 
@@ -697,7 +697,7 @@ final class SchemaManager
             throw new InvalidArgumentException('Cannot create document collection for mapped super classes, embedded documents or query result documents.');
         }
 
-        if ($class->isView()) {
+        if ($class->isView) {
             $options = $this->getWriteOptions($maxTimeMs, $writeConcern);
 
             $rootClass = $class->getRootClass();

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -534,7 +534,7 @@ final class UnitOfWork implements PropertyChangedListener
                 continue;
             }
 
-            if ($class->isView()) {
+            if ($class->isView) {
                 continue;
             }
 
@@ -557,7 +557,7 @@ final class UnitOfWork implements PropertyChangedListener
     {
         foreach ($this->scheduledDocumentInsertions as $document) {
             $class = $this->dm->getClassMetadata($document::class);
-            if ($class->isEmbeddedDocument || $class->isView()) {
+            if ($class->isEmbeddedDocument || $class->isView) {
                 continue;
             }
 
@@ -574,7 +574,7 @@ final class UnitOfWork implements PropertyChangedListener
     {
         foreach ($this->scheduledDocumentUpserts as $document) {
             $class = $this->dm->getClassMetadata($document::class);
-            if ($class->isEmbeddedDocument || $class->isView()) {
+            if ($class->isEmbeddedDocument || $class->isView) {
                 continue;
             }
 
@@ -699,7 +699,7 @@ final class UnitOfWork implements PropertyChangedListener
      */
     private function computeOrRecomputeChangeSet(ClassMetadata $class, object $document, bool $recompute = false): void
     {
-        if ($class->isView()) {
+        if ($class->isView) {
             return;
         }
 
@@ -914,7 +914,7 @@ final class UnitOfWork implements PropertyChangedListener
         // Compute changes for other MANAGED documents. Change tracking policies take effect here.
         foreach ($this->identityMap as $className => $documents) {
             $class = $this->dm->getClassMetadata($className);
-            if ($class->isEmbeddedDocument || $class->isView()) {
+            if ($class->isEmbeddedDocument || $class->isView) {
                 /* we do not want to compute changes to embedded documents up front
                  * in case embedded document was replaced and its changeset
                  * would corrupt data. Embedded documents' change set will
@@ -1772,7 +1772,7 @@ final class UnitOfWork implements PropertyChangedListener
         switch ($documentState) {
             case self::STATE_MANAGED:
                 // Nothing to do, except if policy is "deferred explicit"
-                if ($class->isChangeTrackingDeferredExplicit() && ! $class->isView()) {
+                if ($class->isChangeTrackingDeferredExplicit() && ! $class->isView) {
                     $this->scheduleForSynchronization($document);
                 }
 
@@ -1782,7 +1782,7 @@ final class UnitOfWork implements PropertyChangedListener
                     throw MongoDBException::cannotPersistGridFSFile($class->name);
                 }
 
-                if ($class->isView()) {
+                if ($class->isView) {
                     return;
                 }
 
@@ -1853,7 +1853,7 @@ final class UnitOfWork implements PropertyChangedListener
                 break;
             case self::STATE_MANAGED:
                 $this->lifecycleEventManager->preRemove($class, $document);
-                $this->scheduleForDelete($document, $class->isView());
+                $this->scheduleForDelete($document, $class->isView);
                 break;
             case self::STATE_DETACHED:
                 throw MongoDBException::detachedDocumentCannotBeRemoved();
@@ -2826,7 +2826,7 @@ final class UnitOfWork implements PropertyChangedListener
 
             $data = $this->hydratorFactory->hydrate($document, $data, $hints);
 
-            if (! $class->isQueryResultDocument && ! $class->isView()) {
+            if (! $class->isQueryResultDocument && ! $class->isView) {
                 $this->originalDocumentData[$oid] = $data;
             }
         }

--- a/src/Utility/LifecycleEventManager.php
+++ b/src/Utility/LifecycleEventManager.php
@@ -295,7 +295,7 @@ final class LifecycleEventManager
 
     private function dispatchEvent(ClassMetadata $class, string $eventName, ?EventArgs $eventArgs = null): void
     {
-        if ($class->isView()) {
+        if ($class->isView) {
             return;
         }
 

--- a/tests/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Tests/Mapping/AnnotationDriverTest.php
@@ -43,8 +43,10 @@ class AnnotationDriverTest extends AbstractAnnotationDriverTestCase
             $errors,
         );
 
-        self::assertCount(1, $errors);
-        self::assertSame(sprintf('Since doctrine/mongodb-odm 2.2: The "@Indexes" attribute used in class "%s" is deprecated. Specify all "@Index" and "@UniqueIndex" attributes on the class.', DeprecatedIndexesClassAnnotation::class), $errors[0]);
+        self::assertEquals(
+            [sprintf('Since doctrine/mongodb-odm 2.2: The "@Indexes" attribute used in class "%s" is deprecated. Specify all "@Index" and "@UniqueIndex" attributes on the class.', DeprecatedIndexesClassAnnotation::class)],
+            $errors,
+        );
 
         $indexes = $classMetadata->indexes;
 
@@ -62,8 +64,10 @@ class AnnotationDriverTest extends AbstractAnnotationDriverTestCase
             $errors,
         );
 
-        self::assertCount(1, $errors);
-        self::assertSame(sprintf('Since doctrine/mongodb-odm 2.2: The "indexes" parameter in the "%s" attribute for class "%s" is deprecated. Specify all "@Index" and "@UniqueIndex" attributes on the class.', Document::class, DeprecatedDocumentClassAnnotationIndexesOption::class), $errors[0]);
+        self::assertEquals(
+            [sprintf('Since doctrine/mongodb-odm 2.2: The "indexes" parameter in the "%s" attribute for class "%s" is deprecated. Specify all "@Index" and "@UniqueIndex" attributes on the class.', Document::class, DeprecatedDocumentClassAnnotationIndexesOption::class)],
+            $errors,
+        );
 
         $indexes = $classMetadata->indexes;
 
@@ -81,8 +85,10 @@ class AnnotationDriverTest extends AbstractAnnotationDriverTestCase
             $errors,
         );
 
-        self::assertCount(1, $errors);
-        self::assertSame(sprintf('Since doctrine/mongodb-odm 2.2: The "@Indexes" attribute used in property "foo" of class "%s" is deprecated. Specify all "@Index" and "@UniqueIndex" attributes on the class.', DeprecatedIndexesPropertyAnnotation::class), $errors[0]);
+        self::assertEquals(
+            sprintf('Since doctrine/mongodb-odm 2.2: The "@Indexes" attribute used in property "foo" of class "%s" is deprecated. Specify all "@Index" and "@UniqueIndex" attributes on the class.', DeprecatedIndexesPropertyAnnotation::class),
+            $errors,
+        );
 
         $indexes = $classMetadata->indexes;
 

--- a/tests/Tests/Mapping/AnnotationDriverTest.php
+++ b/tests/Tests/Mapping/AnnotationDriverTest.php
@@ -87,7 +87,7 @@ class AnnotationDriverTest extends AbstractAnnotationDriverTestCase
 
         self::assertEquals(
             sprintf('Since doctrine/mongodb-odm 2.2: The "@Indexes" attribute used in property "foo" of class "%s" is deprecated. Specify all "@Index" and "@UniqueIndex" attributes on the class.', DeprecatedIndexesPropertyAnnotation::class),
-            $errors,
+            $errors[0],
         );
 
         $indexes = $classMetadata->indexes;

--- a/tests/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/Mapping/ClassMetadataTest.php
@@ -48,6 +48,7 @@ use stdClass;
 
 use function array_merge;
 use function serialize;
+use function sprintf;
 use function unserialize;
 
 class ClassMetadataTest extends BaseTestCase
@@ -1146,6 +1147,19 @@ class ClassMetadataTest extends BaseTestCase
         self::assertSame(Granularity::Hours, $metadata->timeSeriesOptions->granularity);
         self::assertSame(15, $metadata->timeSeriesOptions->bucketMaxSpanSeconds);
         self::assertSame(20, $metadata->timeSeriesOptions->bucketRoundingSeconds);
+    }
+
+    public function testDeprecatedPropertyModification(): void
+    {
+        $metadata = $this->dm->getClassMetadata(TimeSeriesTestDocument::class);
+
+        $this->captureDeprecationMessages(
+            static fn () => $metadata->db = 'foo',
+            $errors,
+        );
+
+        self::assertCount(1, $errors);
+        self::assertEquals(sprintf('Since doctrine/mongodb-odm 2.18: Writing to property %s::db is deprecated and will be removed in version 3.0.', ClassMetadata::class), $errors[0]);
     }
 }
 

--- a/tests/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/Mapping/ClassMetadataTest.php
@@ -1159,7 +1159,7 @@ class ClassMetadataTest extends BaseTestCase
         );
 
         self::assertCount(1, $errors);
-        self::assertEquals(sprintf('Since doctrine/mongodb-odm 2.18: Writing to property %s::db is deprecated and will be removed in version 3.0.', ClassMetadata::class), $errors[0]);
+        self::assertEquals(sprintf('Since doctrine/mongodb-odm 2.17: Writing to property %s::db is deprecated and will be removed in version 3.0.', ClassMetadata::class), $errors[0]);
     }
 }
 

--- a/tests/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/Mapping/ClassMetadataTest.php
@@ -41,6 +41,7 @@ use Generator;
 use InvalidArgumentException;
 use MongoDB\BSON\Document;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\TestWith;
 use ReflectionClass;
 use ReflectionException;
@@ -1149,6 +1150,7 @@ class ClassMetadataTest extends BaseTestCase
         self::assertSame(20, $metadata->timeSeriesOptions->bucketRoundingSeconds);
     }
 
+    #[RequiresPhp('>= 8.4')]
     public function testDeprecatedPropertyModification(): void
     {
         $metadata = $this->dm->getClassMetadata(TimeSeriesTestDocument::class);

--- a/tests/Tests/SchemaManagerTest.php
+++ b/tests/Tests/SchemaManagerTest.php
@@ -686,7 +686,7 @@ class SchemaManagerTest extends BaseTestCase
     {
         $dbCommands = [];
         foreach ($this->dm->getMetadataFactory()->getAllMetadata() as $cm) {
-            if ($cm->isMappedSuperclass || $cm->isEmbeddedDocument || $cm->isQueryResultDocument || $cm->isView() || $cm->isFile) {
+            if ($cm->isMappedSuperclass || $cm->isEmbeddedDocument || $cm->isQueryResultDocument || $cm->isView || $cm->isFile) {
                 continue;
             }
 


### PR DESCRIPTION
This PR bumps the minimum PHP requirement to 8.4 in order to leverage property hooks to emit deprecation notices for properties when they are written from outside the `ClassMetadata` class. This will allow us to use asymmetric visibility (as in `public private(set)` for those properties in 3.0, codifying the previously documented read-only behaviour.

Note that this does not work for array properties, as `$foo->bar[]` doesn't go through the `set` hook, but rather reads the property by reference to replace it. Adding a `set` hook to those properties results in a warning about indirect property sets, which we don't want either. For that reason, I've left these properties as they are and will tackle them separately.

The `isView` property was previously private, so this PR deprecates the `isView()` method entirely and uses asymmetric visibility to make the property public for read access.