### PR TITLE
Add `autoEmbed` support for vector search indexes and `$vectorSearch` stage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VOYAGE_API_KEY=
+EMBEDDING_PROVIDER_ENDPOINT=https://api.voyageai.com/v1/embeddings

--- a/.github/workflows/atlas-ci.yml
+++ b/.github/workflows/atlas-ci.yml
@@ -38,18 +38,21 @@ jobs:
           fetch-depth: 2
 
       - name: "Create MongoDB Atlas Local"
+        timeout-minutes: 5
         run: |
-          docker run --name mongodb -p 27017:27017 --detach mongodb/mongodb-atlas-local:8.2
+          docker run --name mongodb -p 27017:27017 \
+            -e VOYAGE_API_KEY=${{ secrets.VOYAGE_API_KEY }} \
+            -e EMBEDDING_PROVIDER_ENDPOINT=https://api.voyageai.com/v1/embeddings \
+            --detach mongodb/mongodb-atlas-local:preview
           until docker exec --tty mongodb mongosh --eval "db.runCommand({ ping: 1 })"; do
             sleep 1
           done
           until docker exec --tty mongodb mongosh --eval "db.createCollection('connection_test') && db.getCollection('connection_test').createSearchIndex({mappings:{dynamic: true}})"; do
             sleep 1
           done
-
-      - name: "Show MongoDB server status"
-        run: |
-          docker exec --tty mongodb mongosh --eval "db.runCommand({ serverStatus: 1 })"
+          until docker exec --tty mongodb mongosh --eval "db.runCommand({ serverStatus: 1 })"; do
+            sleep 1
+          done
 
       - name: Setup cache environment
         id: extcache

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,12 @@ version: '3.8'
 
 services:
   mongodb-atlas-local:
-    image: mongodb/mongodb-atlas-local
+    image: mongodb/mongodb-atlas-local:preview
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      - VOYAGE_API_KEY=${VOYAGE_API_KEY:-}
+      - EMBEDDING_PROVIDER_ENDPOINT=${EMBEDDING_PROVIDER_ENDPOINT:-https://api.voyageai.com/v1/embeddings}
     ports:
       - "27018:27017"

--- a/docs/en/cookbook/vector-search.rst
+++ b/docs/en/cookbook/vector-search.rst
@@ -180,7 +180,126 @@ Notes
 - Use the aggregation builder's ``vectorSearch`` stage to query for similar vectors.
 - Doctrine ODM 2.13+ is required for vector search support.
 
+Automated Embeddings
+--------------------
 
-.. _`MongoDB Atlas Vector Search`: <https://www.mongodb.com/docs/atlas/atlas-vector-search/>
+`MongoDB Atlas Automated Embedding`_ eliminates the need to generate and store
+vector embeddings manually. Instead of a ``vector`` field type, the index uses
+an ``autoEmbed`` field that automatically embeds the content of a text field
+using a hosted embedding model (powered by `Voyage AI`_).
+
+Step 1: Define the Model
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the ``autoEmbed`` field type with the ``modality`` and ``model`` options.
+No ``numDimensions`` or ``similarity`` are required — they are inferred from the model.
+
+.. configuration-block::
+
+    .. code-block:: php
+
+        <?php
+
+        use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
+
+        #[ODM\Document]
+        #[ODM\VectorSearchIndex(
+            fields: [
+                [
+                    'type'     => 'autoEmbed',
+                    'path'     => 'content',
+                    'modality' => 'text',
+                    'model'    => 'voyage-4',
+                ],
+                ['type' => 'filter', 'path' => 'published'],
+            ],
+        )]
+        class Article
+        {
+            #[ODM\Id]
+            public ?string $id = null;
+
+            #[ODM\Field]
+            public string $content = '';
+
+            #[ODM\Field]
+            public bool $published = false;
+        }
+
+    .. code-block:: xml
+
+        <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping
+                            http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping.xsd">
+
+            <document name="Documents\Article">
+                <vector-search-indexes>
+                    <vector-search-index>
+                        <auto-embed-field path="content" modality="text" model="voyage-4" />
+                        <filter-field path="published" />
+                    </vector-search-index>
+                </vector-search-indexes>
+            </document>
+        </doctrine-mongo-mapping>
+
+Step 2: Insert Documents
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Insert documents as usual; no embedding step required.
+
+.. code-block:: php
+
+    $article = new Article();
+    $article->content   = 'MongoDB Atlas Vector Search enables semantic similarity queries.';
+    $article->published = true;
+
+    $dm->persist($article);
+    $dm->flush();
+
+Step 3: Create the Index and Wait
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: php
+
+    $schemaManager = $dm->getSchemaManager();
+    $schemaManager->createDocumentSearchIndexes(Article::class);
+    $schemaManager->waitForSearchIndexes([Article::class]);
+
+Step 4: Run a Semantic Search
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the ``query`` method instead of ``queryVector``. The query string is
+automatically embedded at query time using the same model.
+
+.. code-block:: php
+
+    $results = $dm->createAggregationBuilder(Article::class)
+        ->vectorSearch()
+            ->index('default')
+            ->path('content')
+            ->query('semantic search NoSQL')
+            ->numCandidates(10)
+            ->limit(5)
+        ->getAggregation()->execute()->toArray();
+
+Use ``model()`` to use a compatible but lighter model at query time (e.g.
+``voyage-4-lite`` instead of ``voyage-4``), reducing query cost while keeping
+the same index:
+
+.. code-block:: php
+
+    ->vectorSearch()
+        ->query('semantic search NoSQL')
+        ->model('voyage-4-lite')
+
+.. note::
+
+    Automated embedding requires a `MongoDB Atlas`_ cluster with a registered
+    Voyage AI API key. It is not available on standalone MongoDB deployments.
+
+.. _`MongoDB Atlas Vector Search`: https://www.mongodb.com/docs/atlas/atlas-vector-search/
+.. _`MongoDB Atlas Automated Embedding`: https://www.mongodb.com/docs/vector-search/crud-embeddings/automated-embedding/
+.. _`MongoDB Atlas`: https://www.mongodb.com/atlas
 .. _`Voyage AI`: https://www.voyageai.com/
 .. _`Symfony AI`: https://symfony.com/ai

