### PR TITLE
Compare more index options when detecting schema changes

### DIFF
--- a/src/SchemaManager.php
+++ b/src/SchemaManager.php
@@ -932,9 +932,10 @@ final class SchemaManager
      *
      *   (a) Key/direction pairs differ or are not in the same order
      *   (b) Sparse or unique options differ
-     *   (c) Geospatial options differ (bits, max, min)
+     *   (c) Geospatial options differ (bits, max, min, bucketSize, 2dsphereIndexVersion)
      *   (d) The partialFilterExpression differs
      *   (e) The expireAfterSeconds option differs
+     *   (f) The hidden, collation, wildcardProjection or storageEngine options differ
      *
      * The background option is only relevant to index creation and is not
      * considered.
@@ -960,7 +961,7 @@ final class SchemaManager
             return false;
         }
 
-        foreach (['bits', 'max', 'min'] as $option) {
+        foreach (['bits', 'max', 'min', 'bucketSize', '2dsphereIndexVersion', 'hidden', 'collation', 'wildcardProjection', 'storageEngine'] as $option) {
             if (
                 isset($mongoIndexOptions[$option], $documentIndexOptions[$option]) &&
                 $mongoIndexOptions[$option] !== $documentIndexOptions[$option]
@@ -969,9 +970,6 @@ final class SchemaManager
             }
         }
 
-        /* A TTL index reports expireAfterSeconds on both sides, so a changed retention window is
-         * not caught by indexOptionsAreMissing(). Comparing the values covers the option being
-         * added or removed as well. */
         if (
             ($mongoIndexOptions['expireAfterSeconds'] ?? null) !== ($documentIndexOptions['expireAfterSeconds'] ?? null)
         ) {

--- a/tests/Tests/SchemaManagerTest.php
+++ b/tests/Tests/SchemaManagerTest.php
@@ -1260,6 +1260,106 @@ EOT;
                 'mongoIndex' => ['expireAfterSeconds' => 86400],
                 'documentIndex' => ['options' => ['expireAfterSeconds' => 86400]],
             ],
+            // bucketSize option
+            'bucketSizeOnlyInMongoIndex' => [
+                'expected' => false,
+                'mongoIndex' => ['bucketSize' => 16],
+                'documentIndex' => [],
+            ],
+            'bucketSizeInBothIndexesMismatch' => [
+                'expected' => false,
+                'mongoIndex' => ['bucketSize' => 8],
+                'documentIndex' => ['options' => ['bucketSize' => 16]],
+            ],
+            'bucketSizeInBothIndexes' => [
+                'expected' => true,
+                'mongoIndex' => ['bucketSize' => 16],
+                'documentIndex' => ['options' => ['bucketSize' => 16]],
+            ],
+            // hidden option
+            'hiddenOnlyInMongoIndex' => [
+                'expected' => false,
+                'mongoIndex' => ['hidden' => true],
+                'documentIndex' => [],
+            ],
+            'hiddenOnlyInDocumentIndex' => [
+                'expected' => false,
+                'mongoIndex' => [],
+                'documentIndex' => ['options' => ['hidden' => true]],
+            ],
+            'hiddenInBothIndexesMismatch' => [
+                'expected' => false,
+                'mongoIndex' => ['hidden' => false],
+                'documentIndex' => ['options' => ['hidden' => true]],
+            ],
+            'hiddenInBothIndexes' => [
+                'expected' => true,
+                'mongoIndex' => ['hidden' => true],
+                'documentIndex' => ['options' => ['hidden' => true]],
+            ],
+            // collation option
+            'collationOnlyInMongoIndex' => [
+                'expected' => false,
+                'mongoIndex' => ['collation' => ['locale' => 'en', 'strength' => 2]],
+                'documentIndex' => [],
+            ],
+            'collationOnlyInDocumentIndex' => [
+                'expected' => false,
+                'mongoIndex' => [],
+                'documentIndex' => ['options' => ['collation' => ['locale' => 'en', 'strength' => 2]]],
+            ],
+            'collationInBothIndexesMismatch' => [
+                'expected' => false,
+                'mongoIndex' => ['collation' => ['locale' => 'en', 'strength' => 2]],
+                'documentIndex' => ['options' => ['collation' => ['locale' => 'en', 'strength' => 1]]],
+            ],
+            'collationInBothIndexes' => [
+                'expected' => true,
+                'mongoIndex' => ['collation' => ['locale' => 'en', 'strength' => 2]],
+                'documentIndex' => ['options' => ['collation' => ['locale' => 'en', 'strength' => 2]]],
+            ],
+            // wildcardProjection option
+            'wildcardProjectionOnlyInMongoIndex' => [
+                'expected' => false,
+                'mongoIndex' => ['wildcardProjection' => ['a' => 1, 'b' => 1]],
+                'documentIndex' => [],
+            ],
+            'wildcardProjectionOnlyInDocumentIndex' => [
+                'expected' => false,
+                'mongoIndex' => [],
+                'documentIndex' => ['options' => ['wildcardProjection' => ['a' => 1, 'b' => 1]]],
+            ],
+            'wildcardProjectionInBothIndexesMismatch' => [
+                'expected' => false,
+                'mongoIndex' => ['wildcardProjection' => ['a' => 1, 'b' => 1]],
+                'documentIndex' => ['options' => ['wildcardProjection' => ['a' => 1]]],
+            ],
+            'wildcardProjectionInBothIndexes' => [
+                'expected' => true,
+                'mongoIndex' => ['wildcardProjection' => ['a' => 1, 'b' => 1]],
+                'documentIndex' => ['options' => ['wildcardProjection' => ['a' => 1, 'b' => 1]]],
+            ],
+            // storageEngine option
+            'storageEngineOnlyInMongoIndex' => [
+                'expected' => false,
+                'mongoIndex' => ['storageEngine' => ['wiredTiger' => ['configString' => 'block_compression=zstd']]],
+                'documentIndex' => [],
+            ],
+            'storageEngineOnlyInDocumentIndex' => [
+                'expected' => false,
+                'mongoIndex' => [],
+                'documentIndex' => ['options' => ['storageEngine' => ['wiredTiger' => ['configString' => 'block_compression=zstd']]]],
+            ],
+            'storageEngineInBothIndexesMismatch' => [
+                'expected' => false,
+                'mongoIndex' => ['storageEngine' => ['wiredTiger' => ['configString' => 'block_compression=zstd']]],
+                'documentIndex' => ['options' => ['storageEngine' => ['wiredTiger' => ['configString' => 'block_compression=snappy']]]],
+            ],
+            'storageEngineInBothIndexes' => [
+                'expected' => true,
+                'mongoIndex' => ['storageEngine' => ['wiredTiger' => ['configString' => 'block_compression=zstd']]],
+                'documentIndex' => ['options' => ['storageEngine' => ['wiredTiger' => ['configString' => 'block_compression=zstd']]]],
+            ],
             // index name autogenerated
             'indexNameAutogenerated' => [
                 'expected' => true,
@@ -1287,11 +1387,26 @@ EOT;
                 'mongoIndex' => ['background' => true],
                 'documentIndex' => ['options' => ['background' => true]],
             ],
-            // 2dsphereIndexVersion index options
+            // 2dsphereIndexVersion option
             '2dsphereIndexVersionOptionsDifferent' => [
                 'expected' => true,
                 'mongoIndex' => ['2dsphereIndexVersion' => 3],
                 'documentIndex' => [],
+            ],
+            '2dsphereIndexVersionOnlyInDocumentIndex' => [
+                'expected' => true,
+                'mongoIndex' => [],
+                'documentIndex' => ['options' => ['2dsphereIndexVersion' => 3]],
+            ],
+            '2dsphereIndexVersionInBothIndexesMismatch' => [
+                'expected' => false,
+                'mongoIndex' => ['2dsphereIndexVersion' => 3],
+                'documentIndex' => ['options' => ['2dsphereIndexVersion' => 2]],
+            ],
+            '2dsphereIndexVersionInBothIndexes' => [
+                'expected' => true,
+                'mongoIndex' => ['2dsphereIndexVersion' => 3],
+                'documentIndex' => ['options' => ['2dsphereIndexVersion' => 3]],
             ],
         ];
     }


