### PR TITLE
Fix `odm:schema:drop --class=...` dropping the entire database

### DIFF
--- a/src/SchemaManager.php
+++ b/src/SchemaManager.php
@@ -67,7 +67,7 @@ final class SchemaManager
         '2dsphereIndexVersion',
     ];
 
-    public function __construct(protected DocumentManager $dm, protected ClassMetadataFactoryInterface $metadataFactory)
+    public function __construct(private DocumentManager $dm, private ClassMetadataFactoryInterface $metadataFactory)
     {
     }
 

--- a/src/Tools/Console/Command/Schema/DropCommand.php
+++ b/src/Tools/Console/Command/Schema/DropCommand.php
@@ -50,10 +50,19 @@ class DropCommand extends AbstractCommand
     {
         $drop = array_filter($this->dropOrder, static fn (string $option): bool => (bool) $input->getOption($option));
 
-        // Default to the full drop order if no options were specified
-        $drop = empty($drop) ? $this->dropOrder : $drop;
+        $class = $input->getOption('class');
 
-        $class     = $input->getOption('class');
+        // Default to the full drop order if no options were specified. When
+        // --class is used, exclude DB from the default because MongoDB cannot
+        // drop only a single class's part of a database: dropping the database
+        // would also remove unrelated collections. Users who really want that
+        // behavior must pass --db explicitly.
+        if (empty($drop)) {
+            $drop = is_string($class)
+                ? array_filter($this->dropOrder, static fn (string $option): bool => $option !== self::DB)
+                : $this->dropOrder;
+        }
+
         $sm        = $this->getSchemaManager();
         $isErrored = false;
 

--- a/tests/Tests/Tools/Console/Command/Schema/CreateCommandTest.php
+++ b/tests/Tests/Tools/Console/Command/Schema/CreateCommandTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Tools\Console\Command\Schema;
+
+use Doctrine\ODM\MongoDB\Tests\Tools\Console\Command\AbstractCommandTestCase;
+use Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\CreateCommand;
+use Documents\CmsArticle;
+use Documents\User;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function array_values;
+use function preg_grep;
+use function preg_split;
+
+class CreateCommandTest extends AbstractCommandTestCase
+{
+    private CommandTester $commandTester;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->application->addCommands([new CreateCommand()]);
+        $this->commandTester = new CommandTester($this->application->find('odm:schema:create'));
+    }
+
+    public function testClassScopedCreateOrder(): void
+    {
+        $this->commandTester->execute([
+            '--class' => User::class,
+            '--skip-search-indexes' => true,
+        ]);
+
+        self::assertSame([
+            'Created collection for Documents\User',
+            'Created index(es) for Documents\User',
+        ], $this->createdLines());
+    }
+
+    public function testCollectionOnly(): void
+    {
+        $this->commandTester->execute([
+            '--class' => User::class,
+            '--collection' => true,
+        ]);
+
+        self::assertSame(
+            ['Created collection for Documents\User'],
+            $this->createdLines(),
+        );
+    }
+
+    public function testIndexOnly(): void
+    {
+        $this->commandTester->execute([
+            '--class' => User::class,
+            '--index' => true,
+        ]);
+
+        self::assertSame(
+            ['Created index(es) for Documents\User'],
+            $this->createdLines(),
+        );
+    }
+
+    #[Group('atlas')]
+    public function testClassScopedCreateIncludesSearchIndex(): void
+    {
+        $this->commandTester->execute(['--class' => CmsArticle::class]);
+
+        self::assertSame([
+            'Created collection for Documents\CmsArticle',
+            'Created index(es) for Documents\CmsArticle',
+            'Created search index(es) for Documents\CmsArticle',
+        ], $this->createdLines());
+    }
+
+    /** @return list<string> */
+    private function createdLines(): array
+    {
+        $lines = preg_split('/\R/', $this->commandTester->getDisplay()) ?: [];
+
+        return array_values(preg_grep('/^Created /', $lines) ?: []);
+    }
+}