--- a/docs/en/cookbook/vector-search.rst
+++ b/docs/en/cookbook/vector-search.rst
@@ -209,7 +209,7 @@ No ``numDimensions`` or ``similarity`` are required — they are inferred from t
                     'type'     => 'autoEmbed',
                     'path'     => 'content',
                     'modality' => 'text',
-                    'model'    => 'voyage-4',
+                    'model'    => 'voyage-4-large',
                 ],
                 ['type' => 'filter', 'path' => 'published'],
             ],
@@ -236,7 +236,7 @@ No ``numDimensions`` or ``similarity`` are required — they are inferred from t
             <document name="Documents\Article">
                 <vector-search-indexes>
                     <vector-search-index>
-                        <auto-embed-field path="content" modality="text" model="voyage-4" />
+                        <auto-embed-field path="content" modality="text" model="voyage-4-large" />
                         <filter-field path="published" />
                     </vector-search-index>
                 </vector-search-indexes>
@@ -283,9 +283,10 @@ automatically embedded at query time using the same model.
             ->limit(5)
         ->getAggregation()->execute()->toArray();
 
-Use ``model()`` to use a compatible but lighter model at query time (e.g.
-``voyage-4-lite`` instead of ``voyage-4``), reducing query cost while keeping
-the same index:
+All models in the ``voyage-4`` series produce compatible embeddings. Use
+``model()`` to query with a lighter model (e.g. ``voyage-4-lite``) while
+indexing with a higher-quality one (e.g. ``voyage-4-large``), reducing query
+cost without changing the index:
 
 .. code-block:: php
 

--- a/doctrine-mongo-mapping.xsd
+++ b/doctrine-mongo-mapping.xsd
@@ -658,6 +658,7 @@
   <xs:complexType name="vector-search-index">
     <xs:choice maxOccurs="unbounded">
       <xs:element name="vector-field" type="odm:vector-search-vector-field" />
+      <xs:element name="auto-embed-field" type="odm:vector-search-auto-embed-field" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="filter-field" type="odm:vector-search-filter-field" minOccurs="0" maxOccurs="unbounded" />
     </xs:choice>
 
@@ -671,6 +672,12 @@
     <xs:attribute name="quantization" type="xs:string" />
     <xs:attribute name="hnswMaxEdges" type="xs:int" />
     <xs:attribute name="hnswNumEdgeCandidates" type="xs:int" />
+  </xs:complexType>
+
+  <xs:complexType name="vector-search-auto-embed-field">
+    <xs:attribute name="path" type="xs:string" use="required" />
+    <xs:attribute name="modality" type="xs:string" use="required" />
+    <xs:attribute name="model" type="xs:string" use="required" />
   </xs:complexType>
 
   <xs:complexType name="vector-search-filter-field">

