### PR TITLE
Avoid triggering the metadata write deprecation from the mapping drivers

### DIFF
--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -2021,6 +2021,46 @@ if (PHP_VERSION_ID >= 80400) {
         $this->isReadOnly = true;
     }
 
+    /**
+     * Marks this class as a mapped superclass.
+     */
+    public function markAsMappedSuperclass(): void
+    {
+        $this->isMappedSuperclass = true;
+    }
+
+    /**
+     * Marks this class as an embedded document.
+     */
+    public function markAsEmbeddedDocument(): void
+    {
+        $this->isEmbeddedDocument = true;
+    }
+
+    /**
+     * Marks this class as a query result document.
+     */
+    public function markAsQueryResultDocument(): void
+    {
+        $this->isQueryResultDocument = true;
+    }
+
+    /**
+     * Marks this class as a GridFS file.
+     */
+    public function markAsFile(): void
+    {
+        $this->isFile = true;
+    }
+
+    /**
+     * Marks this class as containing encrypted fields.
+     */
+    public function markAsEncrypted(): void
+    {
+        $this->isEncrypted = true;
+    }
+
     public function getRootClass(): ?string
     {
         return $this->rootClass;

--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -171,7 +171,7 @@ final class ClassMetadataFactory extends AbstractClassMetadataFactory implements
             }
 
             if ($parent->isFile) {
-                $class->isFile = true;
+                $class->markAsFile();
                 $class->setBucketName($parent->bucketName);
 
                 if ($parent->chunkSizeBytes !== null) {

--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -156,7 +156,7 @@ class AttributeDriver implements MappingDriver
                     $metadata->setValidationLevel($attribute->level);
                 }
             } elseif ($attribute instanceof ODM\Encrypt) {
-                $metadata->isEncrypted = true;
+                $metadata->markAsEncrypted();
             }
         }
 
@@ -165,11 +165,11 @@ class AttributeDriver implements MappingDriver
         }
 
         if ($documentAttribute instanceof ODM\MappedSuperclass) {
-            $metadata->isMappedSuperclass = true;
+            $metadata->markAsMappedSuperclass();
         } elseif ($documentAttribute instanceof ODM\EmbeddedDocument) {
-            $metadata->isEmbeddedDocument = true;
+            $metadata->markAsEmbeddedDocument();
         } elseif ($documentAttribute instanceof ODM\QueryResultDocument) {
-            $metadata->isQueryResultDocument = true;
+            $metadata->markAsQueryResultDocument();
         } elseif ($documentAttribute instanceof ODM\View) {
             if (! $documentAttribute->rootClass) {
                 throw MappingException::viewWithoutRootClass($className);
@@ -181,7 +181,7 @@ class AttributeDriver implements MappingDriver
 
             $metadata->markViewOf($documentAttribute->rootClass);
         } elseif ($documentAttribute instanceof ODM\File) {
-            $metadata->isFile = true;
+            $metadata->markAsFile();
 
             if ($documentAttribute->chunkSizeBytes !== null) {
                 $metadata->setChunkSizeBytes($documentAttribute->chunkSizeBytes);

--- a/src/Mapping/Driver/XmlDriver.php
+++ b/src/Mapping/Driver/XmlDriver.php
@@ -96,14 +96,14 @@ class XmlDriver extends FileDriver
             $metadata->setCustomRepositoryClass(
                 isset($xmlRoot['repository-class']) ? (string) $xmlRoot['repository-class'] : null,
             );
-            $metadata->isMappedSuperclass = true;
+            $metadata->markAsMappedSuperclass();
         } elseif ($xmlRoot->getName() === 'embedded-document') {
-            $metadata->isEmbeddedDocument = true;
+            $metadata->markAsEmbeddedDocument();
             if (isset($xmlRoot->encrypt)) {
-                $metadata->isEncrypted = true;
+                $metadata->markAsEncrypted();
             }
         } elseif ($xmlRoot->getName() === 'query-result-document') {
-            $metadata->isQueryResultDocument = true;
+            $metadata->markAsQueryResultDocument();
         } elseif ($xmlRoot->getName() === 'view') {
             if (isset($xmlRoot['repository-class'])) {
                 $metadata->setCustomRepositoryClass((string) $xmlRoot['repository-class']);
@@ -120,7 +120,7 @@ class XmlDriver extends FileDriver
 
             $metadata->markViewOf($rootClass);
         } elseif ($xmlRoot->getName() === 'gridfs-file') {
-            $metadata->isFile = true;
+            $metadata->markAsFile();
 
             if (isset($xmlRoot['chunk-size-bytes'])) {
                 $metadata->setChunkSizeBytes((int) $xmlRoot['chunk-size-bytes']);

--- a/tests/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/Mapping/ClassMetadataTest.php
@@ -24,11 +24,15 @@ use Documents\Account;
 use Documents\Address;
 use Documents\Album;
 use Documents\Bars\Bar;
+use Documents\BaseCategory;
+use Documents\BlogTagAggregation;
 use Documents\Card;
 use Documents\CmsGroup;
 use Documents\CmsUser;
 use Documents\CustomCollection;
 use Documents\CustomRepository\Repository;
+use Documents\Encryption\ClientCard;
+use Documents\FileWithoutMetadata;
 use Documents\SpecialUser;
 use Documents\Suit;
 use Documents\SuitInt;
@@ -1162,6 +1166,23 @@ class ClassMetadataTest extends BaseTestCase
 
         self::assertCount(1, $errors);
         self::assertEquals(sprintf('Since doctrine/mongodb-odm 2.17: Writing to property %s::db is deprecated and will be removed in version 3.0.', ClassMetadata::class), $errors[0]);
+    }
+
+    /** @param class-string<object> $className */
+    #[RequiresPhp('>= 8.4')]
+    #[TestWith([Address::class])]
+    #[TestWith([BaseCategory::class])]
+    #[TestWith([BlogTagAggregation::class])]
+    #[TestWith([FileWithoutMetadata::class])]
+    #[TestWith([ClientCard::class])]
+    public function testLoadingMetadataDoesNotTriggerDeprecation(string $className): void
+    {
+        $this->captureDeprecationMessages(
+            fn () => $this->dm->getClassMetadata($className),
+            $errors,
+        );
+
+        self::assertSame([], $errors);
     }
 }
 


### PR DESCRIPTION
The deprecation added in 2.17 for external writes to `ClassMetadata` properties is triggered by the ODM itself. The attribute driver, the XML driver and `ClassMetadataFactory` write `isMappedSuperclass`, `isEmbeddedDocument`, `isQueryResultDocument`, `isFile` and `isEncrypted` directly, and `ClassMetadata::setPropertyValue()` only allows writes coming from `ClassMetadata.php`.

On PHP 8.4+, loading the metadata of any embedded document, mapped superclass, GridFS file or query result document emits a deprecation, for example:

```
Since doctrine/mongodb-odm 2.17: Writing to property Doctrine\ODM\MongoDB\Mapping\ClassMetadata::isEmbeddedDocument is deprecated and will be removed in version 3.0.
```

This adds `markAsMappedSuperclass()`, `markAsEmbeddedDocument()`, `markAsQueryResultDocument()`, `markAsFile()` and `markAsEncrypted()`, following the naming of the existing `markViewOf()` and `markReadOnly()`, and uses them in the drivers and the factory. Custom drivers now have a replacement API for these writes.

Found while triaging #3038.