### PR TITLE
Fix excludeSubPaths dropping sibling collections with shared prefix

### DIFF
--- a/src/Persisters/CollectionPersister.php
+++ b/src/Persisters/CollectionPersister.php
@@ -27,7 +27,7 @@ use function count;
 use function end;
 use function implode;
 use function sort;
-use function strpos;
+use function str_starts_with;
 
 /**
  * The CollectionPersister is responsible for persisting collections of embedded
@@ -484,7 +484,7 @@ final class CollectionPersister
             $lastUniquePath = end($uniquePaths);
             assert($lastUniquePath !== false);
 
-            if (strpos($paths[$i], $lastUniquePath) === 0) {
+            if ($paths[$i] === $lastUniquePath || str_starts_with($paths[$i], $lastUniquePath . '.')) {
                 continue;
             }
 

--- a/tests/Tests/Functional/CollectionPersisterTest.php
+++ b/tests/Tests/Functional/CollectionPersisterTest.php
@@ -506,9 +506,25 @@ class CollectionPersisterTest extends BaseTestCase
         $this->dm->persist($structure);
         $this->dm->flush();
         self::assertCount(
+            1,
+            $this->logger,
+            'Modification of sibling embedded-many collections by "pushAll" strategy is batched into one query',
+        );
+
+        // Modify the parent collection and a nested collection within one of its
+        // elements in the same flush. "pushAll" and "pushAll.0.pushAll" are a real
+        // parent/sub-path pair: pushing to both in a single update would conflict,
+        // so they must be split into two queries.
+        $structure->pushAll->add(new CollectionPersisterNestedStructure('nested7'));
+        $structure->pushAll->get(0)->pushAll->add(new CollectionPersisterNestedStructure('nested8'));
+
+        $this->logger->clear();
+        $this->dm->persist($structure);
+        $this->dm->flush();
+        self::assertCount(
             2,
             $this->logger,
-            'Modification of embedded-many collections of one document by "pushAll" strategy requires two queries',
+            'Modification of a "pushAll" collection and a nested sub-collection requires two queries',
         );
 
         self::assertSame($structure, $this->dm->getRepository($structure::class)->findOneBy(['id' => $structure->id]));

--- a/tests/Tests/Functional/Ticket/GH2754Test.php
+++ b/tests/Tests/Functional/Ticket/GH2754Test.php
@@ -13,64 +13,76 @@ class GH2754Test extends BaseTestCase
 {
     public function testSiblingCollectionsWithSharedPrefixArePersisted(): void
     {
-        $document           = new GH2754Document();
-        $document->embedded = new GH2754Embedded();
-        $document->embedded->codes->add(new GH2754Item('a'));
-        $document->embedded->codesV2->add(new GH2754Item('b'));
-        $this->dm->persist($document);
+        $user          = new GH2754User();
+        $user->profile = new GH2754Profile();
+        $user->profile->friends->add(new GH2754Friend('alice'));
+        $user->profile->friendsPending->add(new GH2754FriendRequest('bob'));
+        $this->dm->persist($user);
         $this->dm->flush();
         $this->dm->clear();
 
-        $document = $this->dm->find(GH2754Document::class, $document->id);
-        self::assertNotNull($document);
+        $user = $this->dm->find(GH2754User::class, $user->id);
+        self::assertNotNull($user);
 
-        // Replace both sibling collections within the same flush. The field name "codes"
-        // is a prefix of "codesV2", which previously caused the latter to be dropped.
-        $document->embedded->codes   = new ArrayCollection([new GH2754Item('c')]);
-        $document->embedded->codesV2 = new ArrayCollection([new GH2754Item('d'), new GH2754Item('e')]);
+        // Replace both sibling collections within the same flush. The field name "friends"
+        // is a prefix of "friendsPending", which previously caused the latter to be dropped.
+        $user->profile->friends        = new ArrayCollection([new GH2754Friend('carol')]);
+        $user->profile->friendsPending = new ArrayCollection([new GH2754FriendRequest('dave'), new GH2754FriendRequest('erin')]);
         $this->dm->flush();
         $this->dm->clear();
 
-        $document = $this->dm->find(GH2754Document::class, $document->id);
-        self::assertNotNull($document);
-        self::assertCount(1, $document->embedded->codes);
-        self::assertCount(2, $document->embedded->codesV2, 'Sibling collection with prefixed name must be persisted');
-        self::assertSame('d', $document->embedded->codesV2[0]->name);
-        self::assertSame('e', $document->embedded->codesV2[1]->name);
+        $user = $this->dm->find(GH2754User::class, $user->id);
+        self::assertNotNull($user);
+        self::assertCount(1, $user->profile->friends);
+        self::assertCount(2, $user->profile->friendsPending, 'Sibling collection with prefixed name must be persisted');
+        self::assertSame('dave', $user->profile->friendsPending[0]->name);
+        self::assertSame('erin', $user->profile->friendsPending[1]->name);
     }
 }
 
 #[ODM\Document]
-class GH2754Document
+class GH2754User
 {
     /** @var string|null */
     #[ODM\Id]
     public $id;
 