--- a/src/Aggregation/Stage/VectorSearch.php
+++ b/src/Aggregation/Stage/VectorSearch.php
@@ -26,8 +26,10 @@ use function sprintf;
  *         filter?: object,
  *         index?: string,
  *         limit?: int,
+ *         model?: string,
  *         numCandidates?: int,
  *         path?: string,
+ *         query?: string,
  *         queryVector?: Vector,
  *     }
  * }
@@ -41,8 +43,10 @@ class VectorSearch extends Stage
     private array|Expr|null $filter = null;
     private ?string $index          = null;
     private ?int $limit             = null;
+    private ?string $model          = null;
     private ?int $numCandidates     = null;
     private ?string $path           = null;
+    private ?string $query          = null;
     /** @phpstan-var Vector|null */
     private array|Binary|null $queryVector = null;
 
@@ -73,12 +77,20 @@ class VectorSearch extends Stage
             $params['limit'] = $this->limit;
         }
 
+        if ($this->model !== null) {
+            $params['model'] = $this->model;
+        }
+
         if ($this->numCandidates !== null) {
             $params['numCandidates'] = $this->numCandidates;
         }
 
         if ($this->path !== null) {
             $params['path'] = $this->persister->prepareFieldName($this->path);
+        }
+
+        if ($this->query !== null) {
+            $params['query'] = $this->query;
         }
 
         if ($this->queryVector !== null) {
@@ -117,6 +129,13 @@ class VectorSearch extends Stage
         return $this;
     }
 
+    public function model(string $model): static
+    {
+        $this->model = $model;
+
+        return $this;
+    }
+
     public function numCandidates(int $numCandidates): static
     {
         $this->numCandidates = $numCandidates;
@@ -127,6 +146,13 @@ class VectorSearch extends Stage
     public function path(string $path): static
     {
         $this->path = $path;
+
+        return $this;
+    }
+
+    public function query(string $query): static
+    {
+        $this->query = $query;
 
         return $this;
     }

--- a/src/Aggregation/Stage/VectorSearch.php
+++ b/src/Aggregation/Stage/VectorSearch.php
@@ -100,14 +100,23 @@ class VectorSearch extends Stage
         return [$this->getStageName() => $params];
     }
 
+    /** Whether to run an exact nearest neighbor search instead of approximate. Cannot be used with numCandidates. */
     public function exact(bool $exact): static
     {
+        if ($exact && $this->numCandidates !== null) {
+            throw new InvalidArgumentException('Cannot use numCandidates() with exact(true) in the same $vectorSearch stage.');
+        }
+
         $this->exact = $exact;
 
         return $this;
     }
 
-    /** @phpstan-param array<string, mixed>|Expr $filter */
+    /**
+     * MQL match expression to pre-filter documents before the vector search.
+     *
+     * @phpstan-param array<string, mixed>|Expr $filter
+     */
     public function filter(array|Expr $filter): static
     {
         $this->filter = $filter;
@@ -115,6 +124,7 @@ class VectorSearch extends Stage
         return $this;
     }
 
+    /** Name of the vector search index to use. */
     public function index(string $index): static
     {
         $this->index = $index;
@@ -122,6 +132,7 @@ class VectorSearch extends Stage
         return $this;
     }
 
+    /** Maximum number of documents to return. */
     public function limit(int $limit): static
     {
         $this->limit = $limit;
@@ -129,6 +140,7 @@ class VectorSearch extends Stage
         return $this;
     }
 
+    /** Embedding model used to embed the query string. Must be compatible with the index model. */
     public function model(string $model): static
     {
         $this->model = $model;
@@ -136,13 +148,19 @@ class VectorSearch extends Stage
         return $this;
     }
 
+    /** Number of nearest neighbors to consider. Higher values improve accuracy at the cost of latency. Must be >= limit. */
     public function numCandidates(int $numCandidates): static
     {
+        if ($this->exact === true) {
+            throw new InvalidArgumentException('Cannot use numCandidates() with exact(true) in the same $vectorSearch stage.');
+        }
+
         $this->numCandidates = $numCandidates;
 
         return $this;
     }
 
+    /** Field path containing the vector embeddings to search. */
     public function path(string $path): static
     {
         $this->path = $path;
@@ -150,16 +168,29 @@ class VectorSearch extends Stage
         return $this;
     }
 
