### PR TITLE
Add regression test for dirty ReferenceMany collection change detection

### DIFF
--- a/tests/Tests/UnitOfWorkTest.php
+++ b/tests/Tests/UnitOfWorkTest.php
@@ -23,6 +23,7 @@ use Documents\ForumAvatar;
 use Documents\ForumStar;
 use Documents\ForumUser;
 use Documents\Functional\NotSaved;
+use Documents\Group;
 use Documents\User;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Collection as MongoDBCollection;
@@ -487,6 +488,25 @@ class UnitOfWorkTest extends BaseTestCase
 
         self::assertArrayHasKey('city', $changeSet);
         self::assertEquals('Nashville', $changeSet['city'][1]);
+    }
+
+    public function testDirtyReferenceManyCollectionIsDetectedAsChanged(): void
+    {
+        $group = new Group('Admins');
+        $user  = new User();
+        $this->uow->persist($group);
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        // Add a reference to the same PersistentCollection instance (orgValue === actualValue, but dirty).
+        // ReferenceMany collections are not processed through the association changeset loop,
+        // so their detection relies solely on the dirty flag in computeOrRecomputeChangeSet().
+        $user->addGroup($group);
+
+        $this->uow->computeChangeSets();
+        $changeSet = $this->uow->getDocumentChangeSet($user);
+
+        self::assertArrayHasKey('groups', $changeSet);
     }
 
     public function testRecomputeChangesetForUninitializedProxyDoesNotCreateChangeset(): void


### PR DESCRIPTION
`computeOrRecomputeChangeSet()` must detect a `ReferenceMany` `PersistentCollection` as changed when it is dirty (same instance, element added or removed). Unlike `EmbedMany` collections, `ReferenceMany` are explicitly skipped in the association changeset loop (line 879 of `UnitOfWork.php`), so detection relies solely on the dirty flag check in the field comparison block.

This test covers a regression introduced by #3017, where replacing the `$orgValue === $actualValue` guard with `spl_object_hash()` — functionally equivalent for live objects — causes the dirty collection to be skipped instead of falling through to the changeset.