-    #[ODM\EmbedOne(targetDocument: GH2754Embedded::class)]
-    public ?GH2754Embedded $embedded = null;
+    #[ODM\EmbedOne(targetDocument: GH2754Profile::class)]
+    public ?GH2754Profile $profile = null;
 }
 
 #[ODM\EmbeddedDocument]
-class GH2754Embedded
+class GH2754Profile
 {
-    /** @var Collection<int, GH2754Item> */
-    #[ODM\EmbedMany(targetDocument: GH2754Item::class)]
-    public Collection $codes;
+    /** @var Collection<int, GH2754Friend> */
+    #[ODM\EmbedMany(targetDocument: GH2754Friend::class)]
+    public Collection $friends;
 
-    /** @var Collection<int, GH2754Item> */
-    #[ODM\EmbedMany(targetDocument: GH2754Item::class)]
-    public Collection $codesV2;
+    /** @var Collection<int, GH2754FriendRequest> */
+    #[ODM\EmbedMany(targetDocument: GH2754FriendRequest::class)]
+    public Collection $friendsPending;
 
     public function __construct()
     {
-        $this->codes   = new ArrayCollection();
-        $this->codesV2 = new ArrayCollection();
+        $this->friends        = new ArrayCollection();
+        $this->friendsPending = new ArrayCollection();
     }
 }
 
 #[ODM\EmbeddedDocument]
-class GH2754Item
+class GH2754Friend
+{
+    #[ODM\Field(type: 'string')]
+    public string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}
+
+#[ODM\EmbeddedDocument]
+class GH2754FriendRequest
 {
     #[ODM\Field(type: 'string')]
     public string $name;

--- a/tests/Tests/Functional/Ticket/GH2754Test.php
+++ b/tests/Tests/Functional/Ticket/GH2754Test.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+
+class GH2754Test extends BaseTestCase
+{
+    public function testSiblingCollectionsWithSharedPrefixArePersisted(): void
+    {
+        $document           = new GH2754Document();
+        $document->embedded = new GH2754Embedded();
+        $document->embedded->codes->add(new GH2754Item('a'));
+        $document->embedded->codesV2->add(new GH2754Item('b'));
+        $this->dm->persist($document);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $document = $this->dm->find(GH2754Document::class, $document->id);
+        self::assertNotNull($document);
+
+        // Replace both sibling collections within the same flush. The field name "codes"
+        // is a prefix of "codesV2", which previously caused the latter to be dropped.
+        $document->embedded->codes   = new ArrayCollection([new GH2754Item('c')]);
+        $document->embedded->codesV2 = new ArrayCollection([new GH2754Item('d'), new GH2754Item('e')]);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $document = $this->dm->find(GH2754Document::class, $document->id);
+        self::assertNotNull($document);
+        self::assertCount(1, $document->embedded->codes);
+        self::assertCount(2, $document->embedded->codesV2, 'Sibling collection with prefixed name must be persisted');
+        self::assertSame('d', $document->embedded->codesV2[0]->name);
+        self::assertSame('e', $document->embedded->codesV2[1]->name);
+    }
+}
+
+#[ODM\Document]
+class GH2754Document
+{
+    /** @var string|null */
+    #[ODM\Id]
+    public $id;
+
+    #[ODM\EmbedOne(targetDocument: GH2754Embedded::class)]
+    public ?GH2754Embedded $embedded = null;
+}
+
+#[ODM\EmbeddedDocument]
+class GH2754Embedded
+{
+    /** @var Collection<int, GH2754Item> */
+    #[ODM\EmbedMany(targetDocument: GH2754Item::class)]
+    public Collection $codes;
+
+    /** @var Collection<int, GH2754Item> */
+    #[ODM\EmbedMany(targetDocument: GH2754Item::class)]
+    public Collection $codesV2;
+
+    public function __construct()
+    {
+        $this->codes   = new ArrayCollection();
+        $this->codesV2 = new ArrayCollection();
+    }
+}
+
+#[ODM\EmbeddedDocument]
+class GH2754Item
+{
+    #[ODM\Field(type: 'string')]
+    public string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
Fixes #2754.

`CollectionPersister::excludeSubPaths()` removes nested sub-paths from a batched collection update so that a parent path and its sub-path are never updated in the same query (which MongoDB rejects). It used a raw string-prefix test:

```php
if (strpos($paths[$i], $lastUniquePath) === 0) {
```

For sibling `embedMany` fields whose names share a prefix (e.g. `supplier_factory_codes` and `supplier_factory_codes_v2`, or `codes` and `codesV2`), the longer path starts with the shorter one, so it was wrongly treated as a sub-path, excluded from the update, and **never persisted**.

The fix only treats a path as a sub-path when it equals the prefix or is followed by the `.` separator:

```php
if ($paths[$i] === $lastUniquePath || str_starts_with($paths[$i], $lastUniquePath . '.')) {
```

As a side effect, sibling collections using the `pushAll` strategy are now correctly batched into a single query instead of two. The existing `pushAll` test was updated to reflect this and extended to keep covering the genuine parent/sub-path case, which must still split into two queries.

A regression test (`GH2754Test`) replaces two sibling embed-many collections with a shared name prefix in one flush and asserts both are persisted.