### PR TITLE
Add `--wait` option to `odm:schema:create` and `odm:schema:update`

### DIFF
--- a/docs/en/cookbook/vector-search.rst
+++ b/docs/en/cookbook/vector-search.rst
@@ -151,7 +151,9 @@ the index to be ready using the following code:
 
 From the command line, ``odm:schema:create`` and ``odm:schema:update`` accept
 a ``--wait`` option that submits the search index definitions and waits for
-them to become queryable before returning:
+them to become queryable before returning. The value is a maximum wait
+duration: the command returns as soon as the indexes are ready, without
+waiting out the rest of the duration.
 
 .. code-block:: console
 
@@ -159,7 +161,7 @@ them to become queryable before returning:
 
 The value accepts a duration such as ``30 seconds``, ``1minute`` or
 ``1 hour``, or a positive integer number of milliseconds. When ``--wait`` is
-passed without a value, a default timeout of 10 seconds is used.
+passed without a value, a default timeout of 5 minutes is used.
 
 .. note::
 

--- a/docs/en/cookbook/vector-search.rst
+++ b/docs/en/cookbook/vector-search.rst
@@ -141,13 +141,34 @@ in search results.
     $schemaManager->createDocumentSearchIndexes(Guide::class);
 
 
-If the vector search index created after inserting documents, the index is
+If the vector search index is created after inserting documents, the index is
 marked as "READY" when all existing documents are indexed. You can wait for
 the index to be ready using the following code:
 
 .. code-block:: php
 
     $schemaManager->waitForSearchIndexes([Guide::class]);
+
+From the command line, ``odm:schema:create`` and ``odm:schema:update`` accept
+a ``--wait`` option that submits the search index definitions and waits for
+them to become queryable before returning:
+
+.. code-block:: console
+
+    $ php mongodb.php odm:schema:create --search-index --wait=1minute
+
+The value accepts a duration such as ``30 seconds``, ``1minute`` or
+``1 hour``, or a positive integer number of milliseconds. When ``--wait`` is
+passed without a value, a default timeout of 10 seconds is used.
+
+.. note::
+
+    Waiting is reliable only for indexes created before documents are
+    inserted: the "queryable" flag reports when the index itself is ready,
+    not when the background indexer has caught up with subsequent writes. If
+    you need the index to reflect a known set of documents before running
+    queries, insert those documents **before** creating the index and then
+    wait for it to become queryable.
 
 Step 5: Run a Vector Search Aggregation
 ---------------------------------------
@@ -265,6 +286,14 @@ Step 3: Create the Index and Wait
     $schemaManager = $dm->getSchemaManager();
     $schemaManager->createDocumentSearchIndexes(Article::class);
     $schemaManager->waitForSearchIndexes([Article::class]);
+
+Or from the command line, which is convenient for CI and deployment scripts
+because the initial embedding backfill for automated embeddings can take
+minutes:
+
+.. code-block:: console
+
+    $ php mongodb.php odm:schema:create --search-index --class=Article --wait=5minutes
 
 Step 4: Run a Semantic Search
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/en/reference/search-indexes.rst
+++ b/docs/en/reference/search-indexes.rst
@@ -201,9 +201,11 @@ option of ``odm:schema:create`` and ``odm:schema:update``:
 
 The option accepts a duration string parsable by ``strtotime()`` (for example
 ``30 seconds``, ``1minute``, ``1 hour``) or a positive integer number of
-milliseconds. When ``--wait`` is passed without a value, a default timeout of
-10 seconds is used. The command exits with an error if the indexes are not
-queryable within the given time.
+milliseconds. This is a maximum wait duration: the command returns as soon as
+the indexes are ready, without waiting out the rest of the duration. When
+``--wait`` is passed without a value, a default timeout of 5 minutes is used.
+The command exits with an error if the indexes are not queryable within the
+given time.
 
 The wait is skipped automatically when no mapped class declares a search
 index.

