### PR TITLE
Add Doctrine MongoDB ODM agent skill for AI coding assistants

### DIFF
--- a/skills/mongodb-odm/SKILL.md
+++ b/skills/mongodb-odm/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: mongodb-odm
+description: Implementation guide for doctrine/mongodb-odm (Doctrine MongoDB ODM), the PHP object-document mapper for MongoDB. Use whenever the user is writing, debugging, or reviewing PHP code that maps classes to MongoDB collections with Doctrine — mentions of "Doctrine MongoDB ODM", "mongodb-odm", "DocumentManager", "#[Document]"/"@Document", "#[ReferenceOne]"/"#[EmbedOne]", "ODM query builder", "aggregation builder" in a Doctrine/PHP context, "GridFS with Doctrine", "MongoDB queryable encryption PHP", "MongoDB vector search PHP", or combining Doctrine ORM and MongoDB ODM in one app should all trigger this skill. Also use it to correct common mistakes: treating MongoDB ODM like Doctrine ORM (assuming SQL-style joins, automatic cascading, or table-based migrations), calling flush() after every mutation, storing dates as strings, or assuming Vector Search/Queryable Encryption work outside MongoDB Atlas.
+license: MIT
+---
+
+# Doctrine MongoDB ODM
+
+Implementation skill for `doctrine/mongodb-odm` 2.16/2.17, the PHP object-document mapper that persists plain PHP classes to MongoDB. It exists to prevent the mistakes that come from treating it like a SQL ORM: expecting automatic cascading, joining collections like tables, flushing on every mutation, or assuming every advanced MongoDB feature (Vector Search, Queryable Encryption) works outside Atlas.
+
+## Core Workflow
+
+1. Identify the layer: mapping (a document class), persistence (`DocumentManager`), querying (Query Builder / Aggregation Builder), or an advanced/infra concern (search, encryption, sharding, transactions).
+2. Confirm the class has `#[Document]` (or `#[EmbeddedDocument]`/`#[MappedSuperclass]`) and an `#[Id]` property.
+3. Decide **embed vs. reference** deliberately (`references-embedding.md`) — don't default to references out of ORM habit when the data is really owned/composed.
+4. Batch mutations into a single unit of work and call `flush()` once, not after every `persist()`/`remove()` (`setup-architecture.md`).
+5. Use the Query Builder or Aggregation Builder for anything beyond `find()`/`findBy()` — never hand-build a raw driver query when the fluent API covers it (`querying-aggregation.md`).
+6. Validate with the consuming project's own test suite/static analysis, and use `odm:schema:create`/`odm:schema:update` to keep indexes and search indexes in sync with the mapping.
+
+## Suggest the MongoDB MCP Server
+
+Many ODM bugs are really questions about what's in the database — current document shape, whether an index exists yet, whether a vector/search index finished building. None of that is visible from PHP source. When debugging data/query issues or setting up Atlas Search/Vector Search/sharding, suggest connecting the official **MongoDB MCP Server**:
+
+```bash
+npx -y mongodb-mcp-server@latest --readOnly
+```
+
+```json
+{
+  "mcpServers": {
+    "MongoDB": {
+      "command": "npx",
+      "args": ["-y", "mongodb-mcp-server@latest", "--readOnly"],
+      "env": { "MDB_MCP_CONNECTION_STRING": "mongodb://localhost:27017/myDatabase" }
+    }
+  }
+}
+```
+
+It also accepts Atlas API service account credentials (`MDB_MCP_API_CLIENT_ID`/`MDB_MCP_API_CLIENT_SECRET`) for cluster/project-level operations instead of a connection string. Prefer environment variables over CLI args for credentials.
+
+## Reference Guide
+
+| Topic | Reference file | Load when |
+|---|---|---|
+| Installation, `DocumentManager`, UnitOfWork, repositories, console commands, `clear()`/`detach()`/`merge()`, document states | `references/setup-architecture.md` | Bootstrapping ODM, debugging persist/flush behavior, custom repositories, **batch imports, long-running CLI scripts, rising memory or slowdown over a loop, detached documents** |
+| `#[Document]`/`#[Field]`/`#[Id]`, field types, inheritance | `references/mapping.md` | Defining or modifying a document class |
+| `#[ReferenceOne]`/`#[ReferenceMany]`, `#[EmbedOne]`/`#[EmbedMany]`, bidirectional refs, trees, priming | `references/references-embedding.md` | Modeling relationships, fixing N+1 patterns |
+| Query Builder, findAndModify, upserts, geospatial queries, filters, Aggregation Builder | `references/querying-aggregation.md` | Writing any query or aggregation pipeline |
+| Standard indexes, Atlas Search indexes, simple keyword search | `references/indexes-search.md` | Adding indexes, Atlas full-text search |
+| Vector Search (Atlas) | `references/vector-search.md` | Embeddings, semantic search, `$vectorSearch`, hybrid text+vector search |
+| Queryable Encryption (Atlas/Enterprise) | `references/queryable-encryption.md` | Encrypting sensitive fields, `#[Encrypt]` |
+| Combining Doctrine ORM (SQL) and MongoDB ODM | `references/hybrid-orm-odm.md` | An app persists some data to SQL and some to MongoDB and needs them to interoperate |
+| GridFS, capped collections, sharding, transactions/locking, change tracking, storage strategies, events, schema migration, time series | `references/storage-transactions-lifecycle.md` | File storage, sharding, locking, lifecycle callbacks, evolving a mapping |
+
+## Constraints
+
+### MUST DO
+
+- Put `#[Document]` (or `#[EmbeddedDocument]`) plus `#[Id]` on every persisted class; `#[Id]` properties must never be `readonly` (the generator sets it externally).
+- Use `DateTime`/`DateTimeImmutable` (preferably immutable) for dates — never store a date as a string.
+- Batch changes and `flush()` once per logical unit of work (typically 0–2 times per HTTP request).
+- Set `cascade` explicitly on `#[ReferenceOne]`/`#[ReferenceMany]` when you need cascading persist/remove — not automatic for references (it *is* automatic for embeds).
+- Use `Doctrine\Common\Collections\Collection`/`ArrayCollection` (never a plain `array`) for `#[ReferenceMany]`/`#[EmbedMany]` properties.
+- Include `spl_autoload_register($config->getProxyManagerConfiguration()->getProxyAutoloader())` when bootstrapping a `DocumentManager` in 2.16 — omitting it regenerates proxy classes on every request.
+- Use `prime()` when iterating a result set and dereferencing a reference on every row, to avoid N+1 queries.
+- Run `odm:schema:create`/`odm:schema:update` after adding/changing indexes, capped-collection options, or search/vector-search indexes — none of that happens implicitly on first insert beyond a plain collection.
+- Confirm MongoDB Atlas (or Enterprise 7.0+ for Queryable Encryption) before recommending Vector Search, Atlas Search, or Queryable Encryption.
+- **State prerequisites and deprecations in the answer itself**, not just internally: when a feature needs a minimum ODM version (e.g. `vectorSearch()` needs 2.13+, Automated Embeddings 2.17+, `pipeline()` updates 2.15+) or a specific platform, say so; when the mapping the user is reaching for is deprecated (e.g. `COLLECTION_PER_CLASS` since 2.17, the `UUID` id strategy), say that too. The user cannot see these files — an unstated prerequisite is a missing answer.
+
+### MUST NOT DO
+
+- Don't call `flush()` after every `persist()`/`remove()`/`merge()` — batch changes and flush once per unit of work instead.
+- Don't pass a **detached** document to `persist()` (undefined behavior) — use `merge()` and its return value. Calling `remove()` on one **throws**, it does not no-op.
+- Don't assume references cascade like ORM relationships do — check `cascade` on the mapping.
+- Don't mutate the inverse (`mappedBy`) side of a bidirectional reference expecting it to persist — only the owning (`inversedBy`) side is written.
+- Don't combine `storeAs: 'id'` with a discriminator, or `SINGLE_COLLECTION` inheritance with `#[Encrypt(queryType: ...)]`.
+- Don't put arbitrary PHP objects (e.g. `\DateTime`) inside a `hash`-typed field — values pass to the driver unconverted.
+- Don't assume `#[AlsoLoad]` affects queries — it only affects hydration.
+- Don't invent a native ORM↔ODM relationship attribute — none exists; cross-layer links are hand-built via lifecycle events (`references/hybrid-orm-odm.md`).
+- Don't assume `$vectorSearch`/`$search`/`$geoNear` can go anywhere in a pipeline — each must be the **first** stage; `$merge`/`$out` must be **last**.
+
+## Code Templates
+
+### Document with a reference and embeds
+
+```php
+<?php
+
+namespace App\Documents;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
+
+#[ODM\Document(collection: 'orders')]
+class Order
+{
+    #[ODM\Id]
+    public string $id;
+
+    #[ODM\Field]
+    public \DateTimeImmutable $placedAt;
+
+    #[ODM\ReferenceOne(targetDocument: Customer::class, cascade: ['persist'])]
+    public Customer $customer;
+
+    #[ODM\EmbedOne(targetDocument: ShippingAddress::class)]
+    public ShippingAddress $shippingAddress;
+
+    /** @var Collection<int, OrderLine> */
+    #[ODM\EmbedMany(targetDocument: OrderLine::class)]
+    public Collection $lines;
+
+    public function __construct()
+    {
+        $this->lines = new ArrayCollection();
+    }
+}
+```
+
+### Bootstrapping the DocumentManager (2.16)
+
+```php
+<?php
+
+use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
+
+$config = new Configuration();
+$config->setProxyDir(__DIR__ . '/var/proxies');
+$config->setProxyNamespace('Proxies');
+$config->setHydratorDir(__DIR__ . '/var/hydrators');
+$config->setHydratorNamespace('Hydrators');
+$config->setDefaultDB('app');
+$config->setMetadataDriverImpl(AttributeDriver::create(__DIR__ . '/src/Documents'));
+
+$dm = DocumentManager::create(config: $config);
+
+spl_autoload_register($config->getProxyManagerConfiguration()->getProxyAutoloader());
+```
+
+### Query Builder, then one flush
+
+```php
+<?php
+
+$openOrders = $dm->createQueryBuilder(Order::class)
+    ->field('status')->equals('open')
+    ->sort('placedAt', 'desc')
+    ->limit(20)
+    ->getQuery()
+    ->execute();
+
+foreach ($openOrders as $order) {
+    $order->status = 'processing';
+}
+
+$dm->flush(); // one flush for the whole batch
+```
+
+### Aggregation pipeline
+
+```php
+<?php
+
+$revenueByCustomer = $dm->createAggregationBuilder(Order::class)
+    ->match()
+        ->field('status')->equals('completed')
+    ->group()
+        ->field('id')->expression('$customer')
+        ->field('total')->sum('$amount')
+    ->getAggregation()
+    ->execute()
+    ->toArray();
+```
+
+### Vector search query (Atlas)
+
+```php
+<?php
+
+$results = $dm->createAggregationBuilder(Guide::class)
+    ->vectorSearch()
+        ->index('default')
+        ->path('embedding')
+        ->queryVector($queryEmbedding)
+        ->numCandidates(100)
+        ->limit(10)
+    ->getAggregation()
+    ->execute()
+    ->toArray();
+```
+
+See `references/vector-search.md` before writing this for real — index declaration, dimension validation, and index-build-lag matter more than the query itself.
+
+## Validation Checkpoints
+
+| Stage | Command | Expected result |
+|---|---|---|
+| Mapping sanity | `php bin/console doctrine:mongodb:schema:create --index` (or your framework's equivalent) | Collections/indexes created without errors |
+| Static analysis | The project's own `phpstan`/`psalm` | No new errors |
+| Style | The project's own `phpcs`/`php-cs-fixer` | No violations |
+| Tests | The project's own `phpunit` | All green |
+| Query inspection | `$query->debug()` | Prints the fully prepared filter/update array actually sent to the driver |
+| Live data / index state | MongoDB MCP Server (see above) | Confirms what's actually stored and whether search/vector indexes finished building |

--- a/skills/mongodb-odm/references/hybrid-orm-odm.md
+++ b/skills/mongodb-odm/references/hybrid-orm-odm.md
@@ -1,0 +1,102 @@
+# Combining Doctrine ORM and MongoDB ODM (Hybrid Persistence)
+
+## 1. Why / when
+
+Running Doctrine ORM (SQL) and MongoDB ODM side by side, e.g. an `Order` in MySQL referencing a `Product` in MongoDB. There's **no built-in cross-persistence-layer relationship** — it's supported only indirectly, by wiring the two together with lifecycle events. Both `$em` and `$dm` are built completely independently; only the bridge is custom code.
+
+## 2. Pattern A — reference an ODM document from an ORM entity by id
+
+`Product` lives in MongoDB with a plain `#[Document]`/`#[Id]`/`#[Field]` mapping. `Order` lives in SQL and stores the product's id as a plain column, plus an **unmapped** in-memory property populated by an event listener:
+
+```php
+#[Entity]
+#[Table(name: 'orders')]
+class Order
+{
+    #[Column(type: 'string')]
+    private string $productId;
+
+    private Product $product; // NOT an ORM-mapped property
+
+    public function setProduct(Product $product): void
+    {
+        $this->productId = $product->id;
+        $this->product = $product;
+    }
+}
+```
+
+The bridge is a `postLoad` listener on the **ORM**'s `EventManager`, holding a `DocumentManager`, using reflection to set the private property:
+
+```php
+class MyEventSubscriber
+{
+    public function __construct(private readonly DocumentManager $dm) {}
+
+    public function postLoad(LifecycleEventArgs $eventArgs): void
+    {
+        $order = $eventArgs->getEntity();
+
+        if (!$order instanceof Order) {
+            return; // postLoad fires for EVERY entity ORM loads
+        }
+
+        $product = $this->dm->getReference(Product::class, $order->getProductId());
+
+        $eventArgs->getObjectManager()->getClassMetadata(Order::class)
+            ->reflClass->getProperty('product')->setValue($order, $product);
+    }
+}
+
+$em->getEventManager()->addEventListener([\Doctrine\ORM\Events::postLoad], new MyEventSubscriber($dm));
+```
+
+`getReference()` returns a lazy proxy that only hits MongoDB when a field is actually read.
+
+## 3. Pattern B — one class, two independent mappings
+
+A different technique: map the **same class** so it can persist independently to both a SQL table and a Mongo collection. **Not** synchronized dual-write — each mapping and each persist/flush is completely independent. If you persist the same class through both `$em` and `$dm`, you get two separate in-memory instances, since the ORM and ODM are separate libraries that don't share an object manager.
+
+```php
+// ORM mapping
+#[ORM\Entity(repositoryClass: BlogPostRepository::class)]
+class BlogPost
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public int $id;
+
+    #[ORM\Column(type: 'string')]
+    public string $title;
+}
+
+// ODM mapping — separate mapping source, same class name/namespace
+#[ODM\Document(repositoryClass: BlogPostRepository::class)]
+class BlogPost
+{
+    #[ODM\Id(type: 'int', strategy: 'INCREMENT')] // matches the ORM's integer id format
+    public int $id;
+
+    #[ODM\Field]
+    public string $title;
+}
+```
+
+Important: PHP attributes are compile-time bound to one class declaration — you can't literally stack both attribute sets on one file the way the two snippets above might imply. This dual-mapping pattern needs **XML mapping** (one XML file per layer, both pointing at the same class), not combined attributes on one file.
+
+A shared repository interface can be implemented separately by an `EntityRepository` subclass and a `DocumentRepository` subclass, so calling code doesn't need to know which backend it's talking to.
+
+## 4. What's supported vs. not
+
+**Supported**: a scalar id column plus an unmapped, event-populated property (Pattern A); the same class mapped and persisted independently through both managers (Pattern B).
+
+**Not supported**: there is **no native attribute** (no `#[ORM\ReferenceOne]` or ODM equivalent) that lets a mapping directly cross the ORM/ODM boundary and auto-hydrate. Every cross-layer link is hand-built via a scalar id plus an event listener resolving it through `getReference()` and reflection. Don't write `#[ODM\ReferenceOne(targetDocument: SomeOrmEntity::class)]` expecting it to work.
+
+## 5. Gotchas
+
+- Cross-layer linking only happens indirectly, through lifecycle events — there's no direct mapping-level link.
+- `postLoad` fires for **every** entity the ORM loads — always `instanceof`-check.
+- The bridge sets the property via **reflection**, bypassing ORM hydration, since it's intentionally unmapped.
+- Mapping one class to both layers produces **two independent instances**, never synchronized.
+- `INCREMENT` on the ODM side is only for id-format compatibility with an ORM integer id — not a default recommendation.

--- a/skills/mongodb-odm/references/indexes-search.md
+++ b/skills/mongodb-odm/references/indexes-search.md
@@ -1,0 +1,106 @@
+# Indexes & Atlas Search
+
+For Atlas Vector Search, see `vector-search.md`.
+
+## 1. Standard Indexes
+
+```php
+#[Document]
+class User
+{
+    #[Field(type: 'string')]
+    #[Index]
+    public string $username;
+}
+```
+
+`#[Index]` options: `name` (needed when the auto-generated one is too long), `background`, `expireAfterSeconds` (TTL), `order` (`asc`/`desc`), `unique`, `sparse` (with `unique`, allows duplicate `null`s while enforcing uniqueness on set values), `partialFilterExpression` (MongoDB 3.2+).
+
+```php
+#[Field(type: 'string')]
+#[UniqueIndex(order: 'asc')] // shortcut for Index(unique: true)
+public string $username;
+
+// compound index — class-level
+#[Document]
+#[UniqueIndex(keys: ['accountId' => 'asc', 'username' => 'asc'])]
+class User { /* ... */ }
+
+// multiple indexes — repeat the class-level attribute
+#[Document]
+#[Index(keys: ['accountId' => 'asc'])]
+#[Index(keys: ['username' => 'asc'])]
+class User { /* ... */ }
+```
+
+Indexes declared inside an `#[EmbeddedDocument]` are pulled in when building indexes for the owning document. Gotchas: mixed-type embed relationships need a discriminator map before ODM can build their indexes; a `name` on an embedded index gets prefixed with the embedded field path, which can exceed MongoDB's length limit.
+
+Geospatial: `#[Index(keys: ['coordinates' => '2d'])]` (or `'2dsphere'` for GeoJSON — see `querying-aggregation.md` §4 for which query methods pair with which). Partial (MongoDB 3.2+): `#[Index(keys: ['city' => 'asc'], partialFilterExpression: ['version' => ['$gt' => 1]])]`.
+
+## 2. Creating / Syncing Indexes
+
+```php
+$dm->getSchemaManager()->ensureIndexes();
+```
+
+```console
+$ php mongodb.php odm:schema:create --index
+```
+
+`odm:schema:create` flags: `--collection`, `--index`, `--search-index` (Atlas Search/Vector Search), `--skip-search-indexes`, `--background`, `-c/--class`. Related: `odm:schema:update` (indexes only), `odm:schema:drop`, `odm:schema:shard`.
+
+## 3. Atlas Search Indexes
+
+For MongoDB Atlas Search, queried via `$search`/`$searchMeta`. Rules: search indexes only go on **document classes**, never embedded documents; `fields` must use **actual database field names**, since ODM doesn't translate mapped property names here.
+
+`#[SearchIndex]` options: `name` (default `"default"`), `dynamic` (auto-index all supported types vs. requiring `fields`), `fields`, `analyzer`, `searchAnalyzer`, `analyzers`, `storedSource`, `synonyms`.
+
+```php
+#[Document]
+#[SearchIndex(
+    name: 'usernameAndAddresses',
+    fields: [
+        'username' => [['type' => 'string'], ['type' => 'autocomplete']],
+        'addresses' => ['type' => 'embeddedDocuments', 'dynamic' => true],
+    ],
+)]
+class User { /* ... */ }
+```
+
+`addresses`, an embed-many collection, must use `embeddedDocuments` (dynamic mapping only works *inside* that).
+
+```php
+#[Document]
+#[SearchIndex(dynamic: true)]
+class BlogPost { /* ... */ }
+```
+
+Gotcha: dynamic mapping does **not** work for embedded documents in arrays — those always need an explicit static `embeddedDocument(s)` mapping. Dynamic indexes also use more disk space and can be slower — prefer them for changing schemas/prototyping.
+
+## 4. Simple Keyword Search (no Atlas required)
+
+A baseline array-field technique — not a substitute for Atlas Search beyond small/simple cases.
+
+```php
+#[Document]
+class Product
+{
+    #[Field(type: 'collection')]
+    #[Index]
+    public array $keywords = [];
+}
+
+$qb = $dm->createQueryBuilder(Product::class)->field('keywords')->in($keywords);  // match ANY
+$qb = $dm->createQueryBuilder(Product::class)->field('keywords')->all($keywords); // match ALL
+```
+
+Move to Atlas Search (§3) once you need better relevance ranking, stemming, or fuzzy matching. Blending full-text and vector relevance scores isn't built in — that's a custom aggregation (e.g. `$unionWith` plus manual score combination — see `vector-search.md`).
+
+## 5. Gotchas
+
+1. **Search index field names are raw database names**, not PHP properties.
+2. **Dynamic Atlas Search mapping skips embed-many arrays** — use a static mapping there.
+3. **Embedded regular-index names get path-prefixed** — can exceed the length limit.
+4. **Mixed-type embed relationships need a discriminator map** before indexes build.
+5. **Partial indexes require MongoDB 3.2+.**
+6. **`--index` and `--search-index` are independent flags** on `odm:schema:create`.

--- a/skills/mongodb-odm/references/mapping.md
+++ b/skills/mongodb-odm/references/mapping.md
@@ -1,0 +1,210 @@
+# Document Mapping
+
+## Table of contents
+
+1. Mapping drivers
+2. Core attributes (`#[Document]`, `#[Id]`, `#[Field]`, `#[Index]`, and the rest)
+3. Minimal example
+4. Field types
+5. Inheritance
+6. Gotchas
+
+## 1. Mapping Drivers
+
+ODM supports three interchangeable drivers — **PHP attributes**, **XML**, and raw PHP code — cached identically regardless of choice, so no runtime difference. This guide uses attributes, the recommended driver (Doctrine annotations are deprecated).
+
+```php
+use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
+```
+
+Attributes follow the PER Coding Style with **named arguments** — constructor argument names are covered by Doctrine's BC promise.
+
+## 2. Core Attributes
+
+### `#[Document]`
+
+Required on every document class.
+
+```php
+#[Document(db: 'documents', collection: 'users', repositoryClass: MyProject\UserRepository::class, readOnly: true)]
+class User { /* ... */ }
+```
+
+Options: `db`, `collection` (defaults to the class's short name), `repositoryClass`, `readOnly` (insert/upsert/remove only, no updates), `writeConcern`. Set the default database globally instead: `$config->setDefaultDB('my_db')`.
+
+### `#[Id]`
+
+```php
+#[Document]
+class User
+{
+    #[Id]
+    protected string $id;
+}
+```
+
+Gotcha: **cannot be `readonly`** — the id generator sets it from outside the class, which PHP forbids for `readonly`.
+
+Strategies (`#[Id(strategy: '...')]`): `AUTO` (default — ObjectId, or a Symfony UUID if the property is UUID-typed), `ALNUM`, `CUSTOM` (via `class` option), `INCREMENT`, `UUID` (**deprecated** — prefer `AUTO` with a `uuid`-typed field, or `CUSTOM`), `NONE` (set the id manually before persisting).
+
+```php
+#[Id(strategy: 'CUSTOM', type: 'string', options: ['class' => \Vendor\Specific\Generator::class])]
+private string $id;
+```
+
+```php
+class Generator implements \Doctrine\ODM\MongoDB\Id\IdGenerator
+{
+    public function generate(DocumentManager $dm, object $document)
+    {
+        return 'my_generated_id';
+    }
+}
+```
+
+### `#[Field]`
+
+```php
+#[Field(type: 'string', name: 'co', nullable: false, notSaved: false)]
+protected string $country; // stored as "co"
+```
+
+Options: `type` (defaults to what's inferred from the PHP property type, §4), `enumType` (auto-detected for backed enums), `name` (db field name), `nullable` (see gotcha below), `notSaved` (loaded but never written back — useful mid-migration).
+
+### `#[Index]` / `#[UniqueIndex]`
+
+```php
+#[Document]
+#[Index(keys: ['username' => 'desc'], options: ['unique' => true])]
+class User {}
+```
+
+`keys` (class-level, required) maps field → order (`asc`/`desc`/`1`/`-1`) or a special type (`2dsphere`, `text`). `#[UniqueIndex]` is `#[Index]` with `unique` defaulted true. Full option set (TTL, partial, sparse, background) in `indexes-search.md`. `#[Indexes]` is deprecated since 2.2 — repeat class-level `#[Index]` instead.
+
+### Other attributes worth knowing
+
+- `#[EmbeddedDocument]`, `#[EmbedOne]`/`#[EmbedMany]`, `#[ReferenceOne]`/`#[ReferenceMany]` — `references-embedding.md`.
+- `#[AlsoLoad]` — fall back to another field/method for schema migrations — `storage-transactions-lifecycle.md`.
+- `#[ChangeTrackingPolicy]`, `#[Lock]`, `#[Version]` — `storage-transactions-lifecycle.md`.
+- `#[HasLifecycleCallbacks]` — **required** for `#[PrePersist]`/`#[PostLoad]`/etc. method attributes to be honored at all.
+- `#[ShardKey]`, `#[TimeSeries]`, `#[SearchIndex]`, `#[VectorSearchIndex]`, `#[Encrypt]` — their own reference files.
+- `#[MappedSuperclass]`, `#[InheritanceType]`, `#[DiscriminatorField]`, `#[DiscriminatorMap]`, `#[DefaultDiscriminatorValue]` — §5.
+- `#[QueryResultDocument]` — non-persisted class hydrating aggregation results (`querying-aggregation.md`).
+- `#[File]` and `#[File\*]` — GridFS mapping (`storage-transactions-lifecycle.md`).
+
+## 3. Minimal Example
+
+```php
+<?php
+
+namespace Documents;
+
+use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
+
+#[ODM\Document(db: 'my_db', collection: 'users')]
+class User
+{
+    #[ODM\Id]
+    public string $id;
+
+    #[ODM\Field]
+    public string $username;
+
+    #[ODM\Field]
+    public \DateTimeImmutable $createdAt;
+}
+```
+
+Omitting `db`/`collection`/`strategy`/`type` falls back to defaults inferred from context (§4).
+
+## 4. Field Types
+
+Built-in: `bin*` (several binary subtypes), `bool`, `collection`, `custom_id`, `date`, `date_immutable`, `decimal128` (needs `ext-bcmath`), `file`, `float`, `hash`, `id`, `int`, `int64`, `key`, `object_id`, `raw`, `string`, `timestamp`, `uuid`, `vector_float32`, `vector_int8`, `vector_packed_bit` (need MongoDB PHP extension ≥ 2.2.0).
+
+Notable: `collection` ↔ numerically-indexed array. `date`/`date_immutable` ↔ `UTCDateTime`. `hash` ↔ a MongoDB object, but **values are passed to the driver unconverted** — no arbitrary PHP objects (e.g. `\DateTime`) inside a `hash` array; use a driver-native value or an embedded document instead.
+
+### Dates: never store as strings
+
+```php
+#[Field]
+public \DateTimeImmutable $immutableDateTime; // preferred
+```
+
+Prefer `DateTimeImmutable`; assign a new instance to change a date rather than mutating.
+
+### Autodetection
+
+`type` can be omitted and is inferred: `DateTime`→`date`, `DateTimeImmutable`→`date_immutable`, `array`→`hash`, `bool`/`float`/`int`/`string`→same, `Symfony\Component\Uid\Uuid`→`uuid`. Backed enums auto-detect too (`type` matches the backing type, `enumType` set to the enum FQCN).
+
+Gotcha: **a nullable PHP type does not imply `nullable: true`.** Without it, `null` triggers `$unset` instead of storing `null`.
+
+### Custom types
+
+```php
+class DateTimeWithTimezoneType extends \Doctrine\ODM\MongoDB\Types\Type
+{
+    use \Doctrine\ODM\MongoDB\Types\ClosureToPHP;
+
+    public function convertToPHPValue($value): DateTimeImmutable { /* ... */ }
+    public function convertToDatabaseValue($value): array { /* ... */ }
+}
+
+Type::addType('date_with_timezone', DateTimeWithTimezoneType::class);      // errors if already registered
+Type::overrideType('date_immutable', DateTimeWithTimezoneType::class);     // errors if NOT already registered
+Type::registerType('date_immutable', DateTimeWithTimezoneType::class);     // no check
+```
+
+`convertToDatabaseValue()` is never called for `NULL` values, and `UnitOfWork` never passes unchanged values to it. You can also register a type keyed by a value-object's FQCN, letting ODM auto-select it and letting you omit `type` in `#[Field]` entirely.
+
+## 5. Inheritance
+
+**Mapped superclass** — not itself a document, not queryable, just shared mapping:
+
+```php
+#[MappedSuperclass]
+abstract class BaseDocument { /* shared fields */ }
+```
+
+**Single collection inheritance** — all subclasses share one collection via a discriminator:
+
+```php
+#[Document]
+#[InheritanceType('SINGLE_COLLECTION')]
+#[DiscriminatorField('type')]
+#[DiscriminatorMap(['person' => Person::class, 'employee' => Employee::class])]
+class Person { /* ... */ }
+
+#[Document]
+class Employee extends Person { /* ... */ }
+```
+
+`$dm->find(Person::class, $id)` returns the correct subclass. Gotcha: an unlisted class throws `MappingException` — every class sharing the collection must be in the map. For legacy pre-discriminator data, add `#[DefaultDiscriminatorValue('person')]` (value must be a key already in the map). Gotcha: incompatible with queryable encryption's `#[Encrypt(queryType: ...)]`.
+
+**Collection-per-class inheritance** — each class gets its own collection with all inherited fields, no discriminator:
+
+```php
+#[InheritanceType('COLLECTION_PER_CLASS')]
+class Person { /* ... */ }
+```
+
+Deprecated since 2.17, with no replacement: every document class is already mapped to its own collection by default, so this `InheritanceType` mapping can simply be removed rather than migrated to something else.
+
+**Sharing a collection without inheritance** — repeat the same `collection`/`discriminatorField`/`discriminatorMap` on unrelated classes; query across both via `$dm->createQuery([Article::class, Album::class])`.
+
+## 6. Gotchas
+
+1. **`#[Id]` can't be `readonly`.**
+2. **Never store dates as strings.**
+3. **Prefer `DateTimeImmutable`** — assign, don't mutate.
+4. **Nullable PHP type ≠ `nullable` mapping** — without it, `null` triggers `$unset`.
+5. **`hash` values pass to the driver unconverted** — no arbitrary PHP objects inside.
+6. **Discriminator maps must list every class sharing a collection.**
+7. **`#[DefaultDiscriminatorValue]` must be a key already in the map.**
+8. **`SINGLE_COLLECTION` + queryable encryption don't mix.**
+9. **`UUID` id strategy is deprecated** — prefer `AUTO` + `uuid` field, or `CUSTOM`. **`COLLECTION_PER_CLASS` inheritance is deprecated since 2.17**, with no replacement — just remove the `InheritanceType` mapping.
+10. **`#[Lock]`/`#[Version]` can't combine with `#[Id]`**; `#[Lock]` is `int`-only, `#[Version]` needs a `Versionable` type.
+11. **Lifecycle callback attributes need `#[HasLifecycleCallbacks]`** on the class or they're silently ignored.
+12. **`#[Indexes]` is deprecated** — repeat class-level `#[Index]`.
+13. **An embedded index's `name` gets prefixed with the embedded field path** — can exceed MongoDB's length limit.
+14. **A mapped superclass isn't queryable.**
+15. **Embedded documents can't declare their own `db`/`collection`** — always inherit the parent's, though the same embeddable class can be reused across multiple parents.

--- a/skills/mongodb-odm/references/queryable-encryption.md
+++ b/skills/mongodb-odm/references/queryable-encryption.md
@@ -1,0 +1,98 @@
+# Queryable Encryption
+
+**Requires MongoDB Enterprise 7.0+ or Atlas** — not Community Edition.
+
+## 1. Marking fields as encrypted
+
+```php
+<?php
+
+namespace Documents;
+
+use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
+use Doctrine\ODM\MongoDB\Mapping\EncryptQuery;
+
+#[ODM\Document]
+class Patient
+{
+    #[ODM\Id]
+    public string $id;
+
+    #[ODM\EmbedOne(targetDocument: PatientRecord::class)]
+    public PatientRecord $patientRecord;
+}
+
+#[ODM\EmbeddedDocument]
+class PatientRecord
+{
+    // Encrypted, equality-queryable — find a patient by exact SSN.
+    #[ODM\Field(type: 'string')]
+    #[ODM\Encrypt(queryType: EncryptQuery::Equality)]
+    public string $ssn;
+
+    // Encrypted as a whole object; no queryType means non-queryable.
+    #[ODM\EmbedOne(targetDocument: Billing::class)]
+    #[ODM\Encrypt]
+    public Billing $billing;
+
+    // Encrypted, range-queryable.
+    #[ODM\Field(type: 'int')]
+    #[ODM\Encrypt(queryType: EncryptQuery::Range, min: 0, max: 5000, sparsity: 1)]
+    public int $billingAmount;
+}
+```
+
+`#[Encrypt]` with no `queryType` encrypts but makes the field **not queryable at all**. `EncryptQuery::Equality` — exact match. `EncryptQuery::Range` — takes `min`/`max`/`sparsity`. No other query types are currently supported.
+
+## 2. Configuring the encrypted client / key vault / KMS
+
+```php
+<?php
+
+use Doctrine\ODM\MongoDB\Configuration;
+use MongoDB\BSON\Binary;
+
+$keyFile = __DIR__ . '/master-key.bin';
+if (!file_exists($keyFile)) {
+    file_put_contents($keyFile, random_bytes(96)); // 'local' KMS is dev-only; use AWS/Azure/GCP/KMIP in production
+}
+
+$config = new Configuration();
+$config->setAutoEncryption(['keyVaultNamespace' => 'encryption.datakeys']);
+$config->setKmsProvider(['type' => 'local', 'key' => new Binary(file_get_contents($keyFile), Binary::TYPE_GENERIC)]);
+// ...other Configuration setup (hydrator dir, metadata driver, default DB)...
+```
+
+Each `#[Encrypt]` field gets a Data Encryption Key (DEK), generated and stored in the key vault (`<database>.datakeys` by default, or `keyVaultNamespace`).
+
+```php
+<?php
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use MongoDB\Client;
+
+$client = new Client(uri: 'mongodb://localhost:27017/', driverOptions: $config->getDriverOptions());
+$dm = DocumentManager::create($client, $config);
+```
+
+Encrypted collections need explicit creation up front — not implicit on first insert:
+
+```php
+$schemaManager = $dm->getSchemaManager();
+$schemaManager->dropDocumentCollection(Patient::class);
+$schemaManager->createDocumentCollection(Patient::class);
+```
+
+Then persist/query normally — encryption and decryption happen transparently, including `findOneBy(['patientRecord.ssn' => '123-456-7890'])`.
+
+## 3. On-disk representation
+
+`#[Encrypt]` fields store as BSON **binary, subtype 6**, not their original type; the driver adds a `__safeContent__` array field internally to support encrypted equality/range search.
+
+## 4. Gotchas
+
+1. **`Configuration::setKmsProvider()` supports only one KMS provider.** Multiple providers require manually building `kmsProviders` and passing it as a driver option, bypassing the ODM helper.
+2. **Incompatible with `SINGLE_COLLECTION` inheritance** (see `mapping.md`) — the `SchemaManager` can't merge encrypted-field maps across classes sharing a collection.
+3. **No partial updates on encrypted embedded documents/collections** — only `set`/`atomicSet` collection strategies work with them.
+4. **Not every server-side QE limitation is ODM-specific** — see MongoDB's Queryable Encryption limitations documentation (https://www.mongodb.com/docs/manual/core/queryable-encryption/reference/limitations/) for constraints that apply regardless of PHP/ODM.
+5. **Treat an encrypted field's `queryType` as fixed once data exists** — changing it later typically requires re-encrypting and migrating the collection, so plan the query type up front.

--- a/skills/mongodb-odm/references/querying-aggregation.md
+++ b/skills/mongodb-odm/references/querying-aggregation.md
@@ -1,0 +1,233 @@
+# Querying & Aggregation
+
+## Table of contents
+
+1. The Query Builder
+2. findAndUpdate / findAndModify
+3. Upserting documents
+4. Geospatial queries
+5. Filters
+6. The Aggregation Builder
+7. Gotchas
+
+## 1. The Query Builder
+
+```php
+$qb = $dm->createQueryBuilder(User::class);
+```
+
+The class can also be supplied later via `find()`, `updateOne()`, `updateMany()`, or `remove()` (`update()` is deprecated). For simple lookups, skip the builder: `$dm->find(User::class, $id)`, `$dm->getRepository(User::class)->findBy(['type' => 'employee'])`. `Query::execute()` returns an `Iterator`; use `getSingleResult()` for one document.
+
+### Field / conditional operators
+
+`field($name)` then: `where($javascript)`, `in($values)`, `notIn($values)`, `equals($value)`, `notEqual($value)`, `gt/gte/lt/lte($value)`, `range($start, $end)`, `size($size)`, `exists($bool)`, `type($type)`, `all($values)`, `mod($mod)`, `addOr($expr)`, `references($document)`, `includesReferenceTo($document)`.
+
+```php
+$qb = $dm->createQueryBuilder(User::class)->field('type')->equals('admin')->field('active')->equals(true);
+
+// $or, via addOr() + expr()
+$qb = $dm->createQueryBuilder(User::class);
+$qb->addOr($qb->expr()->field('subscriber')->equals(true));
+$qb->addOr($qb->expr()->field('inTrial')->equals(true));
+
+// owning-side reference matches
+$qb = $dm->createQueryBuilder(Article::class)->field('user')->references($user);
+$qb = $dm->createQueryBuilder(User::class)->field('accounts')->includesReferenceTo($account);
+```
+
+### Text search
+
+Requires a `text` index (`#[Index(keys: ['description' => 'text'])]`):
+
+```php
+$qb = $dm->createQueryBuilder(Document::class)->text('words you are looking for');
+$qb = $dm->createQueryBuilder(Document::class)->selectMeta('score', 'textScore')->text('words'); // computed relevance score
+$qb = $dm->createQueryBuilder(Document::class)->text('parole che stai cercando')->language('it'); // stemming language
+```
+
+### Selecting, hints, distinct, limit/skip/sort
+
+```php
+$qb = $dm->createQueryBuilder(User::class)->select('username', 'password');
+$qb = $dm->createQueryBuilder(User::class)->hint('user_pass_idx'); // combine with select() for a covered query
+$ages = $dm->createQueryBuilder(User::class)->distinct('age')->getQuery()->execute(); // plain array, NOT an Iterator
+
+$posts = $dm->createQueryBuilder(BlogPost::class)->limit(20)->skip(40)->getQuery()->execute(); // page 3, 20/page
+$qb = $dm->createQueryBuilder(Article::class)->sort('createdAt', 'desc'); // repeated calls stack in call order
+```
+
+Gotchas on `distinct()`: it can't combine with `sort()` (MongoDB's `distinct` doesn't support server-side sorting) — sort the PHP array yourself; and `execute()` hands back a plain `array`, so calling `->toArray()` on it is a fatal error.
+
+### Debugging
+
+`$dm->createQueryBuilder(User::class)->getQuery()->debug()` returns the fully prepared array actually sent to the driver (field renames, discriminators, applied filters) — useful when a fluent query misbehaves.
+
+### Refresh / read-only / hydration
+
+- **`refresh()`** — forces ODM to overwrite an already-managed instance with fresh data instead of keeping the (possibly stale) in-memory copy.
+- **`readOnly()`** — like `refresh()` but returns a *new*, unmanaged instance; references still managed normally (not deep). Re-attach later with `merge()`, not `persist()`.
+- Both are no-ops with `hydrate(false)`.
+- **`hydrate(false)`** — returns raw arrays instead of objects.
+- **`setRewindable(false)`** — skips the caching-iterator ODM normally wraps around non-rewindable Mongo cursors, saving memory but making a **second iteration throw**.
+
+### Update queries (atomic modifiers)
+
+`set($name, $value, $atomic = true)`, `setNewObj($newObj)`, `inc`, `unsetField`, `push`, `addToSet`, `popFirst`, `popLast`, `pull`, `pullAll`. Gotcha: updates default to **one document** — call `updateMany()` for more.
+
+```php
+$dm->createQueryBuilder(User::class)->updateOne()->field('password')->set('newpassword')->field('username')->equals('jwage')->getQuery()->execute();
+$dm->createQueryBuilder(User::class)->updateMany()->field('someField')->set('newValue')->field('username')->equals('sgoettschkes')->getQuery()->execute();
+
+// $atomic=false replaces the matched value field-by-field instead of via $set
+$dm->createQueryBuilder(User::class)->updateOne()->field('username')->set('jwage', false)->field('username')->equals('jwage')->getQuery()->execute();
+
+// whole-document replace
+$dm->createQueryBuilder(User::class)->setNewObj(['username' => 'jwage'])->field('username')->equals('jwage')->getQuery()->execute();
+
+$dm->createQueryBuilder(Package::class)->field('id')->equals('theid')->field('downloads')->inc(1)->getQuery()->execute();
+$dm->createQueryBuilder(User::class)->updateMany()->field('login')->unsetField()->exists(true)->getQuery()->execute();
+$dm->createQueryBuilder(Article::class)->updateOne()->field('tags')->push('tag5')->field('id')->equals('theid')->getQuery()->execute();
+$dm->createQueryBuilder(Article::class)->updateMany()->field('tags')->pullAll(['tag1', 'tag2'])->getQuery()->execute();
+```
+
+`pipeline()` (since 2.15) accepts an Aggregation Builder, `Pipeline`, or array for atomic updates — but only with `updateOne()`, `updateMany()`, `findAndUpdate()`. This is the way to compute a new field value from other fields on the document server-side, instead of loading and flushing.
+
+```php
+$dm->createQueryBuilder(User::class)->remove()->field('num_logins')->equals(0)->getQuery()->execute();
+```
+
+## 2. findAndUpdate / findAndModify
+
+Atomic "find, modify, return" of **at most one document** — returns the pre-update document by default; add `returnNew()` for the post-update one.
+
+```php
+$job = $dm->createQueryBuilder(Job::class)
+    ->findAndUpdate()->returnNew()
+    ->field('in_progress')->equals(false)
+    ->sort('priority', 'desc')
+    ->field('started')->set(new \MongoDB\BSON\UTCDateTime())
+    ->field('in_progress')->set(true)
+    ->getQuery()->execute();
+
+$job = $dm->createQueryBuilder(Job::class)->findAndRemove()->sort('priority', 'desc')->getQuery()->execute();
+```
+
+Gotcha: if you don't need the affected document returned, use a plain `updateMany()`/`remove()` instead — findAndModify-style calls only ever touch one document.
+
+## 3. Upserting Documents
+
+Set the identifier ahead of time and persist normally — ODM issues an upsert instead of an insert, so you skip fetching the document first:
+
+```php
+$article = new Article();
+$article->setId($articleId);
+$article->incrementNumViews();
+$dm->persist($article);
+$dm->flush();
+```
+
+## 4. Geospatial Queries
+
+```php
+#[Document]
+#[Index(keys: ['coordinates' => '2d'])]
+class City
+{
+    #[EmbedOne(targetDocument: Coordinates::class)]
+    public ?Coordinates $coordinates;
+}
+
+$cities = $dm->createQuery(City::class)->field('coordinates')->near(-120, 40)->execute();
+```
+
+`near($x, $y, $minDistance = null, $maxDistance = null)` also accepts a single GeoJSON point for `2dsphere` (omit `$y`). `nearSphere(...)` is the spherical-distance equivalent. Other `field()` geo ops: `geoWithin($geometry)` (GeoJSON), `geoWithinBox`/`geoWithinCenter`/`geoWithinPolygon` (**`2d` only**), `geoWithinCenterSphere` (works with **both** `2d` and `2dsphere`), `geoIntersects($geometry)`. For nearest-first queries with a distance output, use the `$geoNear` **aggregation** stage instead — there's no query-builder equivalent.
+
+## 5. Filters
+
+A "filter" adds extra criteria to **every** query for matching documents, wherever it originates — even referenced-document loads.
+
+```php
+class MyLocaleFilter extends \Doctrine\ODM\MongoDB\Query\Filter\BsonFilter
+{
+    public function addFilterCriteria(\Doctrine\ODM\MongoDB\Mapping\ClassMetadata $targetDocument): array
+    {
+        if (!$targetDocument->reflClass->implementsInterface('LocaleAware')) {
+            return [];
+        }
+        return ['locale' => $this->getParameter('locale')];
+    }
+}
+
+$config->addFilter('locale', MyLocaleFilter::class, ['locale' => 'en']); // 3rd arg: optional default params
+
+$filter = $dm->getFilterCollection()->enable('locale');
+$filter->setParameter('locale', ['$in' => ['en', 'fr']]);
+$dm->getFilterCollection()->disable('locale');
+```
+
+Gotcha: changing filters has **no effect on already-managed documents** — clear the `DocumentManager` and re-fetch.
+
+## 6. The Aggregation Builder
+
+```php
+$builder = $dm->createAggregationBuilder(\Documents\Orders::class);
+$builder
+    ->match()
+        ->field('purchaseDate')->gte($from)->lt($to)
+        ->field('user')->references($user)
+    ->group()
+        ->field('id')->expression('$user')
+        ->field('numPurchases')->sum(1)
+        ->field('amount')->sum('$amount');
+
+$result = $builder->getAggregation(); // or ->getPipeline() to inspect the raw array
+```
+
+Stage methods (`match()`, `group()`, etc.) each return a stage-specific builder exposing `field()` plus expression methods, chained fluently; `DateTime` values auto-convert to `UTCDateTime`. Nest expressions with `$builder->expr()`.
+
+### Hydrating results as objects
+
+By default results are plain arrays (a pipeline's shape can differ from the source document). Map a `#[QueryResultDocument]` (looks like a document, can't be persisted) and call `hydrate()`:
+
+```php
+#[QueryResultDocument]
+class UserPurchases
+{
+    #[ReferenceOne(targetDocument: User::class, name: '_id')]
+    private User $user;
+
+    #[Field(type: 'int')]
+    private int $numPurchases;
+}
+
+$builder->hydrate(\Documents\UserPurchases::class)->match()/* ... */->group()/* ... */;
+```
+
+`rewindable(false)` avoids the caching-iterator memory cost (same rationale as the query builder) but a second iteration throws; `getAggregation()` always returns a fresh, re-executable instance regardless.
+
+### Supported raw pipeline stages
+
+`$addFields`, `$bucket`, `$bucketAuto`, `$collStats`, `$count`, `$densify`, `$facet`, `$fill`, `$geoNear`, `$graphLookup`, `$group`, `$indexStats`, `$limit`, `$lookup`, `$match`, `$merge`, `$out`, `$project`, `$redact`, `$replaceRoot`, `$replaceWith`, `$sample`, `$search`, `$set`, `$setWindowFields`, `$skip`, `$sort`, `$sortByCount`, `$vectorSearch`, `$unionWith`, `$unset`, `$unwind`. Check your MongoDB server version supports a given stage (e.g. `$vectorSearch` needs Atlas).
+
+Notable gotchas by stage:
+
+- **`$geoNear`** — must be **first**, needs exactly one geo index, `distanceField` required: `->geoNear(120, 40)->spherical(true)->distanceField('distance')->distanceMultiplier(6378.137)`.
+- **`$lookup`** — one-to-many on MongoDB 3.2 returns empty unless `unwind()`ed first and `group()`ed after; one-to-one still returns an array, flatten with `unwind()`; can't target a reference nested in an embedded document; can't be used with `DBRef`-stored references (use `id`/`ref`). Same DBRef limitation applies to `$graphLookup`, whose `connectFromField` target must be the same class the lookup runs against.
+- **`$merge`/`$out`** — must be **last**. `$merge` upserts by match keys (needs a unique index on them); `$out` atomically replaces the target collection.
+- **`$search`**/**`$vectorSearch`** — Atlas only, must be **first**, need `#[SearchIndex]`/`#[VectorSearchIndex]` (see `indexes-search.md`/`vector-search.md`).
+- **`$replaceRoot`/`$replaceWith`** — replace the **entire** document, including `_id`.
+- **`$unionWith`** — combine two pipelines' results, including duplicates.
+
+## 7. Gotchas
+
+1. **`distinct()` + `sort()` don't combine**, and `distinct()` returns a plain `array` — no `toArray()`.
+2. **Updates default to a single document** — use `updateMany()`.
+3. **Pipeline updates only work with `updateOne()`/`updateMany()`/`findAndUpdate()`.**
+4. **`findAndUpdate` returns the pre-update document unless `returnNew()`.**
+5. **Cursors aren't rewindable** — `setRewindable(false)`/`rewindable(false)` save memory but break a second iteration.
+6. **`refresh()`/`readOnly()` are no-ops with `hydrate(false)`.**
+7. **`readOnly()` isn't deep** — re-attach with `merge()`, not `persist()`.
+8. **Filters don't retroactively affect managed documents.**
+9. **Legacy geo operators (`geoWithinBox`/`Center`/`Polygon`) only work with `2d`**, not `2dsphere`. `geoWithinCenterSphere` works with both.
+10. **`$geoNear`/`$search`/`$vectorSearch` must be first; `$merge`/`$out` must be last.**
+11. **`$lookup`/`$graphLookup` can't use `DBRef`-stored references.**

--- a/skills/mongodb-odm/references/references-embedding.md
+++ b/skills/mongodb-odm/references/references-embedding.md
@@ -1,0 +1,186 @@
+# References, Embedding & Trees
+
+Always type `#[ReferenceMany]`/`#[EmbedMany]` fields as `Doctrine\Common\Collections\Collection` (backed by `ArrayCollection`), never a plain PHP `array` — arrays can't be transparently wrapped for the `PersistentCollection` change-tracking mechanism.
+
+## Table of contents
+
+1. `#[ReferenceOne]` / `#[ReferenceMany]`
+2. Bidirectional references
+3. Complex references (custom criteria / inverse-loaded)
+4. `#[EmbedOne]` / `#[EmbedMany]`
+5. Tree structures
+6. Priming references (solving N+1)
+7. Gotchas
+
+## 1. `#[ReferenceOne]` / `#[ReferenceMany]`
+
+```php
+#[Document]
+class User
+{
+    /** @var Collection<int, Account> */
+    #[ReferenceMany(targetDocument: Account::class)]
+    private Collection $accounts;
+
+    public function __construct()
+    {
+        $this->accounts = new ArrayCollection();
+    }
+}
+```
+
+**`targetDocument`** — omit for mixed target types (§1.1).
+
+**`storeAs`** — on-disk shape: `dbRef` (`$ref`+`$id`, **current default**), `dbRefWithDb` (+ `$db`, pre-2.0 default), `ref` (custom embedded object with an `id` field), `id` (just the identifier — leanest, but **incompatible with discriminators**, since there's no DBRef to carry one).
+
+**`cascade`** — no operation cascades by default: `#[ReferenceOne(targetDocument: Profile::class, cascade: ['persist'])]`. Values: `all`, `detach`, `merge`, `refresh`, `remove`, `persist`.
+
+**`mappedBy`/`inversedBy`** — owning vs. inverse side (§2).
+
+**`orphanRemoval`** — deletes the target when the reference is removed from a privately-owning document. Gotcha: assumes the target is **not reused elsewhere** — reassigning an "orphaned" document to a different parent doesn't save it from deletion.
+
+**`storeEmptyArray`** — an empty `ReferenceMany` stores nothing by default; set `true` to persist an actual empty array.
+
+### 1.1 Mixing target types
+
+Omit `targetDocument`; the class name is stored in `_doctrine_class_name` (customizable via `discriminatorField`), or use `discriminatorMap`/`defaultDiscriminatorValue` to avoid storing the FQCN. Gotcha: the mongo shell only shows `$id`/`$ref` of a DBRef, hiding `$db`/discriminator fields — verify via a driver.
+
+## 2. Bidirectional References
+
+Without `mappedBy`/`inversedBy`, both sides are independently owning, storing the reference redundantly. Prefer an explicit owning/inverse pair:
+
+```php
+#[Document]
+class BlogPost
+{
+    #[ReferenceOne(targetDocument: User::class, inversedBy: 'posts')]
+    private User $user;
+}
+
+#[Document]
+class User
+{
+    /** @var Collection<int, BlogPost> */
+    #[ReferenceMany(targetDocument: BlogPost::class, mappedBy: 'user')]
+    private Collection $posts;
+}
+```
+
+Gotcha: **the inverse (`mappedBy`) side is immutable** — always mutate the owning (`inversedBy`) side and flush.
+
+One-to-one: break the relationship from the owning side (`$cart->customer = null; $dm->flush();`). Gotcha: an inverse one-to-one reference loads **eagerly** when the owning document hydrates (loading a `Customer` also loads its `Cart`) — a hidden cost hydrating many at once.
+
+Self-referencing many-to-many:
+
+```php
+#[ReferenceMany(targetDocument: User::class, mappedBy: 'myFriends')]
+public Collection $friendsWithMe;
+
+#[ReferenceMany(targetDocument: User::class, inversedBy: 'friendsWithMe')]
+public Collection $myFriends;
+```
+
+## 3. Complex References (custom criteria / inverse-loaded)
+
+Immutable, mapping-only — no DBRef/id stored on the document. Available on both `ReferenceOne`/`ReferenceMany`: `criteria`, `sort`, `skip`, `limit`, `repositoryMethod`.
+
+```php
+#[ReferenceMany(targetDocument: Comment::class, mappedBy: 'blogPost', sort: ['date' => 'desc'], limit: 5)]
+private Collection $last5Comments;
+
+#[ReferenceMany(targetDocument: Comment::class, mappedBy: 'blogPost', criteria: ['isByAdmin' => true])]
+private Collection $commentsByAdmin;
+```
+
+Fully custom loading:
+
+```php
+#[ReferenceMany(targetDocument: Comment::class, mappedBy: 'blogPost', repositoryMethod: 'findSomeComments')]
+private Collection $someComments;
+
+class CommentRepository extends \Doctrine\ODM\MongoDB\DocumentRepository
+{
+    public function findSomeComments(BlogPost $blogPost): \Doctrine\ODM\MongoDB\Iterator\Iterator
+    {
+        return $this->createQueryBuilder()->field('blogPost')->references($blogPost)->getQuery()->execute();
+    }
+}
+```
+
+Must return an `Iterator`; ODM passes the owning document as the method's first argument. Gotcha: combining `repositoryMethod` with a mapping-level `prime` (§6) means the mapping's `prime` overwrites any primer set up inside the repository method.
+
+## 4. `#[EmbedOne]` / `#[EmbedMany]`
+
+```php
+#[Document]
+class User
+{
+    #[EmbedOne(targetDocument: Address::class)]
+    private ?Address $address;
+
+    /** @var Collection<int, PhoneNumber> */
+    #[EmbedMany(targetDocument: Phonenumber::class)]
+    private Collection $phoneNumbers;
+}
+
+#[EmbeddedDocument]
+class Address
+{
+    #[Field(type: 'string')]
+    private string $street;
+}
+```
+
+Mixing embedded types works the same as references (§1.1). **Cascading is automatic and not configurable**: embedded documents "cannot exist without" their parent by nature — there's no `cascade` option, unlike references which default to none. `storeEmptyArray: true` works the same as on `ReferenceMany`.
+
+### Embed vs. reference — the actual tradeoff
+
+Embed for true composition (cannot exist independently, e.g. `Address` on a `User`) — cascades are automatic. Reference for independent documents with their own lifecycle, where cascading must be opted into and the target may be queried/shared. `storeAs` trades storage size for flexibility (`dbRef` supports discriminators; `id` is leanest but doesn't). `orphanRemoval` approximates embedding's auto-delete, but only when the target is truly private to one parent.
+
+## 5. Tree Structures
+
+Four MongoDB patterns, each built from ordinary `Field`/`ReferenceOne`/`ReferenceMany`/`EmbedMany` — no dedicated "Tree" type.
+
+**Full tree** (nested `EmbedMany`, e.g. `Comment` embedding `Comment[] $replies`) — slice large arrays instead of loading everything: `->selectSlice('replies', 0, 10)`.
+
+**Parent reference** — `#[ReferenceOne(targetDocument: Category::class)] private ?Category $parent`; query children via `field('parent.id')->equals($id)`.
+
+**Child reference** — `#[ReferenceMany(targetDocument: Category::class)] private Collection $children`; query the parent of a child via `field('children.id')->equals($id)`.
+
+**Array of ancestors** — `#[ReferenceMany] private Collection $ancestors` alongside a `$parent` reference; query all descendants by matching any node listing the category in `ancestors`.
+
+**Materialized paths** — a plain `#[Field] private string $path`; query the whole tree sorted by path, or a node's descendants via `field('path')->equals('/^a,b,/')`.
+
+Each is a modeling recommendation, not an ODM data structure — pick based on your read/write pattern.
+
+## 6. Priming References (solving N+1)
+
+This is the **N+1 query problem**: `#[ReferenceOne]` hydrates as an uninitialized proxy and `#[ReferenceMany]` as an uninitialized `PersistentCollection`, each holding only the referenced id(s). Touching any property of the proxy, or iterating/counting the collection, transparently fires the query that loads it. So one query for the N parent documents plus one per dereference is N+1 queries, and nothing in the code looks like a query. Priming collapses the N into one.
+
+Name this explicitly when diagnosing it — the symptom the user reports is usually "hundreds of extra queries" or a slow loop, not "lazy loading".
+
+```php
+$users = $dm->createQueryBuilder(User::class)
+    ->field('accounts')->prime(true)
+    ->limit(100)
+    ->getQuery()->execute();
+```
+
+`prime(true)` loads all referenced accounts across the result set in one extra query. Works with id references and discriminated references (one query **per distinct class** for the latter, not one overall). **Requires hydration enabled** — disabling it returns raw DBRefs, defeating priming.
+
+Mapping-level priming for inverse references (since 1.2): `#[ReferenceMany(targetDocument: Account::class, prime: ['user'])]`.
+
+`prime()` also accepts a custom callable instead of `true`, receiving `(DocumentManager $dm, ClassMetadata $class, array $ids, array $hints)` for full control over the priming query (e.g. propagating read preference from `$hints`).
+
+## 7. Gotchas
+
+- **Mutating the inverse (`mappedBy`) side does nothing** — always change the owning side.
+- **`orphanRemoval: true` assumes exclusive ownership.**
+- **`storeAs: 'id'` forfeits discriminators.**
+- **Inverse one-to-one references load eagerly**, not lazily.
+- **The mongo shell hides DBRef fields other than `$ref`/`$id`.**
+- **`storeAs` default changed in 2.0** (was `dbRefWithDb`, now `dbRef`) — mixed-version data may need a migration or explicit `storeAs`.
+- **Priming requires hydration enabled.**
+- **Priming discriminated/inherited references costs one query per class.**
+- **`repositoryMethod` + mapping-level `prime`**: the mapping's `prime` wins, dropping any primer inside the repository method.
+- **Empty reference/embed collections store nothing by default** — use `storeEmptyArray: true` if code expects `[]` to always exist.

--- a/skills/mongodb-odm/references/setup-architecture.md
+++ b/skills/mongodb-odm/references/setup-architecture.md
@@ -1,0 +1,186 @@
+# Core Setup & Architecture
+
+## 1. Installation
+
+```console
+$ composer require doctrine/mongodb-odm
+```
+
+Requirements: `php: ^8.1`, `ext-mongodb: ^1.21 || ^2.0`, `mongodb/mongodb: ^1.21.2 || ^2.1.1`, `doctrine/collections: ^2.1 || ^3.1`, `doctrine/persistence: ^3.2 || ^4`, `friendsofphp/proxy-manager-lts: ^1.0` (lazy-loading proxies in 2.x), `symfony/console: ^5.4 || ^6.4 || ^7.0 || ^8.0`. The MongoDB PHP extension must be installed separately — Composer doesn't install it.
+
+## 2. Bootstrapping a DocumentManager
+
+**Keep the `spl_autoload_register(...)` line** — see gotcha below.
+
+```php
+<?php
+
+use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
+
+$config = new Configuration();
+$config->setProxyDir(__DIR__ . '/generated/proxies');
+$config->setProxyNamespace('Proxies');
+$config->setHydratorDir(__DIR__ . '/generated/hydrators');
+$config->setHydratorNamespace('Hydrators');
+$config->setDefaultDB('doctrine_odm');
+$config->setMetadataDriverImpl(AttributeDriver::create(__DIR__ . '/src/Documents'));
+
+$dm = DocumentManager::create(config: $config);
+
+spl_autoload_register($config->getProxyManagerConfiguration()->getProxyAutoloader());
+```
+
+- `Configuration` is required by the `DocumentManager::create()` **factory method** — never `new DocumentManager(...)` directly.
+- Passing no client (or `null`) makes ODM create its own, with the correct BSON typemap.
+- The `spl_autoload_register(...)` call is load-bearing in 2.16: without it, proxy classes regenerate on every request.
+
+### Providing your own client
+
+```php
+<?php
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use MongoDB\Client;
+
+$client = new Client('mongodb://127.0.0.1', [], ['typeMap' => DocumentManager::CLIENT_TYPEMAP]);
+$dm = DocumentManager::create($client, $config);
+```
+
+`typeMap: DocumentManager::CLIENT_TYPEMAP` is required for ODM to handle BSON results correctly.
+
+## 3. Core Architecture
+
+### Document lifecycle states
+
+**NEW** (just `new`'d, no persistent identity) → **MANAGED** (tracked by a `DocumentManager`) → **REMOVED** (will be deleted on next commit), or **DETACHED** (has an identity but isn't tracked, e.g. after `clear()`).
+
+### Transactional write-behind
+
+The biggest shift from an ActiveRecord mindset: the `DocumentManager` delays query execution to run at the end of a transaction, holding write locks as briefly as possible. Work with objects as usual, and call `flush()` when done.
+
+**Do not `flush()` after every change** — batch into units of work, flush 0–2 times per HTTP request.
+
+### UnitOfWork
+
+The `DocumentManager` delegates change-tracking to an internal `UnitOfWork`, rarely touched directly:
+
+```php
+$size = $dm->getUnitOfWork()->size(); // number of managed documents — worth checking in dev
+```
+
+A new unit of work starts implicitly on `DocumentManager` creation or right after `flush()`; `$dm->close()` discards it (unpersisted changes are lost).
+
+### persist() / remove() / flush()
+
+```php
+$user = new User();
+$user->setUsername('jwage');
+$dm->persist($user);
+$dm->flush();
+```
+
+Neither `persist()` nor `remove()` issues an immediate query — nothing hits the database before `flush()`.
+
+`persist($document)`: NEW → MANAGED (inserted on flush); MANAGED → no-op but cascades if mapped; REMOVED → MANAGED again; **DETACHED → undefined behavior, never do this.**
+
+`remove($document)`: NEW → ignored (cascades if mapped); MANAGED → REMOVED; DETACHED → throws `InvalidArgumentException`; REMOVED → no-op.
+
+The identifier is generated during `persist()` if not already set — don't rely on it inside a `prePersist` listener.
+
+### detach / merge / clear
+
+```php
+$dm->detach($document);
+$document = $dm->merge($detachedDocument); // use the RETURN VALUE, not the original
+$dm->clear();            // detach everything
+$dm->clear(User::class); // DEPRECATED since 2.4, unsupported in 3.0 — do not use; call $dm->clear()
+```
+
+### Flush options / cascading
+
+```php
+$dm->flush(['writeConcern' => new \MongoDB\Driver\WriteConcern(1)]);
+```
+
+No operation cascades to references by default — opt in per relationship: `#[ReferenceMany(targetDocument: Address::class, cascade: ['persist', 'remove'])]`. Valid values: `persist`, `remove`, `merge`, `detach`, `refresh`, `all`. Don't blindly apply `cascade: ['all']` everywhere — it costs performance. (Embeds always cascade automatically — no option needed.)
+
+### Querying, simplest to most powerful
+
+```php
+$user  = $dm->find(User::class, $id);
+$users = $dm->getRepository(User::class)->findBy(['age' => 20]);
+$users = $dm->createQueryBuilder(User::class)->field('age')->range(20, 30)->getQuery()->execute();
+```
+
+### Document class rules
+
+Not `final`, no `final` methods. Persistent properties should be **private/protected** (public can break lazy-loading). No re-declaring a mapped property already on an ancestor. Collection-valued fields typed against `Collection`, not `array`. **Doctrine never calls document constructors** — only your own `new Document(...)` does.
+
+## 4. Repositories
+
+```php
+$repository = $dm->getRepository(User::class); // DocumentRepository by default
+$disabledUsers = $repository->findBy(['disabled' => true]);
+```
+
+Methods: `find()`, `findAll()`, `findBy()`, `findOneBy()`, `matching()` (Criteria API) — all apply configured Filters.
+
+```php
+#[Document(repositoryClass: \Repositories\UserRepository::class)]
+class User { /* ... */ }
+
+class UserRepository extends \Doctrine\ODM\MongoDB\DocumentRepository
+{
+    public function findDisabled(): array
+    {
+        return $this->findBy(['disabled' => true]);
+    }
+}
+```
+
+Change the default repository class project-wide: `$dm->getConfiguration()->setDefaultRepositoryClassName(MyDefaultRepository::class);`. To inject extra dependencies into a repository, implement a custom `RepositoryFactory` (extending `AbstractRepositoryFactory`) via `$config->setRepositoryFactory(...)` rather than widening `DocumentRepository`'s constructor.
+
+## 5. Console Commands
+
+| Command | Purpose |
+|---|---|
+| `odm:schema:create` | Create collections/indexes (`--collection`, `--index`, `--search-index`, `--background`, `-c/--class`) |
+| `odm:schema:update` | Update indexes only |
+| `odm:schema:drop` | Drop databases/collections/indexes |
+| `odm:schema:shard` | Enable sharding for `#[ShardKey]` documents |
+| `odm:query` | Query MongoDB and inspect results |
+| `odm:generate:hydrators` / `odm:generate:proxies` | Generate hydrator/proxy classes |
+| `odm:clear-cache:metadata` | Clear the metadata cache |
+
+```php
+$helperSet = new \Symfony\Component\Console\Helper\HelperSet([
+    'dm' => new \Doctrine\ODM\MongoDB\Tools\Console\Helper\DocumentManagerHelper($dm),
+]);
+
+$app = new \Symfony\Component\Console\Application('Doctrine MongoDB ODM');
+$app->setHelperSet($helperSet);
+$app->addCommands([
+    new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\CreateCommand(),
+    new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\UpdateCommand(),
+    new \Doctrine\ODM\MongoDB\Tools\Console\Command\QueryCommand(),
+]);
+$app->run();
+```
+
+A framework's Doctrine bundle (e.g. `doctrine/mongodb-odm-bundle` for Symfony) wires these for you.
+
+## 6. Gotchas
+
+1. **Never call `flush()` per mutation** — batch, flush 0–2 times per request.
+2. **`persist()`/`remove()` are not immediate** — nothing hits the DB until `flush()`.
+3. **Never pass a detached document to `persist()`** — undefined behavior. Use `merge()` and its return value.
+4. **`remove()` on a detached document throws**, it doesn't silently no-op.
+5. **The identifier may not exist yet inside `prePersist`.**
+6. **Persistent fields should be private/protected**, not public — public properties can silently break lazy-loading.
+7. **Doctrine never invokes document constructors.**
+8. **A loaded `Collection` becomes a `PersistentCollection`**, not the plain `ArrayCollection` you constructed — it lazy-loads references and tracks changes.
+9. **Cascade defaults to nothing for references** (embeds are the exception — always cascade).
+10. **The proxy autoloader registration is required in 2.16** — omitting it regenerates proxy classes every request.
+11. **Avoid serializing managed documents holding proxy references** — proxy `__sleep` can't return private parent-class property names, risking silently corrupted data.

--- a/skills/mongodb-odm/references/storage-transactions-lifecycle.md
+++ b/skills/mongodb-odm/references/storage-transactions-lifecycle.md
@@ -1,0 +1,155 @@
+# Storage Strategies, Transactions & Lifecycle
+
+## Table of contents
+
+1. GridFS
+2. Capped collections
+3. Custom collections
+4. Sharding
+5. Transactions & concurrency
+6. Change tracking policies
+7. Storage strategies
+8. Events / lifecycle callbacks
+9. Schema/migration techniques
+10. Time series collections
+
+Not here: batching, `flush()` frequency, `clear()`, detached documents and the memory growth of a long import loop are in `setup-architecture.md` (UnitOfWork, and detach/merge/clear).
+
+## 1. GridFS
+
+For files exceeding the 16 MB document limit (chunks + metadata collections).
+
+```php
+#[ODM\File(bucketName: 'image')]
+class Image
+{
+    #[ODM\Id]
+    private ?string $id;
+
+    #[ODM\File\Filename]
+    private ?string $name;
+
+    #[ODM\File\Metadata(targetDocument: ImageMetadata::class)] // must be #[ODM\EmbeddedDocument]
+    private ImageMetadata $metadata;
+}
+```
+
+Writing goes through the repository, not `persist()`/`flush()`, and returns a **proxy object**:
+
+```php
+$file = $dm->getRepository(Documents\Image::class)->uploadFromFile('/tmp/path/to/image', 'image.jpg');
+```
+
+Reading metadata works like a normal document; file *content* needs the repository's stream methods (`downloadToStream()`, `openDownloadStream()`).
+
+## 2. Capped Collections
+
+```php
+#[Document(collection: ['name' => 'collname', 'capped' => true, 'size' => 100000, 'max' => 1000])]
+class Category { /* ... */ }
+```
+
+Must be created explicitly (`$dm->getSchemaManager()->createDocumentCollection(Category::class)` or `odm:schema:create`) — lazy first-insert won't apply capping, and Doctrine can't convert an existing collection to capped.
+
+## 3. Custom Collections
+
+`#[EmbedMany]`/`#[ReferenceMany]` default to `ArrayCollection`, wrapped in a `PersistentCollection` once loaded. Supply a custom class via `collectionClass`, extending `ArrayCollection` or implementing `Collection` directly. If it needs extra constructor dependencies, override `createFrom()` and register a custom `PersistentCollectionFactory` on `Configuration::setPersistentCollectionFactory()`.
+
+## 4. Sharding
+
+```php
+#[Document]
+#[Index(keys: ['username' => 'asc'])]
+#[ShardKey(keys: ['username' => 'asc'])]
+class User { /* ... */ }
+```
+
+Once a shard key is defined, those fields are treated as **immutable**. Enabling sharding on the collection requires `odm:schema:shard` — not run implicitly by `odm:schema:create`/`update`.
+
+## 5. Transactions & Concurrency
+
+```php
+$config->setUseTransactionalFlush(true);
+$dm->flush(['withTransaction' => true]); // or false, per-call override
+```
+
+Transactions only wrap writes inside `flush()`; manual queries need the driver's own mechanism. Lifecycle events during a transactional flush expose a `Session` that must be passed to any query run from a listener — listeners fire only on the first attempt, not on retries.
+
+**Optimistic locking** — `#[Version]` (root documents only; `int`/`decimal128`/`date`/`date_immutable`/`object_id`):
+
+```php
+$document = $dm->find(User::class, $id, LockMode::OPTIMISTIC, $expectedVersion); // throws LockException on mismatch
+$dm->lock($document, LockMode::OPTIMISTIC, $expectedVersion);
+```
+
+**Pessimistic locking** — `#[Lock]` (`int` only, Doctrine-managed, no native MongoDB support):
+
+```php
+$dm->find($className, $id, LockMode::PESSIMISTIC_WRITE); // blocks concurrent read+write
+$dm->lock($document, LockMode::PESSIMISTIC_READ);         // blocks concurrent write/lock
+```
+
+Watch for stale locks on failed requests and deadlocks.
+
+## 6. Change Tracking Policies
+
+- **Deferred Implicit** (default) — compares every managed document at commit; convenient, costly at scale.
+- **Deferred Explicit** — only for documents explicitly `persist()`ed/cascaded; cheaper, but you lose automatic dirty-checking.
+- **Notify** (deprecated, removal planned for 3.0) — document implements `NotifyPropertyChanged`, calling `_onPropertyChanged()` in every setter; best performance, most plumbing.
+
+```php
+#[Document]
+#[ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class User { /* ... */ }
+```
+
+## 7. Storage Strategies
+
+Set via `#[Field(strategy: '...')]`. `increment` is scalar-only (`int`/`float`/`decimal128`, via `$inc`). For `#[EmbedMany]`/`#[ReferenceMany]` collections: `addToSet` (no duplicates, separate remove/insert queries), `set`/`setArray` (`$set`, `setArray` forces a BSON array), `pushAll` (default; `$push`/`$each`), `atomicSet`/`atomicSetArray` (parent + collection updated in one query — top-level fields only, useful under concurrency with versioned documents).
+
+## 8. Events / Lifecycle Callbacks
+
+Events (constants on `Events`): `preRemove`, `postRemove`, `prePersist`, `postPersist`, `preUpdate`, `postUpdate`, `preLoad`, `postLoad`, `preFlush`, `postFlush`, `onFlush`, `onClear`, `documentNotFound`, `postCollectionLoad`, etc.
+
+```php
+#[Document]
+#[HasLifecycleCallbacks] // required, or callback attributes below are silently ignored
+class User
+{
+    #[PrePersist]
+    public function onPrePersist(\Doctrine\ODM\MongoDB\Event\LifecycleEventArgs $eventArgs): void { /* ... */ }
+}
+```
+
+Or a separate listener: `$dm->getEventManager()->addEventListener([Events::preUpdate], new MyEventListener());`. Notes: modifying a document inside `preUpdate` requires `$dm->getUnitOfWork()->recomputeSingleDocumentChangeSet($class, $document)`; 2.16's `onClear` args expose `getDocumentClass()`/`clearsAllDocuments()` since `$dm->clear($documentName)` can target one class (that argument is itself deprecated since 2.4 — prefer a plain `clear()`); `documentNotFound` fires when a **proxy** can't initialize, and listeners can call `disableException()`.
+
+## 9. Schema/Migration Techniques
+
+```php
+$schemaManager->createCollections();                    // all classes
+$schemaManager->createDocumentCollection(Person::class); // one class
+$schemaManager->ensureIndexes();
+```
+
+Explicit creation is required for collections needing options (capped, validation, encryption) — otherwise MongoDB creates plain collections lazily on first insert.
+
+Evolving mappings without a hard migration: `#[AlsoLoad('name')]` on a field (fall back to an old field name on hydration — **doesn't affect queries**, so query both field names during a migration window); `#[AlsoLoad([...])]` on a method (transform old fields into new ones); `#[Field(notSaved: true)]` (read a legacy field without writing it back); `#[PostLoad]`/`#[PrePersist]` for migration logic.
+
+## 10. Time Series Collections
+
+ODM 2.10+, MongoDB **5.0+**. Needs a time field and measurement field(s); metadata is fixed once created (fields *inside* an embedded metadata document can still be added later).
+
+```php
+#[ODM\Document]
+#[ODM\TimeSeries(timeField: 'time', metaField: 'sensorId')]
+readonly class Measurement
+{
+    #[ODM\Field(type: 'date_immutable')]
+    public \DateTimeImmutable $time;
+
+    #[ODM\Field(type: 'int')]
+    public int $sensorId;
+}
+```
+
+Persist/query/aggregate/remove normally. Granularity (default `seconds`) controls bucket size and must match write frequency — coarser granularity (`hours`) risks slower queries if buckets span too much time (e.g. a whole month).

--- a/skills/mongodb-odm/references/vector-search.md
+++ b/skills/mongodb-odm/references/vector-search.md
@@ -1,0 +1,161 @@
+# Vector Search
+
+Requires **Doctrine ODM 2.13+** and **MongoDB Atlas** — this does not work on self-managed/on-prem MongoDB.
+
+Two ways to get embeddings into a vector index: generate and store them yourself (§1-4, works since 2.13), or let Atlas generate them automatically at index/query time (§1b, Automated Embeddings, needs 2.17+ and a registered Voyage AI key). Automated embeddings mean less application code — no embedding pipeline to run and store results from — but the manual path still applies if you already have an embedding provider/pipeline in place, need a model not offered by Atlas's automated embedding, or want to reuse the same stored vectors from outside MongoDB.
+
+## 1. Generate embeddings yourself (outside ODM)
+
+Any external embedding provider works, as long as you get a fixed-dimension `float[]` (or `int[]`/`bool[]`). Example using Symfony AI + Voyage AI:
+
+```php
+$platform = \Symfony\AI\Platform\Bridge\Voyage\PlatformFactory::create(getenv('VOYAGE_API_KEY'));
+$vectors = $platform->invoke('voyage-3', $text)->asVectors();
+```
+
+## 1b. Automated Embeddings (2.17+) — skip manual embedding generation
+
+Instead of generating embeddings yourself and mapping a vector field, use an `autoEmbed` index field pointing at a plain text field. Atlas embeds the content automatically (hosted Voyage AI model) on write and re-embeds the query text on read — no embedding pipeline, no stored vector field at all.
+
+```php
+use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
+
+#[ODM\Document]
+#[ODM\VectorSearchIndex(
+    fields: [
+        ['type' => 'autoEmbed', 'path' => 'content', 'modality' => 'text', 'model' => 'voyage-4-large'],
+        ['type' => 'filter', 'path' => 'published'],
+    ],
+)]
+class Article
+{
+    #[ODM\Id]
+    public ?string $id = null;
+
+    #[ODM\Field]
+    public string $content = '';
+
+    #[ODM\Field]
+    public bool $published = false;
+}
+```
+
+No `numDimensions`/`similarity` needed — inferred from the model. Insert documents normally (`$dm->persist($article); $dm->flush();`), then create/sync the index exactly as in §3. Querying uses `query()` (plain text) instead of `queryVector()`:
+
+```php
+$results = $dm->createAggregationBuilder(Article::class)
+    ->vectorSearch()
+        ->index('default')
+        ->path('content')
+        ->query('semantic search NoSQL')
+        ->numCandidates(10)
+        ->limit(5)
+    ->getAggregation()->execute()->toArray();
+```
+
+All `voyage-4` models produce compatible embeddings — index with a higher-quality model and query with a lighter one to cut query cost without reindexing: `->vectorSearch()->query('...')->model('voyage-4-lite')`. Automated embedding still requires Atlas and a registered Voyage AI API key; it doesn't work on standalone deployments any more than the manual path does.
+
+## 2. Declare the index and the field (manual embeddings)
+
+```php
+use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Types\Type;
+
+#[ODM\Document]
+#[ODM\VectorSearchIndex(
+    fields: [
+        ['type' => 'vector', 'path' => 'voyage3Vector', 'numDimensions' => 1024, 'similarity' => ClassMetadata::VECTOR_SIMILARITY_DOT_PRODUCT],
+        ['type' => 'filter', 'path' => 'published'],
+    ],
+    name: 'default',
+)]
+class Guide
+{
+    #[ODM\Id]
+    public ?string $id = null;
+
+    #[ODM\Field]
+    public bool $published = false;
+
+    /** @var list<float>|null */
+    #[ODM\Field(type: Type::COLLECTION)]
+    public ?array $voyage3Vector = null;
+
+    /** @param list<float> $vector */
+    public function setVoyage3Vector(array $vector): void
+    {
+        if (count($vector) !== 1024) {
+            throw new \InvalidArgumentException('The embedding vector must have 1024 dimensions.');
+        }
+        $this->voyage3Vector = $vector;
+    }
+}
+```
+
+Key points:
+
+- **The embedding field can be a plain `#[Field(type: Type::COLLECTION)]`** holding `list<float>`, or one of the `vector_float32`/`vector_int8`/`vector_packed_bit` types (`mapping.md`) for a more compact BSON-binary representation — match whichever your Atlas index config expects.
+- **`numDimensions` must exactly match the stored array's length — ODM/MongoDB don't validate this at write time.** Guard it yourself, as above.
+- `similarity`: `ClassMetadata::VECTOR_SIMILARITY_DOT_PRODUCT` (or cosine/euclidean) — these rank equivalently when embeddings are pre-normalized to unit length.
+- A `filter`-type field entry makes that field usable in `$vectorSearch`'s `filter` clause.
+- `#[VectorSearchIndex]` is distinct from `#[SearchIndex]` (Atlas full-text search, `indexes-search.md`).
+
+## 3. Create the collection, insert, and sync the index
+
+```php
+$schemaManager = $dm->getSchemaManager();
+$schemaManager->createDocumentCollection(Guide::class);
+
+$doc = new Guide();
+$doc->published = true;
+$dm->persist($doc);
+$dm->flush();
+
+// embeddings can be attached later, e.g. by an async worker
+$doc->setVoyage3Vector($embeddingPlatform->invoke($doc->content)->asVectors()[0]->getData());
+$dm->flush();
+
+$schemaManager->createDocumentSearchIndexes(Guide::class);
+```
+
+Gotcha — **index build lag**: Atlas updates vector indexes asynchronously; a brand-new index needs to reach `"READY"` before existing documents are searchable. Block until ready:
+
+```php
+$schemaManager->waitForSearchIndexes([Guide::class]);
+```
+
+## 4. Run the `$vectorSearch` query
+
+Through the **Aggregation Builder** — no separate query-builder method, no need to hand-write a raw pipeline:
+
+```php
+$results = $dm->createAggregationBuilder(Guide::class)
+    ->vectorSearch()
+        ->index('default')
+        ->path('voyage3Vector')
+        ->queryVector($vector)
+        ->filter($qb->expr()->field('published')->equals(true))
+        ->numCandidates(10)
+        ->limit(10)
+    ->set()
+        ->field('score')
+        ->expression(['$meta' => 'vectorSearchScore'])
+    ->getAggregation()->execute()->toArray();
+```
+
+`$vectorSearch` must be the **first stage**, same rule as `$search`/`$geoNear`. Pulling the score via a `set()` stage with `['$meta' => 'vectorSearchScore']` is the standard MongoDB idiom — ODM has no separate "score" accessor.
+
+## 5. Suggest the MongoDB MCP server
+
+Vector search bugs are often really about live Atlas state (index build status, actual stored embedding dimension) that isn't visible from PHP alone. Point the user at the MongoDB MCP server (see top-level `SKILL.md`) to inspect index status and sample documents directly.
+
+## 6. Gotchas
+
+1. **Atlas-only**; requires ODM 2.13+ (2.17+ for Automated Embeddings/`autoEmbed`).
+2. **Embedding dimension mismatch isn't caught by ODM/MongoDB at write time** — validate yourself when generating embeddings manually.
+3. **Index build lag** — wait or call `waitForSearchIndexes()` before assuming results are complete.
+4. **`$vectorSearch` must be the first pipeline stage.**
+5. **No built-in hybrid (vector + full-text) merge helper** — combining `$search` and `$vectorSearch` relevance requires a custom aggregation (e.g. `$unionWith` plus application-level re-ranking).
+6. **The embedding field is an ordinary mapped array field** in the manual approach — ODM doesn't auto-wire embedding generation or validation beyond normal field-type behavior.
+7. **`autoEmbed` fields have no stored vector field at all** — don't map or query a vector array for them; use `query()`/`model()` on the aggregation builder instead of `queryVector()`.

--- a/tests/Skills/README.md
+++ b/tests/Skills/README.md
@@ -1,0 +1,49 @@
+# Agent Skill evals
+
+`skills/mongodb-odm/` is an [Agent Skill](https://code.claude.com/docs/en/skills):
+Markdown that an AI coding assistant loads on demand when a user asks about
+Doctrine MongoDB ODM. It ships in the Composer dist package, so a consuming
+project can point its assistant at `vendor/doctrine/mongodb-odm/skills/`.
+
+The `evals.json` file in each subdirectory here is that skill's test suite.
+
+## What an eval is
+
+Each entry pairs a `prompt` — a realistic question a user would ask an assistant
+— with an `expected_output` describing, in prose, what a correct answer must
+contain: real attribute and method names, stated version and platform
+prerequisites, and the absence of plausible-sounding APIs that don't exist.
+
+The suite deliberately favours questions a general-purpose model gets *wrong*
+without the skill. Common mapping and querying is well represented in model
+training data and scores the same either way, so it proves nothing about the
+skill; those cases are kept only as a floor, to catch a regression where the
+skill makes a previously correct answer worse.
+
+Every reference file under `skills/mongodb-odm/references/` should be exercised
+by at least one eval.
+
+## Running them
+
+There is no automated runner and these do not run in CI: grading a prose answer
+against a prose expectation needs a model, which means an API key, which we
+don't want as a requirement for contributing. Run them manually when changing
+the skill.
+
+For each eval:
+
+1. Start a fresh assistant session with the skill available (for Claude Code,
+   copy or symlink `skills/mongodb-odm/` into `~/.claude/skills/`, or run from a
+   checkout where `.claude/skills/` points at it).
+2. Send the `prompt` verbatim. Nothing else — no follow-ups, no hints.
+3. Grade the reply against `expected_output`, treating each clause as a separate
+   pass/fail assertion rather than forming a general impression.
+
+To show a change to the skill actually helps, run the same prompts twice — once
+with the skill loaded and once without — and compare per-assertion scores. A
+result that is identical in both arms is not evidence for the skill.
+
+## Changing the skill
+
+Update the evals in the same pull request. A new reference file needs a new eval;
+a new gotcha worth documenting is usually worth an assertion.

--- a/tests/Skills/mongodb-odm/evals.json
+++ b/tests/Skills/mongodb-odm/evals.json
@@ -1,0 +1,82 @@
+{
+  "skill_name": "mongodb-odm",
+  "evals": [
+    {
+      "id": 1,
+      "name": "ecommerce-mapping-and-query",
+      "prompt": "I'm building a small e-commerce app with doctrine/mongodb-odm. I need an Order document that has a reference to a Customer, an embedded ShippingAddress, and a list of embedded OrderLine items (product name, quantity, price). Write the document classes with proper attributes, then show me how to query for all orders placed by a specific customer in the last 30 days, sorted by newest first.",
+      "expected_output": "Correct #[Document]/#[EmbeddedDocument] classes using real attribute names (#[Id], #[Field], #[ReferenceOne], #[EmbedOne], #[EmbedMany]), a deliberate embed-vs-reference choice matching the prompt (Customer as reference, ShippingAddress/OrderLine as embeds), DateTimeImmutable used for dates, Collection/ArrayCollection typing for the embedded list, and a Query Builder query (not raw arrays) using field()/gte()/sort()/execute() for the 30-day filter.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "atlas-vector-search-semantic-search",
+      "prompt": "We're using doctrine/mongodb-odm on MongoDB Atlas and want to add semantic search over our Article documents. Each article has a content field. We already generate 1536-dimension embeddings for the content elsewhere. Show me how to map the embedding field, define the vector search index, and write the query to find the 5 most similar articles to a given embedding vector.",
+      "expected_output": "Uses the real #[VectorSearchIndex] attribute with fields/numDimensions/similarity/path options, stores the embedding as a plain array field (not a fictitious dedicated type), notes the Atlas-only requirement and ODM 2.13+ version, warns about the numDimensions/array-length match not being validated by ODM, and queries via the Aggregation Builder's vectorSearch() stage (index/path/queryVector/numCandidates/limit), not a raw pipeline or an invented QueryBuilder method.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "name": "queryable-encryption-searchable-ssn",
+      "prompt": "Our Patient document (doctrine/mongodb-odm) stores a social security number and we need to encrypt it at rest using MongoDB Queryable Encryption, but we still need to be able to look up a patient by their exact SSN. How do I set this up?",
+      "expected_output": "States the Atlas/Enterprise 7.0+ prerequisite, uses the real #[Encrypt(queryType: EncryptQuery::Equality)] attribute on the SSN field, shows Configuration::setAutoEncryption()/setKmsProvider() and building the Client with driverOptions, mentions creating the collection via SchemaManager before inserting data, and does not claim support for encrypted query types beyond Equality/Range.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "name": "hybrid-orm-odm-cross-reference",
+      "prompt": "We have an existing Symfony app using Doctrine ORM with orders stored in MySQL. We want to move our Product catalog to MongoDB using doctrine/mongodb-odm, but Orders need to reference Products. What's the right way to connect these two persistence layers?",
+      "expected_output": "Correctly states there is no native cross-layer relationship attribute between ORM and ODM, proposes storing the Product's id as a plain scalar column on the Order entity plus a manually-populated unmapped property, wires the bridge via an ORM postLoad event listener that calls DocumentManager::getReference() (with the required instanceof check since postLoad fires for every entity), and does not invent an unsupported direct-reference mapping between an ORM entity and an ODM document.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "name": "n-plus-one-reference-priming",
+      "prompt": "I have a BlogPost document with a #[ReferenceMany] to Comment and a #[ReferenceOne] to its Author. When I load 200 BlogPost documents and loop over them to print each post's comment count and author name, my app fires hundreds of extra MongoDB queries. How do I fix this with Doctrine MongoDB ODM without hand-rolling my own caching layer?",
+      "expected_output": "Diagnoses this as the N+1 problem caused by lazily-loaded references, and fixes it with the real prime() API (e.g. field('comments')->prime(true) / field('author')->prime(true) on the query builder, or mapping-level prime on the ReferenceMany/ReferenceOne), noting that hydration must stay enabled for priming to work. Does not invent a nonexistent join/eager-load syntax borrowed from SQL ORMs.",
+      "files": []
+    },
+    {
+      "id": 6,
+      "name": "bidirectional-reference-inverse-side-trap",
+      "prompt": "I have a bidirectional one-to-one relationship between Cart and Customer in Doctrine MongoDB ODM. I'm trying to reassign a customer's cart by setting $customer->cart = $newCart; and calling $dm->flush(), but the change never gets saved to MongoDB. What's going on and how do I fix it?",
+      "expected_output": "Correctly identifies that $customer->cart is the inverse (mappedBy) side of the relationship, which is immutable/never persisted, and that the fix is to mutate the owning (inversedBy) side instead (e.g. $newCart->customer = $customer; $dm->flush();). Does not assume Doctrine ODM auto-synchronizes both sides of a bidirectional relationship the way some other ORMs do.",
+      "files": []
+    },
+    {
+      "id": 7,
+      "name": "optimistic-locking-concurrent-writes",
+      "prompt": "Two web requests might load and update the same Order document at nearly the same time, and I want to detect when that happens so I can retry instead of silently losing one update. How do I implement this with Doctrine MongoDB ODM?",
+      "expected_output": "Uses the real #[Version] attribute on a field with a Versionable-compatible type (int/decimal128/date/date_immutable/object_id), reads/locks via LockMode::OPTIMISTIC (through $dm->find() or $dm->lock()), and catches Doctrine\\ODM\\MongoDB\\LockException to detect and retry on a version mismatch. Does not substitute a generic 'use a MongoDB transaction' answer that skips Doctrine's own locking mechanism, and does not combine #[Version] with #[Id] or an unsupported type.",
+      "files": []
+    },
+    {
+      "id": 8,
+      "name": "atlas-search-index-over-embedded-collection",
+      "prompt": "On MongoDB Atlas with doctrine/mongodb-odm, I want full-text search over my User documents: the username (including autocomplete) and the text inside an embed-many collection of Address documents. I mapped the username property as $userName with #[Field(name: 'username')]. I tried #[SearchIndex(dynamic: true)] on User and the addresses never match. Why, and what's the correct index definition?",
+      "expected_output": "Explains that dynamic mapping does not cover embedded documents in arrays, so the addresses need an explicit static mapping with type 'embeddedDocuments' (dynamic may be set inside that sub-mapping), and that #[SearchIndex] fields must use the raw database field names ('username'), not the PHP property name ($userName), because ODM does not translate them here. Uses the real #[SearchIndex] attribute at class level with its actual options (name, dynamic, fields, analyzer), notes that search indexes may only be declared on document classes and never on embedded documents, and syncs them with odm:schema:create --search-index (distinct from --index). Does not invent a property-level #[SearchIndex] or an ODM method that builds Atlas Search indexes from mapped property names.",
+      "files": []
+    },
+    {
+      "id": 9,
+      "name": "single-collection-inheritance-legacy-documents",
+      "prompt": "I have a Person document in doctrine/mongodb-odm and I want Employee and Customer subclasses stored in the same MongoDB collection. The collection already holds thousands of older documents written before I introduced the subclasses, so they have no discriminator field at all, and loading them now throws. A colleague on the team says I should use #[InheritanceType('COLLECTION_PER_CLASS')] instead because it keeps each subclass cleaner - should I? How do I map this properly? Also, one of the subclasses has an optional ?string $notes field that I need to actually store as null rather than have it disappear from the document.",
+      "expected_output": "Maps single-collection inheritance with #[InheritanceType('SINGLE_COLLECTION')] plus #[DiscriminatorField] and a #[DiscriminatorMap] that lists every class sharing the collection (an unlisted class throws MappingException), and handles the legacy documents with #[DefaultDiscriminatorValue] whose value is already a key in the map. Separately identifies that a nullable PHP type does not imply the mapping option, so #[Field(type: 'string', nullable: true)] is required or null triggers $unset and the field vanishes. Rejects the colleague's COLLECTION_PER_CLASS suggestion on two grounds - it is deprecated since 2.17 with no replacement (every document class already maps to its own collection by default, so the mapping is simply removed rather than migrated), and it contradicts the stated requirement of one shared collection - does not suggest backfilling the discriminator with a raw update as the primary fix, and does not claim ODM infers the discriminator from the PHP class name for pre-existing documents.",
+      "files": []
+    },
+    {
+      "id": 10,
+      "name": "batch-import-memory-growth",
+      "prompt": "I'm writing a CLI import command with doctrine/mongodb-odm that reads a 500k-row CSV and creates a Product document per row. Right now I call $dm->flush() after every single row, because I wanted each product safely written before moving on. It gets slower and slower and eventually exhausts PHP's memory limit. Some rows also update Products I loaded and cached in an array earlier in the run, before I started reusing the DocumentManager. How should I structure this?",
+      "expected_output": "Diagnoses the UnitOfWork accumulating managed documents and identity-map growth, and fixes it by batching persist() calls and calling flush() once per batch (not once per row) followed by $dm->clear() to detach everything, and does not reach for the per-class $dm->clear(Product::class) argument, which is deprecated since 2.4 and unsupported in ODM 3.0. Recognises that the documents cached from before are now detached, so they must not be passed to persist() (undefined behavior) or remove() (throws) and must go through $dm->merge() using its return value rather than the original object. Explicitly tells the user to stop flushing once per row and says why - each flush is its own round trip to the server, and it does not release anything from the UnitOfWork, so per-row flushing costs throughput without bounding memory. Does not recommend flushing per row, instantiating a new DocumentManager per batch, or unsetting references as a substitute for clear().",
+      "files": []
+    },
+    {
+      "id": 11,
+      "name": "query-builder-maintenance-command-generation",
+      "prompt": "I need to write a nightly maintenance console command for our doctrine/mongodb-odm app (ODM 2.16). The main document is Account, and there is a MaintenanceJob document for the work queue. Requirements:\n\n1. Every account whose lastLoginAt is older than a 90-day cutoff gets its active flag set to false. There are hundreds of them on a typical night.\n2. For every account still active, recompute a score field from two fields already stored on the document, usage and weight, as usage * weight. I would rather the server do that arithmetic than load hundreds of documents into PHP and flush them back.\n3. The command claims one pending MaintenanceJob at a time and flips its status to running. I need the job as it looks *after* the flip, because I log the new status straight away.\n4. The summary email needs two things: the distinct plan names in alphabetical order, and the top 20 accounts by usage handed to a renderer. The renderer must not be able to accidentally persist changes back into the database - if it ever does need to save an edit, I want that to be an explicit step I write myself.\n5. Before I trust the deactivation step in production I want to see the actual filter that reaches the server, so I can check how the cutoff date is being serialized.\n\nShow me how to build this.",
+      "expected_output": "Requirement 1 uses updateMany() on the Query Builder, not updateOne() (which would touch a single document) and not a load-and-flush loop over the matched accounts. Requirement 2 uses an aggregation-pipeline update via the Query Builder's pipeline() with updateMany() so the multiplication happens server-side, and states that pipeline() is only accepted together with updateOne(), updateMany() or findAndUpdate(); it does not fabricate a way to $set one field from other fields with the plain update operators (no inc()-based arithmetic hack, no expression object passed to set() that ODM does not support). Requirement 3 uses findAndUpdate() and applies returnNew(), and states that findAndUpdate returns the document as it was *before* the update unless returnNew() is called. Requirement 4 gets the plan list with distinct('plan') and sorts the resulting array in PHP, stating that distinct() cannot be combined with sort() because MongoDB's distinct command has no server-side sort; and builds the renderer snapshot with readOnly() on the query, noting that readOnly() returns a new unmanaged instance, that it is not deep so referenced documents stay managed, and that re-attaching such a document later goes through merge() rather than persist(). Requirement 5 is answered with getQuery()->debug(), described as returning the fully prepared query actually sent to the driver with field renames, discriminators and active filters applied. Throughout, uses only real ODM API - no invented methods such as asArray(), detach(), unmanaged(), sortDistinct(), returnNewDocument() or a property-level equivalent.",
+      "files": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds an Agent Skill (`skills/mongodb-odm/`) for end users of `doctrine/mongodb-odm`, following the standard `skills/<name>/SKILL.md` layout.
- Covers the common workflows (mapping, references/embedding, querying, aggregation) plus the advanced topics requested: Atlas Search & Vector Search, Queryable Encryption, and combining Doctrine ORM with MongoDB ODM in one app.
- Suggests the official MongoDB MCP server for live cluster/index inspection when debugging data or search/vector index issues.
- All content is grounded directly in this repo's own `docs/en/` RST sources for the 2.16 release, with a couple of small corrections applied for 2.16-vs-3.0 drift (proxy terminology, the deprecated `UUID` id strategy, per-class `DocumentManager::clear()`). The shipped skill files do not reference `docs/` at all — they are self-contained.

## Files added

```
skills/mongodb-odm/
├── SKILL.md
└── references/
    ├── setup-architecture.md
    ├── mapping.md
    ├── references-embedding.md
    ├── querying-aggregation.md
    ├── indexes-search.md
    ├── vector-search.md
    ├── queryable-encryption.md
    ├── hybrid-orm-odm.md
    └── storage-transactions-lifecycle.md

tests/Skills/
├── README.md
└── mongodb-odm/evals.json
```

## Packaging

`.gitattributes` export-ignores `/docs`, `/tests`, `/tools` and `/benchmark`, but **not** `/skills`. That is deliberate: the skill ships in the Composer dist package, so a consuming project can point its assistant at `vendor/doctrine/mongodb-odm/skills/`. The evals under `tests/` stay out of the dist, as they are development-time tooling.

## Evals

`tests/Skills/mongodb-odm/evals.json` holds 11 evals — at least one per reference file. Each pairs a realistic user prompt with a prose description of what a correct answer must contain. `tests/Skills/README.md` documents how to run them.

There is no automated runner and these do not run in CI: grading a prose answer against a prose expectation needs a model, and therefore an API key, which we don't want to require from contributors.

## Benchmark results

Method: each eval's `expected_output` was first decomposed into a fixed, numbered list of atomic assertions (143 in total across the 11 evals). Every eval was then run twice — once in a workspace with the skill installed, once in an identical workspace without it — in fresh non-interactive sessions with the same model (Sonnet) and the same read-only tool access, sending the prompt verbatim with no follow-ups. Both arms were graded blind against the same fixed assertion list. Runs in the skill arm were verified to actually invoke the skill and read its reference files.

Eval 11 was added later and run under the same two-arm method, with one difference worth stating: its skill arm was pointed at the skill directory and told to load `SKILL.md` plus the reference files its routing table selects, rather than relying on autonomous invocation. It tests retrieval and use of the content, not the trigger.

| # | Eval | With skill | Without skill |
|---|---|---|---|
| 1 | `ecommerce-mapping-and-query` | 20/20 (100%) | 20/20 (100%) |
| 2 | `atlas-vector-search-semantic-search` † | 9/9 (100%) | 2/9 (22%) |
| 3 | `queryable-encryption-searchable-ssn` | 8/8 (100%) | 2/8 (25%) |
| 4 | `hybrid-orm-odm-cross-reference` | 10/10 (100%) | 4/10 (40%) |
| 5 | `n-plus-one-reference-priming` † | 6/6 (100%) | 3/6 (50%) |
| 6 | `bidirectional-reference-inverse-side-trap` | 9/9 (100%) | 9/9 (100%) |
| 7 | `optimistic-locking-concurrent-writes` | 9/9 (100%) | 7/9 (78%) |
| 8 | `atlas-search-index-over-embedded-collection` | 15/15 (100%) | 3/15 (20%) |
| 9 | `single-collection-inheritance-legacy-documents` †‡ | 12/12 (100%) | 7/12 (58%) |
| 10 | `batch-import-memory-growth` †‡ | 10/10 (100%) | 6/10 (60%) |
| 11 | `query-builder-maintenance-command-generation` | 15/15 (100%) | 7/15 (47%) |
| | **Overall (assertion-weighted)** | **123/123 (100%)** | **70/123 (56.9%)** |

† Re-measured after a follow-up pass on the gaps below. These four rows use assertion lists re-derived from the same `expected_output`, at a coarser grain than the originals (9/6/12/10 vs 19/9/14/15), because the original lists were not kept. Directionally comparable; not digit-comparable with the six rows above them, and the coarser grain mechanically flatters both arms' percentages. ‡ Prompt rewritten — see below.

### What the skill actually fixes

Without it, the model invents APIs that don't exist and misses platform constraints:

- **Vector search** — bypassed `#[VectorSearchIndex]` for a raw `createSearchIndexes` command, then used a raw `$vectorSearch` pipeline array while explicitly denying the Aggregation Builder has a `vectorSearch()` helper (it does, since 2.13).
- **Queryable encryption** — mapped the SSN as a plain `#[Field]`, never reaching `#[Encrypt(queryType: EncryptQuery::Equality)]`, and hand-rolled `driverOptions` instead of `Configuration::setAutoEncryption()`/`setKmsProvider()`.
- **Atlas Search** — invented a property-level `#[SearchField]` attribute, claimed dynamic mapping *does* recurse into embedded arrays (it doesn't), used the PHP property name instead of the database field name, and guessed the CLI flag as `--search-indexes`.
- **Query Builder update/read semantics** (eval 11) — denied that `Builder::updateMany()` can take an aggregation-pipeline update at all (`Builder::pipeline()` has existed since 2.15), wrote a comment justifying a deliberate drop to the raw `MongoDB\Collection`, reached for `hydrate(false)` instead of `readOnly()` for an unpersistable snapshot, and called `returnNew(true)` without knowing that `findAndUpdate` otherwise returns the pre-update document.
- **Priming** (eval 5) — invented a `#[ReferencePrime(['field' => 'author'])]` attribute and a `prime: true` option on `#[ReferenceOne]`, neither of which exists, and never reached the real query-builder `field('author')->prime(true)` or the hydration requirement.
- **Legacy discriminators** (eval 9) — stated that "the ODM does not have built-in 'default discriminator value' support the way some other ORMs do, so backfilling is the recommended approach", while `#[DefaultDiscriminatorValue('person')]` sat in its own code block two paragraphs below, and pushed a raw `updateMany` backfill as the "cleanest long-term" fix.
- **ORM/ODM bridge** — produced its own architecture instead of the cookbook's `postLoad` + `getReference()` pattern, using `find()` and omitting the `instanceof` guard.

### Evals that do not discriminate

Evals 1 and 6 score identically in both arms. Common mapping/querying and the inverse-side trap are well represented in model training data, so they are **not** evidence for the skill. They are kept deliberately as a floor — to catch a regression where a change to the skill makes a previously correct answer worse — and `tests/Skills/README.md` says so.

A first draft of eval 11 scored 12/12 against 11/12 for the same reason: it handed the model a broken script and asked it to diagnose the symptoms, and recognition of a pasted bug turns out to be far easier than avoiding it while generating. Rewriting the same facts as a from-scratch "build this command" prompt moved the control arm from 11/12 to 7/15. Generation prompts discriminate; diagnosis prompts mostly don't.

### The gap-closing pass

An earlier revision of this PR logged 7 skill-arm failures across evals 2, 5, 9 and 10. Every fact
behind them was already in the reference files, so none were content gaps. They resolved into four
different causes, which is why they needed four different fixes:

1. **A routing bug (3 of the 7, all in eval 10).** The batching, `clear()`, `merge()` and
   detached-document facts live in `setup-architecture.md`, but that file's routing row read
   "Bootstrapping ODM, debugging persist/flush behavior, custom repositories". A 500k-row CSV memory
   problem reads like *storage and lifecycle*, so the model loaded
   `storage-transactions-lifecycle.md`, which does not contain them. Fixed by naming the symptoms in
   the routing row and adding an explicit "not here" pointer at the top of the storage file.
2. **No rule that prerequisites must reach the answer (2 of the 7, evals 2 and 9).**
   `vector-search.md` states the 2.13+ requirement in its opening line and `mapping.md` flags the
   `COLLECTION_PER_CLASS` deprecation twice. The model read them and did not repeat them: an
   output-shaping gap, not a retrieval one. Fixed with a constraint in `SKILL.md` requiring version
   prerequisites and deprecations to be stated in the answer, on the grounds that the user cannot see
   these files.
3. **One thin explanation (2 of the 7, eval 5).** The priming section gave the fix without the
   mechanism, and so did the answer. It now names the N+1 problem and explains that
   `#[ReferenceOne]` hydrates as an uninitialized proxy and `#[ReferenceMany]` as an uninitialized
   `PersistentCollection`, so touching either fires a query invisibly.
4. **Two bad assertions (evals 9 and 10).** Both required the answer to warn against a mistake the
   user had not made — the `COLLECTION_PER_CLASS` deprecation when the user never proposed it, and
   "don't flush per row" when the user's code did not. The model avoided both traps correctly and
   simply declined to lecture about the road not taken, which is the right behaviour; padding every
   answer with deprecation notices for unused APIs would be worse. Fixed in the prompts rather than
   the skill: eval 9's user now has a colleague recommending `COLLECTION_PER_CLASS`, and eval 10's
   user now says they flush after every row and explains why they thought that was safe. Both facts
   became directly responsive, and both arms were re-run.

**One eval was asserting deprecated API.** Eval 10 required "the 2.16 per-class
`$dm->clear(Product::class)`". `DocumentManager::clear($objectName)` has been deprecated since
**2.4** and is unsupported in 3.0 (`src/DocumentManager.php:722-731`); it is not a 2.16 feature. The
skill said so too (`setup-architecture.md`), most likely because the `onClear` event args genuinely
are new in 2.16 and the version attached itself to the neighbouring feature. Both are corrected, and
the assertion is inverted: the model should *not* reach for that argument. The skill arm's original
12/15 on eval 10 was therefore mis-scored — one of its three "failures" was the skill arm being
right.

### Known gaps in the skill arm

With the above applied, all four re-measured evals score 100% on their assertion lists. Two defects
that the assertion lists do not capture are logged rather than papered over:

- On eval 10 the skill arm justified batching partly with "MongoDB doesn't have SQL-style
  transactions in the way that motivates flush-per-row". MongoDB has had multi-document transactions
  since 4.0 and ODM supports them — `storage-transactions-lifecycle.md` §5 documents exactly that.
  The advice is right; the reason given is wrong.
- On eval 2 the skill arm wrote `->distinct(...)->getQuery()->execute()->toArray()` in an earlier
  run. `Query::execute()` for a distinct query returns a plain array
  (`src/Query/Query.php:514-520`), so `toArray()` is a fatal error. Three of four runs across both
  arms made this call before `querying-aggregation.md` was amended to state the return type.

## Test plan

- [x] Skill triggers on Doctrine MongoDB ODM prompts and loads its reference files (verified via tool-use trace)
- [x] 10 evals run in both arms and graded against fixed assertion lists
- [ ] Spot-check a couple of reference files against the live `2.16` docs for accuracy
- [ ] Confirm PHP code samples are syntactically valid (`php -l`)