--- a/tests/Tests/Tools/Console/Command/Schema/DropCommandTest.php
+++ b/tests/Tests/Tools/Console/Command/Schema/DropCommandTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Tools\Console\Command\Schema;
+
+use Doctrine\ODM\MongoDB\Tests\Tools\Console\Command\AbstractCommandTestCase;
+use Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\DropCommand;
+use Documents\CmsArticle;
+use Documents\User;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function array_values;
+use function preg_grep;
+use function preg_split;
+
+class DropCommandTest extends AbstractCommandTestCase
+{
+    private CommandTester $commandTester;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->application->addCommands([new DropCommand()]);
+        $this->commandTester = new CommandTester($this->application->find('odm:schema:drop'));
+
+        // Pre-create the User collection so index-drop operations do not error
+        // with "ns not found".
+        $this->dm->getSchemaManager()->createDocumentCollection(User::class);
+    }
+
+    public function testClassScopedDropExcludesDatabase(): void
+    {
+        $this->commandTester->execute([
+            '--class' => User::class,
+            '--skip-search-indexes' => true,
+        ]);
+
+        self::assertSame([
+            'Dropped index(es) for Documents\User',
+            'Dropped collection for Documents\User',
+        ], $this->droppedLines());
+    }
+
+    public function testClassScopedDropWithExplicitDbFlagDropsDatabase(): void
+    {
+        $this->commandTester->execute([
+            '--class' => User::class,
+            '--db' => true,
+        ]);
+
+        self::assertSame(
+            ['Dropped database for Documents\User'],
+            $this->droppedLines(),
+        );
+    }
+
+    public function testCollectionOnly(): void
+    {
+        $this->commandTester->execute([
+            '--class' => User::class,
+            '--collection' => true,
+        ]);
+
+        self::assertSame(
+            ['Dropped collection for Documents\User'],
+            $this->droppedLines(),
+        );
+    }
+
+    public function testIndexOnly(): void
+    {
+        $this->commandTester->execute([
+            '--class' => User::class,
+            '--index' => true,
+        ]);
+
+        self::assertSame(
+            ['Dropped index(es) for Documents\User'],
+            $this->droppedLines(),
+        );
+    }
+
+    public function testClassScopedDropCombinedFlagsPreservesOrder(): void
+    {
+        $this->commandTester->execute([
+            '--class' => User::class,
+            '--collection' => true,
+            '--index' => true,
+        ]);
+
+        self::assertSame([
+            'Dropped index(es) for Documents\User',
+            'Dropped collection for Documents\User',
+        ], $this->droppedLines());
+    }
+
+    public function testAllClassesDropRunsFullOrderIncludingDatabase(): void
+    {
+        $this->commandTester->execute([
+            '--collection' => true,
+            '--db' => true,
+        ]);
+
+        self::assertSame([
+            'Dropped collections for all classes',
+            'Dropped databases for all classes',
+        ], $this->droppedLines());
+    }
+
+    #[Group('atlas')]
+    public function testClassScopedDropIncludesSearchIndex(): void
+    {
+        $sm = $this->dm->getSchemaManager();
+        $sm->createDocumentCollection(CmsArticle::class);
+        $sm->createDocumentSearchIndexes(CmsArticle::class);
+
+        $this->commandTester->execute(['--class' => CmsArticle::class]);
+
+        self::assertSame([
+            'Dropped search index(es) for Documents\CmsArticle',
+            'Dropped index(es) for Documents\CmsArticle',
+            'Dropped collection for Documents\CmsArticle',
+        ], $this->droppedLines());
+    }
+
+    /** @return list<string> */
+    private function droppedLines(): array
+    {
+        $lines = preg_split('/\R/', $this->commandTester->getDisplay()) ?: [];
+
+        return array_values(preg_grep('/^Dropped /', $lines) ?: []);
+    }
+}

--- a/tests/Tests/Tools/Console/Command/Schema/UpdateCommandTest.php
+++ b/tests/Tests/Tools/Console/Command/Schema/UpdateCommandTest.php
@@ -9,12 +9,17 @@ use Doctrine\ODM\MongoDB\Tests\Tools\Console\Command\AbstractCommandTestCase;
 use Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\UpdateCommand;
 use Doctrine\Persistence\Mapping\Driver\ClassNames;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Documents\CmsArticle;
 use Documents\Ecommerce;
 use Documents\SchemaValidated;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
+use function array_values;
 use function class_exists;
+use function preg_grep;
+use function preg_split;
 
 class UpdateCommandTest extends AbstractCommandTestCase
 {
@@ -87,6 +92,43 @@ class UpdateCommandTest extends AbstractCommandTestCase
         $this->commandTester->execute(['--disable-validators' => true]);
         $output = $this->commandTester->getDisplay();
         self::assertStringNotContainsString('Updated validation for all classes', $output);
+    }
+
+    public function testClassScopedUpdateOrder(): void
+    {
+        $this->commandTester->execute([
+            '--class' => SchemaValidated::class,
+            '--skip-search-indexes' => true,
+        ]);
+
+        self::assertSame([
+            'Updated index(es) for Documents\SchemaValidated',
+            'Updated validation for Documents\SchemaValidated',
+        ], $this->updatedLines());
+    }
+
+    #[Group('atlas')]
+    public function testClassScopedUpdateIncludesSearchIndex(): void
+    {
+        $sm = $this->dm->getSchemaManager();
+        $sm->createDocumentCollection(CmsArticle::class);
+        $sm->createDocumentSearchIndexes(CmsArticle::class);
+
+        $this->commandTester->execute(['--class' => CmsArticle::class]);
+
+        self::assertSame([
+            'Updated index(es) for Documents\CmsArticle',
+            'Updated validation for Documents\CmsArticle',
+            'Updated search index(es) for Documents\CmsArticle',
+        ], $this->updatedLines());
+    }
+
+    /** @return list<string> */
+    private function updatedLines(): array
+    {
+        $lines = preg_split('/\R/', $this->commandTester->getDisplay()) ?: [];
+
+        return array_values(preg_grep('/^Updated /', $lines) ?: []);
     }
 
     private function createDriver(): MappingDriver


### PR DESCRIPTION
`odm:schema:drop --class=X` used to run the full default order (search-index, index, collection, db). The DB step calls `dropDocumentDatabase()`, which drops the entire database resolved from the class metadata, wiping unrelated collections. MongoDB cannot drop only a single class's portion of a database.

`--class` now excludes the DB step from the default order. To drop the whole database, `--db` must be passed explicitly.

Adds output-based tests for `odm:schema:drop`, `odm:schema:create` and `odm:schema:update`. Search-index cases are isolated in the `atlas` group so the default suite works against a plain MongoDB server.

Fixes #3025