### PR TITLE
Add compatibility with doctrine/collections v3, add SortDirection support in Query Builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8.1",
         "ext-mongodb": "^1.21 || ^2.0",
-        "doctrine/collections": "^2.1",
+        "doctrine/collections": "^2.1 || ^3.0",
         "doctrine/event-manager": "^1.0 || ^2.0",
         "doctrine/instantiator": "^1.1 || ^2",
         "doctrine/persistence": "^3.2 || ^4",

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "symfony/console": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0",
         "symfony/polyfill-php84": "^1.33",
+        "symfony/polyfill-php86": "^1.37",
         "symfony/var-dumper": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/var-exporter": "^6.4.1 || ^7.0 || ^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8.1",
         "ext-mongodb": "^1.21 || ^2.0",
-        "doctrine/collections": "^2.1 || ^3.0",
+        "doctrine/collections": "^2.1 || ^3.1",
         "doctrine/event-manager": "^1.0 || ^2.0",
         "doctrine/instantiator": "^1.1 || ^2",
         "doctrine/persistence": "^3.2 || ^4",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -67,6 +67,7 @@
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>src/Mapping/Driver/CompatibilityAnnotationDriver.php</exclude-pattern>
+        <exclude-pattern>src/PersistentCollection/PersistentCollectionCompatibility.php</exclude-pattern>
         <exclude-pattern>src/Tools/Console/Command/CommandCompatibility.php</exclude-pattern>
         <exclude-pattern>src/Tools/Console/Command/Schema/AbstractCommandCompatibility.php</exclude-pattern>
         <exclude-pattern>src/Tools/Console/Helper/DocumentManagerHelper.php</exclude-pattern>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -577,6 +577,12 @@ parameters:
 			path: src/PersistentCollection.php
 
 		-
+			message: '#^Instanceof between Doctrine\\Common\\Collections\\Collection and Doctrine\\Common\\Collections\\Selectable will always evaluate to true.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: src/PersistentCollection/PersistentCollectionTrait.php
+
+		-
 			message: '#^Method Doctrine\\ODM\\MongoDB\\PersistentCollection\\AbstractPersistentCollectionFactory\:\:createCollectionClass\(\) return type with generic interface Doctrine\\Common\\Collections\\Collection does not specify its types\: TKey, T$#'
 			identifier: missingType.generics
 			count: 1

--- a/src/PersistentCollection/PersistentCollectionCompatibility.php
+++ b/src/PersistentCollection/PersistentCollectionCompatibility.php
@@ -7,43 +7,304 @@ namespace Doctrine\ODM\MongoDB\PersistentCollection;
 use Closure;
 use Doctrine\Common\Collections\Collection as BaseCollection;
 use Doctrine\Common\Collections\Criteria;
-use Doctrine\Common\Collections\Selectable;
-use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
-use Doctrine\ODM\MongoDB\MongoDBException;
-use Doctrine\ODM\MongoDB\UnitOfWork;
-use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
-use LogicException;
-use ReturnTypeWillChange;
 use Traversable;
 
-use function array_combine;
-use function array_diff_key;
-use function array_map;
-use function array_udiff_assoc;
-use function array_values;
-use function count;
-use function get_class;
-use function is_object;
-use function sprintf;
-
 /**
- * Compatibility trait for PersistentCollection between collections 2 and 3.
+ * Compatibility trait for PersistentCollection between doctrine/collections v2 and v3.
+ *
+ * The `add()` return type changed from bool (v2) to void (v3). All other Collection/ReadableCollection
+ * methods gained type declarations in v3. Both branches are duplicated here so that the version in
+ * use does not impose new type constraints on classes that extend PersistentCollection.
+ *
+ * @internal
  * @template TKey of array-key
  * @template T of object
  */