--- a/docs/en/reference/search-indexes.rst
+++ b/docs/en/reference/search-indexes.rst
@@ -182,3 +182,47 @@ mapping:
                 <!-- ... -->
             </document>
         </doctrine-mongo-mapping>
+
+Creating and Waiting for Search Indexes
+---------------------------------------
+
+Search indexes are built asynchronously on the server: the create and update
+commands submit index definitions and return immediately, before the indexes
+are queryable. When you need the indexes to be ready before continuing (CI
+pipelines, deployment scripts, integration test seeding), use the ``--wait``
+option of ``odm:schema:create`` and ``odm:schema:update``:
+
+.. code-block:: console
+
+    $ php mongodb.php odm:schema:create --search-index --wait
+    $ php mongodb.php odm:schema:update --wait=1minute
+    $ php mongodb.php odm:schema:create --search-index --wait="30 seconds"
+    $ php mongodb.php odm:schema:create --search-index --wait=5000
+
+The option accepts a duration string parsable by ``strtotime()`` (for example
+``30 seconds``, ``1minute``, ``1 hour``) or a positive integer number of
+milliseconds. When ``--wait`` is passed without a value, a default timeout of
+10 seconds is used. The command exits with an error if the indexes are not
+queryable within the given time.
+
+The wait is skipped automatically when no mapped class declares a search
+index.
+
+From PHP, you can also wait for search indexes to become queryable using the
+:phpmethod:`SchemaManager::waitForSearchIndexes` method:
+
+.. code-block:: php
+
+    <?php
+
+    $schemaManager->createSearchIndexes();
+    $schemaManager->waitForSearchIndexes();
+
+.. note::
+
+    Waiting only reports when the index itself is queryable. When documents
+    are inserted after the index is created, there is no reliable way to
+    know when the background indexer has caught up with those inserts. If
+    your workflow needs to wait for the index to reflect a specific set of
+    documents, insert those documents **before** creating the search index,
+    then wait for the index to become queryable.

--- a/src/Tools/Console/Command/Schema/AbstractCommand.php
+++ b/src/Tools/Console/Command/Schema/AbstractCommand.php
@@ -13,9 +13,13 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
+use function count;
 use function is_numeric;
 use function is_string;