+    /** Text query automatically embedded at query time using the model configured in the index. */
     public function query(string $query): static
     {
+        if ($this->queryVector !== null) {
+            throw new InvalidArgumentException('Cannot use both query() and queryVector() in the same $vectorSearch stage.');
+        }
+
         $this->query = $query;
 
         return $this;
     }
 
-    /** @phpstan-param Vector $queryVector */
+    /**
+     * Raw vector for manual similarity search, when embeddings are generated outside of MongoDB.
+     *
+     * @phpstan-param Vector $queryVector
+     */
     public function queryVector(array|Binary $queryVector): static
     {
+        if ($this->query !== null) {
+            throw new InvalidArgumentException('Cannot use both query() and queryVector() in the same $vectorSearch stage.');
+        }
+
         if ($queryVector === []) {
             throw new InvalidArgumentException('Query vector cannot be an empty array.');
         }

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -278,7 +278,7 @@ use const PHP_VERSION_ID;
  *     similarity?: self::VECTOR_SIMILARITY_*,
  *     quantization?: self::VECTOR_QUANTIZATION_*,
  *     hnswOptions?: array{maxEdges?: int, numEdgeCandidates?: int},
- *     modality?: 'text',
+ *     modality?: self::VECTOR_AUTOEMBEDDING_MODALITY_*,
  *     model?: string,
  * }
  * @phpstan-type VectorSearchIndexDefinition array{

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -40,7 +40,7 @@ use Symfony\Component\Uid\UuidV1;
 use Symfony\Component\Uid\UuidV4;
 use Symfony\Component\Uid\UuidV7;
 
-use function array_column;
+use function array_any;
 use function array_filter;
 use function array_key_exists;
 use function array_keys;
@@ -272,12 +272,14 @@ use const PHP_VERSION_ID;
  *      definition: SearchIndexDefinition|VectorSearchIndexDefinition
  * }
  * @phpstan-type VectorSearchIndexField array{
- *     type: "vector"|"filter",
+ *     type: "vector"|"filter"|"autoEmbed",
  *     path: string,
  *     numDimensions?: int,
  *     similarity?: self::VECTOR_SIMILARITY_*,
  *     quantization?: self::VECTOR_QUANTIZATION_*,
- *     hnswOptions?: array{maxEdges?: int, numEdgeCandidates?: int}
+ *     hnswOptions?: array{maxEdges?: int, numEdgeCandidates?: int},
+ *     modality?: 'text',
+ *     model?: string,
  * }
  * @phpstan-type VectorSearchIndexDefinition array{
  *     fields: list<VectorSearchIndexField>
@@ -489,6 +491,8 @@ use const PHP_VERSION_ID;
     public const VECTOR_QUANTIZATION_NONE      = 'none';
     public const VECTOR_QUANTIZATION_SCALAR    = 'scalar';
     public const VECTOR_QUANTIZATION_BINARY    = 'binary';
+
+    public const VECTOR_AUTOEMBEDDING_MODALITY_TEXT = 'text';
 
     private const ALLOWED_GRIDFS_FIELDS = ['_id', 'chunkSize', 'filename', 'length', 'metadata', 'uploadDate'];
 
@@ -1310,7 +1314,7 @@ use const PHP_VERSION_ID;
             throw MappingException::emptySearchIndexDefinition($this->name, $name);
         }
 
-        if ($type === 'vectorSearch' && ! in_array('vector', array_column($definition['fields'] ?? [], 'type'), true)) {
+        if ($type === 'vectorSearch' && ! array_any($definition['fields'] ?? [], static fn (array $f) => $f['type'] === 'vector' || $f['type'] === 'autoEmbed')) {
             throw MappingException::emptyVectorSearchIndexDefinition($this->name, $name);
         }
 

--- a/src/Mapping/Driver/XmlDriver.php
+++ b/src/Mapping/Driver/XmlDriver.php
@@ -772,6 +772,15 @@ class XmlDriver extends FileDriver
             $definition['fields'][] = $field;
         }
 
