### PR TITLE
Deprecate COLLECTION_PER_CLASS inheritance type

### DIFF
--- a/UPGRADE-2.17.md
+++ b/UPGRADE-2.17.md
@@ -1,0 +1,20 @@
+# UPGRADE FROM 2.16 to 2.17
+
+## Deprecate `COLLECTION_PER_CLASS` inheritance type
+
+The `COLLECTION_PER_CLASS` inheritance type has been deprecated with no replacement. It persisted one
+collection per class, which is already the default behavior: every document class is mapped to its own
+collection. The strategy provided no additional behavior and could not guarantee `_id` uniqueness across
+the distinct collections of a hierarchy.
+
+Remove the `InheritanceType` attribute/annotation (or the `inheritance-type` XML attribute) from the
+affected classes. Each class remains mapped to its own collection.
+
+```diff
+ #[ODM\Document]
+-#[ODM\InheritanceType('COLLECTION_PER_CLASS')]
+ class Section {}
+```
+
+This effectively deprecates `ClassMetadata::isInheritanceTypeCollectionPerClass()` and
+`ClassMetadata::INHERITANCE_TYPE_COLLECTION_PER_CLASS`.

--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -690,6 +690,12 @@ This attribute must appear on the top-most class in an
 :ref:`inheritance hierarchy <inheritance_mapping>`. ``SINGLE_COLLECTION`` and
 ``COLLECTION_PER_CLASS`` are currently supported.
 
+.. note::
+
+    ``COLLECTION_PER_CLASS`` is deprecated since 2.17 with no replacement. Each
+    document class is already mapped to its own collection, so you can remove the
+    ``InheritanceType`` mapping.
+
 Examples:
 
 .. code-block:: php

--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -188,6 +188,12 @@ discriminator field:
 Collection Per Class Inheritance
 --------------------------------
 
+.. deprecated:: 2.17
+
+    The ``COLLECTION_PER_CLASS`` inheritance type is deprecated with no
+    replacement. Each document class is already mapped to its own collection,
+    so you can simply remove the ``InheritanceType`` mapping.
+
 With collection per class inheritance, each document is stored in its own
 collection and contains all inherited fields:
 

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -431,7 +431,14 @@
   <xs:simpleType name="inheritance-type">
     <xs:restriction base="xs:token">
       <xs:enumeration value="SINGLE_COLLECTION" />
-      <xs:enumeration value="COLLECTION_PER_CLASS" />
+      <xs:enumeration value="COLLECTION_PER_CLASS">
+        <xs:annotation>
+          <xs:documentation>
+            Deprecated since 2.17 with no replacement. Each class is already mapped to its own
+            collection, so the COLLECTION_PER_CLASS inheritance type can be removed.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
     </xs:restriction>
   </xs:simpleType>
 

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -2128,6 +2128,8 @@ use const PHP_VERSION_ID;
      */
     public function isInheritanceTypeCollectionPerClass(): bool
     {
+        trigger_deprecation('doctrine/mongodb-odm', '2.17', 'The method %s() is deprecated with no replacement.', __FUNCTION__);
+
         return $this->inheritanceType === self::INHERITANCE_TYPE_COLLECTION_PER_CLASS;
     }
 

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -429,6 +429,8 @@ use const PHP_VERSION_ID;
     /**
      * COLLECTION_PER_CLASS means the class will be persisted according to the rules
      * of <tt>Concrete Collection Inheritance</tt>.
+     *
+     * @deprecated since 2.17 with no replacement. Each class is already mapped to its own collection.
      */
     public const INHERITANCE_TYPE_COLLECTION_PER_CLASS = 3;
 
@@ -2121,6 +2123,8 @@ use const PHP_VERSION_ID;
 
     /**
      * Checks whether the mapped class uses the COLLECTION_PER_CLASS inheritance mapping strategy.
+     *
+     * @deprecated since 2.17 with no replacement.
      */
     public function isInheritanceTypeCollectionPerClass(): bool
     {

--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -227,7 +227,7 @@ final class ClassMetadataFactory extends AbstractClassMetadataFactory implements
         }
 
         // phpcs:ignore SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