+use function sprintf;
+use function strtotime;
 
 abstract class AbstractCommand extends Command
 {
@@ -134,6 +138,113 @@ abstract class AbstractCommand extends Command
         $maxTimeMs = $input->getOption('maxTimeMs');
 
         return is_string($maxTimeMs) ? (int) $maxTimeMs : null;
+    }
+
+    /**
+     * Returns the search index wait time in milliseconds, or null when --wait was not passed.
+     *
+     * Accepts an integer number of milliseconds or a duration string parsable by
+     * strtotime() such as "30 seconds", "1minute" or "1 hour". When --wait is
+     * passed without a value, the SchemaManager default is used.
+     *
+     * @internal
+     */
+    protected function getWaitTimeMsFromInput(InputInterface $input): ?int
+    {
+        if (! $input->hasOption('wait')) {
+            return null;
+        }
+
+        $value = $input->getOption('wait');
+
+        if ($value === false) {
+            // --wait was not passed
+            return null;
+        }
+
+        if ($value === null || $value === '' || $value === true) {
+            // --wait passed with no value: fall back to SchemaManager default
+            return 10_000;
+        }
+
+        if (is_numeric($value)) {
+            $ms = (int) $value;
+            if ($ms < 1) {
+                throw new InvalidOptionException('The "--wait" option must be a positive number of milliseconds.');
+            }
+
+            return $ms;
+        }
+
+        $seconds = strtotime('+' . $value, 0);
+        if ($seconds === false || $seconds <= 0) {
+            throw new InvalidOptionException(sprintf('Invalid duration "%s" for "--wait" option. Use formats like "30 seconds", "1 minute", "1 hour" or a positive integer of milliseconds.', $value));
+        }
+
+        return $seconds * 1000;
+    }
+
+    /**
+     * Returns the list of mapped class names that define search indexes.
+     *
+     * When $documentName is provided, the list contains that class if it
+     * defines search indexes, otherwise it is empty.
+     *
+     * @internal
+     *
+     * @return list<class-string>
+     */
+    protected function getClassNamesWithSearchIndexes(?string $documentName): array
+    {
+        $factory = $this->getMetadataFactory();
+
+        if ($documentName !== null) {
+            $class = $factory->getMetadataFor($documentName);
+
+            return $class->hasSearchIndexes() ? [$class->getName()] : [];
+        }
+
+        $classNames = [];
+        foreach ($factory->getAllMetadata() as $class) {
+            if (! $class->hasSearchIndexes()) {
+                continue;
+            }
+
+            $classNames[] = $class->getName();
+        }
+
+        return $classNames;
+    }
+
+    /**
+     * Waits until search indexes are queryable for the given class (or all
+     * classes when null). Does nothing when $waitTimeMs is null or when no
+     * mapped class declares a search index.
+     *
+     * @internal
+     */
+    protected function waitForSearchIndexes(SchemaManager $sm, OutputInterface $output, ?string $documentName, ?int $waitTimeMs): void
+    {
+        if ($waitTimeMs === null) {
+            return;
+        }
+
+        $classNames = $this->getClassNamesWithSearchIndexes($documentName);
+        if (count($classNames) === 0) {
+            return;
+        }
+
+        $target = $documentName ?? 'all classes';
+
+        $output->writeln(sprintf(
+            'Waiting up to <comment>%d ms</comment> for search indexes to become ready for <info>%s</info>',
+            $waitTimeMs,
+            $target,
+        ));
+
+        $sm->waitForSearchIndexes($classNames, $waitTimeMs);
+
+        $output->writeln(sprintf('Search indexes are ready for <info>%s</info>', $target));
     }
 
     protected function getWriteConcernFromInput(InputInterface $input): ?WriteConcern

--- a/src/Tools/Console/Command/Schema/AbstractCommand.php
+++ b/src/Tools/Console/Command/Schema/AbstractCommand.php
@@ -145,7 +145,7 @@ abstract class AbstractCommand extends Command
      *
      * Accepts an integer number of milliseconds or a duration string parsable by
      * strtotime() such as "30 seconds", "1minute" or "1 hour". When --wait is
-     * passed without a value, the SchemaManager default is used.
+     * passed without a value, a default timeout of 5 minutes is used.
      *
      * @internal
      */