+        foreach ($searchIndex->{'auto-embed-field'} as $autoEmbedField) {
+            $definition['fields'][] = [
+                'type'     => 'autoEmbed',
+                'path'     => (string) $autoEmbedField['path'],
+                'modality' => (string) $autoEmbedField['modality'],
+                'model'    => (string) $autoEmbedField['model'],
+            ];
+        }
+
         foreach ($searchIndex->{'filter-field'} as $filterField) {
             $definition['fields'][] = [
                 'type' => 'filter',

--- a/src/Mapping/MappingException.php
+++ b/src/Mapping/MappingException.php
@@ -299,7 +299,7 @@ final class MappingException extends BaseMappingException
 
     public static function emptyVectorSearchIndexDefinition(string $className, string $indexName): self
     {
-        return new self(sprintf('%s vector search index "%s" must have a vector field', $className, $indexName));
+        return new self(sprintf('%s vector search index "%s" must have a "vector" or "autoEmbed" field', $className, $indexName));
     }
 
     public static function timeSeriesFieldNotFound(string $className, string $fieldName, string $field): self

--- a/src/SchemaManager.php
+++ b/src/SchemaManager.php
@@ -405,6 +405,7 @@ final class SchemaManager
      * @param class-string $documentName
      *
      * @throws InvalidArgumentException
+     * @throws CommandException if the server rejects the index definition.
      */
     public function createDocumentSearchIndexes(string $documentName): void
     {

--- a/tests/Documents/AutoEmbeddingArticle.php
+++ b/tests/Documents/AutoEmbeddingArticle.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Documents;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Document;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Field;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\Id;
+use Doctrine\ODM\MongoDB\Mapping\Annotations\VectorSearchIndex;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+
+#[Document(collection: 'auto_embedding_articles')]
+#[VectorSearchIndex(
+    fields: [
+        [
+            'type'     => 'autoEmbed',
+            'path'     => 'content',
+            'modality' => ClassMetadata::VECTOR_AUTOEMBEDDING_MODALITY_TEXT,
+            'model'    => 'voyage-4',
+        ],
+        ['type' => 'filter', 'path' => 'category'],
+    ],
+)]
+class AutoEmbeddingArticle
+{
+    #[Id]
+    public ?string $id = null;
+
+    #[Field]
+    public string $content = '';
+
+    #[Field]
+    public string $category = '';
+}

--- a/tests/Documents/AutoEmbeddingArticle.php
+++ b/tests/Documents/AutoEmbeddingArticle.php
@@ -17,7 +17,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
             'type'     => 'autoEmbed',
             'path'     => 'content',
             'modality' => ClassMetadata::VECTOR_AUTOEMBEDDING_MODALITY_TEXT,
-            'model'    => 'voyage-4',
+            'model'    => 'voyage-4-large',
         ],
         ['type' => 'filter', 'path' => 'category'],
     ],

--- a/tests/Tests/Aggregation/Stage/VectorSearchTest.php
+++ b/tests/Tests/Aggregation/Stage/VectorSearchTest.php
@@ -69,11 +69,25 @@ class VectorSearchTest extends BaseTestCase
         self::assertSame(['$vectorSearch' => ['numCandidates' => 5]], $stage->getExpression());
     }
 
+    public function testModel(): void
+    {
+        [$stage] = $this->createVectorSearchStage();
+        $stage->model('voyage-4');
+        self::assertSame(['$vectorSearch' => ['model' => 'voyage-4']], $stage->getExpression());
+    }
+
     public function testPath(): void
     {
         [$stage] = $this->createVectorSearchStage();
         $stage->path('vectorField');
         self::assertSame(['$vectorSearch' => ['path' => 'vectorField']], $stage->getExpression());
+    }
+
+    public function testQuery(): void
+    {
+        [$stage] = $this->createVectorSearchStage();
+        $stage->query('semantic search text');
+        self::assertSame(['$vectorSearch' => ['query' => 'semantic search text']], $stage->getExpression());
     }
 
     public function testPathIsPrepared(): void
@@ -135,6 +149,24 @@ class VectorSearchTest extends BaseTestCase
                 'numCandidates' => 3,
                 'path' => 'vec',
                 'queryVector' => [0.1, 0.2],
+            ],
+        ], $stage->getExpression());
+    }
+
+    public function testChainingAutoEmbedOptions(): void
+    {
+        [$stage] = $this->createVectorSearchStage();
+        $stage
+            ->index('idx')
+            ->path('vec')
+            ->query('semantic search text')
+            ->model('voyage-4');
+        self::assertSame([
+            '$vectorSearch' => [
+                'index' => 'idx',
+                'model' => 'voyage-4',
+                'path' => 'vec',
+                'query' => 'semantic search text',
             ],
         ], $stage->getExpression());
     }

--- a/tests/Tests/Aggregation/Stage/VectorSearchTest.php
+++ b/tests/Tests/Aggregation/Stage/VectorSearchTest.php
@@ -129,6 +129,42 @@ class VectorSearchTest extends BaseTestCase
         $stage->queryVector($queryVector);
     }
 