-if (defined(Criteria::class . '::ASC')) {
-    // collections 2
-    /** @internal */
+if (! defined(Criteria::class . '::ASC')) {
+    // collections 3 — full type declarations required by the interface
+    /**
+     * @internal
+     * @template TKey of array-key
+     * @template T of object
+     */
     trait PersistentCollectionCompatibility
     {
-        abstract private function doAdd(mixed $value, bool $arrayAccess): bool;
-
         /**
          * Adds an element at the end of the collection.
          *
-         * @param mixed $element The element to add.
-         * @phpstan-param T $element
+         * @phpstan-param T $value
+         */
+        public function add(mixed $value): void
+        {
+            $this->doAdd($value, false);
+        }
+
+        public function first(): mixed
+        {
+            $this->initialize();
+
+            return $this->coll->first();
+        }
+
+        public function last(): mixed
+        {
+            $this->initialize();
+
+            return $this->coll->last();
+        }
+
+        public function key(): int|string|null
+        {
+            return $this->coll->key();
+        }
+
+        public function current(): mixed
+        {
+            return $this->coll->current();
+        }
+
+        public function next(): mixed
+        {
+            return $this->coll->next();
+        }
+
+        public function contains(mixed $element): bool
+        {
+            $this->initialize();
+
+            return $this->coll->contains($element);
+        }
+
+        public function isEmpty(): bool
+        {
+            return $this->initialized ? $this->coll->isEmpty() : $this->count() === 0;
+        }
+
+        public function containsKey(string|int $key): bool
+        {
+            $this->initialize();
+
+            return $this->coll->containsKey($key);
+        }
+
+        public function get(string|int $key): mixed
+        {
+            $this->initialize();
+
+            return $this->coll->get($key);
+        }
+
+        public function getKeys(): array
+        {
+            $this->initialize();
+
+            return $this->coll->getKeys();
+        }
+
+        public function getValues(): array
+        {
+            $this->initialize();
+
+            return $this->coll->getValues();
+        }
+
+        public function toArray(): array
+        {
+            $this->initialize();
+
+            return $this->coll->toArray();
+        }
+
+        public function slice(int $offset, int|null $length = null): array
+        {
+            $this->initialize();
+
+            return $this->coll->slice($offset, $length);
+        }
+
+        public function exists(Closure $p): bool
+        {
+            $this->initialize();
+
+            return $this->coll->exists($p);
+        }
+
+        public function indexOf(mixed $element): int|string|false
+        {
+            $this->initialize();
+
+            return $this->coll->indexOf($element);
+        }
+
+        public function filter(Closure $p): BaseCollection
+        {
+            $this->initialize();
+
+            return $this->coll->filter($p);
+        }
+
+        public function map(Closure $func): BaseCollection
+        {
+            $this->initialize();
+
+            return $this->coll->map($func);
+        }
+
+        public function partition(Closure $p): array
+        {
+            $this->initialize();
+
+            return $this->coll->partition($p);
+        }
+
+        public function forAll(Closure $p): bool
+        {
+            $this->initialize();
+
+            return $this->coll->forAll($p);
+        }
+
+        /**
+         * @phpstan-param Closure(TKey, T):bool $p
+         * @phpstan-return T|null
+         */
+        public function findFirst(Closure $p): mixed
+        {
+            return $this->coll->findFirst($p);
+        }
+
+        /**
+         * @phpstan-param Closure(TReturn|TInitial|null, T):(TInitial|TReturn) $func
+         * @phpstan-param TInitial|null $initial
+         * @phpstan-return TReturn|TInitial|null
+         * @phpstan-template TReturn
+         * @phpstan-template TInitial
+         */
+        public function reduce(Closure $func, mixed $initial = null): mixed
+        {
+            return $this->coll->reduce($func, $initial);
+        }
+
+        public function remove(string|int $key): mixed
+        {
+            return $this->doRemove($key, false);
+        }
+
+        public function removeElement(mixed $element): bool
+        {
+            $this->initialize();
+            $removed = $this->coll->removeElement($element);
+
+            if (! $removed) {
+                return $removed;
+            }
+
+            $this->changed();
+
+            return $removed;
+        }
+
+        public function set(string|int $key, mixed $value): void
+        {
+            $this->doSet($key, $value, false);
+        }
+
+        public function clear(): void
+        {
+            if ($this->initialized && $this->isEmpty()) {
+                return;
+            }
+
+            if ($this->isOrphanRemovalEnabled()) {
+                $this->initialize();
+                foreach ($this->coll as $element) {
+                    $this->uow->scheduleOrphanRemoval($element);
+                }
+            }
+
+            $this->mongoData = [];
+            $this->coll->clear();
+
+            // Nothing to do for inverse-side collections
+            if (! $this->mapping['isOwningSide']) {
+                return;
+            }
+
+            // Nothing to do if the collection was initialized but contained no data
+            if ($this->initialized && empty($this->snapshot)) {
+                return;
+            }
+
+            $this->changed();
+            $this->uow->scheduleCollectionDeletion($this);
+            $this->takeSnapshot();
+        }
+
+        public function count(): int
+        {
+            // Workaround around not being able to directly count inverse collections anymore
+            $this->initialize();
+
+            return $this->coll->count();
+        }
+
+        /**
+         * @phpstan-return Traversable<TKey, T>
+         */
+        public function getIterator(): Traversable
+        {
+            $this->initialize();
+
+            return $this->coll->getIterator();
+        }
+
+        public function offsetExists(mixed $offset): bool
+        {
+            $this->initialize();
+
+            return $this->coll->offsetExists($offset);
+        }
+
+        /**
+         * @phpstan-return T|null
+         */
+        public function offsetGet(mixed $offset): mixed
+        {
+            $this->initialize();
+
+            return $this->coll->offsetGet($offset);
+        }
+
+        public function offsetSet(mixed $offset, mixed $value): void
+        {
+            if (! isset($offset)) {
+                $this->doAdd($value, true);
+
+                return;
+            }
+
+            $this->doSet($offset, $value, true);
+        }
+
+        public function offsetUnset(mixed $offset): void
+        {
+            $this->doRemove($offset, true);
+        }
+    }
+} else {
+    // collections 2 — no doctrine/collections type declarations
+    /**
+     * @internal
+     * @template TKey of array-key
+     * @template T of object
+     */
+    trait PersistentCollectionCompatibility
+    {
+        /**
+         * Adds an element at the end of the collection.
+         *
+         * @param mixed $value
+         * @phpstan-param T $value
          *
          * @return true The return value is kept for BC reasons, but will be void in doctrine/mongodb-odm 3.0.
          */
@@ -53,23 +314,269 @@ if (defined(Criteria::class . '::ASC')) {
 
             return true;
         }
-    }
-} else {
-    // collections 3
-    /** @internal */
-    trait PersistentCollectionCompatibility
-    {
-        abstract private function doAdd(mixed $value, bool $arrayAccess): bool;
+
+        public function first()
+        {
+            $this->initialize();
+
+            return $this->coll->first();
+        }
+
+        public function last()
+        {
+            $this->initialize();
+
+            return $this->coll->last();
+        }
+
+        public function key()
+        {
+            return $this->coll->key();
+        }
+
+        public function current()
+        {
+            return $this->coll->current();
+        }
+
+        public function next()
+        {
+            return $this->coll->next();
+        }
+
+        public function contains($element)
+        {
+            $this->initialize();
+
+            return $this->coll->contains($element);
+        }
+
+        public function isEmpty()
+        {
+            return $this->initialized ? $this->coll->isEmpty() : $this->count() === 0;
+        }
+
+        public function containsKey($key)
+        {
+            $this->initialize();
+
+            return $this->coll->containsKey($key);
+        }
+
+        public function get($key)
+        {
+            $this->initialize();
+
+            return $this->coll->get($key);
+        }
+
+        public function getKeys()
+        {
+            $this->initialize();
+
+            return $this->coll->getKeys();
+        }
+
+        public function getValues()
+        {
+            $this->initialize();
+
+            return $this->coll->getValues();
+        }
+
+        public function toArray()
+        {
+            $this->initialize();
+
+            return $this->coll->toArray();
+        }
+
+        public function slice($offset, $length = null)
+        {
+            $this->initialize();
+
+            return $this->coll->slice($offset, $length);
+        }
+
+        public function exists(Closure $p)
+        {
+            $this->initialize();
+
+            return $this->coll->exists($p);
+        }
+
+        public function indexOf($element)
+        {
+            $this->initialize();
+
+            return $this->coll->indexOf($element);
+        }
+
+        public function filter(Closure $p)
+        {
+            $this->initialize();
+
+            return $this->coll->filter($p);
+        }
+
+        public function map(Closure $func)
+        {
+            $this->initialize();
+
+            return $this->coll->map($func);
+        }
+
+        public function partition(Closure $p)
+        {
+            $this->initialize();
+
+            return $this->coll->partition($p);
+        }
+
+        public function forAll(Closure $p)
+        {
+            $this->initialize();
+
+            return $this->coll->forAll($p);
+        }
 
         /**
-         * Adds an element at the end of the collection.
-         *
-         * @param mixed $element The element to add.
-         * @phpstan-param T $element
+         * @phpstan-param Closure(TKey, T):bool $p
+         * @phpstan-return T|null
          */
-        public function add(mixed $value): void
+        public function findFirst(Closure $p)
         {
-            $this->doAdd($value, false);
+            return $this->coll->findFirst($p);
+        }
+
+        /**
+         * @phpstan-param Closure(TReturn|TInitial|null, T):(TInitial|TReturn) $func
+         * @phpstan-param TInitial|null $initial
+         * @phpstan-return TReturn|TInitial|null
+         * @phpstan-template TReturn
+         * @phpstan-template TInitial
+         */
+        public function reduce(Closure $func, $initial = null)
+        {
+            return $this->coll->reduce($func, $initial);
+        }
+
+        public function remove($key)
+        {
+            return $this->doRemove($key, false);
+        }
+
+        public function removeElement($element)
+        {
+            $this->initialize();
+            $removed = $this->coll->removeElement($element);
+
+            if (! $removed) {
+                return $removed;
+            }
+
+            $this->changed();
+
+            return $removed;
+        }
+
+        public function set($key, $value)
+        {
+            $this->doSet($key, $value, false);
+        }
+
+        public function clear(): void
+        {
+            if ($this->initialized && $this->isEmpty()) {
+                return;
+            }
+
+            if ($this->isOrphanRemovalEnabled()) {
+                $this->initialize();
+                foreach ($this->coll as $element) {
+                    $this->uow->scheduleOrphanRemoval($element);
+                }
+            }
+
+            $this->mongoData = [];
+            $this->coll->clear();
+
+            // Nothing to do for inverse-side collections
+            if (! $this->mapping['isOwningSide']) {
+                return;
+            }
+
+            // Nothing to do if the collection was initialized but contained no data
+            if ($this->initialized && empty($this->snapshot)) {
+                return;
+            }
+
+            $this->changed();
+            $this->uow->scheduleCollectionDeletion($this);
+            $this->takeSnapshot();
+        }
+
+        /** @return int */
+        public function count(): int
+        {
+            // Workaround around not being able to directly count inverse collections anymore
+            $this->initialize();
+
+            return $this->coll->count();
+        }
+
+        /**
+         * @phpstan-return Traversable<TKey, T>
+         */
+        public function getIterator(): Traversable
+        {
+            $this->initialize();
+
+            return $this->coll->getIterator();
+        }
+
+        /**
+         * @param mixed $offset
+         */
+        public function offsetExists(mixed $offset): bool
+        {
+            $this->initialize();
+
+            return $this->coll->offsetExists($offset);
+        }
+
+        /**
+         * @param mixed $offset
+         * @phpstan-return T|null
+         */
+        public function offsetGet(mixed $offset): mixed
+        {
+            $this->initialize();
+
+            return $this->coll->offsetGet($offset);
+        }
+
+        /**
+         * @param mixed $offset
+         * @param mixed $value
+         */
+        public function offsetSet(mixed $offset, mixed $value): void
+        {
+            if (! isset($offset)) {
+                $this->doAdd($value, true);
+
+                return;
+            }
+
+            $this->doSet($offset, $value, true);
+        }
+
+        /**
+         * @param mixed $offset
+         */
+        public function offsetUnset(mixed $offset): void
+        {
+            $this->doRemove($offset, true);
         }
     }
 }

--- a/src/PersistentCollection/PersistentCollectionCompatibility.php
+++ b/src/PersistentCollection/PersistentCollectionCompatibility.php
@@ -7,12 +7,16 @@ namespace Doctrine\ODM\MongoDB\PersistentCollection;
 use Closure;
 use Doctrine\Common\Collections\Collection as BaseCollection;
 use Doctrine\Common\Collections\Criteria;
+use ReturnTypeWillChange;
 use Traversable;
+
+use function defined;
 
 /**
  * Compatibility trait for PersistentCollection between doctrine/collections v2 and v3.
  *
  * @internal
+ *
  * @template TKey of array-key
  * @template T of object
  */
@@ -20,6 +24,7 @@ if (! defined(Criteria::class . '::ASC')) {
     // doctrine/collections 3 — full type declarations required by the interface
     /**
      * @internal
+     *
      * @template TKey of array-key
      * @template T of object
      */
@@ -162,6 +167,7 @@ if (! defined(Criteria::class . '::ASC')) {
 
         /**
          * @phpstan-param Closure(TKey, T):bool $p
+         *
          * @phpstan-return T|null
          */
         public function findFirst(Closure $p): mixed
@@ -172,7 +178,9 @@ if (! defined(Criteria::class . '::ASC')) {
         /**
          * @phpstan-param Closure(TReturn|TInitial|null, T):(TInitial|TReturn) $func
          * @phpstan-param TInitial|null $initial
+         *
          * @phpstan-return TReturn|TInitial|null
+         *
          * @phpstan-template TReturn
          * @phpstan-template TInitial
          */
@@ -244,9 +252,7 @@ if (! defined(Criteria::class . '::ASC')) {
             return $this->coll->count();
         }
 
-        /**
-         * @phpstan-return Traversable<TKey, T>
-         */
+        /** @phpstan-return Traversable<TKey, T> */
         public function getIterator(): Traversable
         {
             $this->initialize();
@@ -261,9 +267,7 @@ if (! defined(Criteria::class . '::ASC')) {
             return $this->coll->offsetExists($offset);
         }
 
-        /**
-         * @phpstan-return T|null
-         */
+        /** @phpstan-return T|null */
         public function offsetGet(mixed $offset): mixed
         {
             $this->initialize();
@@ -291,6 +295,7 @@ if (! defined(Criteria::class . '::ASC')) {
     // doctrine/collections 2 — no type declarations
     /**
      * @internal
+     *
      * @template TKey of array-key
      * @template T of object
      */
@@ -299,7 +304,6 @@ if (! defined(Criteria::class . '::ASC')) {
         /**
          * Adds an element at the end of the collection.
          *
-         * @param mixed $value
          * @phpstan-param T $value
          *
          * @return true The return value is kept for BC reasons, but will be void in doctrine/mongodb-odm 3.0.
@@ -438,6 +442,7 @@ if (! defined(Criteria::class . '::ASC')) {
 
         /**
          * @phpstan-param Closure(TKey, T):bool $p
+         *
          * @phpstan-return T|null
          */
         public function findFirst(Closure $p)
@@ -448,7 +453,9 @@ if (! defined(Criteria::class . '::ASC')) {
         /**
          * @phpstan-param Closure(TReturn|TInitial|null, T):(TInitial|TReturn) $func
          * @phpstan-param TInitial|null $initial
+         *
          * @phpstan-return TReturn|TInitial|null
+         *
          * @phpstan-template TReturn
          * @phpstan-template TInitial
          */
@@ -513,7 +520,7 @@ if (! defined(Criteria::class . '::ASC')) {
         }
 
         /** @return int */
-        #[\ReturnTypeWillChange]
+        #[ReturnTypeWillChange]
         public function count()
         {
             // Workaround around not being able to directly count inverse collections anymore
@@ -522,10 +529,8 @@ if (! defined(Criteria::class . '::ASC')) {
             return $this->coll->count();
         }
 
-        /**
-         * @phpstan-return Traversable<TKey, T>
-         */
-        #[\ReturnTypeWillChange]
+        /** @phpstan-return Traversable<TKey, T> */
+        #[ReturnTypeWillChange]
         public function getIterator()
         {
             $this->initialize();
@@ -533,10 +538,8 @@ if (! defined(Criteria::class . '::ASC')) {
             return $this->coll->getIterator();
         }
 
-        /**
-         * @param mixed $offset
-         */
-        #[\ReturnTypeWillChange]
+        /** @param mixed $offset */
+        #[ReturnTypeWillChange]
         public function offsetExists($offset)
         {
             $this->initialize();
@@ -546,9 +549,10 @@ if (! defined(Criteria::class . '::ASC')) {
 
         /**
          * @param mixed $offset
+         *
          * @phpstan-return T|null
          */
-        #[\ReturnTypeWillChange]
+        #[ReturnTypeWillChange]
         public function offsetGet($offset)
         {
             $this->initialize();
@@ -560,7 +564,7 @@ if (! defined(Criteria::class . '::ASC')) {
          * @param mixed $offset
          * @param mixed $value
          */
-        #[\ReturnTypeWillChange]
+        #[ReturnTypeWillChange]
         public function offsetSet($offset, $value)
         {
             if (! isset($offset)) {
@@ -572,10 +576,8 @@ if (! defined(Criteria::class . '::ASC')) {
             $this->doSet($offset, $value, true);
         }
 
-        /**
-         * @param mixed $offset
-         */
-        #[\ReturnTypeWillChange]
+        /** @param mixed $offset */
+        #[ReturnTypeWillChange]
         public function offsetUnset($offset)
         {
             $this->doRemove($offset, true);

--- a/src/PersistentCollection/PersistentCollectionCompatibility.php
+++ b/src/PersistentCollection/PersistentCollectionCompatibility.php
@@ -12,16 +12,12 @@ use Traversable;
 /**
  * Compatibility trait for PersistentCollection between doctrine/collections v2 and v3.
  *
- * The `add()` return type changed from bool (v2) to void (v3). All other Collection/ReadableCollection
- * methods gained type declarations in v3. Both branches are duplicated here so that the version in
- * use does not impose new type constraints on classes that extend PersistentCollection.
- *
  * @internal
  * @template TKey of array-key
  * @template T of object
  */
 if (! defined(Criteria::class . '::ASC')) {
-    // collections 3 — full type declarations required by the interface
+    // doctrine/collections 3 — full type declarations required by the interface
     /**
      * @internal
      * @template TKey of array-key
@@ -292,7 +288,7 @@ if (! defined(Criteria::class . '::ASC')) {
         }
     }
 } else {
-    // collections 2 — no doctrine/collections type declarations
+    // doctrine/collections 2 — no type declarations
     /**
      * @internal
      * @template TKey of array-key
@@ -517,7 +513,8 @@ if (! defined(Criteria::class . '::ASC')) {
         }
 
         /** @return int */
-        public function count(): int
+        #[\ReturnTypeWillChange]
+        public function count()
         {
             // Workaround around not being able to directly count inverse collections anymore
             $this->initialize();
@@ -528,7 +525,8 @@ if (! defined(Criteria::class . '::ASC')) {
         /**
          * @phpstan-return Traversable<TKey, T>
          */
-        public function getIterator(): Traversable
+        #[\ReturnTypeWillChange]
+        public function getIterator()
         {
             $this->initialize();
 
@@ -538,7 +536,8 @@ if (! defined(Criteria::class . '::ASC')) {
         /**
          * @param mixed $offset
          */
-        public function offsetExists(mixed $offset): bool
+        #[\ReturnTypeWillChange]
+        public function offsetExists($offset)
         {
             $this->initialize();
 
@@ -549,7 +548,8 @@ if (! defined(Criteria::class . '::ASC')) {
          * @param mixed $offset
          * @phpstan-return T|null
          */
-        public function offsetGet(mixed $offset): mixed
+        #[\ReturnTypeWillChange]
+        public function offsetGet($offset)
         {
             $this->initialize();
 
@@ -560,7 +560,8 @@ if (! defined(Criteria::class . '::ASC')) {
          * @param mixed $offset
          * @param mixed $value
          */
-        public function offsetSet(mixed $offset, mixed $value): void
+        #[\ReturnTypeWillChange]
+        public function offsetSet($offset, $value)
         {
             if (! isset($offset)) {
                 $this->doAdd($value, true);
@@ -574,7 +575,8 @@ if (! defined(Criteria::class . '::ASC')) {
         /**
          * @param mixed $offset
          */
-        public function offsetUnset(mixed $offset): void
+        #[\ReturnTypeWillChange]
+        public function offsetUnset($offset)
         {
             $this->doRemove($offset, true);
         }

--- a/src/PersistentCollection/PersistentCollectionCompatibility.php
+++ b/src/PersistentCollection/PersistentCollectionCompatibility.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\PersistentCollection;
+
+use Closure;
+use Doctrine\Common\Collections\Collection as BaseCollection;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Selectable;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\MongoDBException;
+use Doctrine\ODM\MongoDB\UnitOfWork;
+use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
+use LogicException;
+use ReturnTypeWillChange;
+use Traversable;
+
+use function array_combine;
+use function array_diff_key;
+use function array_map;
+use function array_udiff_assoc;
+use function array_values;
+use function count;
+use function get_class;
+use function is_object;
+use function sprintf;
+
+/**
+ * Compatibility trait for PersistentCollection between collections 2 and 3.
+ * @template TKey of array-key
+ * @template T of object
+ */
+if (defined(Criteria::class . '::ASC')) {
+    // collections 2
+    /** @internal */
+    trait PersistentCollectionCompatibility
+    {
+        abstract private function doAdd(mixed $value, bool $arrayAccess): bool;
+
+        /**
+         * Adds an element at the end of the collection.
+         *
+         * @param mixed $element The element to add.
+         * @phpstan-param T $element
+         *
+         * @return true The return value is kept for BC reasons, but will be void in doctrine/mongodb-odm 3.0.
+         */
+        public function add(mixed $value): bool
+        {
+            $this->doAdd($value, false);
+
+            return true;
+        }
+    }
+} else {
+    // collections 3
+    /** @internal */
+    trait PersistentCollectionCompatibility
+    {
+        abstract private function doAdd(mixed $value, bool $arrayAccess): bool;
+
+        /**
+         * Adds an element at the end of the collection.
+         *
+         * @param mixed $element The element to add.
+         * @phpstan-param T $element
+         */
+        public function add(mixed $value): void
+        {
+            $this->doAdd($value, false);
+        }
+    }
+}

--- a/src/PersistentCollection/PersistentCollectionInterface.php
+++ b/src/PersistentCollection/PersistentCollectionInterface.php
@@ -28,122 +28,103 @@ interface PersistentCollectionInterface extends Collection, Selectable
 {
     /**
      * Sets the document manager and unit of work (used during merge operations).
-     *
-     * @return void
      */
-    public function setDocumentManager(DocumentManager $dm);
+    public function setDocumentManager(DocumentManager $dm): void;
 
     /**
      * Sets the array of raw mongo data that will be used to initialize this collection.
      *
      * @param mixed[] $mongoData
-     *
-     * @return void
      */
-    public function setMongoData(array $mongoData);
+    public function setMongoData(array $mongoData): void;
 
     /**
      * Gets the array of raw mongo data that will be used to initialize this collection.
      *
-     * @return mixed[] $mongoData
+     * @return mixed[]
      */
-    public function getMongoData();
+    public function getMongoData(): array;
 
     /**
      * Set hints to account for during reconstitution/lookup of the documents.
      *
-     * @param Hints $hints
-     *
-     * @return void
+     * @phpstan-param Hints $hints
      */
-    public function setHints(array $hints);
+    public function setHints(array $hints): void;
 
     /**
      * Get hints to account for during reconstitution/lookup of the documents.
      *
-     * @return Hints $hints
+     * @return array<int, mixed>
+     * @phpstan-return Hints
      */
-    public function getHints();
+    public function getHints(): array;
 
     /**
      * Initializes the collection by loading its contents from the database
      * if the collection is not yet initialized.
-     *
-     * @return void
      */
-    public function initialize();
+    public function initialize(): void;
 
     /**
      * Gets a boolean flag indicating whether this collection is dirty which means
      * its state needs to be synchronized with the database.
-     *
-     * @return bool TRUE if the collection is dirty, FALSE otherwise.
      */
-    public function isDirty();
+    public function isDirty(): bool;
 
     /**
      * Sets a boolean flag, indicating whether this collection is dirty.
-     *
-     * @param bool $dirty Whether the collection should be marked dirty or not.
-     *
-     * @return void
      */
-    public function setDirty($dirty);
+    public function setDirty(bool $dirty): void;
 
     /**
      * Sets the collection's owning document together with the AssociationMapping that
      * describes the association between the owner and the elements of the collection.
      *
      * @phpstan-param FieldMapping $mapping
-     *
-     * @return void
      */
-    public function setOwner(object $document, array $mapping);
+    public function setOwner(object $document, array $mapping): void;
 
     /**
      * Tells this collection to take a snapshot of its current state reindexing
      * itself numerically if using save strategy that is enforcing BSON array.
      * Reindexing is safe as snapshot is taken only after synchronizing collection
      * with database or clearing it.
-     *
-     * @return void
      */
-    public function takeSnapshot();
+    public function takeSnapshot(): void;
 
     /**
      * Clears the internal snapshot information and sets isDirty to true if the collection
      * has elements.
-     *
-     * @return void
      */
-    public function clearSnapshot();
+    public function clearSnapshot(): void;
 
     /**
      * Returns the last snapshot of the elements in the collection.
      *
-     * @return object[] The last snapshot of the elements.
+     * @return object[]
      */
-    public function getSnapshot();
+    public function getSnapshot(): array;
 
     /** @return array<string, object> */
-    public function getDeleteDiff();
+    public function getDeleteDiff(): array;
 
     /**
      * Get objects that were removed, unlike getDeleteDiff this doesn't care about indices.
      *
      * @return list<object>
      */
-    public function getDeletedDocuments();
+    public function getDeletedDocuments(): array;
 
     /** @return array<string, object> */
-    public function getInsertDiff();
+    public function getInsertDiff(): array;
 
     /**
      * Get objects that were added, unlike getInsertDiff this doesn't care about indices.
      *
      * @return list<object>
      */
-    public function getInsertedDocuments();
+    public function getInsertedDocuments(): array;
 
     /**
      * Gets the collection owner.
@@ -154,36 +135,29 @@ interface PersistentCollectionInterface extends Collection, Selectable
      * @return array
      * @phpstan-return FieldMapping
      */
-    public function getMapping();
+    public function getMapping(): array;
 
     /**
-     * @return ClassMetadata
      * @phpstan-return ClassMetadata<T>
      *
      * @throws MongoDBException
      */
-    public function getTypeClass();
+    public function getTypeClass(): ClassMetadata;
 
     /**
      * Sets the initialized flag of the collection, forcing it into that state.
-     *
-     * @param bool $bool
-     *
-     * @return void
      */
-    public function setInitialized($bool);
+    public function setInitialized(bool $bool): void;
 
     /**
      * Checks whether this collection has been initialized.
-     *
-     * @return bool
      */
-    public function isInitialized();
+    public function isInitialized(): bool;
 
     /**
      * Returns the wrapped Collection instance.
      *
      * @return Collection<TKey, T>
      */
-    public function unwrap();
+    public function unwrap(): Collection;
 }

--- a/src/PersistentCollection/PersistentCollectionInterface.php
+++ b/src/PersistentCollection/PersistentCollectionInterface.php
@@ -28,103 +28,122 @@ interface PersistentCollectionInterface extends Collection, Selectable
 {
     /**
      * Sets the document manager and unit of work (used during merge operations).
+     *
+     * @return void
      */
-    public function setDocumentManager(DocumentManager $dm): void;
+    public function setDocumentManager(DocumentManager $dm);
 
     /**
      * Sets the array of raw mongo data that will be used to initialize this collection.
      *
      * @param mixed[] $mongoData
+     *
+     * @return void
      */
-    public function setMongoData(array $mongoData): void;
+    public function setMongoData(array $mongoData);
 
     /**
      * Gets the array of raw mongo data that will be used to initialize this collection.
      *
-     * @return mixed[]
+     * @return mixed[] $mongoData
      */
-    public function getMongoData(): array;
+    public function getMongoData();
 
     /**
      * Set hints to account for during reconstitution/lookup of the documents.
      *
-     * @phpstan-param Hints $hints
+     * @param Hints $hints
+     *
+     * @return void
      */
-    public function setHints(array $hints): void;
+    public function setHints(array $hints);
 
     /**
      * Get hints to account for during reconstitution/lookup of the documents.
      *
-     * @return array<int, mixed>
-     * @phpstan-return Hints
+     * @return Hints $hints
      */
-    public function getHints(): array;
+    public function getHints();
 
     /**
      * Initializes the collection by loading its contents from the database
      * if the collection is not yet initialized.
+     *
+     * @return void
      */
-    public function initialize(): void;
+    public function initialize();
 
     /**
      * Gets a boolean flag indicating whether this collection is dirty which means
      * its state needs to be synchronized with the database.
+     *
+     * @return bool TRUE if the collection is dirty, FALSE otherwise.
      */
-    public function isDirty(): bool;
+    public function isDirty();
 
     /**
      * Sets a boolean flag, indicating whether this collection is dirty.
+     *
+     * @param bool $dirty Whether the collection should be marked dirty or not.
+     *
+     * @return void
      */
-    public function setDirty(bool $dirty): void;
+    public function setDirty($dirty);
 
     /**
      * Sets the collection's owning document together with the AssociationMapping that
      * describes the association between the owner and the elements of the collection.
      *
      * @phpstan-param FieldMapping $mapping
+     *
+     * @return void
      */
-    public function setOwner(object $document, array $mapping): void;
+    public function setOwner(object $document, array $mapping);
 
     /**
      * Tells this collection to take a snapshot of its current state reindexing
      * itself numerically if using save strategy that is enforcing BSON array.
      * Reindexing is safe as snapshot is taken only after synchronizing collection
      * with database or clearing it.
+     *
+     * @return void
      */
-    public function takeSnapshot(): void;
+    public function takeSnapshot();
 
     /**
      * Clears the internal snapshot information and sets isDirty to true if the collection
      * has elements.
+     *
+     * @return void
      */
-    public function clearSnapshot(): void;
+    public function clearSnapshot();
 
     /**
      * Returns the last snapshot of the elements in the collection.
      *
-     * @return object[]
+     * @return object[] The last snapshot of the elements.
      */
-    public function getSnapshot(): array;
+    public function getSnapshot();
 
     /** @return array<string, object> */
-    public function getDeleteDiff(): array;
+    public function getDeleteDiff();
 
     /**
      * Get objects that were removed, unlike getDeleteDiff this doesn't care about indices.
      *
      * @return list<object>
      */
-    public function getDeletedDocuments(): array;
+    public function getDeletedDocuments();
 
     /** @return array<string, object> */
-    public function getInsertDiff(): array;
+    public function getInsertDiff();
 
     /**
      * Get objects that were added, unlike getInsertDiff this doesn't care about indices.
      *
      * @return list<object>
      */
-    public function getInsertedDocuments(): array;
+    public function getInsertedDocuments();
 
     /**
      * Gets the collection owner.
@@ -135,29 +154,36 @@ interface PersistentCollectionInterface extends Collection, Selectable
      * @return array
      * @phpstan-return FieldMapping
      */
-    public function getMapping(): array;
+    public function getMapping();
 
     /**
+     * @return ClassMetadata
      * @phpstan-return ClassMetadata<T>
      *
      * @throws MongoDBException
      */
-    public function getTypeClass(): ClassMetadata;
+    public function getTypeClass();
 
     /**
      * Sets the initialized flag of the collection, forcing it into that state.
+     *
+     * @param bool $bool
+     *
+     * @return void
      */
-    public function setInitialized(bool $bool): void;
+    public function setInitialized($bool);
 
     /**
      * Checks whether this collection has been initialized.
+     *
+     * @return bool
      */
-    public function isInitialized(): bool;
+    public function isInitialized();
 
     /**
      * Returns the wrapped Collection instance.
      *
      * @return Collection<TKey, T>
      */
-    public function unwrap(): Collection;
+    public function unwrap();
 }

--- a/src/PersistentCollection/PersistentCollectionTrait.php
+++ b/src/PersistentCollection/PersistentCollectionTrait.php
@@ -14,7 +14,6 @@ use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 use LogicException;
-use ReturnTypeWillChange;
 use Traversable;
 
 use function array_combine;
@@ -37,6 +36,8 @@ use function sprintf;
  */
 trait PersistentCollectionTrait
 {
+    use PersistentCollectionCompatibility;
+
     /**
      * A snapshot of the collection at the moment it was fetched from the database.
      * This is used to create a diff of the collection at commit time.
@@ -99,33 +100,33 @@ trait PersistentCollectionTrait
      */
     private array $hints = [];
 
-    public function setDocumentManager(DocumentManager $dm)
+    public function setDocumentManager(DocumentManager $dm): void
     {
         $this->dm  = $dm;
         $this->uow = $dm->getUnitOfWork();
     }
 
-    public function setMongoData(array $mongoData)
+    public function setMongoData(array $mongoData): void
     {
         $this->mongoData = $mongoData;
     }
 
-    public function getMongoData()
+    public function getMongoData(): array
     {
         return $this->mongoData;
     }
 
-    public function setHints(array $hints)
+    public function setHints(array $hints): void
     {
         $this->hints = $hints;
     }
 
-    public function getHints()
+    public function getHints(): array
     {
         return $this->hints;
     }
 
-    public function initialize()
+    public function initialize(): void
     {
         if ($this->initialized || ! $this->mapping) {
             return;
@@ -181,7 +182,7 @@ trait PersistentCollectionTrait
         $this->uow->scheduleForSynchronization($this->owner);
     }
 
-    public function isDirty()
+    public function isDirty(): bool
     {
         if ($this->isDirty) {
             return true;
@@ -200,18 +201,18 @@ trait PersistentCollectionTrait
         return false;
     }
 
-    public function setDirty($dirty)
+    public function setDirty(bool $dirty): void
     {
         $this->isDirty = $dirty;
     }
 
-    public function setOwner(object $document, array $mapping)
+    public function setOwner(object $document, array $mapping): void
     {
         $this->owner   = $document;
         $this->mapping = $mapping;
     }
 
-    public function takeSnapshot()
+    public function takeSnapshot(): void
     {
         if ($this->mapping !== null && CollectionHelper::isList($this->mapping['strategy'])) {
             $array = $this->coll->toArray();
@@ -225,18 +226,18 @@ trait PersistentCollectionTrait
         $this->isDirty  = false;
     }
 
-    public function clearSnapshot()
+    public function clearSnapshot(): void
     {
         $this->snapshot = [];
         $this->isDirty  = $this->coll->count() !== 0;
     }
 
-    public function getSnapshot()
+    public function getSnapshot(): array
     {
         return $this->snapshot;
     }
 
-    public function getDeleteDiff()
+    public function getDeleteDiff(): array
     {
         return array_udiff_assoc(
             $this->snapshot,
@@ -245,7 +246,7 @@ trait PersistentCollectionTrait
         );
     }
 
-    public function getDeletedDocuments()
+    public function getDeletedDocuments(): array
     {
         $coll               = $this->coll->toArray();
         $loadedObjectsByOid = array_combine(array_map('spl_object_id', $this->snapshot), $this->snapshot);
@@ -254,7 +255,7 @@ trait PersistentCollectionTrait
         return array_values(array_diff_key($loadedObjectsByOid, $newObjectsByOid));
     }
 
-    public function getInsertDiff()
+    public function getInsertDiff(): array
     {
         return array_udiff_assoc(
             $this->coll->toArray(),
@@ -263,7 +264,7 @@ trait PersistentCollectionTrait
         );
     }
 
-    public function getInsertedDocuments()
+    public function getInsertedDocuments(): array
     {
         $coll               = $this->coll->toArray();
         $newObjectsByOid    = array_combine(array_map('spl_object_id', $coll), $coll);
@@ -277,12 +278,12 @@ trait PersistentCollectionTrait
         return $this->owner;
     }
 
-    public function getMapping()
+    public function getMapping(): array
     {
         return $this->mapping;
     }
 
-    public function getTypeClass()
+    public function getTypeClass(): ClassMetadata
     {
         if (! isset($this->dm)) {
             throw new MongoDBException('No DocumentManager is associated with this PersistentCollection, please set one using setDocumentManager method.');
@@ -299,36 +300,36 @@ trait PersistentCollectionTrait
         return $this->dm->getClassMetadata($this->mapping['targetDocument']);
     }
 
-    public function setInitialized($bool)
+    public function setInitialized(bool $bool): void
     {
         $this->initialized = $bool;
     }
 
-    public function isInitialized()
+    public function isInitialized(): bool
     {
         return $this->initialized;
     }
 
-    public function first()
+    public function first(): mixed
     {
         $this->initialize();
 
         return $this->coll->first();
     }
 
-    public function last()
+    public function last(): mixed
     {
         $this->initialize();
 
         return $this->coll->last();
     }
 
-    public function remove($key)
+    public function remove(string|int $key): mixed
     {
         return $this->doRemove($key, false);
     }
 
-    public function removeElement($element)
+    public function removeElement(mixed $element): bool
     {
         $this->initialize();
         $removed = $this->coll->removeElement($element);
@@ -342,7 +343,7 @@ trait PersistentCollectionTrait
         return $removed;
     }
 
-    public function containsKey($key)
+    public function containsKey(string|int $key): bool
     {
         $this->initialize();
 
@@ -350,14 +351,14 @@ trait PersistentCollectionTrait
     }
 
     /** @template TMaybeContained */
-    public function contains($element)
+    public function contains(mixed $element): bool
     {
         $this->initialize();
 
         return $this->coll->contains($element);
     }
 
-    public function exists(Closure $p)
+    public function exists(Closure $p): bool
     {
         $this->initialize();
 
@@ -369,37 +370,35 @@ trait PersistentCollectionTrait
      *
      * @template TMaybeContained
      */
-    public function indexOf($element)
+    public function indexOf(mixed $element): int|string|false
     {
         $this->initialize();
 
         return $this->coll->indexOf($element);
     }
 
-    public function get($key)
+    public function get(string|int $key): mixed
     {
         $this->initialize();
 
         return $this->coll->get($key);
     }
 
-    public function getKeys()
+    public function getKeys(): array
     {
         $this->initialize();
 
         return $this->coll->getKeys();
     }
 
-    public function getValues()
+    public function getValues(): array
     {
         $this->initialize();
 
         return $this->coll->getValues();
     }
 
-    /** @return int */
-    #[ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         // Workaround around not being able to directly count inverse collections anymore
         $this->initialize();
@@ -407,77 +406,62 @@ trait PersistentCollectionTrait
         return $this->coll->count();
     }
 
-    public function set($key, $value)
+    public function set(string|int $key, mixed $value): void
     {
         $this->doSet($key, $value, false);
     }
 
-    /**
-     * Adds an element at the end of the collection.
-     *
-     * @param mixed $element The element to add.
-     * @phpstan-param T $element
-     *
-     * @return true The return value is kept for BC reasons, but will be void in doctrine/mongodb-odm 3.0.
-     */
-    public function add($element)
-    {
-        return $this->doAdd($element, false);
-    }
-
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return $this->initialized ? $this->coll->isEmpty() : $this->count() === 0;
     }
 
     /**
-     * @return Traversable
      * @phpstan-return Traversable<TKey, T>
      */
-    #[ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         $this->initialize();
 
         return $this->coll->getIterator();
     }
 
-    public function map(Closure $func)
+    public function map(Closure $func): BaseCollection
     {
         $this->initialize();
 
         return $this->coll->map($func);
     }
 
-    public function filter(Closure $p)
+    public function filter(Closure $p): BaseCollection
     {
         $this->initialize();
 
         return $this->coll->filter($p);
     }
 
-    public function forAll(Closure $p)
+    public function forAll(Closure $p): bool
     {
         $this->initialize();
 
         return $this->coll->forAll($p);
     }
 
-    public function partition(Closure $p)
+    public function partition(Closure $p): array
     {
         $this->initialize();
 
         return $this->coll->partition($p);
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         $this->initialize();
 
         return $this->coll->toArray();
     }
 
-    public function clear()
+    public function clear(): void
     {
         if ($this->initialized && $this->isEmpty()) {
             return;
@@ -508,7 +492,7 @@ trait PersistentCollectionTrait
         $this->takeSnapshot();
     }
 
-    public function slice($offset, $length = null)
+    public function slice(int $offset, int|null $length = null): array
     {
         $this->initialize();
 
@@ -545,13 +529,7 @@ trait PersistentCollectionTrait
 
     /* ArrayAccess implementation */
 
-    /**
-     * @param mixed $offset
-     *
-     * @return bool
-     */
-    #[ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         $this->initialize();
 
@@ -559,27 +537,16 @@ trait PersistentCollectionTrait
     }
 
     /**
-     * @param mixed $offset
-     *
-     * @return mixed
      * @phpstan-return T|null
      */
-    #[ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         $this->initialize();
 
         return $this->coll->offsetGet($offset);
     }
 
-    /**
-     * @param mixed $offset
-     * @param mixed $value
-     *
-     * @return void
-     */
-    #[ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (! isset($offset)) {
             $this->doAdd($value, true);
@@ -590,18 +557,12 @@ trait PersistentCollectionTrait
         $this->doSet($offset, $value, true);
     }
 
-    /**
-     * @param mixed $offset
-     *
-     * @return void
-     */
-    #[ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         $this->doRemove($offset, true);
     }
 
-    public function key()
+    public function key(): int|string|null
     {
         return $this->coll->key();
     }
@@ -609,17 +570,17 @@ trait PersistentCollectionTrait
     /**
      * Gets the element of the collection at the current iterator position.
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->coll->current();
     }
 
-    public function next()
+    public function next(): mixed
     {
         return $this->coll->next();
     }
 
-    public function unwrap()
+    public function unwrap(): BaseCollection
     {
         return $this->coll;
     }
@@ -652,12 +613,9 @@ trait PersistentCollectionTrait
     /**
      * Actual logic for adding an element to the collection.
      *
-     * @param mixed $value
-     * @param bool  $arrayAccess
-     *
      * @return true
      */
-    private function doAdd($value, $arrayAccess)
+    private function doAdd(mixed $value, bool $arrayAccess): bool
     {
         /* Initialize the collection before calling add() so this append operation
          * uses the appropriate key. Otherwise, we risk overwriting original data
@@ -680,16 +638,13 @@ trait PersistentCollectionTrait
     /**
      * Actual logic for removing element by its key.
      *
-     * @param mixed $offset
-     *
-     * @return bool|T|null
      * @phpstan-return (
      *      $arrayAccess is false
      *      ? T|null
      *      : T|true|null
      * )
      */
-    private function doRemove($offset, bool $arrayAccess)
+    private function doRemove(mixed $offset, bool $arrayAccess): mixed
     {
         $this->initialize();
         if ($arrayAccess) {
@@ -710,11 +665,8 @@ trait PersistentCollectionTrait
 
     /**
      * Actual logic for setting an element in the collection.
-     *
-     * @param mixed $offset
-     * @param mixed $value
      */
-    private function doSet($offset, $value, bool $arrayAccess): void
+    private function doSet(mixed $offset, mixed $value, bool $arrayAccess): void
     {
         $arrayAccess ? $this->coll->offsetSet($offset, $value) : $this->coll->set($offset, $value);
 
@@ -759,7 +711,7 @@ trait PersistentCollectionTrait
      *
      * @phpstan-return T|null
      */
-    public function findFirst(Closure $p)
+    public function findFirst(Closure $p): mixed
     {
         return $this->coll->findFirst($p);
     }
@@ -773,7 +725,7 @@ trait PersistentCollectionTrait
      * @phpstan-template TReturn
      * @phpstan-template TInitial
      */
-    public function reduce(Closure $func, $initial = null)
+    public function reduce(Closure $func, mixed $initial = null): mixed
     {
         return $this->coll->reduce($func, $initial);
     }

--- a/src/PersistentCollection/PersistentCollectionTrait.php
+++ b/src/PersistentCollection/PersistentCollectionTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\PersistentCollection;
 
-use Closure;
 use Doctrine\Common\Collections\Collection as BaseCollection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;

--- a/src/PersistentCollection/PersistentCollectionTrait.php
+++ b/src/PersistentCollection/PersistentCollectionTrait.php
@@ -104,33 +104,33 @@ trait PersistentCollectionTrait
      */
     private array $hints = [];
 
-    public function setDocumentManager(DocumentManager $dm): void
+    public function setDocumentManager(DocumentManager $dm)
     {
         $this->dm  = $dm;
         $this->uow = $dm->getUnitOfWork();
     }
 
-    public function setMongoData(array $mongoData): void
+    public function setMongoData(array $mongoData)
     {
         $this->mongoData = $mongoData;
     }
 
-    public function getMongoData(): array
+    public function getMongoData()
     {
         return $this->mongoData;
     }
 
-    public function setHints(array $hints): void
+    public function setHints(array $hints)
     {
         $this->hints = $hints;
     }
 
-    public function getHints(): array
+    public function getHints()
     {
         return $this->hints;
     }
 
-    public function initialize(): void
+    public function initialize()
     {
         if ($this->initialized || ! $this->mapping) {
             return;
@@ -168,7 +168,25 @@ trait PersistentCollectionTrait
         $this->isDirty = true;
     }
 
-    public function isDirty(): bool
+    /**
+     * Marks this collection as changed/dirty.
+     */
+    private function changed(): void
+    {
+        if ($this->isDirty) {
+            return;
+        }
+
+        $this->isDirty = true;
+
+        if (! $this->needsSchedulingForSynchronization() || $this->owner === null) {
+            return;
+        }
+
+        $this->uow->scheduleForSynchronization($this->owner);
+    }
+
+    public function isDirty()
     {
         if ($this->isDirty) {
             return true;
@@ -187,18 +205,18 @@ trait PersistentCollectionTrait
         return false;
     }
 
-    public function setDirty($dirty): void
+    public function setDirty($dirty)
     {
         $this->isDirty = $dirty;
     }
 
-    public function setOwner(object $document, array $mapping): void
+    public function setOwner(object $document, array $mapping)
     {
         $this->owner   = $document;
         $this->mapping = $mapping;
     }
 
-    public function takeSnapshot(): void
+    public function takeSnapshot()
     {
         if ($this->mapping !== null && CollectionHelper::isList($this->mapping['strategy'])) {
             $array = $this->coll->toArray();
@@ -212,18 +230,18 @@ trait PersistentCollectionTrait
         $this->isDirty  = false;
     }
 
-    public function clearSnapshot(): void
+    public function clearSnapshot()
     {
         $this->snapshot = [];
         $this->isDirty  = $this->coll->count() !== 0;
     }
 
-    public function getSnapshot(): array
+    public function getSnapshot()
     {
         return $this->snapshot;
     }
 
-    public function getDeleteDiff(): array
+    public function getDeleteDiff()
     {
         return array_udiff_assoc(
             $this->snapshot,
@@ -232,7 +250,7 @@ trait PersistentCollectionTrait
         );
     }
 
-    public function getDeletedDocuments(): array
+    public function getDeletedDocuments()
     {
         $coll               = $this->coll->toArray();
         $loadedObjectsByOid = array_combine(array_map('spl_object_id', $this->snapshot), $this->snapshot);
@@ -241,7 +259,7 @@ trait PersistentCollectionTrait
         return array_values(array_diff_key($loadedObjectsByOid, $newObjectsByOid));
     }
 
-    public function getInsertDiff(): array
+    public function getInsertDiff()
     {
         return array_udiff_assoc(
             $this->coll->toArray(),
@@ -250,7 +268,7 @@ trait PersistentCollectionTrait
         );
     }
 
-    public function getInsertedDocuments(): array
+    public function getInsertedDocuments()
     {
         $coll               = $this->coll->toArray();
         $newObjectsByOid    = array_combine(array_map('spl_object_id', $coll), $coll);
@@ -264,12 +282,12 @@ trait PersistentCollectionTrait
         return $this->owner;
     }
 
-    public function getMapping(): array
+    public function getMapping()
     {
         return $this->mapping;
     }
 
-    public function getTypeClass(): ClassMetadata
+    public function getTypeClass()
     {
         if (! isset($this->dm)) {
             throw new MongoDBException('No DocumentManager is associated with this PersistentCollection, please set one using setDocumentManager method.');
@@ -286,17 +304,17 @@ trait PersistentCollectionTrait
         return $this->dm->getClassMetadata($this->mapping['targetDocument']);
     }
 
-    public function setInitialized($bool): void
+    public function setInitialized($bool)
     {
         $this->initialized = $bool;
     }
 
-    public function isInitialized(): bool
+    public function isInitialized()
     {
         return $this->initialized;
     }
 
-    public function unwrap(): BaseCollection
+    public function unwrap()
     {
         return $this->coll;
     }
@@ -354,44 +372,12 @@ trait PersistentCollectionTrait
         $this->changed();
     }
 
-    /** @return BaseCollection<TKey, T> */
-    public function matching(Criteria $criteria): BaseCollection
-    {
-        $this->initialize();
-
-        $coll = $this->coll->matching($criteria);
-
-        if (! $coll instanceof BaseCollection) {
-            throw new LogicException(sprintf('The matching() method of the backed collection must return an instance of "%s".', BaseCollection::class));
-        }
-
-        return $coll;
-    }
-
-    /**
-     * Marks this collection as changed/dirty.
-     */
-    protected function changed(): void
-    {
-        if ($this->isDirty) {
-            return;
-        }
-
-        $this->isDirty = true;
-
-        if (! $this->needsSchedulingForSynchronization() || $this->owner === null) {
-            return;
-        }
-
-        $this->uow->scheduleForSynchronization($this->owner);
-    }
-
     /**
      * Actual logic for adding an element to the collection.
      *
      * @return true
      */
-    protected function doAdd(mixed $value, bool $arrayAccess): bool
+    private function doAdd(mixed $value, bool $arrayAccess): bool
     {
         /* Initialize the collection before calling add() so this append operation
          * uses the appropriate key. Otherwise, we risk overwriting original data
@@ -420,7 +406,7 @@ trait PersistentCollectionTrait
      *      : T|true|null
      * )
      */
-    protected function doRemove(mixed $offset, bool $arrayAccess): mixed
+    private function doRemove(mixed $offset, bool $arrayAccess): mixed
     {
         $this->initialize();
         if ($arrayAccess) {
@@ -442,7 +428,7 @@ trait PersistentCollectionTrait
     /**
      * Actual logic for setting an element in the collection.
      */
-    protected function doSet(mixed $offset, mixed $value, bool $arrayAccess): void
+    private function doSet(mixed $offset, mixed $value, bool $arrayAccess): void
     {
         $arrayAccess ? $this->coll->offsetSet($offset, $value) : $this->coll->set($offset, $value);
 
@@ -460,7 +446,7 @@ trait PersistentCollectionTrait
      * Embedded documents are automatically considered as "orphan removal enabled" because they might have references
      * that require to trigger cascade remove operations.
      */
-    protected function isOrphanRemovalEnabled(): bool
+    private function isOrphanRemovalEnabled(): bool
     {
         if ($this->mapping === null) {
             return false;
@@ -480,5 +466,23 @@ trait PersistentCollectionTrait
     {
         return $this->owner && isset($this->dm) && ! empty($this->mapping['isOwningSide'])
             && $this->dm->getClassMetadata(get_class($this->owner))->isChangeTrackingNotify();
+    }
+
+    /** @return BaseCollection<TKey, T> */
+    public function matching(Criteria $criteria): BaseCollection
+    {
+        $this->initialize();
+
+        if (! $this->coll instanceof Selectable) {
+            throw new LogicException('The backed collection must implement Selectable to use matching().');
+        }
+
+        $coll = $this->coll->matching($criteria);
+
+        if (! $coll instanceof BaseCollection) {
+            throw new LogicException(sprintf('The matching() method of the backed collection must return an instance of "%s".', BaseCollection::class));
+        }
+
+        return $coll;
     }
 }

--- a/src/PersistentCollection/PersistentCollectionTrait.php
+++ b/src/PersistentCollection/PersistentCollectionTrait.php
@@ -14,7 +14,6 @@ use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\UnitOfWork;
 use Doctrine\ODM\MongoDB\Utility\CollectionHelper;
 use LogicException;
-use Traversable;
 
 use function array_combine;
 use function array_diff_key;
@@ -29,6 +28,10 @@ use function sprintf;
 /**
  * Trait with methods needed to implement PersistentCollectionInterface.
  *
+ * Collection/ReadableCollection/ArrayAccess interface methods live in
+ * PersistentCollectionCompatibility so they can be typed or untyped depending
+ * on which version of doctrine/collections is installed.
+ *
  * @phpstan-import-type Hints from UnitOfWork
  * @phpstan-import-type FieldMapping from ClassMetadata
  * @template TKey of array-key
@@ -36,6 +39,7 @@ use function sprintf;
  */
 trait PersistentCollectionTrait
 {
+    /** @use PersistentCollectionCompatibility<TKey, T> */
     use PersistentCollectionCompatibility;
 
     /**
@@ -164,24 +168,6 @@ trait PersistentCollectionTrait
         $this->isDirty = true;
     }
 
-    /**
-     * Marks this collection as changed/dirty.
-     */
-    private function changed(): void
-    {
-        if ($this->isDirty) {
-            return;
-        }
-
-        $this->isDirty = true;
-
-        if (! $this->needsSchedulingForSynchronization() || $this->owner === null) {
-            return;
-        }
-
-        $this->uow->scheduleForSynchronization($this->owner);
-    }
-
     public function isDirty(): bool
     {
         if ($this->isDirty) {
@@ -201,7 +187,7 @@ trait PersistentCollectionTrait
         return false;
     }
 
-    public function setDirty(bool $dirty): void
+    public function setDirty($dirty): void
     {
         $this->isDirty = $dirty;
     }
@@ -300,7 +286,7 @@ trait PersistentCollectionTrait
         return $this->dm->getClassMetadata($this->mapping['targetDocument']);
     }
 
-    public function setInitialized(bool $bool): void
+    public function setInitialized($bool): void
     {
         $this->initialized = $bool;
     }
@@ -310,193 +296,9 @@ trait PersistentCollectionTrait
         return $this->initialized;
     }
 
-    public function first(): mixed
+    public function unwrap(): BaseCollection
     {
-        $this->initialize();
-
-        return $this->coll->first();
-    }
-
-    public function last(): mixed
-    {
-        $this->initialize();
-
-        return $this->coll->last();
-    }
-
-    public function remove(string|int $key): mixed
-    {
-        return $this->doRemove($key, false);
-    }
-
-    public function removeElement(mixed $element): bool
-    {
-        $this->initialize();
-        $removed = $this->coll->removeElement($element);
-
-        if (! $removed) {
-            return $removed;
-        }
-
-        $this->changed();
-
-        return $removed;
-    }
-
-    public function containsKey(string|int $key): bool
-    {
-        $this->initialize();
-
-        return $this->coll->containsKey($key);
-    }
-
-    /** @template TMaybeContained */
-    public function contains(mixed $element): bool
-    {
-        $this->initialize();
-
-        return $this->coll->contains($element);
-    }
-
-    public function exists(Closure $p): bool
-    {
-        $this->initialize();
-
-        return $this->coll->exists($p);
-    }
-
-    /**
-     * @phpstan-return (TMaybeContained is T ? TKey|false : false)
-     *
-     * @template TMaybeContained
-     */
-    public function indexOf(mixed $element): int|string|false
-    {
-        $this->initialize();
-
-        return $this->coll->indexOf($element);
-    }
-
-    public function get(string|int $key): mixed
-    {
-        $this->initialize();
-
-        return $this->coll->get($key);
-    }
-
-    public function getKeys(): array
-    {
-        $this->initialize();
-
-        return $this->coll->getKeys();
-    }
-
-    public function getValues(): array
-    {
-        $this->initialize();
-
-        return $this->coll->getValues();
-    }
-
-    public function count(): int
-    {
-        // Workaround around not being able to directly count inverse collections anymore
-        $this->initialize();
-
-        return $this->coll->count();
-    }
-
-    public function set(string|int $key, mixed $value): void
-    {
-        $this->doSet($key, $value, false);
-    }
-
-    public function isEmpty(): bool
-    {
-        return $this->initialized ? $this->coll->isEmpty() : $this->count() === 0;
-    }
-
-    /**
-     * @phpstan-return Traversable<TKey, T>
-     */
-    public function getIterator(): Traversable
-    {
-        $this->initialize();
-
-        return $this->coll->getIterator();
-    }
-
-    public function map(Closure $func): BaseCollection
-    {
-        $this->initialize();
-
-        return $this->coll->map($func);
-    }
-
-    public function filter(Closure $p): BaseCollection
-    {
-        $this->initialize();
-
-        return $this->coll->filter($p);
-    }
-
-    public function forAll(Closure $p): bool
-    {
-        $this->initialize();
-
-        return $this->coll->forAll($p);
-    }
-
-    public function partition(Closure $p): array
-    {
-        $this->initialize();
-
-        return $this->coll->partition($p);
-    }
-
-    public function toArray(): array
-    {
-        $this->initialize();
-
-        return $this->coll->toArray();
-    }
-
-    public function clear(): void
-    {
-        if ($this->initialized && $this->isEmpty()) {
-            return;
-        }
-
-        if ($this->isOrphanRemovalEnabled()) {
-            $this->initialize();
-            foreach ($this->coll as $element) {
-                $this->uow->scheduleOrphanRemoval($element);
-            }
-        }
-
-        $this->mongoData = [];
-        $this->coll->clear();
-
-        // Nothing to do for inverse-side collections
-        if (! $this->mapping['isOwningSide']) {
-            return;
-        }
-
-        // Nothing to do if the collection was initialized but contained no data
-        if ($this->initialized && empty($this->snapshot)) {
-            return;
-        }
-
-        $this->changed();
-        $this->uow->scheduleCollectionDeletion($this);
-        $this->takeSnapshot();
-    }
-
-    public function slice(int $offset, int|null $length = null): array
-    {
-        $this->initialize();
-
-        return $this->coll->slice($offset, $length);
+        return $this->coll;
     }
 
     /**
@@ -527,64 +329,6 @@ trait PersistentCollectionTrait
         return ['coll', 'initialized', 'mongoData', 'snapshot', 'isDirty', 'hints'];
     }
 
-    /* ArrayAccess implementation */
-
-    public function offsetExists(mixed $offset): bool
-    {
-        $this->initialize();
-
-        return $this->coll->offsetExists($offset);
-    }
-
-    /**
-     * @phpstan-return T|null
-     */
-    public function offsetGet(mixed $offset): mixed
-    {
-        $this->initialize();
-
-        return $this->coll->offsetGet($offset);
-    }
-
-    public function offsetSet(mixed $offset, mixed $value): void
-    {
-        if (! isset($offset)) {
-            $this->doAdd($value, true);
-
-            return;
-        }
-
-        $this->doSet($offset, $value, true);
-    }
-
-    public function offsetUnset(mixed $offset): void
-    {
-        $this->doRemove($offset, true);
-    }
-
-    public function key(): int|string|null
-    {
-        return $this->coll->key();
-    }
-
-    /**
-     * Gets the element of the collection at the current iterator position.
-     */
-    public function current(): mixed
-    {
-        return $this->coll->current();
-    }
-
-    public function next(): mixed
-    {
-        return $this->coll->next();
-    }
-
-    public function unwrap(): BaseCollection
-    {
-        return $this->coll;
-    }
-
     /**
      * Cleanup internal state of cloned persistent collection.
      *
@@ -610,12 +354,44 @@ trait PersistentCollectionTrait
         $this->changed();
     }
 
+    /** @return BaseCollection<TKey, T> */
+    public function matching(Criteria $criteria): BaseCollection
+    {
+        $this->initialize();
+
+        $coll = $this->coll->matching($criteria);
+
+        if (! $coll instanceof BaseCollection) {
+            throw new LogicException(sprintf('The matching() method of the backed collection must return an instance of "%s".', BaseCollection::class));
+        }
+
+        return $coll;
+    }
+
+    /**
+     * Marks this collection as changed/dirty.
+     */
+    protected function changed(): void
+    {
+        if ($this->isDirty) {
+            return;
+        }
+
+        $this->isDirty = true;
+
+        if (! $this->needsSchedulingForSynchronization() || $this->owner === null) {
+            return;
+        }
+
+        $this->uow->scheduleForSynchronization($this->owner);
+    }
+
     /**
      * Actual logic for adding an element to the collection.
      *
      * @return true
      */
-    private function doAdd(mixed $value, bool $arrayAccess): bool
+    protected function doAdd(mixed $value, bool $arrayAccess): bool
     {
         /* Initialize the collection before calling add() so this append operation
          * uses the appropriate key. Otherwise, we risk overwriting original data
@@ -644,7 +420,7 @@ trait PersistentCollectionTrait
      *      : T|true|null
      * )
      */
-    private function doRemove(mixed $offset, bool $arrayAccess): mixed
+    protected function doRemove(mixed $offset, bool $arrayAccess): mixed
     {
         $this->initialize();
         if ($arrayAccess) {
@@ -666,7 +442,7 @@ trait PersistentCollectionTrait
     /**
      * Actual logic for setting an element in the collection.
      */
-    private function doSet(mixed $offset, mixed $value, bool $arrayAccess): void
+    protected function doSet(mixed $offset, mixed $value, bool $arrayAccess): void
     {
         $arrayAccess ? $this->coll->offsetSet($offset, $value) : $this->coll->set($offset, $value);
 
@@ -684,7 +460,7 @@ trait PersistentCollectionTrait
      * Embedded documents are automatically considered as "orphan removal enabled" because they might have references
      * that require to trigger cascade remove operations.
      */
-    private function isOrphanRemovalEnabled(): bool
+    protected function isOrphanRemovalEnabled(): bool
     {
         if ($this->mapping === null) {
             return false;
@@ -704,47 +480,5 @@ trait PersistentCollectionTrait
     {
         return $this->owner && isset($this->dm) && ! empty($this->mapping['isOwningSide'])
             && $this->dm->getClassMetadata(get_class($this->owner))->isChangeTrackingNotify();
-    }
-
-    /**
-     * @phpstan-param Closure(TKey, T):bool $p
-     *
-     * @phpstan-return T|null
-     */
-    public function findFirst(Closure $p): mixed
-    {
-        return $this->coll->findFirst($p);
-    }
-
-    /**
-     * @phpstan-param Closure(TReturn|TInitial|null, T):(TInitial|TReturn) $func
-     * @phpstan-param TInitial|null $initial
-     *
-     * @phpstan-return TReturn|TInitial|null
-     *
-     * @phpstan-template TReturn
-     * @phpstan-template TInitial
-     */
-    public function reduce(Closure $func, mixed $initial = null): mixed
-    {
-        return $this->coll->reduce($func, $initial);
-    }
-
-    /** @return BaseCollection<TKey, T> */
-    public function matching(Criteria $criteria): BaseCollection
-    {
-        $this->initialize();
-
-        if (! $this->coll instanceof Selectable) {
-            throw new LogicException('The backed collection must implement Selectable to use matching().');
-        }
-
-        $coll = $this->coll->matching($criteria);
-
-        if (! $coll instanceof BaseCollection) {
-            throw new LogicException(sprintf('The matching() method of the backed collection must return an instance of "%s".', BaseCollection::class));
-        }
-
-        return $coll;
     }
 }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -18,6 +18,7 @@ use MongoDB\BSON\Javascript;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Collection;
 use MongoDB\Driver\ReadPreference;
+use SortDirection;
 
 use function array_filter;
 use function array_key_exists;
@@ -1474,8 +1475,8 @@ class Builder
      * If sorting by multiple fields, the first argument should be an array of
      * field name (key) and order (value) pairs.
      *
-     * @param array<string, int|string>|string $fieldName Field name or array of field/order pairs
-     * @param int|string                       $order     Field order (if one field is specified)
+     * @param array<string, int|string|SortDirection>|string $fieldName Field name or array of field/order pairs
+     * @param int|string|SortDirection                       $order     Field order (if one field is specified)
      */
     public function sort($fieldName, $order = 1): self
     {
@@ -1483,7 +1484,9 @@ class Builder
         $fields                = is_array($fieldName) ? $fieldName : [$fieldName => $order];
 
         foreach ($fields as $fieldName => $order) {
-            if (is_string($order)) {
+            if ($order instanceof SortDirection) {
+                $order = $order === SortDirection::Ascending ? 1 : -1;
+            } elseif (is_string($order)) {
                 $order = strtolower($order) === 'asc' ? 1 : -1;
             }
 

--- a/src/Query/QueryExpressionVisitor.php
+++ b/src/Query/QueryExpressionVisitor.php
@@ -112,7 +112,7 @@ final class QueryExpressionVisitor extends ExpressionVisitor
      *
      * @return mixed
      */
-    public function walkValue(Value $value)
+    public function walkValue(Value $value): mixed
     {
         return $value->getValue();
     }

--- a/src/Query/QueryExpressionVisitor.php
+++ b/src/Query/QueryExpressionVisitor.php
@@ -109,8 +109,6 @@ final class QueryExpressionVisitor extends ExpressionVisitor
      * Converts a value expression into the target query language part.
      *
      * @see ExpressionVisitor::walkValue()
-     *
-     * @return mixed
      */
     public function walkValue(Value $value): mixed
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #2986 

#### Summary

  - Expands `doctrine/collections` constraint from `^2.1` to `^2.1 || ^3.1`
  - Adds `PersistentCollectionCompatibility` trait (renamed from `PersistentCollectionImplementationTrait`) that conditionally defines `add()` with `bool` return (v2) or `void` return (v3) using a runtime
  version check via `defined(Criteria::class . '::ASC')`
  - Adds explicit PHP type declarations to all methods in `PersistentCollectionTrait` and `PersistentCollectionInterface` to satisfy v3's fully-typed `Collection`/`ReadableCollection`/`ArrayAccess`
  interfaces; removes now-redundant `#[ReturnTypeWillChange]` attributes
  - Fixes `QueryExpressionVisitor::walkValue()` missing `: mixed` return type (caught by the same type-declaration pass)

  ## Notable design decisions

  `add()` is the only method whose return type changed between v2 (`bool`) and v3 (`void`); all other methods were untyped in v2 and only gained types in v3. The conditional-trait approach isolates that
  single incompatibility. `filter()` and `map()` declare `): Collection` as their return type — identical to how `AbstractLazyCollection` handles it in doctrine/collections itself.