### PR DESCRIPTION
`isEquivalentIndexOptions()` has the same blind spot for several other index options that #3045 fixed for `expireAfterSeconds`: a one-sided presence is detected (the option is not in `ALLOWED_MISSING_INDEX_OPTIONS`, so `indexOptionsAreMissing()` flags it), but once both sides carry the option, the value is never compared. Any value was treated as equivalent to any other.

This left the live index in place after a mapping change, so the `createIndex()` that follows collided with it (`An equivalent index already exists with the same name but different options`) and `odm:schema:update` errored out, leaving every class after the failing one unprocessed. Affected options:

- `bucketSize` (geoHaystack)
- `collation`
- `hidden` (MongoDB 4.4+)
- `wildcardProjection`
- `storageEngine`
- `2dsphereIndexVersion`

The fix compares these values when both sides carry them, so a changed option takes the normal drop-and-recreate path. One-sided presence is still caught by `indexOptionsAreMissing()`, except for `2dsphereIndexVersion`: it is a server default listed in `ALLOWED_MISSING_INDEX_OPTIONS`, so a one-sided presence is intentional and stays allowed. Only a value mismatch when both sides specify it now triggers a rebuild. This also makes `2dsphereIndexVersion` consistent with `textIndexVersion`, which was already compared when both sides carried it.

The comparison is strict (`!==`), consistent with the existing `bits/max/min` and `partialFilterExpression` checks. For the document options (`collation`, `wildcardProjection`, `storageEngine`), which are arrays, this is order-sensitive, matching how `partialFilterExpression` is already compared.

Follow-up to #3045, which fixed the same gap for `expireAfterSeconds`. That change is left untouched here.

Tests: added cases to `dataIsMongoIndexEquivalentToDocumentIndex` for each new option (one-sided each direction where applicable, mismatch, equal). The mismatch cases fail without this change. Full `SchemaManagerTest` green (185 tests), `phpcs` and `phpstan` clean.

Targeted at `2.18.x` to land alongside #3045. Happy to rebase onto an older maintenance branch if preferred.