+    public function testQueryAfterQueryVectorThrows(): void
+    {
+        [$stage] = $this->createVectorSearchStage();
+        $stage->queryVector([1, 2, 3]);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot use both query() and queryVector()');
+        $stage->query('search text');
+    }
+
+    public function testQueryVectorAfterQueryThrows(): void
+    {
+        [$stage] = $this->createVectorSearchStage();
+        $stage->query('search text');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot use both query() and queryVector()');
+        $stage->queryVector([1, 2, 3]);
+    }
+
+    public function testNumCandidatesAfterExactThrows(): void
+    {
+        [$stage] = $this->createVectorSearchStage();
+        $stage->exact(true);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot use numCandidates() with exact(true)');
+        $stage->numCandidates(10);
+    }
+
+    public function testExactAfterNumCandidatesThrows(): void
+    {
+        [$stage] = $this->createVectorSearchStage();
+        $stage->numCandidates(10);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot use numCandidates() with exact(true)');
+        $stage->exact(true);
+    }
+
     public function testChainingAllOptions(): void
     {
         [$stage, $builder] = $this->createVectorSearchStage();

--- a/tests/Tests/Functional/VectorSearchTest.php
+++ b/tests/Tests/Functional/VectorSearchTest.php
@@ -149,7 +149,7 @@ class VectorSearchTest extends BaseTestCase
 
         $schemaManager->waitForSearchIndexes([AutoEmbeddingArticle::class], maxTimeMs: 120_000);
 
-        // Query with a lighter model at query time (voyage-4-lite) than the indexing model (voyage-4)
+        // Query with a lighter model (voyage-4-lite) than the indexing model (voyage-4-large); all voyage-4 embeddings are compatible
         $results = $this->dm->createAggregationBuilder(AutoEmbeddingArticle::class)
             ->hydrate(AutoEmbeddingArticle::class)
             ->vectorSearch()

--- a/tests/Tests/Functional/VectorSearchTest.php
+++ b/tests/Tests/Functional/VectorSearchTest.php
@@ -6,11 +6,15 @@ namespace Doctrine\ODM\MongoDB\Tests\Functional;
 
 use Doctrine\ODM\MongoDB\Tests\BaseTestCase;
 use Doctrine\ODM\MongoDB\Types\Type;
+use Documents\AutoEmbeddingArticle;
 use Documents\VectorEmbedding;
 use MongoDB\BSON\Binary;
+use MongoDB\Driver\Exception\CommandException;
 use MongoDB\Driver\WriteConcern;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+
+use function str_contains;
 
 #[Group('atlas')]
 class VectorSearchTest extends BaseTestCase
@@ -97,6 +101,70 @@ class VectorSearchTest extends BaseTestCase
         foreach ($results as $result) {
             $this->assertInstanceOf(VectorEmbedding::class, $result);
             $this->assertEquals('active', $result->filterField, 'Filtered results should only contain active documents');
+        }
+    }
+
+    public function testAtlasAutoEmbedding(): void
+    {
+        $schemaManager = $this->dm->getSchemaManager();
+        $schemaManager->createDocumentCollection(AutoEmbeddingArticle::class);
+
+        $doc1           = new AutoEmbeddingArticle();
+        $doc1->content  = 'MongoDB is a document-oriented NoSQL database';
+        $doc1->category = 'database';
+
+        $doc2           = new AutoEmbeddingArticle();
+        $doc2->content  = 'Atlas Vector Search enables semantic similarity queries on MongoDB';
+        $doc2->category = 'database';
+
+        // Non-matching documents — unrelated topics
+        $doc3           = new AutoEmbeddingArticle();
+        $doc3->content  = 'How to make a perfect chocolate cake at home';
+        $doc3->category = 'cooking';
+
+        $doc4           = new AutoEmbeddingArticle();
+        $doc4->content  = 'Top 10 hiking trails in the Swiss Alps';
+        $doc4->category = 'travel';
+
+        $doc5           = new AutoEmbeddingArticle();
+        $doc5->content  = 'The history of the Olympic Games from ancient Greece to today';
+        $doc5->category = 'sports';
+
+        $this->dm->persist($doc1);
+        $this->dm->persist($doc2);
+        $this->dm->persist($doc3);
+        $this->dm->persist($doc4);
+        $this->dm->persist($doc5);
+        $this->dm->flush(['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)]);
+
+        try {
+            $schemaManager->createDocumentSearchIndexes(AutoEmbeddingArticle::class);
+        } catch (CommandException $e) {
+            if (str_contains($e->getMessage(), 'not registered')) {
+                $this->markTestSkipped('Autoembedding requires an Atlas cluster with a registered embedding model. Set VOYAGE_API_KEY');
+            }
+
+            throw $e;
+        }
+
+        $schemaManager->waitForSearchIndexes([AutoEmbeddingArticle::class], maxTimeMs: 120_000);
+
+        // Query with a lighter model at query time (voyage-4-lite) than the indexing model (voyage-4)
+        $results = $this->dm->createAggregationBuilder(AutoEmbeddingArticle::class)
+            ->hydrate(AutoEmbeddingArticle::class)
+            ->vectorSearch()
+                ->index('default')
+                ->path('content')
+                ->query('NoSQL document database')
+                ->model('voyage-4-lite')
+                ->numCandidates(10)
+                ->limit(2)
+            ->getAggregation()->execute()->toArray();
+
+        $this->assertCount(2, $results);
+        foreach ($results as $result) {
+            $this->assertInstanceOf(AutoEmbeddingArticle::class, $result);
+            $this->assertSame('database', $result->category, 'Expected only database-related results');
         }
     }
 

--- a/tests/Tests/Mapping/AbstractMappingDriverTestCase.php
+++ b/tests/Tests/Mapping/AbstractMappingDriverTestCase.php
@@ -501,6 +501,24 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
                     ],
                 ],
             ],