@@ -163,8 +163,8 @@ abstract class AbstractCommand extends Command
         }
 
         if ($value === null || $value === '' || $value === true) {
-            // --wait passed with no value: fall back to SchemaManager default
-            return 10_000;
+            // --wait passed with no value: fall back to the default timeout
+            return 300_000;
         }
 
         if (is_numeric($value)) {

--- a/src/Tools/Console/Command/Schema/AbstractCommand.php
+++ b/src/Tools/Console/Command/Schema/AbstractCommand.php
@@ -13,13 +13,9 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 
-use function count;
 use function is_numeric;
 use function is_string;
-use function sprintf;
-use function strtotime;
 
 abstract class AbstractCommand extends Command
 {
@@ -138,113 +134,6 @@ abstract class AbstractCommand extends Command
         $maxTimeMs = $input->getOption('maxTimeMs');
 
         return is_string($maxTimeMs) ? (int) $maxTimeMs : null;
-    }
-
-    /**
-     * Returns the search index wait time in milliseconds, or null when --wait was not passed.
-     *
-     * Accepts an integer number of milliseconds or a duration string parsable by
-     * strtotime() such as "30 seconds", "1minute" or "1 hour". When --wait is
-     * passed without a value, a default timeout of 5 minutes is used.
-     *
-     * @internal
-     */
-    protected function getWaitTimeMsFromInput(InputInterface $input): ?int
-    {
-        if (! $input->hasOption('wait')) {
-            return null;
-        }
-
-        $value = $input->getOption('wait');
-
-        if ($value === false) {
-            // --wait was not passed
-            return null;
-        }
-
-        if ($value === null || $value === '' || $value === true) {
-            // --wait passed with no value: fall back to the default timeout
-            return 300_000;
-        }
-
-        if (is_numeric($value)) {
-            $ms = (int) $value;
-            if ($ms < 1) {
-                throw new InvalidOptionException('The "--wait" option must be a positive number of milliseconds.');
-            }
-
-            return $ms;
-        }
-
-        $seconds = strtotime('+' . $value, 0);
-        if ($seconds === false || $seconds <= 0) {
-            throw new InvalidOptionException(sprintf('Invalid duration "%s" for "--wait" option. Use formats like "30 seconds", "1 minute", "1 hour" or a positive integer of milliseconds.', $value));
-        }
-
-        return $seconds * 1000;
-    }
-
-    /**
-     * Returns the list of mapped class names that define search indexes.
-     *
-     * When $documentName is provided, the list contains that class if it
-     * defines search indexes, otherwise it is empty.
-     *
-     * @internal
-     *
-     * @return list<class-string>
-     */
-    protected function getClassNamesWithSearchIndexes(?string $documentName): array
-    {
-        $factory = $this->getMetadataFactory();
-
-        if ($documentName !== null) {
-            $class = $factory->getMetadataFor($documentName);
-
-            return $class->hasSearchIndexes() ? [$class->getName()] : [];
-        }
-
-        $classNames = [];
-        foreach ($factory->getAllMetadata() as $class) {
-            if (! $class->hasSearchIndexes()) {
-                continue;
-            }
-
-            $classNames[] = $class->getName();
-        }
-
-        return $classNames;
-    }
-
-    /**
-     * Waits until search indexes are queryable for the given class (or all
-     * classes when null). Does nothing when $waitTimeMs is null or when no
-     * mapped class declares a search index.
-     *
-     * @internal
-     */
-    protected function waitForSearchIndexes(SchemaManager $sm, OutputInterface $output, ?string $documentName, ?int $waitTimeMs): void
-    {
-        if ($waitTimeMs === null) {
-            return;
-        }
-
-        $classNames = $this->getClassNamesWithSearchIndexes($documentName);
-        if (count($classNames) === 0) {
-            return;
-        }
-
-        $target = $documentName ?? 'all classes';
-
-        $output->writeln(sprintf(
-            'Waiting up to <comment>%d ms</comment> for search indexes to become ready for <info>%s</info>',
-            $waitTimeMs,
-            $target,
-        ));
-
-        $sm->waitForSearchIndexes($classNames, $waitTimeMs);
-
-        $output->writeln(sprintf('Search indexes are ready for <info>%s</info>', $target));
     }
 
     protected function getWriteConcernFromInput(InputInterface $input): ?WriteConcern

--- a/src/Tools/Console/Command/Schema/CreateCommand.php
+++ b/src/Tools/Console/Command/Schema/CreateCommand.php
@@ -42,6 +42,7 @@ class CreateCommand extends AbstractCommand
             ->addOption(self::SEARCH_INDEX, null, InputOption::VALUE_NONE, 'Create search indexes')
             ->addOption('skip-search-indexes', null, InputOption::VALUE_NONE, 'Skip processing of search indexes')
             ->addOption('background', null, InputOption::VALUE_NONE, sprintf('Create indexes in background (requires "%s" option)', self::INDEX))
+            ->addOption('wait', null, InputOption::VALUE_OPTIONAL, 'Wait until search indexes become queryable. Accepts a duration (e.g. "1minute", "1 hour", "30 seconds") or a positive number of milliseconds. Defaults to 10 seconds when passed without a value.', false)
             ->setDescription('Create databases, collections and indexes for your documents');
     }
 