-        if ($class->isInheritanceTypeCollectionPerClass()) {
+        if ($class->inheritanceType === ClassMetadata::INHERITANCE_TYPE_COLLECTION_PER_CLASS) {
             trigger_deprecation(
                 'doctrine/mongodb-odm',
                 '2.17',

--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -217,12 +217,21 @@ final class ClassMetadataFactory extends AbstractClassMetadataFactory implements
             new LoadClassMetadataEventArgs($class, $this->dm),
         );
 
-        // phpcs:ignore SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
         if ($class->isChangeTrackingNotify()) {
             trigger_deprecation(
                 'doctrine/mongodb-odm',
                 '2.4',
                 'NOTIFY tracking policy used in class "%s" is deprecated. Please use DEFERRED_EXPLICIT instead.',
+                $class->name,
+            );
+        }
+
+        // phpcs:ignore SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
+        if ($class->isInheritanceTypeCollectionPerClass()) {
+            trigger_deprecation(
+                'doctrine/mongodb-odm',
+                '2.17',
+                'COLLECTION_PER_CLASS inheritance type used in class "%s" is deprecated with no replacement. Remove the InheritanceType attribute/annotation: each class is already mapped to its own collection.',
                 $class->name,
             );
         }

--- a/tests/Documents/User.php
+++ b/tests/Documents/User.php
@@ -15,7 +15,6 @@ use MongoDB\BSON\UTCDateTime;
 use function bcadd;
 
 #[ODM\Document(collection: 'users')]
-#[ODM\InheritanceType('COLLECTION_PER_CLASS')]
 class User extends BaseDocument
 {
     /** @var ObjectId|string|null */

--- a/tests/Documents/VersionedUser.php
+++ b/tests/Documents/VersionedUser.php
@@ -7,7 +7,6 @@ namespace Documents;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 #[ODM\Document(collection: 'users')]
-#[ODM\InheritanceType('COLLECTION_PER_CLASS')]
 class VersionedUser extends User
 {
     /** @var int|null */

--- a/tests/Tests/Functional/Ticket/MODM116Test.php
+++ b/tests/Tests/Functional/Ticket/MODM116Test.php
@@ -6,12 +6,14 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional\Ticket;
 
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 
 use function array_values;
 use function get_class;
 
 class MODM116Test extends BaseTestCase
 {
+    #[IgnoreDeprecations]
     public function testIssue(): void
     {
         $parent = new MODM116Parent();

--- a/tests/Tests/Mapping/CollectionPerClassInheritanceDeprecationTest.php
+++ b/tests/Tests/Mapping/CollectionPerClassInheritanceDeprecationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Mapping;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
+use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use Doctrine\ODM\MongoDB\Tests\CaptureDeprecationMessages;
+
+use function sprintf;
+
+class CollectionPerClassInheritanceDeprecationTest extends BaseTestCase
+{
+    use CaptureDeprecationMessages;
+
+    public function testCollectionPerClassInheritanceEmitsDeprecation(): void
+    {
+        $factory = new ClassMetadataFactory();
+        $factory->setDocumentManager($this->dm);
+        $factory->setConfiguration($this->dm->getConfiguration());
+
+        $this->captureDeprecationMessages(
+            static fn () => $factory->getMetadataFor(CollectionPerClassDeprecatedDocument::class),
+            $errors,
+        );
+
+        self::assertContains(
+            sprintf('Since doctrine/mongodb-odm 2.17: COLLECTION_PER_CLASS inheritance type used in class "%s" is deprecated with no replacement. Remove the InheritanceType attribute/annotation: each class is already mapped to its own collection.', CollectionPerClassDeprecatedDocument::class),
+            $errors,
+        );
+    }
+}
+
+#[ODM\Document]
+#[ODM\InheritanceType('COLLECTION_PER_CLASS')]
+class CollectionPerClassDeprecatedDocument
+{
+    /** @var string|null */
+    #[ODM\Id]
+    private $id;
+}

--- a/tests/Tests/Mapping/ShardKeyInheritanceMappingTest.php
+++ b/tests/Tests/Mapping/ShardKeyInheritanceMappingTest.php
@@ -8,6 +8,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactory;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 
 class ShardKeyInheritanceMappingTest extends BaseTestCase
 {
@@ -44,6 +45,7 @@ class ShardKeyInheritanceMappingTest extends BaseTestCase
         $this->factory->getMetadataFor(ShardedSingleCollInheritance3::class);
     }
 
+    #[IgnoreDeprecations]
     public function testShardKeyCollectionPerClassInheritance(): void
     {
         $class = $this->factory->getMetadataFor(ShardedCollectionPerClass2::class);
@@ -52,6 +54,7 @@ class ShardKeyInheritanceMappingTest extends BaseTestCase
         self::assertEquals(['keys' => ['_id' => 1], 'options' => []], $class->getShardKey());
     }
 
+    #[IgnoreDeprecations]
     public function testShardKeyCollectionPerClassInheritanceOverriding(): void
     {
         $class = $this->factory->getMetadataFor(ShardedCollectionPerClass3::class);


### PR DESCRIPTION
Fixes #2742.

The `COLLECTION_PER_CLASS` inheritance type persists one collection per class, which is already the default behavior for any document. It provides no additional behavior, has almost no documentation, and cannot guarantee `_id` uniqueness across the distinct collections of a hierarchy ([context](https://github.com/doctrine/mongodb-odm/pull/2725#discussion_r1940947597)).

Deprecated with no replacement. The migration is to remove the `InheritanceType` mapping; each class remains mapped to its own collection.

- Runtime deprecation in `ClassMetadataFactory::loadMetadata()` (modeled on the `NOTIFY` deprecation)
- `@deprecated` on `ClassMetadata::INHERITANCE_TYPE_COLLECTION_PER_CLASS` and `isInheritanceTypeCollectionPerClass()`
- Deprecation note in the XSD enumeration
- `UPGRADE-2.17.md` and docs notes
- Migrated `User`/`VersionedUser` fixtures off `COLLECTION_PER_CLASS`; `#[IgnoreDeprecations]` on the remaining intentional usages