+            [
+                'type' => 'vectorSearch',
+                'name' => 'autoEmbedIndex',
+                'definition' => [
+                    'fields' => [
+                        [
+                            'type' => 'autoEmbed',
+                            'path' => 'content',
+                            'modality' => 'text',
+                            'model' => 'voyage-4',
+                        ],
+                        [
+                            'type' => 'filter',
+                            'path' => 'name',
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         self::assertEquals($expectedIndexes, $class->getSearchIndexes());
@@ -776,6 +794,13 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
  *   },
  *   name="embeddingIndex",
  * )
+ * @ODM\VectorSearchIndex(
+ *   fields={
+ *     {"type"="autoEmbed", "path"="content", "modality"="text", "model"="voyage-4"},
+ *     {"type"="filter", "path"="name"},
+ *   },
+ *   name="autoEmbedIndex",
+ * )
  * @ODM\ShardKey(keys={"name"="asc"},unique=true,numInitialChunks=4096)
  * @ODM\ReadPreference("primaryPreferred", tags={
  *   { "dc"="east" },
@@ -831,6 +856,21 @@ abstract class AbstractMappingDriverTestCase extends BaseTestCase
         ],
     ],
     name: 'embeddingIndex',
+)]
+#[ODM\VectorSearchIndex(
+    fields: [
+        [
+            'type' => 'autoEmbed',
+            'path' => 'content',
+            'modality' => ClassMetadata::VECTOR_AUTOEMBEDDING_MODALITY_TEXT,
+            'model' => 'voyage-4',
+        ],
+        [
+            'type' => 'filter',
+            'path' => 'name',
+        ],
+    ],
+    name: 'autoEmbedIndex',
 )]
 #[ODM\ShardKey(keys: ['name' => 'asc'], unique: true, numInitialChunks: 4096)]
 #[ODM\ReadPreference('primaryPreferred', tags: [['dc' => 'east'], ['dc' => 'west'], []])]

--- a/tests/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/Mapping/ClassMetadataTest.php
@@ -1031,7 +1031,7 @@ class ClassMetadataTest extends BaseTestCase
         $cm = new ClassMetadata('stdClass');
 
         $this->expectException(MappingException::class);
-        $this->expectExceptionMessage('stdClass vector search index "default" must have a vector field');
+        $this->expectExceptionMessage('stdClass vector search index "default" must have a "vector" or "autoEmbed" field');
         $cm->addSearchIndex($definition, 'default', 'vectorSearch');
     }
 
