### PR TITLE
Improve index documentation

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -21,9 +21,3 @@ Getting Started
 The best way to get started is with the :doc:`Setup <reference/introduction#setup>` section
 in the introduction tutorial. Use the sidebar to browse other tutorials and documentation
 for the Doctrine PHP MongoDB ODM.
-
-Useful reference pages
-----------------------
-
-- :doc:`Indexes <reference/indexes>` — how to define indexes on your mapped documents and create them
-- :doc:`Console Commands <reference/console-commands>` — ``odm:schema:create``, ``odm:schema:update`` and other command-line tools for schema and index management

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -21,3 +21,9 @@ Getting Started
 The best way to get started is with the :doc:`Setup <reference/introduction#setup>` section
 in the introduction tutorial. Use the sidebar to browse other tutorials and documentation
 for the Doctrine PHP MongoDB ODM.
+
+Useful reference pages
+----------------------
+
+- :doc:`Indexes <reference/indexes>` — how to define indexes on your mapped documents and create them
+- :doc:`Console Commands <reference/console-commands>` — ``odm:schema:create``, ``odm:schema:update`` and other command-line tools for schema and index management

--- a/docs/en/reference/indexes.rst
+++ b/docs/en/reference/indexes.rst
@@ -283,13 +283,6 @@ database:
 
     db.BlogPost.ensureIndexes({ 'slug' : 1, 'comments.date': 1 })
 
-Also, for your convenience you can create the indexes for your mapped documents from the
-:doc:`console <console-commands>`:
-
-.. code-block:: console
-
-    $ php mongodb.php odm:schema:create --index
-
 .. note::
 
     If you are :ref:`mixing document types <embed_mixing_document_types>` for your

--- a/docs/en/reference/indexes.rst
+++ b/docs/en/reference/indexes.rst
@@ -6,6 +6,22 @@ You can have multiple indexes, they can consist of multiple fields,
 they can be unique and you can give them an order. In this chapter
 we'll show you examples of indexes using attributes.
 
+Declaring an index on a mapped document is the first step; the index
+itself is created in MongoDB when you run a schema command. Use the
+:doc:`console <console-commands>` to create indexes from the command
+line:
+
+.. code-block:: console
+
+    $ php mongodb.php odm:schema:create --index
+
+You can also update existing indexes (adding newly declared ones)
+without recreating the whole schema:
+
+.. code-block:: console
+
+    $ php mongodb.php odm:schema:update
+
 First here is an example where we put an index on a single
 property:
 


### PR DESCRIPTION
## Summary

Per #1536: index creation was hard to find (a small paragraph at the end of Embedded Indexes) and the Console Commands chapter was only reachable from that sentence.

## Changes

- `docs/en/reference/indexes.rst`: added an **introductory "how to create indexes"** block right after the chapter overview — shows `odm:schema:create --index` and `odm:schema:update` console usage before diving into mapping examples, so readers creating indexes can find the commands immediately
- `docs/en/index.rst`: new **"Useful reference pages"** section on the front page linking to both `Indexes` and `Console Commands`, so the console chapter is reachable from the documentation home

## Acceptance criteria

- [x] Creating indexes is discoverable at the start of the chapter, not only at the end
- [x] Console Commands is exposed on the front page