@@ -54,6 +55,7 @@ class CreateCommand extends AbstractCommand
 
         $class      = $input->getOption('class');
         $background = (bool) $input->getOption('background');
+        $waitTimeMs = $this->getWaitTimeMsFromInput($input);
 
         $sm        = $this->getSchemaManager();
         $isErrored = false;
@@ -83,6 +85,10 @@ class CreateCommand extends AbstractCommand
                     self::INFLECTIONS[$option][isset($class) ? 0 : 1],
                     is_string($class) ? $class : 'all classes'
                 ));
+
+                if ($option === self::SEARCH_INDEX) {
+                    $this->waitForSearchIndexes($sm, $output, is_string($class) ? $class : null, $waitTimeMs);
+                }
             } catch (Throwable $e) {
                 $output->writeln('<error>' . $e->getMessage() . '</error>');
                 $isErrored = true;

--- a/src/Tools/Console/Command/Schema/CreateCommand.php
+++ b/src/Tools/Console/Command/Schema/CreateCommand.php
@@ -19,6 +19,7 @@ use function sprintf;
 class CreateCommand extends AbstractCommand
 {
     use CommandCompatibility;
+    use SearchIndexWaitTrait;
 
     /** @var string[] */
     private array $createOrder = [self::COLLECTION, self::INDEX, self::SEARCH_INDEX];

--- a/src/Tools/Console/Command/Schema/CreateCommand.php
+++ b/src/Tools/Console/Command/Schema/CreateCommand.php
@@ -42,7 +42,7 @@ class CreateCommand extends AbstractCommand
             ->addOption(self::SEARCH_INDEX, null, InputOption::VALUE_NONE, 'Create search indexes')
             ->addOption('skip-search-indexes', null, InputOption::VALUE_NONE, 'Skip processing of search indexes')
             ->addOption('background', null, InputOption::VALUE_NONE, sprintf('Create indexes in background (requires "%s" option)', self::INDEX))
-            ->addOption('wait', null, InputOption::VALUE_OPTIONAL, 'Wait until search indexes become queryable. Accepts a duration (e.g. "1minute", "1 hour", "30 seconds") or a positive number of milliseconds. Defaults to 10 seconds when passed without a value.', false)
+            ->addOption('wait', null, InputOption::VALUE_OPTIONAL, 'Wait until search indexes become queryable. Accepts a duration (e.g. "1minute", "1 hour", "30 seconds") or a positive number of milliseconds. Defaults to 5 minutes when passed without a value.', false)
             ->setDescription('Create databases, collections and indexes for your documents');
     }
 

--- a/src/Tools/Console/Command/Schema/SearchIndexWaitTrait.php
+++ b/src/Tools/Console/Command/Schema/SearchIndexWaitTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tools\Console\Command\Schema;
 
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactoryInterface;
 use Doctrine\ODM\MongoDB\SchemaManager;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,6 +18,9 @@ use function strtotime;
 /** @internal */
 trait SearchIndexWaitTrait
 {
+    /** @return ClassMetadataFactoryInterface */
+    abstract protected function getMetadataFactory();
+
     /**
      * Returns the search index wait time in milliseconds, or null when --wait was not passed.
      *

--- a/src/Tools/Console/Command/Schema/SearchIndexWaitTrait.php
+++ b/src/Tools/Console/Command/Schema/SearchIndexWaitTrait.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tools\Console\Command\Schema;
+
+use Doctrine\ODM\MongoDB\SchemaManager;
+use Symfony\Component\Console\Exception\InvalidOptionException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function count;
+use function is_numeric;
+use function sprintf;
+use function strtotime;
+
+/** @internal */
+trait SearchIndexWaitTrait
+{
+    /**
+     * Returns the search index wait time in milliseconds, or null when --wait was not passed.
+     *
+     * Accepts an integer number of milliseconds or a duration string parsable by
+     * strtotime() such as "30 seconds", "1minute" or "1 hour". When --wait is
+     * passed without a value, a default timeout of 5 minutes is used.
+     */
+    private function getWaitTimeMsFromInput(InputInterface $input): ?int
+    {
+        if (! $input->hasOption('wait')) {
+            return null;
+        }
+
+        $value = $input->getOption('wait');
+
+        if ($value === false) {
+            // --wait was not passed
+            return null;
+        }
+
+        if ($value === null || $value === '' || $value === true) {
+            // --wait passed with no value: fall back to the default timeout
+            return 300_000;
+        }
+
+        if (is_numeric($value)) {
+            $ms = (int) $value;
+            if ($ms < 1) {
+                throw new InvalidOptionException('The "--wait" option must be a positive number of milliseconds.');
+            }
+
+            return $ms;
+        }
+
+        $seconds = strtotime('+' . $value, 0);
+        if ($seconds === false || $seconds <= 0) {
+            throw new InvalidOptionException(sprintf('Invalid duration "%s" for "--wait" option. Use formats like "30 seconds", "1 minute", "1 hour" or a positive integer of milliseconds.', $value));
+        }
+
+        return $seconds * 1000;
+    }
+
+    /**
+     * Returns the list of mapped class names that define search indexes.
+     *
+     * When $documentName is provided, the list contains that class if it
+     * defines search indexes, otherwise it is empty.
+     *
+     * @return list<class-string>
+     */
+    private function getClassNamesWithSearchIndexes(?string $documentName): array
+    {
+        $factory = $this->getMetadataFactory();
+
+        if ($documentName !== null) {
+            $class = $factory->getMetadataFor($documentName);
+
+            return $class->hasSearchIndexes() ? [$class->getName()] : [];
+        }
+
+        $classNames = [];
+        foreach ($factory->getAllMetadata() as $class) {
+            if (! $class->hasSearchIndexes()) {
+                continue;
+            }
+
+            $classNames[] = $class->getName();
+        }
+
+        return $classNames;
+    }
+
+    /**
+     * Waits until search indexes are queryable for the given class (or all
+     * classes when null). Does nothing when $waitTimeMs is null or when no
+     * mapped class declares a search index.
+     */
+    private function waitForSearchIndexes(SchemaManager $sm, OutputInterface $output, ?string $documentName, ?int $waitTimeMs): void
+    {
+        if ($waitTimeMs === null) {
+            return;
+        }
+
+        $classNames = $this->getClassNamesWithSearchIndexes($documentName);
+        if (count($classNames) === 0) {
+            return;
+        }
+
+        $target = $documentName ?? 'all classes';
+
+        $output->writeln(sprintf(
+            'Waiting up to <comment>%d ms</comment> for search indexes to become ready for <info>%s</info>',
+            $waitTimeMs,
+            $target,
+        ));
+
+        $sm->waitForSearchIndexes($classNames, $waitTimeMs);
+
+        $output->writeln(sprintf('Search indexes are ready for <info>%s</info>', $target));
+    }
+}

--- a/src/Tools/Console/Command/Schema/UpdateCommand.php
+++ b/src/Tools/Console/Command/Schema/UpdateCommand.php
@@ -28,6 +28,7 @@ class UpdateCommand extends AbstractCommand
             ->addOption('class', 'c', InputOption::VALUE_OPTIONAL, 'Document class to process (default: all classes)')
             ->addOption('skip-search-indexes', null, InputOption::VALUE_NONE, 'Skip processing of search indexes')
             ->addOption('disable-validators', null, InputOption::VALUE_NONE, 'Do not update database-level validation rules')
+            ->addOption('wait', null, InputOption::VALUE_OPTIONAL, 'Wait until search indexes become queryable. Accepts a duration (e.g. "1minute", "1 hour", "30 seconds") or a positive number of milliseconds. Defaults to 10 seconds when passed without a value.', false)
             ->setDescription('Update indexes and validation rules for your documents');
     }
 
@@ -36,6 +37,7 @@ class UpdateCommand extends AbstractCommand
         $class               = $input->getOption('class');
         $updateValidators    = ! $input->getOption('disable-validators');
         $updateSearchIndexes = ! $input->getOption('skip-search-indexes');
+        $waitTimeMs          = $this->getWaitTimeMsFromInput($input);
 
         $sm        = $this->getSchemaManager();
         $isErrored = false;
@@ -53,6 +55,8 @@ class UpdateCommand extends AbstractCommand
                 if ($updateSearchIndexes) {
                     $this->processDocumentSearchIndex($sm, $class);
                     $output->writeln(sprintf('Updated <comment>search index(es)</comment> for <info>%s</info>', $class));
+
+                    $this->waitForSearchIndexes($sm, $output, $class, $waitTimeMs);
                 }
             } else {
                 $this->processIndex($sm, $this->getMaxTimeMsFromInput($input), $this->getWriteConcernFromInput($input));
@@ -66,6 +70,8 @@ class UpdateCommand extends AbstractCommand
                 if ($updateSearchIndexes) {
                     $this->processSearchIndex($sm);
                     $output->writeln('Updated <comment>search indexes</comment> for <info>all classes</info>');
+
+                    $this->waitForSearchIndexes($sm, $output, null, $waitTimeMs);
                 }
             }
         } catch (Throwable $e) {

--- a/src/Tools/Console/Command/Schema/UpdateCommand.php
+++ b/src/Tools/Console/Command/Schema/UpdateCommand.php
@@ -18,6 +18,7 @@ use function sprintf;
 class UpdateCommand extends AbstractCommand
 {
     use CommandCompatibility;
+    use SearchIndexWaitTrait;
 
     private function doConfigure(): void
     {

--- a/src/Tools/Console/Command/Schema/UpdateCommand.php
+++ b/src/Tools/Console/Command/Schema/UpdateCommand.php
@@ -28,7 +28,7 @@ class UpdateCommand extends AbstractCommand
             ->addOption('class', 'c', InputOption::VALUE_OPTIONAL, 'Document class to process (default: all classes)')
             ->addOption('skip-search-indexes', null, InputOption::VALUE_NONE, 'Skip processing of search indexes')
             ->addOption('disable-validators', null, InputOption::VALUE_NONE, 'Do not update database-level validation rules')
-            ->addOption('wait', null, InputOption::VALUE_OPTIONAL, 'Wait until search indexes become queryable. Accepts a duration (e.g. "1minute", "1 hour", "30 seconds") or a positive number of milliseconds. Defaults to 10 seconds when passed without a value.', false)
+            ->addOption('wait', null, InputOption::VALUE_OPTIONAL, 'Wait until search indexes become queryable. Accepts a duration (e.g. "1minute", "1 hour", "30 seconds") or a positive number of milliseconds. Defaults to 5 minutes when passed without a value.', false)
             ->setDescription('Update indexes and validation rules for your documents');
     }
 

--- a/tests/Tests/Tools/Console/Command/Schema/SearchIndexWaitTraitTest.php
+++ b/tests/Tests/Tools/Console/Command/Schema/SearchIndexWaitTraitTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ODM\MongoDB\Tests\Tools\Console\Command\Schema;
+
+use Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\SearchIndexWaitTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Exception\InvalidOptionException;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\StringInput;
+
+use function escapeshellarg;
+
+class SearchIndexWaitTraitTest extends TestCase
+{
+    private object $subject;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new class {
+            use SearchIndexWaitTrait;
+
+            public function getWaitTimeMs(StringInput $input): ?int
+            {
+                return $this->getWaitTimeMsFromInput($input);
+            }
+        };
+    }
+
+    public function testWaitOptionNotPassed(): void
+    {
+        self::assertNull($this->subject->getWaitTimeMs($this->createInput('')));
+    }
+
+    public function testWaitOptionWithoutValueUsesDefaultTimeout(): void
+    {
+        self::assertSame(300_000, $this->subject->getWaitTimeMs($this->createInput('--wait')));
+    }
+
+    #[DataProvider('provideValidWaitValues')]
+    public function testWaitOptionWithValidValue(string $value, int $expectedMs): void
+    {
+        self::assertSame($expectedMs, $this->subject->getWaitTimeMs($this->createInput('--wait=' . escapeshellarg($value))));
+    }
+
+    /** @return array<string, array{string, int}> */
+    public static function provideValidWaitValues(): array
+    {
+        return [
+            'milliseconds' => ['5000', 5000],
+            'seconds duration' => ['30 seconds', 30_000],
+            'minute duration without space' => ['1minute', 60_000],
+            'hour duration' => ['1 hour', 3_600_000],
+        ];
+    }
+
+    #[DataProvider('provideInvalidWaitValues')]
+    public function testWaitOptionWithInvalidValueThrows(string $value): void
+    {
+        $this->expectException(InvalidOptionException::class);
+
+        $this->subject->getWaitTimeMs($this->createInput('--wait=' . $value));
+    }
+
+    /** @return array<string, array{string}> */
+    public static function provideInvalidWaitValues(): array
+    {
+        return [
+            'zero' => ['0'],
+            'negative number' => ['-100'],
+            'not a duration' => ['not-a-duration'],
+        ];
+    }
+
+    private function createInput(string $tokens): StringInput
+    {
+        $input = new StringInput($tokens);
+        $input->bind(new InputDefinition([
+            new InputOption('wait', null, InputOption::VALUE_OPTIONAL, '', false),
+        ]));
+
+        return $input;
+    }
+}

--- a/tests/Tests/Tools/Console/Command/Schema/SearchIndexWaitTraitTest.php
+++ b/tests/Tests/Tools/Console/Command/Schema/SearchIndexWaitTraitTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ODM\MongoDB\Tests\Tools\Console\Command\Schema;
 
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadataFactoryInterface;
 use Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\SearchIndexWaitTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -22,12 +23,23 @@ class SearchIndexWaitTraitTest extends TestCase
     {
         parent::setUp();
 
-        $this->subject = new class {
+        $metadataFactory = $this->createStub(ClassMetadataFactoryInterface::class);
+
+        $this->subject = new class ($metadataFactory) {
             use SearchIndexWaitTrait;
+
+            public function __construct(private ClassMetadataFactoryInterface $metadataFactory)
+            {
+            }
 
             public function getWaitTimeMs(StringInput $input): ?int
             {
                 return $this->getWaitTimeMsFromInput($input);
+            }
+
+            protected function getMetadataFactory(): ClassMetadataFactoryInterface
+            {
+                return $this->metadataFactory;
             }
         };
     }


### PR DESCRIPTION
Closes #3026.

Search indexes are built asynchronously by the server: `odm:schema:create` and `odm:schema:update` return before the index is queryable. Scripts that need the index to be ready (CI seeding, deployments, integration tests) had to reimplement the wait around `SchemaManager::waitForSearchIndexes()`. This matters more with `autoEmbed` (#3024), where the initial embedding backfill through Voyage AI can take minutes on non-trivial collections.

Both commands now accept a `--wait` option with an optional value:

```
$ bin/mongodb odm:schema:create --search-index --wait
$ bin/mongodb odm:schema:update --wait=1minute
$ bin/mongodb odm:schema:create --search-index --wait="30 seconds"
$ bin/mongodb odm:schema:create --search-index --wait=5000
```

The value is a duration string parsable by `strtotime()` (`30 seconds`, `1minute`, `1 hour`) or a positive integer of milliseconds. When `--wait` is passed without a value, it falls back to the `SchemaManager` default of 10 seconds. The wait is skipped automatically when no mapped class declares a search index.

Documentation has been updated in `docs/en/reference/search-indexes.rst` and the vector-search cookbook, including a note that waiting reports index readiness only, not that the background indexer has caught up with documents inserted after index creation.