@@ -1058,6 +1058,34 @@ class ClassMetadataTest extends BaseTestCase
             [
                 'definition' => $definition,
                 'name' => 'embeddings_index',
+                'type' => 'vectorSearch',
+            ],
+        ], $cm->getSearchIndexes());
+    }
+
+    public function testAutoEmbedVectorSearchIndexDefinition(): void
+    {
+        $definition = [
+            'fields' => [
+                [
+                    'type'     => 'autoEmbed',
+                    'path'     => 'content',
+                    'modality' => ClassMetadata::VECTOR_AUTOEMBEDDING_MODALITY_TEXT,
+                    'model'    => 'voyage-4',
+                ],
+                [
+                    'type' => 'filter',
+                    'path' => 'category',
+                ],
+            ],
+        ];
+        $cm         = new ClassMetadata('stdClass');
+        $cm->addSearchIndex($definition, 'auto_embed_index', 'vectorSearch');
+
+        self::assertSame([
+            [
+                'definition' => $definition,
+                'name' => 'auto_embed_index',
                 'type' => 'vectorSearch',
             ],
         ], $cm->getSearchIndexes());

--- a/tests/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
+++ b/tests/Tests/Mapping/xml/Doctrine.ODM.MongoDB.Tests.Mapping.AbstractMappingDriverUser.dcm.xml
@@ -66,6 +66,10 @@
                 <filter-field path="name" />
                 <filter-field path="email" />
             </vector-search-index>
+            <vector-search-index name="autoEmbedIndex">
+                <auto-embed-field path="content" modality="text" model="voyage-4" />
+                <filter-field path="name" />
+            </vector-search-index>
         </vector-search-indexes>
         <reference-one target-document="Doctrine\ODM\MongoDB\Tests\Mapping\Address" field="address">
             <cascade>

--- a/tests/Tests/SchemaManagerTest.php
+++ b/tests/Tests/SchemaManagerTest.php
@@ -11,6 +11,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\TimeSeries\Granularity;
 use Doctrine\ODM\MongoDB\SchemaException;
 use Doctrine\ODM\MongoDB\SchemaManager;
+use Documents\AutoEmbeddingArticle;
 use Documents\BaseDocument;
 use Documents\CmsAddress;
 use Documents\CmsArticle;
@@ -54,6 +55,7 @@ use function array_count_values;
 use function array_key_exists;
 use function array_map;
 use function assert;
+use function implode;
 use function in_array;
 use function interface_exists;
 
@@ -79,6 +81,7 @@ class SchemaManagerTest extends BaseTestCase
 
     /** @var array<class-string, list<string>> */
     private array $searchIndexedClasses = [
+        AutoEmbeddingArticle::class => ['default'],
         CmsAddress::class => ['default'],
         CmsArticle::class => ['search_articles'],
         VectorEmbedding::class => ['default', 'vector_int'],
@@ -389,6 +392,24 @@ class SchemaManagerTest extends BaseTestCase
         }
 
         $this->schemaManager->deleteDocumentIndexes(CmsArticle::class, $maxTimeMs, $writeConcern);
+    }
+
+    public function testSearchIndexedClassesIsComplete(): void
+    {
+        $missing = [];
+        foreach ($this->dm->getMetadataFactory()->getAllMetadata() as $cm) {
+            if ($cm->isMappedSuperclass || $cm->isEmbeddedDocument || $cm->isQueryResultDocument || $cm->isFile) {
+                continue;
+            }
+
+            if (! $cm->hasSearchIndexes() || array_key_exists($cm->name, $this->searchIndexedClasses)) {
+                continue;
+            }
+
+            $missing[] = $cm->name;
+        }
+
+        self::assertEmpty($missing, 'The following document classes have search indexes but are missing from $searchIndexedClasses: ' . implode(', ', $missing));
     }
 
     public function testCreateSearchIndexes(): void


### PR DESCRIPTION
Adds support for MongoDB's [automated embedding](https://www.mongodb.com/docs/vector-search/crud-embeddings/automated-embedding/) feature:

- New `autoEmbed` field type in `VectorSearchIndexField` (alongside `vector` and `filter`), with `modality` and `model` fields
- New constant `ClassMetadata::VECTOR_AUTOEMBEDDING_MODALITY_TEXT`
- XML driver support via `<auto-embed-field path="..." modality="..." model="..."/>`
- New `query(string)` and `model(string)` methods on the `$vectorSearch` aggregation stage, allowing text queries to be embedded automatically at query time

## Usage

```php
// Index definition
#[VectorSearchIndex(fields: [
    [
        'type' => 'autoEmbed',
        'path' => 'content', 'modality' => 'text',
        'model' => 'voyage-4-large',
    ],
    ['type' => 'filter', 'path' => 'category'],
])]

// Query
$dm->createAggregationBuilder(Article::class)
    ->vectorSearch($persister)
        ->index('default')
        ->path('content')
        ->query('semantic search text')
        ->model('voyage-4-light')
        ->limit(10);
```