### PR TITLE
Ignore static properties when merging detached documents

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -1951,6 +1951,10 @@ final class UnitOfWork implements PropertyChangedListener
 
             // Merge state of $document into existing (managed) document
             foreach ($class->reflClass->getProperties() as $nativeReflection) {
+                if ($nativeReflection->isStatic()) {
+                    continue;
+                }
+
                 $name = $nativeReflection->name;
                 $prop = $this->reflectionService->getAccessibleProperty($class->name, $name);
                 assert($prop instanceof ReflectionProperty);

--- a/tests/Tests/Functional/DetachedDocumentTest.php
+++ b/tests/Tests/Functional/DetachedDocumentTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionInterface;
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Documents\CmsArticle;
@@ -115,4 +116,32 @@ class DetachedDocumentTest extends BaseTestCase
 
         self::assertSame('alcaeus', $cmsArticle->user->getUsername());
     }
+
+    public function testMergeIgnoresStaticProperties(): void
+    {
+        $document       = new DocumentWithStaticProperty();
+        $document->name = 'foo';
+        $this->dm->persist($document);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $document->name = 'bar';
+
+        $merged = $this->dm->merge($document);
+
+        self::assertSame('bar', $merged->name);
+        self::assertSame('staticValue', DocumentWithStaticProperty::$staticProperty);
+    }
+}
+
+#[ODM\Document]
+class DocumentWithStaticProperty
+{
+    public static string $staticProperty = 'staticValue';
+
+    #[ODM\Id]
+    public ?string $id = null;
+
+    #[ODM\Field(type: 'string')]
+    public string $name;
 }


### PR DESCRIPTION
Fixes #3013.

`UnitOfWork::doMerge()` iterates over all reflection properties of a class via `$class->reflClass->getProperties()`, including `static` ones, regardless of whether they are mapped. `RuntimeReflectionProperty::getValue($document)` returns `null` for static properties (unlike the native `ReflectionProperty`), so the merge assigned `null` back and crashed with `TypeError: Cannot assign null to property ...::$type of type string` on non-nullable typed static properties.

Static properties are never mapped fields, so `doMerge()` now skips them.